### PR TITLE
Backup-DbaDbCertificate - Remove default date suffix

### DIFF
--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -130,7 +130,7 @@ function Backup-DbaDbCertificate {
         [Security.SecureString]$EncryptionPassword,
         [Security.SecureString]$DecryptionPassword,
         [System.IO.FileInfo]$Path,
-        [string]$Suffix = "$(Get-Date -format 'yyyyMMddHHmmssms')",
+        [string]$Suffix,
         [parameter(ValueFromPipeline, ParameterSetName = "collection")]
         [Microsoft.SqlServer.Management.Smo.Certificate[]]$InputObject,
         [switch]$EnableException

--- a/functions/Copy-DbaDbAssembly.ps1
+++ b/functions/Copy-DbaDbAssembly.ps1
@@ -165,7 +165,7 @@ function Copy-DbaDbAssembly {
                     $copyDbAssemblyStatus.Notes = "Destination database does not exist"
                     $copyDbAssemblyStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
 
-                    Write-Message -Level Verbose -Message "Destination database $dbName does not exist. Skipping $assemblyName.";
+                    Write-Message -Level Verbose -Message "Destination database $dbName does not exist. Skipping $assemblyName."
                     continue
                 }
 

--- a/functions/Copy-DbaDbAssembly.ps1
+++ b/functions/Copy-DbaDbAssembly.ps1
@@ -229,6 +229,7 @@ function Copy-DbaDbAssembly {
 
                     } catch {
                         $copyDbAssemblyStatus.Status = "Failed"
+                        $copyDbAssemblyStatus.Notes = $PSItem
                         $copyDbAssemblyStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
 
                         Stop-Function -Message "Issue creating assembly." -Target $assemblyName -ErrorRecord $_

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -6,9 +6,7 @@ function Copy-DbaDbCertificate {
     .DESCRIPTION
         By default, all certificates are copied.
 
-        If the certificate already exists on the destination, it will be skipped unless -Force is used.
-
-        This script does not yet copy dependencies or dependent objects.
+        If the certificate already exists on the destination, it will be skipped.
 
     .PARAMETER Source
         Source SQL Server. You must have sysadmin access and server version must be SQL Server version 2000 or higher.
@@ -102,12 +100,12 @@ function Copy-DbaDbCertificate {
     begin {
         try {
             $parms = @{
-                SqlInstance        = $Source
-                SqlCredential      = $SourceSqlCredential
-                Database           = $Database
-                ExcludeDatabase    = $ExcludeDatabase
-                Certificate        = $Certificate
-                EnableException    = $true
+                SqlInstance     = $Source
+                SqlCredential   = $SourceSqlCredential
+                Database        = $Database
+                ExcludeDatabase = $ExcludeDatabase
+                Certificate     = $Certificate
+                EnableException = $true
             }
             # Get presumably user certs, no way to tell if its a system object
             $sourcecertificates = Get-DbaDbCertificate @parms | Where-Object Name -notlike "#*" | Where-Object Name -notin $ExcludeCertificate
@@ -131,7 +129,6 @@ function Copy-DbaDbCertificate {
         }
     }
     process {
-        # THIS MAKES ASSUMPTIONS ABOUT THE CERTIFICATE THAT ITS ENCRYPTED BY A MASTER KEY
         # FOR START-DBAMIGRATION, IT NEEDS TO JUST BE COPY-DBADBMASTER
 
         if (Test-FunctionInterrupt) { return }

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -28,6 +28,7 @@ function Copy-DbaDbCertificate {
 
         For MFA support, please use Connect-DbaInstance.
 
+
     .PARAMETER Certificate
         The certificate(ies) to process. This list is auto-populated from the server. If unspecified, all certificates will be processed.
 
@@ -261,7 +262,7 @@ function Copy-DbaDbCertificate {
                                 Write-Message -Level Verbose -Message "Backing up certificate $cername for $($dbName) on $($server.Name)"
                                 try {
                                     $tempPath = Join-DbaPath -SqlInstance $server -Path $SharedPath -ChildPath "$certname.cer"
-                                    $tempKey  = Join-DbaPath -SqlInstance $server -Path $SharedPath -ChildPath "$certname.pvk"
+                                    $tempKey = Join-DbaPath -SqlInstance $server -Path $SharedPath -ChildPath "$certname.pvk"
 
                                     if ((Test-DbaPath -SqlInstance $server -Path $tempPath) -and (Test-DbaPath -SqlInstance $server -Path $tempKey)) {
                                         $export = [pscustomobject]@{

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -89,7 +89,7 @@ function Copy-DbaDbCertificate {
         >>  }
         PS C:\> Copy-DbaDbCertificate @params1 -Confirm:$false -OutVariable results
 
-        Copies database certificates for matching databases on sql02
+        Copies database certificates for matching databases on sql02 and creates master keys if needed
 
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = "High")]

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -80,21 +80,16 @@ function Copy-DbaDbCertificate {
         https://dbatools.io/Copy-DbaDbCertificate
 
     .EXAMPLE
-        PS C:\> Copy-DbaDbCertificate -Source mssql1 -Destination mssql2
+        PS C:\> $params1 = @{
+        >>      Source = "sql01"
+        >>      Destination = "sql02"
+        >>      EncryptionPassword = $passwd
+        >>      MasterKeyPassword = $passwd
+        >>      SharedPath = "\\nas\sql\shared"
+        >>  }
+        PS C:\> Copy-DbaDbCertificate @params1 -Confirm:$false -OutVariable results
 
-        Copies all certificates from mssql1 to mssql2 using Windows credentials. If certificates with the same name exist on mssql2, they will be skipped.
-
-    .EXAMPLE
-        PS C:\> Copy-DbaDbCertificate -Source mssql1 -Destination mssql2 -Certificate dbname.certificatename, dbname3.anothercertificate -SourceSqlCredential $cred -Force
-
-        Copies two certificates, the dbname.certificatename and dbname3.anothercertificate from mssql1 to mssql2 using SQL credentials for mssql1 and Windows credentials for mssql2. If certificates with the same name exist on mssql2, they will be skipped.
-
-        In this example, anothercertificate will be copied to the dbname3 database on the server mssql2.
-
-    .EXAMPLE
-        PS C:\> Copy-DbaDbCertificate -Source mssql1 -Destination mssql2 -WhatIf -Force
-
-        Shows what would happen if the command were executed using force.
+        Copies database certificates for matching databases on sql02
 
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = "High")]
@@ -148,7 +143,7 @@ function Copy-DbaDbCertificate {
     }
     process {
         # FOR START-DBAMIGRATION, IT NEEDS TO JUST BE COPY-DBADBMASTER
-
+        # NEED TO DELETE ANY EXPORTED KEY
         if (Test-FunctionInterrupt) { return }
         foreach ($destinstance in $Destination) {
             try {

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -1,0 +1,293 @@
+function Copy-DbaDbCertificate {
+    <#
+    .SYNOPSIS
+        Copy-DbaDbCertificate migrates certificates from one SQL Server to another.
+
+    .DESCRIPTION
+        By default, all certificates are copied.
+
+        If the certificate already exists on the destination, it will be skipped unless -Force is used.
+
+        This script does not yet copy dependencies or dependent objects.
+
+    .PARAMETER Source
+        Source SQL Server. You must have sysadmin access and server version must be SQL Server version 2000 or higher.
+
+    .PARAMETER SourceSqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Destination
+        Destination SQL Server. You must have sysadmin access and the server must be SQL Server 2000 or higher.
+
+    .PARAMETER DestinationSqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Certificate
+        The certificate(ies) to process. This list is auto-populated from the server. If unspecified, all certificates will be processed.
+
+    .PARAMETER ExcludeCertificate
+        The certificate(ies) to exclude. This list is auto-populated from the server.
+
+    .PARAMETER WhatIf
+        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+    .PARAMETER Confirm
+        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .PARAMETER Force
+        If this switch is enabled, existing certificates on Destination with matching names from Source will be dropped.
+
+    .NOTES
+        Tags: Migration, Certificate
+        Author: Chrissy LeMaire (@cl), netnerds.net
+
+        Website: https://dbatools.io
+        Copyright: (c) 2022 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+        Requires: sysadmin access on SQL Servers
+
+    .LINK
+        https://dbatools.io/Copy-DbaDbCertificate
+
+    .EXAMPLE
+        PS C:\> Copy-DbaDbCertificate -Source mssql1 -Destination mssql2
+
+        Copies all certificates from mssql1 to mssql2 using Windows credentials. If certificates with the same name exist on mssql2, they will be skipped.
+
+    .EXAMPLE
+        PS C:\> Copy-DbaDbCertificate -Source mssql1 -Destination mssql2 -Certificate dbname.certificatename, dbname3.anothercertificate -SourceSqlCredential $cred -Force
+
+        Copies two certificates, the dbname.certificatename and dbname3.anothercertificate from mssql1 to mssql2 using SQL credentials for mssql1 and Windows credentials for mssql2. If certificates with the same name exist on mssql2, they will be skipped.
+
+        In this example, anothercertificate will be copied to the dbname3 database on the server mssql2.
+
+    .EXAMPLE
+        PS C:\> Copy-DbaDbCertificate -Source mssql1 -Destination mssql2 -WhatIf -Force
+
+        Shows what would happen if the command were executed using force.
+
+    #>
+    [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = "High")]
+    param (
+        [parameter(Mandatory)]
+        [DbaInstanceParameter]$Source,
+        [PSCredential]$SourceSqlCredential,
+        [parameter(Mandatory)]
+        [DbaInstanceParameter[]]$Destination,
+        [PSCredential]$DestinationSqlCredential,
+        [string[]]$Database,
+        [string[]]$ExcludeDatabase,
+        [string[]]$Certificate,
+        [string[]]$ExcludeCertificate,
+        [string]$SharedPath,
+        [Security.SecureString]$MasterKeyPassword,
+        [Security.SecureString]$EncryptionPassword,
+        [Security.SecureString]$DecryptionPassword,
+        [switch]$EnableException
+    )
+    begin {
+        try {
+            $parms = @{
+                SqlInstance        = $Source
+                SqlCredential      = $SourceSqlCredential
+                Database           = $Database
+                ExcludeDatabase    = $ExcludeDatabase
+                Certificate        = $Certificate
+                EnableException    = $true
+            }
+            # Get presumably user certs, no way to tell if its a system object
+            $sourcecertificates = Get-DbaDbCertificate @parms | Where-Object Name -notlike "#*" | Where-Object Name -notin $ExcludeCertificate
+            $dbsnames = $sourcecertificates.Parent.Name | Select-Object -Unique
+            $server = ($sourcecertificates | Select-Object -First 1).Parent.Parent
+            $serviceAccount = $server.ServiceAccount
+        } catch {
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Source
+            return
+        }
+
+        if (-not $PSBoundParameter.EncryptionPassword) {
+            $backupEncryptionPassword = Get-RandomPassword
+        } else {
+            $backupEncryptionPassword = $EncryptionPassword
+        }
+
+        If ($serviceAccount -and -not (Test-DbaPath -SqlInstance $Source -SqlCredential $SourceSqlCredential -Path $SharedPath)) {
+            Stop-Function -Message "The SQL Server service account ($serviceAccount) for $Source does not have access to $SharedPath"
+            return
+        }
+    }
+    process {
+        # THIS MAKES ASSUMPTIONS ABOUT THE CERTIFICATE THAT ITS ENCRYPTED BY A MASTER KEY
+        # FOR START-DBAMIGRATION, IT NEEDS TO JUST BE COPY-DBADBMASTER
+
+        if (Test-FunctionInterrupt) { return }
+        foreach ($destinstance in $Destination) {
+            try {
+                $destServer = Connect-DbaInstance -SqlInstance $destinstance -SqlCredential $DestinationSqlCredential -MinimumVersion 10
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $destinstance -Continue
+            }
+            $serviceAccount = $destserver.ServiceAccount
+
+            If (-not (Test-DbaPath -SqlInstance $destServer -Path $SharedPath)) {
+                Stop-Function -Message "The SQL Server service account ($serviceAccount) for $destinstance does not have access to $SharedPath" -Continue
+            }
+
+            if (($sourcecertificates | Where-Object PrivateKeyEncryptionType -eq MasterKey)) {
+                $masterkey = Get-DbaDbMasterKey -SqlInstance $db.Parent -Database master
+                if (-not $masterkey) {
+                    Write-Message -Level Verbose -Message "master key not found, seeing if MasterKeyPassword was specified"
+                    if ($MasterKeyPassword) {
+                        Write-Message -Level Verbose -Message "master key not found, creating one"
+                        try {
+                            $params = @{
+                                SqlInstance     = $destServer
+                                SecurePassword  = $MasterKeyPassword
+                                EnableException = $true
+                            }
+                            $masterkey = New-DbaServiceMasterKey @params
+                        } catch {
+                            Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
+                        }
+                    } else {
+                        return $PSBoundParameters
+                        Stop-Function -Message "Master service key not found on $destinstance and MasterKeyPassword not specified, so it cannot be created" -Continue
+                    }
+                }
+                $null = $destServer.Databases["master"].Refresh()
+            }
+
+            $destdbs = $destServer.Databases | Where-Object Name -in $dbsnames
+
+            foreach ($db in $destdbs) {
+                $dbName = $db.Name
+                $sourcerts = $sourcecertificates | Where-Object { $PSItem.Parent.Name -eq $db.Name }
+
+                # Check for master key requirement
+                if (($sourcerts | Where-Object PrivateKeyEncryptionType -eq MasterKey)) {
+                    $masterkey = Get-DbaDbMasterKey -SqlInstance $db.Parent -Database $db.Name
+
+                    if (-not $masterkey) {
+                        Write-Message -Level Verbose -Message "Master key not found, seeing if MasterKeyPassword was specified"
+                        if ($MasterKeyPassword) {
+                            try {
+                                $params = @{
+                                    SqlInstance     = $destServer
+                                    SecurePassword  = $MasterKeyPassword
+                                    Database        = $db.Name
+                                    EnableException = $true
+                                }
+                                $masterkey = New-DbaDbMasterKey @params
+                                $domasterkeymessage = $false
+                                $domasterkeypasswordmessage = $false
+                            } catch {
+                                $domasterkeymessage = "Master key auto-generation failure: $PSItem"
+                                Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
+                            }
+
+                        } else {
+                            $domasterkeypasswordmessage = $true
+                        }
+                    }
+
+                    foreach ($cert in $sourcerts) {
+                        $certname = $cert.Name
+                        Write-Message -Level VeryVerbose -Message "Processing $certname on $dbName"
+
+                        $copyDbCertificateStatus = [pscustomobject]@{
+                            SourceServer        = $Source
+                            SourceDatabase      = $dbName
+                            DestinationServer   = $destServer.Name
+                            DestinationDatabase = $dbName
+                            type                = "Database Certificate"
+                            Name                = $certname
+                            Status              = $null
+                            Notes               = $null
+                            DateTime            = [Sqlcollaborative.Dbatools.Utility.DbaDateTime](Get-Date)
+                        }
+
+                        if ($domasterkeymessage) {
+                            $copyDbCertificateStatus.Status = "Skipped"
+                            $copyDbCertificateStatus.Notes = $domasterkeymessage
+                            $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+
+                            Write-Message -Level Verbose -Message $domasterkeymessage
+                            continue
+                        }
+
+                        if ($domasterkeypasswordmessage) {
+                            $copyDbCertificateStatus.Status = "Skipped"
+                            $copyDbCertificateStatus.Notes = "Master service key not found and MasterKeyPassword not provided for auto-creation"
+                            $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+
+                            Write-Message -Level Verbose -Message "Master service key not found and MasterKeyPassword not provided for auto-creation"
+                            continue
+                        }
+                        $null = $db.Refresh()
+                        if ($db.Certificates.Name -contains $certname) {
+                            $copyDbCertificateStatus.Status = "Skipped"
+                            $copyDbCertificateStatus.Notes = "Already exists on destination"
+                            $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+
+                            Write-Message -Level Verbose -Message "Certificate $certname exists at destination in the $dbName database"
+                            continue
+                        }
+
+                        if ($Pscmdlet.ShouldProcess($destinstance.Name, "Copying certificate $certname from database.")) {
+                            try {
+                                # Back up certificate
+                                $null = $db.Refresh()
+                                $params = @{
+                                    SqlInstance        = $cert.Parent.Parent
+                                    Database           = $db.Name
+                                    Certificate        = $certname
+                                    Path               = $SharedPath
+                                    EnableException    = $true
+                                    Suffix             = $null
+                                    EncryptionPassword = $backupEncryptionPassword
+                                    DecryptionPassword = $DecryptionPassword
+                                }
+                                Write-Message -Level Verbose -Message "Backing up certificate $cername for $($dbName) on $($server.Name)"
+                                $export = Backup-DbaDbCertificate @params
+
+                                # Restore certificate
+                                $params = @{
+                                    SqlInstance        = $db.Parent
+                                    Database           = $db.Name
+                                    Path               = $export.Path
+                                    KeyFilePath        = $export.Key
+                                    EnableException    = $true
+                                    EncryptionPassword = $DecryptionPassword
+                                    DecryptionPassword = $backupEncryptionPassword
+                                }
+
+                                $null = Restore-DbaDbCertificate @params
+                                $copyDbCertificateStatus.Status = "Successful"
+                                $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+                            } catch {
+                                $copyDbCertificateStatus.Status = "Failed"
+                                $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+
+                                Stop-Function -Message "Issue creating certificate $certname from $($export.Path) for $dbname on $($db.Parent.Name)" -Target $certname -ErrorRecord $_
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -28,12 +28,29 @@ function Copy-DbaDbCertificate {
 
         For MFA support, please use Connect-DbaInstance.
 
+    .PARAMETER Database
+        The database(s) to process.
+
+    .PARAMETER ExcludeDatabase
+        The database(s) to exclude.
 
     .PARAMETER Certificate
-        The certificate(ies) to process. This list is auto-populated from the server. If unspecified, all certificates will be processed.
+        The certificate(s) to process.
 
     .PARAMETER ExcludeCertificate
-        The certificate(ies) to exclude. This list is auto-populated from the server.
+        The certificate(s) to exclude.
+
+    .PARAMETER SharedPath
+        Specifies the network location for the backup files. The SQL Server service accounts on both Source and Destination must have read/write permission to access this location.
+
+    .PARAMETER EncryptionPassword
+        A string value that specifies the secure password to encrypt the private key.
+
+    .PARAMETER DecryptionPassword
+        Secure string used to decrypt the private key.
+
+    .PARAMETER MasterKeyPassword
+        The password to encrypt the exported key. This must be a SecureString.
 
     .PARAMETER WhatIf
         If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.

--- a/functions/Get-DbaFile.ps1
+++ b/functions/Get-DbaFile.ps1
@@ -90,11 +90,11 @@ function Get-DbaFile {
             $q1 += "DECLARE @myPath nvarchar(4000);
                     DECLARE @depth SMALLINT = $Depth;
 
-                    IF OBJECT_ID('tempdb..#DirectoryTree') IS NOT NULL
+                    IF OBJECT_id('tempdb..#DirectoryTree') IS NOT NULL
                     DROP TABLE #DirectoryTree;
 
                     CREATE TABLE #DirectoryTree (
-                       id int IDENTITY(1,1)
+                       id int idENTITY(1,1)
                        ,subdirectory nvarchar(512)
                        ,depth int
                        ,isfile bit
@@ -112,22 +112,22 @@ function Get-DbaFile {
 
                     UPDATE #DirectoryTree
                        SET ParentDirectory = (
-                          SELECT MAX(Id) FROM #DirectoryTree
-                          WHERE Depth = d.Depth - 1 AND Id < d.Id   )
+                          SELECT MAX(id) FROM #DirectoryTree
+                          WHERE depth = d.depth - 1 AND id < d.id   )
                     FROM #DirectoryTree d
                     WHERE ParentDirectory is NULL;"
 
             $query_files_sql = "-- SEE all with full paths
                     WITH dirs AS (
                         SELECT
-                           Id,subdirectory,depth,isfile,ParentDirectory,flag
+                           id,subdirectory,depth,isfile,ParentDirectory,flag
                            , CAST (null AS NVARCHAR(MAX)) AS container
                            , CAST([subdirectory] AS NVARCHAR(MAX)) AS dpath
                            FROM #DirectoryTree
                            WHERE ParentDirectory IS NULL
                         UNION ALL
                         SELECT
-                           d.Id,d.subdirectory,d.depth,d.isfile,d.ParentDirectory,d.flag
+                           d.id,d.subdirectory,d.depth,d.isfile,d.ParentDirectory,d.flag
                            , dpath as container
                            , dpath +'\'+d.[subdirectory]
                         FROM #DirectoryTree AS d
@@ -169,13 +169,20 @@ function Get-DbaFile {
             }
 
             # Get the default data and log directories from the instance
-            if (-not (Test-Bound -ParameterName Path)) { $Path = (Get-DbaDefaultPath -SqlInstance $server).Data }
+            if (-not (Test-Bound -ParameterName Path)) {
+                $Path = (Get-DbaDefaultPath -SqlInstance $server).Data
+            }
+            if (Test-HostOSLinux -SqlInstance $server) {
+                $separator = "/"
+            } else {
+                $separator = "\"
+            }
 
             Write-Message -Level Verbose -Message "Adding paths"
             $sql = Get-SQLDirTreeQuery $Path
             Write-Message -Level Debug -Message $sql
 
-            # This should remain as not .Query() to be compat with a PSProvider Chrissy is working on
+            # This should remain as not .Query() to be compat with a PSProvider Chrissy was working on
             $datatable = $server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows
 
             Write-Message -Level Verbose -Message "$($datatable.Rows.Count) files found."
@@ -183,24 +190,27 @@ function Get-DbaFile {
                 foreach ($row in $datatable) {
                     foreach ($type in $FileTypeComparison) {
                         if ($row.filename.ToLowerInvariant().EndsWith(".$type")) {
+                            $fullpath = $row.fullpath.Replace("\", $separator)
                             [pscustomobject]@{
                                 ComputerName   = $server.ComputerName
                                 InstanceName   = $server.ServiceName
                                 SqlInstance    = $server.DomainInstanceName
-                                Filename       = $row.fullpath
-                                RemoteFilename = Join-AdminUnc -Servername $server.ComputerName -Filepath $row.fullpath
+                                Filename       = $fullpath
+                                RemoteFilename = Join-AdminUnc -Servername $server.ComputerName -Filepath $fullpath
                             } | Select-DefaultView -ExcludeProperty ComputerName, InstanceName, RemoteFilename
                         }
                     }
                 }
             } else {
                 foreach ($row in $datatable) {
+                    $fullpath = $row.fullpath
+                    $fullpath = $row.fullpath.Replace("\", $separator)
                     [pscustomobject]@{
                         ComputerName   = $server.ComputerName
                         InstanceName   = $server.ServiceName
                         SqlInstance    = $server.DomainInstanceName
-                        Filename       = $row.fullpath
-                        RemoteFilename = Join-AdminUnc -Servername $server.ComputerName -Filepath $row.fullpath
+                        Filename       = $fullpath
+                        RemoteFilename = Join-AdminUnc -Servername $server.ComputerName -Filepath $fullpath
                     } | Select-DefaultView -ExcludeProperty ComputerName, InstanceName, RemoteFilename
                 }
             }

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -1,0 +1,49 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'Source', 'SourceSqlCredential', 'Destination', 'DestinationSqlCredential', 'Database', 'ExcludeDatabase', 'Certificate', 'ExcludeCertificate', 'SharedPath', 'MasterKeyPassword', 'EncryptionPassword', 'DecryptionPassword', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Can create a database certificate" {
+        BeforeAll {
+            if (-not (Get-DbaDbMasterKey -SqlInstance $script:instance2 -Database master)) {
+                $masterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database master -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
+            }
+
+            $passwd = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
+            $tempdbmasterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database tempdb -Password $passwd -Confirm:$false
+            $certificateName1 = "Cert_$(Get-random)"
+            $certificateName2 = "Cert_$(Get-random)"
+            $cert1 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName1 -Confirm:$false
+            $cert2 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName2 -Database tempdb -Confirm:$false
+        }
+        AfterAll {
+            if ($tempdbmasterkey) { $tempdbmasterkey | Remove-DbaDbMasterKey -Confirm:$false }
+            if ($masterKey) { $masterkey | Remove-DbaDbMasterKey -Confirm:$false }
+            $null = $cert1 | Remove-DbaDbCertificate -Confirm:$false
+            $null = $cert2 | Remove-DbaDbCertificate -Confirm:$false
+        }
+
+        It "Successfully copies a certificate" {
+            $params1 = @{
+                Source             = $script:instance2
+                Destination        = $script:instance3
+                EncryptionPassword = $passwd
+                MasterKeyPassword  = $passwd
+                SharedPath         = "C:\temp"
+            }
+            $results = Copy-DbaDbCertificate @params1 -Confirm:$false | Where-Object SourceDatabase -eq tempdb | Select-Object -First 1
+            $results.Status | Should -Be "Successful"
+        }
+    }
+}

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -22,8 +22,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
             $passwd = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
             $tempdbmasterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database tempdb -Password $passwd -Confirm:$false
-            $certificateName1 = "Cert_$(Get-random)"
-            $certificateName2 = "Cert_$(Get-random)"
+            $certificateName1 = "Cert_$(Get-Random)"
+            $certificateName2 = "Cert_$(Get-Random)"
             $cert1 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName1 -Confirm:$false
             $cert2 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName2 -Database tempdb -Confirm:$false
         }
@@ -42,7 +42,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 MasterKeyPassword  = $passwd
                 SharedPath         = "C:\temp"
             }
-            $results = Copy-DbaDbCertificate @params1 -Confirm:$false | Where-Object SourceDatabase -eq tempdb | Select-Object -First 1
+            $results = Copy-DbaDbCertificate @params1 -Confirm:$false | Where-Object SourceDatabase -EQ tempdb | Select-Object -First 1
             $results.Status | Should -Be "Successful"
         }
     }

--- a/tests/Restore-DbaDbCertificate.Tests.ps1
+++ b/tests/Restore-DbaDbCertificate.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Path', 'EncryptionPassword', 'Database', 'DecryptionPassword', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Path', 'EncryptionPassword', 'Database', 'DecryptionPassword', 'KeyFilePath', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )

### Purpose
The suffix was added so that there were no clobber issues. But it also renames the certificate in the database when you restore it with our default method and you can't do a regex for it, really (or maybe we can and i dont know how)

Maybe changing the restore command with a regex detection is a better idea.

### Approach
Make it the regular name, and if that exists, then use the backup name.
