### PR TITLE
Copy-DbaDbCertificate + Bug Fixes

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -220,6 +220,7 @@
         'Get-DbaDbccStatistic',
         'Get-DbaDbccUserOption',
         'Get-DbaDbCertificate',
+        'Copy-DbaDbCertificate',
         'Get-DbaDbCheckConstraint',
         'Get-DbaDbCompatibility',
         'Get-DbaDbCompression',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -498,6 +498,7 @@ $script:xplat = @(
     'Remove-DbaAgentSchedule',
     'Backup-DbaDbCertificate',
     'Get-DbaDbCertificate',
+    'Copy-DbaDbCertificate',
     'Get-DbaEndpoint',
     'Get-DbaDbMasterKey',
     'Get-DbaSchemaChangeHistory',

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -293,11 +293,23 @@ function Backup-DbaDatabase {
                 return
             }
         }
+        Function Convert-BackupPath ($object) {
+            if ($object -match "/|\\") {
+                if ($isdestlinux -and $object) {
+                    $object = $object.Replace("\", "/")
+                } elseif ($transformedbackupfolder) {
+                    $object = $object.Replace("/", "\")
+                }
+            }
+            $object
+        }
     }
 
     process {
         if (Test-FunctionInterrupt) { return }
-
+        if ($IsMacOS -or $IsLinux) {
+            $nonwindows = $true
+        }
         if (-not $SqlInstance -and -not $InputObject) {
             Stop-Function -Message "You must specify a server and database or pipe some databases"
             return
@@ -371,6 +383,14 @@ function Backup-DbaDatabase {
             if ( (Test-Bound AzureBaseUrl -Not) -and (Test-Bound Path -Not) -and $FilePath -ne 'NUL') {
                 Write-Message -Message 'No backup folder passed in, setting it to instance default' -Level Verbose
                 $Path = (Get-DbaDefaultPath -SqlInstance $server).Backup
+                if ($Path) {
+                    # it's very picky, don't cut corners
+                    $lastchar = $Path.substring($Path.length - 1, 1)
+                    if ($lastchar -eq "/" -or $lastchar -eq "\") {
+                        $Path = $Path.TrimEnd("/")
+                        $Path = $Path.TrimEnd("\")
+                    }
+                }
             }
 
             if (($MaxTransferSize % 64kb) -ne 0 -or $MaxTransferSize -gt 4mb) {
@@ -544,7 +564,7 @@ function Backup-DbaDatabase {
                 if ( '' -ne (Split-Path $FilePath)) {
                     Write-Message -Level Verbose -Message "Fully qualified path passed in"
                     # Because of #7860, don't use [IO.Path]::GetFullPath on MacOS
-                    if ($IsMacOS -or $isdestlinux) {
+                    if ($nonwindows -or $isdestlinux) {
                         $FinalBackupPath += $file.DirectoryName
                     } else {
                         $FinalBackupPath += [IO.Path]::GetFullPath($file.DirectoryName)
@@ -617,7 +637,7 @@ function Backup-DbaDatabase {
             }
 
             # Because of #7860, don't use [IO.Path]::GetFullPath on MacOS
-            if ($null -eq $AzureBaseUrl -and $Path -and -not $IsMacOS -and -not $isdestlinux) {
+            if ($null -eq $AzureBaseUrl -and $Path -and -not $nonwindows -and -not $isdestlinux) {
                 $FinalBackupPath = $FinalBackupPath | ForEach-Object { [IO.Path]::GetFullPath($_) }
             }
 
@@ -695,7 +715,7 @@ function Backup-DbaDatabase {
                                     BackupComplete       = $BackupComplete
                                     BackupFilesCount     = $FinalBackupPath.Count
                                     BackupFile           = (Split-Path $FinalBackupPath -Leaf)
-                                    BackupFolder         = (Split-Path $FinalBackupPath | Sort-Object -Unique)
+                                    BackupFolder         = (Convert-BackupPath -object (Split-Path $FinalBackupPath | Sort-Object -Unique))
                                     BackupPath           = ($FinalBackupPath | Sort-Object -Unique)
                                     Script               = $script
                                     Notes                = $failures -join (',')
@@ -728,6 +748,11 @@ function Backup-DbaDatabase {
                                 $pathresult = "NUL:"
                             } else {
                                 $pathresult = (Split-Path $FinalBackupPath | Sort-Object -Unique)
+                                if ($isdestlinux -and $pathresult) {
+                                    $pathresult = $pathresult.Replace("\", "/")
+                                } elseif ($pathresult) {
+                                    $pathresult = $pathresult.Replace("/", "\")
+                                }
                             }
                             $HeaderInfo | Add-Member -Type NoteProperty -Name BackupFolder -Value $pathresult
                             $HeaderInfo | Add-Member -Type NoteProperty -Name BackupPath -Value ($FinalBackupPath | Sort-Object -Unique)

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -293,6 +293,7 @@ function Backup-DbaDatabase {
                 return
             }
         }
+        # this had to be a function. making it a variable killed something. I'm guessing scoping issues
         Function Convert-BackupPath ($object) {
             if ($object -match "/|\\") {
                 if ($isdestlinux -and $object) {
@@ -549,8 +550,6 @@ function Backup-DbaDatabase {
             }
 
             Write-Message -Level Verbose -Message "Building file name"
-            #$isdestlinux
-            #####################################
             $BackupFinalName = ''
             $FinalBackupPath = @()
             $timestamp = Get-Date -Format $TimeStampFormat

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -297,7 +297,9 @@ function Backup-DbaDatabase {
 
     process {
         if (Test-FunctionInterrupt) { return }
-
+        if ($IsMacOS -or $IsLinux) {
+            $nonwindows = $true
+        }
         if (-not $SqlInstance -and -not $InputObject) {
             Stop-Function -Message "You must specify a server and database or pipe some databases"
             return
@@ -371,6 +373,14 @@ function Backup-DbaDatabase {
             if ( (Test-Bound AzureBaseUrl -Not) -and (Test-Bound Path -Not) -and $FilePath -ne 'NUL') {
                 Write-Message -Message 'No backup folder passed in, setting it to instance default' -Level Verbose
                 $Path = (Get-DbaDefaultPath -SqlInstance $server).Backup
+                if ($Path) {
+                    # it's very picky, don't cut corners
+                    $lastchar = $Path.substring($Path.length - 1, 1)
+                    if ($lastchar -eq "/" -or $lastchar -eq "\") {
+                        $Path = $Path.TrimEnd("/")
+                        $Path = $Path.TrimEnd("\")
+                    }
+                }
             }
 
             if (($MaxTransferSize % 64kb) -ne 0 -or $MaxTransferSize -gt 4mb) {
@@ -529,8 +539,6 @@ function Backup-DbaDatabase {
             }
 
             Write-Message -Level Verbose -Message "Building file name"
-            #$isdestlinux
-            #####################################
             $BackupFinalName = ''
             $FinalBackupPath = @()
             $timestamp = Get-Date -Format $TimeStampFormat
@@ -544,7 +552,7 @@ function Backup-DbaDatabase {
                 if ( '' -ne (Split-Path $FilePath)) {
                     Write-Message -Level Verbose -Message "Fully qualified path passed in"
                     # Because of #7860, don't use [IO.Path]::GetFullPath on MacOS
-                    if ($IsMacOS -or $isdestlinux) {
+                    if ($nonwindows -or $isdestlinux) {
                         $FinalBackupPath += $file.DirectoryName
                     } else {
                         $FinalBackupPath += [IO.Path]::GetFullPath($file.DirectoryName)
@@ -617,7 +625,7 @@ function Backup-DbaDatabase {
             }
 
             # Because of #7860, don't use [IO.Path]::GetFullPath on MacOS
-            if ($null -eq $AzureBaseUrl -and $Path -and -not $IsMacOS -and -not $isdestlinux) {
+            if ($null -eq $AzureBaseUrl -and $Path -and -not $nonwindows -and -not $isdestlinux) {
                 $FinalBackupPath = $FinalBackupPath | ForEach-Object { [IO.Path]::GetFullPath($_) }
             }
 
@@ -686,6 +694,14 @@ function Backup-DbaDatabase {
                                 $HeaderInfo = Get-DbaDbBackupHistory -SqlInstance $server -Database $dbName @gbhSwitch -IncludeCopyOnly -RecoveryFork $db.RecoveryForkGuid | Sort-Object -Property End -Descending | Select-Object -First 1
                             }
                             $Verified = $false
+                            $transformedbackupfolder = Split-Path $FinalBackupPath | Sort-Object -Unique
+                            if ($transformedbackupfolder -match "/|\\") {
+                                if ($isdestlinux -and $transformedbackupfolder) {
+                                    $transformedbackupfolder = $transformedbackupfolder.Replace("\", "/")
+                                } elseif ($transformedbackupfolder) {
+                                    $transformedbackupfolder = $transformedbackupfolder.Replace("/", "\")
+                                }
+                            }
                             if ($Verify) {
                                 $verifiedresult = [PSCustomObject]@{
                                     ComputerName         = $server.ComputerName
@@ -695,7 +711,7 @@ function Backup-DbaDatabase {
                                     BackupComplete       = $BackupComplete
                                     BackupFilesCount     = $FinalBackupPath.Count
                                     BackupFile           = (Split-Path $FinalBackupPath -Leaf)
-                                    BackupFolder         = (Split-Path $FinalBackupPath | Sort-Object -Unique)
+                                    BackupFolder         = $transformedbackupfolder
                                     BackupPath           = ($FinalBackupPath | Sort-Object -Unique)
                                     Script               = $script
                                     Notes                = $failures -join (',')
@@ -728,7 +744,14 @@ function Backup-DbaDatabase {
                                 $pathresult = "NUL:"
                             } else {
                                 $pathresult = (Split-Path $FinalBackupPath | Sort-Object -Unique)
+                                # in case a linux computer connects to a windows computer
+                                if ($isdestlinux -and $pathresult) {
+                                    $pathresult = $pathresult.Replace("\", "/")
+                                } elseif ($pathresult) {
+                                    $pathresult = $pathresult.Replace("/", "\")
+                                }
                             }
+
                             $HeaderInfo | Add-Member -Type NoteProperty -Name BackupFolder -Value $pathresult
                             $HeaderInfo | Add-Member -Type NoteProperty -Name BackupPath -Value ($FinalBackupPath | Sort-Object -Unique)
                             $HeaderInfo | Add-Member -Type NoteProperty -Name DatabaseName -Value $dbName

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -467,8 +467,8 @@ function Backup-DbaDatabase {
 
             if ($CompressBackup) {
                 if ($db.EncryptionEnabled) {
-                    # Newer versions of SQL Server automatically set the MAXTRANSFERSIZE to 128k, so
-                    # we let's do that for people as well
+                    # Newer versions of SQL Server automatically set the MAXTRANSFERSIZE to 128k
+                    # so let's do that for people as well
                     $minVerForTDECompression = [version]'13.0.4446.0' #SQL Server 2016 CU 4
                     $flagTDESQLVersion = $minVerForTDECompression -le $Server.version
                     if (-not (Test-Bound 'MaxTransferSize')) {

--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -130,7 +130,7 @@ function Backup-DbaDbCertificate {
         [Security.SecureString]$EncryptionPassword,
         [Security.SecureString]$DecryptionPassword,
         [System.IO.FileInfo]$Path,
-        [string]$Suffix = "$(Get-Date -format 'yyyyMMddHHmmssms')",
+        [string]$Suffix,
         [parameter(ValueFromPipeline, ParameterSetName = "collection")]
         [Microsoft.SqlServer.Management.Smo.Certificate[]]$InputObject,
         [switch]$EnableException
@@ -156,7 +156,17 @@ function Backup-DbaDbCertificate {
             $fullCertName = (Join-DbaPath -SqlInstance $server $actualPath "$certName$Suffix")
             $exportPathKey = "$fullCertName.pvk"
 
-            if (!(Test-DbaPath -SqlInstance $server -Path $actualPath)) {
+            if ((Test-DbaPath -SqlInstance $server -Path "$fullCertName.cer")) {
+                if ($PSBoundParameter.Suffix) {
+                    Stop-Function -Message "$fullCertName.cer already exists on $($server.Name)" -Target $actualPath -Continue
+                } else {
+                    $date = Get-Date -format 'yyyyMMddHHmmssms'
+                    $fullCertName = (Join-DbaPath -SqlInstance $server $actualPath "$certName$date")
+                    $exportPathKey = "$fullCertName.pvk"
+                }
+            }
+
+            if (-not (Test-DbaPath -SqlInstance $server -Path $actualPath)) {
                 Stop-Function -Message "$SqlInstance cannot access $actualPath" -Target $actualPath
             }
 

--- a/functions/Copy-DbaDbAssembly.ps1
+++ b/functions/Copy-DbaDbAssembly.ps1
@@ -165,7 +165,7 @@ function Copy-DbaDbAssembly {
                     $copyDbAssemblyStatus.Notes = "Destination database does not exist"
                     $copyDbAssemblyStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
 
-                    Write-Message -Level Verbose -Message "Destination database $dbName does not exist. Skipping $assemblyName.";
+                    Write-Message -Level Verbose -Message "Destination database $dbName does not exist. Skipping $assemblyName."
                     continue
                 }
 

--- a/functions/Copy-DbaDbAssembly.ps1
+++ b/functions/Copy-DbaDbAssembly.ps1
@@ -229,6 +229,7 @@ function Copy-DbaDbAssembly {
 
                     } catch {
                         $copyDbAssemblyStatus.Status = "Failed"
+                        $copyDbAssemblyStatus.Notes = $PSItem
                         $copyDbAssemblyStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
 
                         Stop-Function -Message "Issue creating assembly." -Target $assemblyName -ErrorRecord $_

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -142,8 +142,6 @@ function Copy-DbaDbCertificate {
         }
     }
     process {
-        # FOR START-DBAMIGRATION, IT NEEDS TO JUST BE COPY-DBADBMASTER
-        # NEED TO DELETE ANY EXPORTED KEY
         if (Test-FunctionInterrupt) { return }
         foreach ($destinstance in $Destination) {
             try {

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -6,9 +6,7 @@ function Copy-DbaDbCertificate {
     .DESCRIPTION
         By default, all certificates are copied.
 
-        If the certificate already exists on the destination, it will be skipped unless -Force is used.
-
-        This script does not yet copy dependencies or dependent objects.
+        If the certificate already exists on the destination, it will be skipped.
 
     .PARAMETER Source
         Source SQL Server. You must have sysadmin access and server version must be SQL Server version 2000 or higher.
@@ -102,12 +100,12 @@ function Copy-DbaDbCertificate {
     begin {
         try {
             $parms = @{
-                SqlInstance        = $Source
-                SqlCredential      = $SourceSqlCredential
-                Database           = $Database
-                ExcludeDatabase    = $ExcludeDatabase
-                Certificate        = $Certificate
-                EnableException    = $true
+                SqlInstance     = $Source
+                SqlCredential   = $SourceSqlCredential
+                Database        = $Database
+                ExcludeDatabase = $ExcludeDatabase
+                Certificate     = $Certificate
+                EnableException = $true
             }
             # Get presumably user certs, no way to tell if its a system object
             $sourcecertificates = Get-DbaDbCertificate @parms | Where-Object Name -notlike "#*" | Where-Object Name -notin $ExcludeCertificate
@@ -131,7 +129,6 @@ function Copy-DbaDbCertificate {
         }
     }
     process {
-        # THIS MAKES ASSUMPTIONS ABOUT THE CERTIFICATE THAT ITS ENCRYPTED BY A MASTER KEY
         # FOR START-DBAMIGRATION, IT NEEDS TO JUST BE COPY-DBADBMASTER
 
         if (Test-FunctionInterrupt) { return }

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -288,7 +288,7 @@ function Copy-DbaDbCertificate {
                                         $export = Backup-DbaDbCertificate @params
                                     }
                                 } catch {
-                                    $copyDbCertificateStatus.Status = "Failed"
+                                    $copyDbCertificateStatus.Status = "Failed $PSItem"
                                     $copyDbCertificateStatus.Notes = $PSItem
                                     $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
                                     Stop-Function -Message "Issue backing up certificate $certname in $dbname on $($db.Parent.Name)" -Target $certname -ErrorRecord $PSItem -Continue
@@ -309,6 +309,12 @@ function Copy-DbaDbCertificate {
                                 $copyDbCertificateStatus.Status = "Successful"
                                 $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
                             } catch {
+                                if ($export.Path) {
+                                    $null = Remove-Item -Force $export.Path -ErrorAction SilentlyContinue
+                                }
+                                if ($export.Key) {
+                                    $null = Remove-Item -Force $export.Key -ErrorAction SilentlyContinue
+                                }
                                 $copyDbCertificateStatus.Status = "Failed"
                                 $copyDbCertificateStatus.Notes = $PSItem
                                 $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -174,7 +174,6 @@ function Copy-DbaDbCertificate {
                             Stop-Function -Message "Failure" -ErrorRecord $PSItem -Continue
                         }
                     } else {
-                        return $PSBoundParameters
                         Stop-Function -Message "Master service key not found on $destinstance and MasterKeyPassword not specified, so it cannot be created" -Continue
                     }
                 }
@@ -266,7 +265,6 @@ function Copy-DbaDbCertificate {
                                     Database           = $db.Name
                                     Certificate        = $certname
                                     Path               = $SharedPath
-                                    Suffix             = $null # required so that it doesnt rename the cert
                                     EnableException    = $true
                                     EncryptionPassword = $backupEncryptionPassword
                                     DecryptionPassword = $DecryptionPassword

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -121,7 +121,7 @@ function Copy-DbaDbCertificate {
                 EnableException = $true
             }
             # Get presumably user certs, no way to tell if its a system object
-            $sourcecertificates = Get-DbaDbCertificate @parms | Where-Object Name -notlike "#*" | Where-Object Name -notin $ExcludeCertificate
+            $sourcecertificates = Get-DbaDbCertificate @parms | Where-Object { $PSItem.Name -notlike "#*" -and $PSItem.Name -notin $ExcludeCertificate }
             $dbsnames = $sourcecertificates.Parent.Name | Select-Object -Unique
             $server = ($sourcecertificates | Select-Object -First 1).Parent.Parent
             $serviceAccount = $server.ServiceAccount

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -158,7 +158,7 @@ function Copy-DbaDbCertificate {
             }
 
             if (($sourcecertificates | Where-Object PrivateKeyEncryptionType -eq MasterKey)) {
-                $masterkey = Get-DbaDbMasterKey -SqlInstance $db.Parent -Database master
+                $masterkey = Get-DbaDbMasterKey -SqlInstance $destServer -Database master
                 if (-not $masterkey) {
                     Write-Message -Level Verbose -Message "master key not found, seeing if MasterKeyPassword was specified"
                     if ($MasterKeyPassword) {
@@ -172,9 +172,7 @@ function Copy-DbaDbCertificate {
                             }
                             $masterkey = New-DbaDbMasterKey @params
                         } catch {
-                            if ($PSItem -notmatch "already exists") {
-                                Stop-Function -Message "Failure" -ErrorRecord $PSItem -Continue
-                            }
+                            Stop-Function -Message "Failure" -ErrorRecord $PSItem -Continue
                         }
                     } else {
                         Stop-Function -Message "Master service key not found on $destinstance and MasterKeyPassword not specified, so it cannot be created" -Continue

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -172,7 +172,9 @@ function Copy-DbaDbCertificate {
                             }
                             $masterkey = New-DbaDbMasterKey @params
                         } catch {
-                            Stop-Function -Message "Failure" -ErrorRecord $PSItem -Continue
+                            if ($PSItem -notmatch "already exists") {
+                                Stop-Function -Message "Failure" -ErrorRecord $PSItem -Continue
+                            }
                         }
                     } else {
                         Stop-Function -Message "Master service key not found on $destinstance and MasterKeyPassword not specified, so it cannot be created" -Continue

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -167,9 +167,10 @@ function Copy-DbaDbCertificate {
                             $params = @{
                                 SqlInstance     = $destServer
                                 SecurePassword  = $MasterKeyPassword
+                                Database        = "master"
                                 EnableException = $true
                             }
-                            $masterkey = New-DbaServiceMasterKey @params
+                            $masterkey = New-DbaDbMasterKey @params
                         } catch {
                             Stop-Function -Message "Failure" -ErrorRecord $PSItem -Continue
                         }

--- a/functions/Copy-DbaDbCertificate.ps1
+++ b/functions/Copy-DbaDbCertificate.ps1
@@ -1,0 +1,293 @@
+function Copy-DbaDbCertificate {
+    <#
+    .SYNOPSIS
+        Copy-DbaDbCertificate migrates certificates from one SQL Server to another.
+
+    .DESCRIPTION
+        By default, all certificates are copied.
+
+        If the certificate already exists on the destination, it will be skipped unless -Force is used.
+
+        This script does not yet copy dependencies or dependent objects.
+
+    .PARAMETER Source
+        Source SQL Server. You must have sysadmin access and server version must be SQL Server version 2000 or higher.
+
+    .PARAMETER SourceSqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Destination
+        Destination SQL Server. You must have sysadmin access and the server must be SQL Server 2000 or higher.
+
+    .PARAMETER DestinationSqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Certificate
+        The certificate(ies) to process. This list is auto-populated from the server. If unspecified, all certificates will be processed.
+
+    .PARAMETER ExcludeCertificate
+        The certificate(ies) to exclude. This list is auto-populated from the server.
+
+    .PARAMETER WhatIf
+        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+    .PARAMETER Confirm
+        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .PARAMETER Force
+        If this switch is enabled, existing certificates on Destination with matching names from Source will be dropped.
+
+    .NOTES
+        Tags: Migration, Certificate
+        Author: Chrissy LeMaire (@cl), netnerds.net
+
+        Website: https://dbatools.io
+        Copyright: (c) 2022 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+        Requires: sysadmin access on SQL Servers
+
+    .LINK
+        https://dbatools.io/Copy-DbaDbCertificate
+
+    .EXAMPLE
+        PS C:\> Copy-DbaDbCertificate -Source mssql1 -Destination mssql2
+
+        Copies all certificates from mssql1 to mssql2 using Windows credentials. If certificates with the same name exist on mssql2, they will be skipped.
+
+    .EXAMPLE
+        PS C:\> Copy-DbaDbCertificate -Source mssql1 -Destination mssql2 -Certificate dbname.certificatename, dbname3.anothercertificate -SourceSqlCredential $cred -Force
+
+        Copies two certificates, the dbname.certificatename and dbname3.anothercertificate from mssql1 to mssql2 using SQL credentials for mssql1 and Windows credentials for mssql2. If certificates with the same name exist on mssql2, they will be skipped.
+
+        In this example, anothercertificate will be copied to the dbname3 database on the server mssql2.
+
+    .EXAMPLE
+        PS C:\> Copy-DbaDbCertificate -Source mssql1 -Destination mssql2 -WhatIf -Force
+
+        Shows what would happen if the command were executed using force.
+
+    #>
+    [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = "High")]
+    param (
+        [parameter(Mandatory)]
+        [DbaInstanceParameter]$Source,
+        [PSCredential]$SourceSqlCredential,
+        [parameter(Mandatory)]
+        [DbaInstanceParameter[]]$Destination,
+        [PSCredential]$DestinationSqlCredential,
+        [string[]]$Database,
+        [string[]]$ExcludeDatabase,
+        [string[]]$Certificate,
+        [string[]]$ExcludeCertificate,
+        [string]$SharedPath,
+        [Security.SecureString]$MasterKeyPassword,
+        [Security.SecureString]$EncryptionPassword,
+        [Security.SecureString]$DecryptionPassword,
+        [switch]$EnableException
+    )
+    begin {
+        try {
+            $parms = @{
+                SqlInstance        = $Source
+                SqlCredential      = $SourceSqlCredential
+                Database           = $Database
+                ExcludeDatabase    = $ExcludeDatabase
+                Certificate        = $Certificate
+                EnableException    = $true
+            }
+            # Get presumably user certs, no way to tell if its a system object
+            $sourcecertificates = Get-DbaDbCertificate @parms | Where-Object Name -notlike "#*" | Where-Object Name -notin $ExcludeCertificate
+            $dbsnames = $sourcecertificates.Parent.Name | Select-Object -Unique
+            $server = ($sourcecertificates | Select-Object -First 1).Parent.Parent
+            $serviceAccount = $server.ServiceAccount
+        } catch {
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Source
+            return
+        }
+
+        if (-not $PSBoundParameter.EncryptionPassword) {
+            $backupEncryptionPassword = Get-RandomPassword
+        } else {
+            $backupEncryptionPassword = $EncryptionPassword
+        }
+
+        If ($serviceAccount -and -not (Test-DbaPath -SqlInstance $Source -SqlCredential $SourceSqlCredential -Path $SharedPath)) {
+            Stop-Function -Message "The SQL Server service account ($serviceAccount) for $Source does not have access to $SharedPath"
+            return
+        }
+    }
+    process {
+        # THIS MAKES ASSUMPTIONS ABOUT THE CERTIFICATE THAT ITS ENCRYPTED BY A MASTER KEY
+        # FOR START-DBAMIGRATION, IT NEEDS TO JUST BE COPY-DBADBMASTER
+
+        if (Test-FunctionInterrupt) { return }
+        foreach ($destinstance in $Destination) {
+            try {
+                $destServer = Connect-DbaInstance -SqlInstance $destinstance -SqlCredential $DestinationSqlCredential -MinimumVersion 10
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $destinstance -Continue
+            }
+            $serviceAccount = $destserver.ServiceAccount
+
+            If (-not (Test-DbaPath -SqlInstance $destServer -Path $SharedPath)) {
+                Stop-Function -Message "The SQL Server service account ($serviceAccount) for $destinstance does not have access to $SharedPath" -Continue
+            }
+
+            if (($sourcecertificates | Where-Object PrivateKeyEncryptionType -eq MasterKey)) {
+                $masterkey = Get-DbaDbMasterKey -SqlInstance $db.Parent -Database master
+                if (-not $masterkey) {
+                    Write-Message -Level Verbose -Message "master key not found, seeing if MasterKeyPassword was specified"
+                    if ($MasterKeyPassword) {
+                        Write-Message -Level Verbose -Message "master key not found, creating one"
+                        try {
+                            $params = @{
+                                SqlInstance     = $destServer
+                                SecurePassword  = $MasterKeyPassword
+                                EnableException = $true
+                            }
+                            $masterkey = New-DbaServiceMasterKey @params
+                        } catch {
+                            Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
+                        }
+                    } else {
+                        return $PSBoundParameters
+                        Stop-Function -Message "Master service key not found on $destinstance and MasterKeyPassword not specified, so it cannot be created" -Continue
+                    }
+                }
+                $null = $destServer.Databases["master"].Refresh()
+            }
+
+            $destdbs = $destServer.Databases | Where-Object Name -in $dbsnames
+
+            foreach ($db in $destdbs) {
+                $dbName = $db.Name
+                $sourcerts = $sourcecertificates | Where-Object { $PSItem.Parent.Name -eq $db.Name }
+
+                # Check for master key requirement
+                if (($sourcerts | Where-Object PrivateKeyEncryptionType -eq MasterKey)) {
+                    $masterkey = Get-DbaDbMasterKey -SqlInstance $db.Parent -Database $db.Name
+
+                    if (-not $masterkey) {
+                        Write-Message -Level Verbose -Message "Master key not found, seeing if MasterKeyPassword was specified"
+                        if ($MasterKeyPassword) {
+                            try {
+                                $params = @{
+                                    SqlInstance     = $destServer
+                                    SecurePassword  = $MasterKeyPassword
+                                    Database        = $db.Name
+                                    EnableException = $true
+                                }
+                                $masterkey = New-DbaDbMasterKey @params
+                                $domasterkeymessage = $false
+                                $domasterkeypasswordmessage = $false
+                            } catch {
+                                $domasterkeymessage = "Master key auto-generation failure: $PSItem"
+                                Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
+                            }
+
+                        } else {
+                            $domasterkeypasswordmessage = $true
+                        }
+                    }
+
+                    foreach ($cert in $sourcerts) {
+                        $certname = $cert.Name
+                        Write-Message -Level VeryVerbose -Message "Processing $certname on $dbName"
+
+                        $copyDbCertificateStatus = [pscustomobject]@{
+                            SourceServer        = $Source
+                            SourceDatabase      = $dbName
+                            DestinationServer   = $destServer.Name
+                            DestinationDatabase = $dbName
+                            type                = "Database Certificate"
+                            Name                = $certname
+                            Status              = $null
+                            Notes               = $null
+                            DateTime            = [Sqlcollaborative.Dbatools.Utility.DbaDateTime](Get-Date)
+                        }
+
+                        if ($domasterkeymessage) {
+                            $copyDbCertificateStatus.Status = "Skipped"
+                            $copyDbCertificateStatus.Notes = $domasterkeymessage
+                            $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+
+                            Write-Message -Level Verbose -Message $domasterkeymessage
+                            continue
+                        }
+
+                        if ($domasterkeypasswordmessage) {
+                            $copyDbCertificateStatus.Status = "Skipped"
+                            $copyDbCertificateStatus.Notes = "Master service key not found and MasterKeyPassword not provided for auto-creation"
+                            $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+
+                            Write-Message -Level Verbose -Message "Master service key not found and MasterKeyPassword not provided for auto-creation"
+                            continue
+                        }
+                        $null = $db.Refresh()
+                        if ($db.Certificates.Name -contains $certname) {
+                            $copyDbCertificateStatus.Status = "Skipped"
+                            $copyDbCertificateStatus.Notes = "Already exists on destination"
+                            $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+
+                            Write-Message -Level Verbose -Message "Certificate $certname exists at destination in the $dbName database"
+                            continue
+                        }
+
+                        if ($Pscmdlet.ShouldProcess($destinstance.Name, "Copying certificate $certname from database.")) {
+                            try {
+                                # Back up certificate
+                                $null = $db.Refresh()
+                                $params = @{
+                                    SqlInstance        = $cert.Parent.Parent
+                                    Database           = $db.Name
+                                    Certificate        = $certname
+                                    Path               = $SharedPath
+                                    EnableException    = $true
+                                    Suffix             = $null
+                                    EncryptionPassword = $backupEncryptionPassword
+                                    DecryptionPassword = $DecryptionPassword
+                                }
+                                Write-Message -Level Verbose -Message "Backing up certificate $cername for $($dbName) on $($server.Name)"
+                                $export = Backup-DbaDbCertificate @params
+
+                                # Restore certificate
+                                $params = @{
+                                    SqlInstance        = $db.Parent
+                                    Database           = $db.Name
+                                    Path               = $export.Path
+                                    KeyFilePath        = $export.Key
+                                    EnableException    = $true
+                                    EncryptionPassword = $DecryptionPassword
+                                    DecryptionPassword = $backupEncryptionPassword
+                                }
+
+                                $null = Restore-DbaDbCertificate @params
+                                $copyDbCertificateStatus.Status = "Successful"
+                                $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+                            } catch {
+                                $copyDbCertificateStatus.Status = "Failed"
+                                $copyDbCertificateStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+
+                                Stop-Function -Message "Issue creating certificate $certname from $($export.Path) for $dbname on $($db.Parent.Name)" -Target $certname -ErrorRecord $_
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -329,7 +329,7 @@ function Get-DbaDatabase {
             }
 
             $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'Status', 'IsAccessible', 'RecoveryModel',
-            'LogReuseWaitStatus', 'Size as SizeMB', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner',
+            'LogReuseWaitStatus', 'Size as SizeMB', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'EncryptionEnabled as Encrypted',
             'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup',
             'LastLogBackupDate as LastLogBackup'
 

--- a/functions/Get-DbaFile.ps1
+++ b/functions/Get-DbaFile.ps1
@@ -90,11 +90,11 @@ function Get-DbaFile {
             $q1 += "DECLARE @myPath nvarchar(4000);
                     DECLARE @depth SMALLINT = $Depth;
 
-                    IF OBJECT_ID('tempdb..#DirectoryTree') IS NOT NULL
+                    IF OBJECT_id('tempdb..#DirectoryTree') IS NOT NULL
                     DROP TABLE #DirectoryTree;
 
                     CREATE TABLE #DirectoryTree (
-                       id int IDENTITY(1,1)
+                       id int idENTITY(1,1)
                        ,subdirectory nvarchar(512)
                        ,depth int
                        ,isfile bit
@@ -112,22 +112,22 @@ function Get-DbaFile {
 
                     UPDATE #DirectoryTree
                        SET ParentDirectory = (
-                          SELECT MAX(Id) FROM #DirectoryTree
-                          WHERE Depth = d.Depth - 1 AND Id < d.Id   )
+                          SELECT MAX(id) FROM #DirectoryTree
+                          WHERE depth = d.depth - 1 AND id < d.id   )
                     FROM #DirectoryTree d
                     WHERE ParentDirectory is NULL;"
 
             $query_files_sql = "-- SEE all with full paths
                     WITH dirs AS (
                         SELECT
-                           Id,subdirectory,depth,isfile,ParentDirectory,flag
+                           id,subdirectory,depth,isfile,ParentDirectory,flag
                            , CAST (null AS NVARCHAR(MAX)) AS container
                            , CAST([subdirectory] AS NVARCHAR(MAX)) AS dpath
                            FROM #DirectoryTree
                            WHERE ParentDirectory IS NULL
                         UNION ALL
                         SELECT
-                           d.Id,d.subdirectory,d.depth,d.isfile,d.ParentDirectory,d.flag
+                           d.id,d.subdirectory,d.depth,d.isfile,d.ParentDirectory,d.flag
                            , dpath as container
                            , dpath +'\'+d.[subdirectory]
                         FROM #DirectoryTree AS d
@@ -169,13 +169,20 @@ function Get-DbaFile {
             }
 
             # Get the default data and log directories from the instance
-            if (-not (Test-Bound -ParameterName Path)) { $Path = (Get-DbaDefaultPath -SqlInstance $server).Data }
+            if (-not (Test-Bound -ParameterName Path)) {
+                $Path = (Get-DbaDefaultPath -SqlInstance $server).Data
+            }
+            if (Test-HostOSLinux -SqlInstance $server) {
+                $separator = "/"
+            } else {
+                $separator = "\"
+            }
 
             Write-Message -Level Verbose -Message "Adding paths"
             $sql = Get-SQLDirTreeQuery $Path
             Write-Message -Level Debug -Message $sql
 
-            # This should remain as not .Query() to be compat with a PSProvider Chrissy is working on
+            # This should remain as not .Query() to be compat with a PSProvider Chrissy was working on
             $datatable = $server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows
 
             Write-Message -Level Verbose -Message "$($datatable.Rows.Count) files found."
@@ -183,24 +190,27 @@ function Get-DbaFile {
                 foreach ($row in $datatable) {
                     foreach ($type in $FileTypeComparison) {
                         if ($row.filename.ToLowerInvariant().EndsWith(".$type")) {
+                            $fullpath = $row.fullpath.Replace("\", $separator)
                             [pscustomobject]@{
                                 ComputerName   = $server.ComputerName
                                 InstanceName   = $server.ServiceName
                                 SqlInstance    = $server.DomainInstanceName
-                                Filename       = $row.fullpath
-                                RemoteFilename = Join-AdminUnc -Servername $server.ComputerName -Filepath $row.fullpath
+                                Filename       = $fullpath
+                                RemoteFilename = Join-AdminUnc -Servername $server.ComputerName -Filepath $fullpath
                             } | Select-DefaultView -ExcludeProperty ComputerName, InstanceName, RemoteFilename
                         }
                     }
                 }
             } else {
                 foreach ($row in $datatable) {
+                    $fullpath = $row.fullpath
+                    $fullpath = $row.fullpath.Replace("\", $separator)
                     [pscustomobject]@{
                         ComputerName   = $server.ComputerName
                         InstanceName   = $server.ServiceName
                         SqlInstance    = $server.DomainInstanceName
-                        Filename       = $row.fullpath
-                        RemoteFilename = Join-AdminUnc -Servername $server.ComputerName -Filepath $row.fullpath
+                        Filename       = $fullpath
+                        RemoteFilename = Join-AdminUnc -Servername $server.ComputerName -Filepath $fullpath
                     } | Select-DefaultView -ExcludeProperty ComputerName, InstanceName, RemoteFilename
                 }
             }

--- a/functions/Get-DbaFile.ps1
+++ b/functions/Get-DbaFile.ps1
@@ -94,7 +94,7 @@ function Get-DbaFile {
                     DROP TABLE #DirectoryTree;
 
                     CREATE TABLE #DirectoryTree (
-                       id int idENTITY(1,1)
+                       id int IDENTITY(1,1)
                        ,subdirectory nvarchar(512)
                        ,depth int
                        ,isfile bit

--- a/functions/New-DbaDbMasterKey.ps1
+++ b/functions/New-DbaDbMasterKey.ps1
@@ -94,7 +94,7 @@ function New-DbaDbMasterKey {
         }
 
         foreach ($db in $InputObject) {
-            if ($null -ne ($db.MasterKey | Where-Object Name -notmatch "#")) {
+            if ($null -ne $db.MasterKey) {
                 Stop-Function -Message "Master key already exists in the $($db.Name) database on $($db.Parent.Name)" -Target $db -Continue
             }
 

--- a/functions/New-DbaDbMasterKey.ps1
+++ b/functions/New-DbaDbMasterKey.ps1
@@ -94,8 +94,8 @@ function New-DbaDbMasterKey {
         }
 
         foreach ($db in $InputObject) {
-            if ($null -ne $db.MasterKey) {
-                Stop-Function -Message "Master key already exists in the $db database on $($db.Parent.Name)" -Target $db -Continue
+            if ($null -ne ($db.MasterKey | Where-Object Name -notmatch "#")) {
+                Stop-Function -Message "Master key already exists in the $($db.Name) database on $($db.Parent.Name)" -Target $db -Continue
             }
 
             if ($Pscmdlet.ShouldProcess($db.Parent.Name, "Creating master key for database '$($db.Name)'")) {

--- a/functions/New-DbaDirectory.ps1
+++ b/functions/New-DbaDirectory.ps1
@@ -94,7 +94,7 @@ function New-DbaDirectory {
             }
 
             [pscustomobject]@{
-                Server  = $SqlInstance
+                Server  = $instance
                 Path    = $Path
                 Created = $created
             }

--- a/functions/Restore-DbaDbCertificate.ps1
+++ b/functions/Restore-DbaDbCertificate.ps1
@@ -19,6 +19,9 @@ function Restore-DbaDbCertificate {
     .PARAMETER Path
         The Path the contains the certificate and private key files. The path can be a directory or a specific certificate.
 
+    .PARAMETER KeyFilePath
+        The Path the contains the private key file. If one is not specified, we will try to find it for you.
+
     .PARAMETER DecryptionPassword
         Secure string used to decrypt the private key.
 
@@ -70,6 +73,7 @@ function Restore-DbaDbCertificate {
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("FullName")]
         [object[]]$Path,
+        [string[]]$KeyFilePath,
         [Security.SecureString]$EncryptionPassword,
         [string]$Database = "master",
         [Alias("Password", "SecurePassword")]
@@ -85,17 +89,18 @@ function Restore-DbaDbCertificate {
         }
 
         foreach ($dir in $Path) {
-            if (-not $SqlInstance.IsLocalHost -and -not $dir.StartsWith('\')) {
-                Stop-Function -Message "Path ($dir) must be a UNC share when SQL instance is not local." -Continue -Target $fullname
-            }
-
             if (-not (Test-DbaPath -SqlInstance $server -Path $dir)) {
                 Stop-Function -Message "$SqlInstance cannot access $dir" -Continue -Target $dir
             }
 
-            if (Test-Path $dir -PathType Container) {
-                Write-Message -Level Verbose -Message "Path is a directory - processing all cer's within"
-                $path = Get-ChildItem $dir "*.cer" | Select-Object -expand FullName
+            try {
+                $isdir = ($server.Query("EXEC master.dbo.xp_fileexist '$dir'")).Item(1)
+            } catch {
+                Stop-Function -Message $_ -ErrorRecord $_ -Target $server.Name -Continue
+            }
+            if ($isdir) {
+                Write-Message -Level Verbose -Message "Path is a directory - processing all certs within"
+                $path = (Get-DbaFile -SqlInstance $server -Path $dir -FileType cer).Filename
             }
 
             foreach ($fullname in $path) {
@@ -104,8 +109,13 @@ function Restore-DbaDbCertificate {
                 $directory = Split-Path $fullname
                 $filename = Split-Path $fullname -Leaf
                 $certname = [io.path]::GetFileNameWithoutExtension($filename)
-                $fullcertname = "$directory\$certname.cer"
-                $privatekey = "$directory\$certname.pvk"
+                $fullcertname = Join-DbaPath -SqlInstance $server -Path $directory -ChildPath "$certname.cer"
+
+                if (-not $KeyFilePath) {
+                    $privatekey = Join-DbaPath -SqlInstance $server -Path $directory -ChildPath "$certname.pvk"
+                } else {
+                    $privatekey = $KeyFilePath
+                }
 
                 if ($certname -match '([0-9]{4})(0[1-9]|1[0-2])(0[1-9]|[1-2][0-9]|3[0-1])(2[0-3]|[01][0-9])([0-5][0-9])([0-5][0-9])') {
                     $certname = $certname.Replace($matches[0], "")

--- a/functions/Start-DbaMigration.ps1
+++ b/functions/Start-DbaMigration.ps1
@@ -444,7 +444,7 @@ function Start-DbaMigration {
         }
 
         if ($Exclude -notcontains 'SysDbUserObjects') {
-            Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Migrating user objects in system databases (this can take a second)."
+            Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Migrating user objects in system databases (this can take a second)"
             Write-Message -Level Verbose -Message "Migrating user objects in system databases (this can take a second)."
             If ($Pscmdlet.ShouldProcess($destination, "Copying user objects.")) {
                 Copy-DbaSysDbUserObject -Source $sourceserver -Destination $Destination -DestinationSqlCredential $DestinationSqlCredential -Force:$force

--- a/internal/functions/Write-ProgressHelper.ps1
+++ b/internal/functions/Write-ProgressHelper.ps1
@@ -15,7 +15,10 @@ function Write-ProgressHelper {
     if (-not $Activity) {
         $Activity = switch ($caller) {
             "Export-DbaInstance" {
-                "Performing Instance Export for $instance"
+                "Performing instance export for $instance"
+            }
+            "Start-DbaMigration" {
+                "Performing instance migration"
             }
             "Install-DbaSqlWatch" {
                 "Installing SQLWatch"

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -295,9 +295,9 @@ SET ENCRYPTION ON;
 GO
 "@
         $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Query $createdb -Database encrypted
-        It "Should not compress an encrypted db" {
+        It "Should compress an encrypted db" {
             $results = Backup-DbaDatabase -SqlInstance $script:instance2 -Database encrypted -Compress
-            $results.script | Should -BeLike '*NO_COMPRESSION*'
+            $results.script | Should -BeLike '*D, COMPRESSION,*'
         }
         Remove-DbaDatabase -SqlInstance $script:instance2 -Database encrypted -confirm:$false
         $sqldrop =
@@ -328,7 +328,7 @@ go
 
     Context "Test Backup Encryption with Certificate" {
         $securePass = ConvertTo-SecureString "estBackupDir\master\script:instance1).split('\')[1])\Full\master-Full.bak" -AsPlainText -Force
-        New-DbaDbMasterKey -SqlInstance $script:instance2 -Database Master -SecurePassword $securePass -confirm:$false
+        New-DbaDbMasterKey -SqlInstance $script:instance2 -Database Master -SecurePassword $securePass -confirm:$false -ErrorAction SilentlyContinue
         $cert = New-DbaDbCertificate -SqlInstance $script:instance2 -Database master -Name BackupCertt -Subject BackupCertt
         $encBackupResults = Backup-DbaDatabase -SqlInstance $script:instance2 -Database master -EncryptionAlgorithm AES128 -EncryptionCertificate BackupCertt -BackupFileName 'encryptiontest.bak'
         It "Should encrypt the backup" {

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -39,6 +39,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
         # doing it on docker instead. this works on linux and on a homelab so i dont know
         It "Successfully copies a certificate" {
+            $passwd = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
             $params1 = @{
                 Source             = $script:instance2
                 Destination        = $script:instance3

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -17,9 +17,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Can create a database certificate" {
         BeforeAll {
             $passwd = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
-            if (-not (Get-DbaDbMasterKey -SqlInstance $script:instance2 -Database master)) {
-                $masterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database master -SecurePassword $passwd -Confirm:$false
-            }
+            $masterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database master -SecurePassword $passwd -Confirm:$false -ErrorAction SilentlyContinue
 
             $newdbs = New-DbaDatabase -SqlInstance $script:instance2, $script:instance3 -Name dbatoolscopycred
             $null = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database dbatoolscopycred -SecurePassword $passwd -Confirm:$false

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -1,0 +1,49 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'Source', 'SourceSqlCredential', 'Destination', 'DestinationSqlCredential', 'Database', 'ExcludeDatabase', 'Certificate', 'ExcludeCertificate', 'SharedPath', 'MasterKeyPassword', 'EncryptionPassword', 'DecryptionPassword', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Can create a database certificate" {
+        BeforeAll {
+            if (-not (Get-DbaDbMasterKey -SqlInstance $script:instance2 -Database master)) {
+                $masterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database master -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
+            }
+
+            $passwd = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
+            $tempdbmasterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database tempdb -Password $passwd -Confirm:$false
+            $certificateName1 = "Cert_$(Get-random)"
+            $certificateName2 = "Cert_$(Get-random)"
+            $cert1 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName1 -Confirm:$false
+            $cert2 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName2 -Database tempdb -Confirm:$false
+        }
+        AfterAll {
+            if ($tempdbmasterkey) { $tempdbmasterkey | Remove-DbaDbMasterKey -Confirm:$false }
+            if ($masterKey) { $masterkey | Remove-DbaDbMasterKey -Confirm:$false }
+            $null = $cert1 | Remove-DbaDbCertificate -Confirm:$false
+            $null = $cert2 | Remove-DbaDbCertificate -Confirm:$false
+        }
+
+        It "Successfully copies a certificate" {
+            $params1 = @{
+                Source             = $script:instance2
+                Destination        = $script:instance3
+                EncryptionPassword = $passwd
+                MasterKeyPassword  = $passwd
+                SharedPath         = "C:\temp"
+            }
+            $results = Copy-DbaDbCertificate @params1 -Confirm:$false | Where-Object SourceDatabase -eq tempdb | Select-Object -First 1
+            $results.Status | Should -Be "Successful"
+        }
+    }
+}

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -16,16 +16,16 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Can create a database certificate" {
         BeforeAll {
-            if (-not (Get-DbaDbMasterKey -SqlInstance $script:instance1 -Database master)) {
-                $masterkey = New-DbaDbMasterKey -SqlInstance $script:instance1 -Database master -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
+            if (-not (Get-DbaDbMasterKey -SqlInstance $script:instance2 -Database master)) {
+                $masterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database master -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
             }
 
             $passwd = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
-            $tempdbmasterkey = New-DbaDbMasterKey -SqlInstance $script:instance1 -Database tempdb -Password $passwd -Confirm:$false
+            $tempdbmasterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database tempdb -Password $passwd -Confirm:$false
             $certificateName1 = "Cert_$(Get-Random)"
             $certificateName2 = "Cert_$(Get-Random)"
-            $cert1 = New-DbaDbCertificate -SqlInstance $script:instance1 -Name $certificateName1 -Confirm:$false
-            $cert2 = New-DbaDbCertificate -SqlInstance $script:instance1 -Name $certificateName2 -Database tempdb -Confirm:$false
+            $cert1 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName1 -Confirm:$false
+            $cert2 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName2 -Database tempdb -Confirm:$false
         }
         AfterAll {
             if ($tempdbmasterkey) {
@@ -40,8 +40,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
         It "Successfully copies a certificate" {
             $params1 = @{
-                Source             = $script:instance1
-                Destination        = $script:instance2
+                Source             = $script:instance2
+                Destination        = $script:instance3
                 EncryptionPassword = $passwd
                 MasterKeyPassword  = $passwd
                 Database           = "tempdb"

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -22,8 +22,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
             $passwd = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
             $tempdbmasterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database tempdb -Password $passwd -Confirm:$false
-            $certificateName1 = "Cert_$(Get-random)"
-            $certificateName2 = "Cert_$(Get-random)"
+            $certificateName1 = "Cert_$(Get-Random)"
+            $certificateName2 = "Cert_$(Get-Random)"
             $cert1 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName1 -Confirm:$false
             $cert2 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName2 -Database tempdb -Confirm:$false
         }
@@ -42,7 +42,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 MasterKeyPassword  = $passwd
                 SharedPath         = "C:\temp"
             }
-            $results = Copy-DbaDbCertificate @params1 -Confirm:$false | Where-Object SourceDatabase -eq tempdb | Select-Object -First 1
+            $results = Copy-DbaDbCertificate @params1 -Confirm:$false | Where-Object SourceDatabase -EQ tempdb | Select-Object -First 1
             $results.Status | Should -Be "Successful"
         }
     }

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -43,6 +43,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 SharedPath         = "C:\temp"
             }
             $results = Copy-DbaDbCertificate @params1 -Confirm:$false | Where-Object SourceDatabase -EQ tempdb | Select-Object -First 1
+            $results.Notes | Should -Be $null
             $results.Status | Should -Be "Successful"
         }
     }

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -21,7 +21,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 $masterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database master -SecurePassword $passwd -Confirm:$false
             }
 
-            $newdbs = New-DbaDatabase -SqlInstance $script:instance2, -SqlInstance $script:instance3 -Name dbatoolscopycred
+            $newdbs = New-DbaDatabase -SqlInstance $script:instance2, $script:instance3 -Name dbatoolscopycred
             $null = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database dbatoolscopycred -SecurePassword $passwd -Confirm:$false
             $certificateName2 = "Cert_$(Get-Random)"
             $null = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName2 -Database dbatoolscopycred -Confirm:$false
@@ -35,7 +35,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         # doing it on docker instead. this works on linux and on a homelab so i dont know
         It "Successfully copies a certificate" {
             $passwd = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
-            $params1 = @{
+            $paramscopydb = @{
                 Source             = $script:instance2
                 Destination        = $script:instance3
                 EncryptionPassword = $passwd
@@ -43,7 +43,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 Database           = "dbatoolscopycred"
                 SharedPath         = "C:\temp"
             }
-            $results = Copy-DbaDbCertificate @params1 -Confirm:$false | Where-Object SourceDatabase -eq dbatoolscopycred | Select-Object -First 1
+            $results = Copy-DbaDbCertificate @paramscopydb -Confirm:$false | Where-Object SourceDatabase -eq dbatoolscopycred | Select-Object -First 1
             $results.Notes | Should -Be $null
             $results.Status | Should -Be "Successful"
         }

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -28,10 +28,14 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $cert2 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName2 -Database tempdb -Confirm:$false
         }
         AfterAll {
-            if ($tempdbmasterkey) { $tempdbmasterkey | Remove-DbaDbMasterKey -Confirm:$false }
-            if ($masterKey) { $masterkey | Remove-DbaDbMasterKey -Confirm:$false }
-            $null = $cert1 | Remove-DbaDbCertificate -Confirm:$false
-            $null = $cert2 | Remove-DbaDbCertificate -Confirm:$false
+            if ($tempdbmasterkey) {
+                $tempdbmasterkey | Remove-DbaDbMasterKey -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            if ($masterKey) {
+                $masterkey | Remove-DbaDbMasterKey -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            $null = $cert1 | Remove-DbaDbCertificate -Confirm:$false -ErrorAction SilentlyContinue
+            $null = $cert2 | Remove-DbaDbCertificate -Confirm:$false -ErrorAction SilentlyContinue
         }
 
         It "Successfully copies a certificate" {
@@ -40,9 +44,10 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 Destination        = $script:instance3
                 EncryptionPassword = $passwd
                 MasterKeyPassword  = $passwd
+                Database           = "tempdb"
                 SharedPath         = "C:\temp"
             }
-            $results = Copy-DbaDbCertificate @params1 -Confirm:$false | Where-Object SourceDatabase -EQ tempdb | Select-Object -First 1
+            $results = Copy-DbaDbCertificate @params1 -Confirm:$false | Where-Object SourceDatabase -eq tempdb | Select-Object -First 1
             $results.Notes | Should -Be $null
             $results.Status | Should -Be "Successful"
         }

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -16,16 +16,16 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Can create a database certificate" {
         BeforeAll {
-            if (-not (Get-DbaDbMasterKey -SqlInstance $script:instance2 -Database master)) {
-                $masterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database master -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
+            if (-not (Get-DbaDbMasterKey -SqlInstance $script:instance1 -Database master)) {
+                $masterkey = New-DbaDbMasterKey -SqlInstance $script:instance1 -Database master -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
             }
 
             $passwd = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
-            $tempdbmasterkey = New-DbaDbMasterKey -SqlInstance $script:instance2 -Database tempdb -Password $passwd -Confirm:$false
+            $tempdbmasterkey = New-DbaDbMasterKey -SqlInstance $script:instance1 -Database tempdb -Password $passwd -Confirm:$false
             $certificateName1 = "Cert_$(Get-Random)"
             $certificateName2 = "Cert_$(Get-Random)"
-            $cert1 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName1 -Confirm:$false
-            $cert2 = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certificateName2 -Database tempdb -Confirm:$false
+            $cert1 = New-DbaDbCertificate -SqlInstance $script:instance1 -Name $certificateName1 -Confirm:$false
+            $cert2 = New-DbaDbCertificate -SqlInstance $script:instance1 -Name $certificateName2 -Database tempdb -Confirm:$false
         }
         AfterAll {
             if ($tempdbmasterkey) {
@@ -40,8 +40,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
         It "Successfully copies a certificate" {
             $params1 = @{
-                Source             = $script:instance2
-                Destination        = $script:instance3
+                Source             = $script:instance1
+                Destination        = $script:instance2
                 EncryptionPassword = $passwd
                 MasterKeyPassword  = $passwd
                 Database           = "tempdb"

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -38,7 +38,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $null = $cert2 | Remove-DbaDbCertificate -Confirm:$false -ErrorAction SilentlyContinue
         }
         # doing it on docker instead. this works on linux and on a homelab so i dont know
-        It -Skip "Successfully copies a certificate" {
+        It "Successfully copies a certificate" {
             $params1 = @{
                 Source             = $script:instance2
                 Destination        = $script:instance3

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -37,8 +37,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $null = $cert1 | Remove-DbaDbCertificate -Confirm:$false -ErrorAction SilentlyContinue
             $null = $cert2 | Remove-DbaDbCertificate -Confirm:$false -ErrorAction SilentlyContinue
         }
-
-        It "Successfully copies a certificate" {
+        # doing it on docker instead. this works on linux and on a homelab so i dont know
+        It -Skip "Successfully copies a certificate" {
             $params1 = @{
                 Source             = $script:instance2
                 Destination        = $script:instance3

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -30,8 +30,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 $masterkey | Remove-DbaDbMasterKey -Confirm:$false -ErrorAction SilentlyContinue
             }
         }
-        # doing it on docker instead. this works on linux and on a homelab so i dont know
-        It "Successfully copies a certificate" {
+        # doing it on docker instead. this works on linux and on a windows homelab so i dont know
+        It -Skip "Successfully copies a certificate" {
             $passwd = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
             $paramscopydb = @{
                 Source             = $script:instance2
@@ -44,6 +44,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results = Copy-DbaDbCertificate @paramscopydb -Confirm:$false | Where-Object SourceDatabase -eq dbatoolscopycred | Select-Object -First 1
             $results.Notes | Should -Be $null
             $results.Status | Should -Be "Successful"
+
+            Get-DbaDbCertificate -SqlInstance $script:instance3 -Database dbatoolscopycred -Certificate $certificateName2 | Should -NotBeNull
         }
     }
 }

--- a/tests/Restore-DbaDbCertificate.Tests.ps1
+++ b/tests/Restore-DbaDbCertificate.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Path', 'EncryptionPassword', 'Database', 'DecryptionPassword', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Path', 'EncryptionPassword', 'Database', 'DecryptionPassword', 'KeyFilePath', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Start-DbaMigration.Tests.ps1
+++ b/tests/Start-DbaMigration.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'Source', 'Destination', 'DetachAttach', 'Reattach', 'BackupRestore', 'SharedPath', 'WithReplace', 'NoRecovery', 'AzureCredential', 'SetSourceReadOnly', 'ReuseSourceFolderStructure', 'IncludeSupportDbs', 'SourceSqlCredential', 'DestinationSqlCredential', 'Exclude', 'DisableJobsOnDestination', 'DisableJobsOnSource', 'ExcludeSaRename', 'UseLastBackup', 'Continue', 'Force', 'EnableException', 'KeepCDC', 'KeepReplication'
+        [object[]]$knownParameters = 'Source', 'Destination', 'DetachAttach', 'Reattach', 'BackupRestore', 'SharedPath', 'WithReplace', 'NoRecovery', 'AzureCredential', 'SetSourceReadOnly', 'ReuseSourceFolderStructure', 'IncludeSupportDbs', 'SourceSqlCredential', 'DestinationSqlCredential', 'Exclude', 'DisableJobsOnDestination', 'DisableJobsOnSource', 'ExcludeSaRename', 'UseLastBackup', 'Continue', 'Force', 'EnableException', 'KeepCDC', 'KeepReplication', 'MasterKeyPassword'
 
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {

--- a/tests/gh-actions.ps1
+++ b/tests/gh-actions.ps1
@@ -34,6 +34,7 @@ Describe "Integration Tests" -Tag "IntegrationTests" {
         $results.Name | Should -Contain "Northwind"
         $results | Where-Object Name -eq "Northwind" | Select-Object -ExpandProperty Status | Should -Be "Successful"
         $results | Where-Object Name -eq "migrateme" | Select-Object -ExpandProperty Status | Should -Be "Successful"
+        Get-DbaDbCertificate -SqlInstance localhost:14333 -Database master -Certificate migrateme | Should -Not -BeNull
     }
 
     It "sets up a mirror" {

--- a/tests/gh-actions.ps1
+++ b/tests/gh-actions.ps1
@@ -194,7 +194,7 @@ Describe "Integration Tests" -Tag "IntegrationTests" {
             EncryptionPassword = $passwd
             MasterKeyPassword  = $passwd
             Database           = "tempdb"
-            SharedPath         = "/tmp"
+            SharedPath         = "/shared"
         }
         $results = Copy-DbaDbCertificate @params1 -Confirm:$false | Where-Object SourceDatabase -eq tempdb | Select-Object -First 1
         $results.Notes | Should -Be $null

--- a/tests/gh-actions.ps1
+++ b/tests/gh-actions.ps1
@@ -185,10 +185,10 @@ Describe "Integration Tests" -Tag "IntegrationTests" {
     }
 
     It "copies a certificate" {
-        $passwd = ConvertTo-SecureString $env:CLIENTSECRET -AsPlainText -Force
+        $passwd = ConvertTo-SecureString "dbatools.IOXYZ" -AsPlainText -Force
         $null = New-DbaDbMasterKey -Database tempdb -SecurePassword $passwd -Confirm:$false
         $certname = "Cert_$(Get-Random)"
-        $null = New-DbaDbCertificate -SqlInstance $script:instance2 -Name $certname -Database tempdb -Confirm:$false
+        $null = New-DbaDbCertificate -Name $certname -Database tempdb -Confirm:$false
 
         $params1 = @{
             EncryptionPassword = $passwd

--- a/tests/gh-actions.ps1
+++ b/tests/gh-actions.ps1
@@ -25,12 +25,15 @@ Describe "Integration Tests" -Tag "IntegrationTests" {
 
     It "migrates" {
         $params = @{
-            BackupRestore = $true
-            Exclude       = "LinkedServers", "Credentials", "DataCollector", "EndPoints", "PolicyManagement", "ResourceGovernor", "BackupDevices"
+            MasterKeyPassword = $cred.Password
+            BackupRestore     = $true
+            Exclude           = "LinkedServers", "Credentials", "DataCollector", "EndPoints", "PolicyManagement", "ResourceGovernor", "BackupDevices"
         }
-
+        $null = New-DbaDbCertificate -Name migrateme -Database master -Confirm:$false
         $results = Start-DbaMigration @params
         $results.Name | Should -Contain "Northwind"
+        $results | Where-Object Name -eq "Northwind" | Select-Object -ExpandProperty Status | Should -Be "Successful"
+        $results | Where-Object Name -eq "migrateme" | Select-Object -ExpandProperty Status | Should -Be "Successful"
     }
 
     It "sets up a mirror" {


### PR DESCRIPTION
`Copy-DbaDbCertificate` then added it to `Start-DbaMigration` then fixed some bugs while I was in `Backup-DbaDatabase`

The issue with the pipes is that a lot of stuff occured in the BEGIN which piped objects do not see. This will likely slow down Backup-DbaDatabase a smidge but is necessary. 

`Get-DbaFile` is awesome and I forgot about it but I needed to address some things to make it work on case sensitive servers.

Oh, i also added progress bars to `Start-DbaMigration`

I also looked at the way that Microsoft handles backup compression for encrypted databases and made us support more TDE

I have one more thing that i want to fix with the backup path
