### PR TITLE
Install-DbaInstance / Update-DbaInstance: Use CredSSP when restarting computer

### DIFF
--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -182,6 +182,7 @@ function Invoke-DbaAdvancedInstall {
     }
     if ($Credential) {
         $restartParams.Credential = $Credential
+        $restartParams.WsmanAuthentication = 'CredSSP'
     }
     $activity = "Installing SQL Server ($Version) components on $ComputerName"
     try {
@@ -199,7 +200,7 @@ function Invoke-DbaAdvancedInstall {
             $null = Restart-Computer @restartParams
             $output.Restarted = $true
         } catch {
-            Stop-Function -Message "Failed to restart computer" -ErrorRecord $_
+            Stop-Function -Message "Failed to restart computer $($ComputerName)" -ErrorRecord $_
         }
     }
     # save config if needed
@@ -325,8 +326,8 @@ function Invoke-DbaAdvancedInstall {
                 $null = Restart-Computer @restartParams
                 $output.Restarted = $true
             } catch {
-                Stop-Function -Message "Failed to restart computer $($ComputerName)" -ErrorRecord $_ -FunctionName Install-DbaInstance
-                return $output
+                Stop-Function -Message "Failed to restart computer $($ComputerName)" -ErrorRecord $_
+                $output.Notes += "Restart is required for computer $($ComputerName) to finish the installation of Sql Server version $Version"
             }
         } else {
             $output.Notes += "Restart is required for computer $($ComputerName) to finish the installation of Sql Server version $Version"

--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -182,7 +182,7 @@ function Invoke-DbaAdvancedInstall {
     }
     if ($Credential) {
         $restartParams.Credential = $Credential
-        $restartParams.WsmanAuthentication = 'CredSSP'
+        $restartParams.WsmanAuthentication = $Authentication
     }
     $activity = "Installing SQL Server ($Version) components on $ComputerName"
     try {

--- a/functions/Invoke-DbaAdvancedUpdate.ps1
+++ b/functions/Invoke-DbaAdvancedUpdate.ps1
@@ -97,7 +97,7 @@ Function Invoke-DbaAdvancedUpdate {
     }
     if ($Credential) {
         $restartParams.Credential = $Credential
-        $restartParams.WsmanAuthentication = 'CredSSP'
+        $restartParams.WsmanAuthentication = $Authentication
     }
     try {
         $restartNeeded = Test-PendingReboot -ComputerName $computer -Credential $Credential -NoPendingRename:$NoPendingRenameCheck

--- a/functions/Invoke-DbaAdvancedUpdate.ps1
+++ b/functions/Invoke-DbaAdvancedUpdate.ps1
@@ -97,6 +97,7 @@ Function Invoke-DbaAdvancedUpdate {
     }
     if ($Credential) {
         $restartParams.Credential = $Credential
+        $restartParams.WsmanAuthentication = 'CredSSP'
     }
     try {
         $restartNeeded = Test-PendingReboot -ComputerName $computer -Credential $Credential -NoPendingRename:$NoPendingRenameCheck
@@ -112,7 +113,7 @@ Function Invoke-DbaAdvancedUpdate {
             $null = Restart-Computer @restartParams
             $restarted = $true
         } catch {
-            Stop-Function -Message "Failed to restart computer" -ErrorRecord $_
+            Stop-Function -Message "Failed to restart computer $($computer)" -ErrorRecord $_
         }
     }
     Write-Message -Level Debug -Message "Processing $($computer) with $(($Actions | Measure-Object).Count) actions"
@@ -222,8 +223,8 @@ Function Invoke-DbaAdvancedUpdate {
                     $null = Restart-Computer @restartParams
                     $output.Restarted = $true
                 } catch {
-                    Stop-Function -Message "Failed to restart computer" -ErrorRecord $_
-                    return $output
+                    Stop-Function -Message "Failed to restart computer $($computer)" -ErrorRecord $_
+                    $output.Notes += "Restart is required for computer $($computer) to finish the installation of SQL$($currentAction.MajorVersion)$($currentAction.TargetLevel)"
                 }
             } else {
                 $output.Notes += "Restart is required for computer $($computer) to finish the installation of SQL$($currentAction.MajorVersion)$($currentAction.TargetLevel)"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Together with `Set-DbatoolsConfig -FullName 'commands.initialize-credssp.bypass' -Value $true` to suppress the configuration of CredSSP, with this change the installation of an instance can be started from an unelevated powershell session. 

I also aligned the error messages and added the notes if restart failed.