### PR TITLE
Backup-DbaDbCertificate - Remove default date suffix

### DIFF
--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -153,18 +153,16 @@ function Backup-DbaDbCertificate {
             }
 
             $actualPath = "$actualPath".TrimEnd('\').TrimEnd('/')
-
             $fullCertName = (Join-DbaPath -SqlInstance $server $actualPath "$certName$Suffix")
             $exportPathKey = "$fullCertName.pvk"
 
             if ((Test-DbaPath -SqlInstance $server -Path "$fullCertName.cer")) {
                 if ($PSBoundParameter.Suffix) {
-                    Stop-Function -Message "$fullCertName.cer already exists on $($server.Name)" -Target $actualPath
+                    Stop-Function -Message "$fullCertName.cer already exists on $($server.Name)" -Target $actualPath -Continue
                 } else {
                     $date = Get-Date -format 'yyyyMMddHHmmssms'
                     $fullCertName = (Join-DbaPath -SqlInstance $server $actualPath "$certName$date")
                     $exportPathKey = "$fullCertName.pvk"
-
                 }
             }
 

--- a/functions/Restore-DbaDbCertificate.ps1
+++ b/functions/Restore-DbaDbCertificate.ps1
@@ -104,14 +104,18 @@ function Restore-DbaDbCertificate {
                 $directory = Split-Path $fullname
                 $filename = Split-Path $fullname -Leaf
                 $certname = [io.path]::GetFileNameWithoutExtension($filename)
+                $fullcertname = "$directory\$certname.cer"
+                $privatekey = "$directory\$certname.pvk"
+
+                if ($certname -match '([0-9]{4})(0[1-9]|1[0-2])(0[1-9]|[1-2][0-9]|3[0-1])(2[0-3]|[01][0-9])([0-5][0-9])([0-5][0-9])') {
+                    $certname = $certname.Replace($matches[0], "")
+                }
 
                 if ($Pscmdlet.ShouldProcess("$certname on $SqlInstance", "Importing Certificate")) {
                     $smocert = New-Object Microsoft.SqlServer.Management.Smo.Certificate
                     $smocert.Name = $certname
                     $smocert.Parent = $server.Databases[$Database]
                     Write-Message -Level Verbose -Message "Creating Certificate: $certname"
-                    $fullcertname = "$directory\$certname.cer"
-                    $privatekey = "$directory\$certname.pvk"
                     Write-Message -Level Verbose -Message "Full certificate path: $fullcertname"
                     Write-Message -Level Verbose -Message "Private key: $privatekey"
                     try {


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Breaking change

### Purpose
The suffix was added so that there were no clobber issues. But it also renames the certificate in the database when you restore it with our default method. So I fixed both commands. Backup now defaults to no date unless the file exists then it appends a date if a suffix has not been specified.

Then, in Restore, it looks for that string and removes it so that the cert looks prettier and maintains the same name. This is a mild breaking change that impacts people who are looking for that string in their backup file.

Also, this site for regex is awesome: https://www.regextester.com/112363

### Approach
Make it the regular name, and if that exists, then add the date to the name.
