### PR TITLE
New-DbaComputerCertificate - Fix for DNS parameter with more than 254 chars

### DIFF
--- a/functions/New-DbaComputerCertificate.ps1
+++ b/functions/New-DbaComputerCertificate.ps1
@@ -148,6 +148,8 @@ function New-DbaComputerCertificate {
             )
             $hex = [String]::Format("{0:X2}", $strLen)
 
+            if (($hex.length % 2) -gt 0) { $hex = "0$hex" }
+
             if ($strLen -gt 127) { [String]::Format("{0:X2}", 128 + ($hex.Length / 2)) + $hex }
             else { $hex }
         }


### PR DESCRIPTION
Bugfix for DNS parameter with more than 254 chars
(#8044)

## Type of Change
 - [x] Bug fix (non-breaking change, fixes #8044 )
 
