### PR TITLE
Initialize-CredSSP - Don't try to configure CredSSP if not possible / Install-DbaInstance+Update-DbaInstance - align documentation and parameters

### DIFF
--- a/functions/Install-DbaInstance.ps1
+++ b/functions/Install-DbaInstance.ps1
@@ -63,7 +63,8 @@ function Install-DbaInstance {
     .PARAMETER Authentication
         Chooses an authentication protocol for remote connections.
         Allowed values: 'Default', 'Basic', 'Negotiate', 'NegotiateWithImplicitCredential', 'Credssp', 'Digest', 'Kerberos'.
-        If the protocol fails to establish a connection (HELP: What should be the end of this sentence?)
+        If the protocol fails to establish a connection and explicit -Credentials were used, a failback authentication method would be attempted that configures PSSessionConfiguration
+        on the remote machine. This method, however, is considered insecure and would, therefore, prompt an additional confirmation when used.
 
         Defaults:
         * CredSSP when -Credential is specified - due to the fact that repository Path is usually a network share and credentials need to be passed to the remote host to avoid the double-hop issue.

--- a/functions/Install-DbaInstance.ps1
+++ b/functions/Install-DbaInstance.ps1
@@ -506,6 +506,8 @@ function Install-DbaInstance {
                         $connectSuccess = Invoke-Command2 -ComputerName $fullComputerName -Credential $Credential -Authentication $Authentication -ScriptBlock { $true } -Raw
                     } catch {
                         $connectSuccess = $false
+                        # tell the user why we could not configure CredSSP
+                        Write-Message -Level Warning -Message $_
                     }
                 }
                 # in case we are still not successful, ask the user to use unsecure protocol once

--- a/functions/Update-DbaInstance.ps1
+++ b/functions/Update-DbaInstance.ps1
@@ -71,7 +71,8 @@ function Update-DbaInstance {
     .PARAMETER Authentication
         Chooses an authentication protocol for remote connections.
         Allowed values: 'Default', 'Basic', 'Negotiate', 'NegotiateWithImplicitCredential', 'Credssp', 'Digest', 'Kerberos'.
-        If the protocol fails to establish a connection (HELP: What should be the end of this sentence?)
+        If the protocol fails to establish a connection and explicit -Credentials were used, a failback authentication method would be attempted that configures PSSessionConfiguration
+        on the remote machine. This method, however, is considered insecure and would, therefore, prompt an additional confirmation when used.
 
         Defaults:
         * CredSSP when -Credential is specified - due to the fact that repository Path is usually a network share and credentials need to be passed to the remote host to avoid the double-hop issue.

--- a/functions/Update-DbaInstance.ps1
+++ b/functions/Update-DbaInstance.ps1
@@ -467,6 +467,8 @@ function Update-DbaInstance {
                             $connectSuccess = Invoke-Command2 -ComputerName $resolvedName -Credential $Credential -Authentication $Authentication -ScriptBlock { $true } -Raw
                         } catch {
                             $connectSuccess = $false
+                            # tell the user why we could not configure CredSSP
+                            Write-Message -Level Warning -Message $_
                         }
                     }
                     # in case we are still not successful, ask the user to use unsecure protocol once

--- a/functions/Update-DbaInstance.ps1
+++ b/functions/Update-DbaInstance.ps1
@@ -18,16 +18,11 @@ function Update-DbaInstance {
         * Repeat for each consequent KB and computer
 
         The impact of this function is set to High, if you don't want to receive interactive prompts, set -Confirm to $false.
-        Credentials are a required parameter for remote machines. Without specifying -Credential, the installation will fail due to lack of permissions.
 
-        CredSSP is a recommended transport for running the updates remotely. Update-DbaInstance will attempt to reconfigure
-        local and remote hosts to support CredSSP, which is why it is desirable to run this command in an elevated console at all times.
-        CVE-2018-0886 security update is required for both local and remote hosts. If CredSSP connections are failing, make sure to
-        apply recent security updates prior to doing anything else.
-
-        When using CredSSP authentication, this function will configure CredSSP authentication for PowerShell Remoting sessions.
+        When using CredSSP authentication, this function will try to configure CredSSP authentication for PowerShell Remoting sessions.
         If this is not desired (e.g.: CredSSP authentication is managed externally, or is already configured appropriately,)
         it can be disabled by setting the dbatools configuration option 'commands.initialize-credssp.bypass' value to $true.
+        To be able to configure CredSSP, the command needs to be run in an elevated PowerShell session.
 
         Always backup databases and configurations prior to upgrade.
 
@@ -37,6 +32,9 @@ function Update-DbaInstance {
     .PARAMETER Credential
         Windows Credential with permission to log on to the remote server.
         Must be specified for any remote connection if update Repository is located on a network folder.
+
+        Authentication will default to CredSSP if -Credential is used.
+        For CredSSP see also additional information in DESCRIPTION.
 
     .PARAMETER Type
         Type of the update: All | ServicePack | CumulativeUpdate.
@@ -72,11 +70,14 @@ function Update-DbaInstance {
 
     .PARAMETER Authentication
         Chooses an authentication protocol for remote connections.
-        If the protocol fails to establish a connection
+        Allowed values: 'Default', 'Basic', 'Negotiate', 'NegotiateWithImplicitCredential', 'Credssp', 'Digest', 'Kerberos'.
+        If the protocol fails to establish a connection (HELP: What should be the end of this sentence?)
 
         Defaults:
         * CredSSP when -Credential is specified - due to the fact that repository Path is usually a network share and credentials need to be passed to the remote host to avoid the double-hop issue.
         * Default when -Credential is not specified. Will likely fail if a network path is specified.
+
+        For CredSSP see also additional information in DESCRIPTION.
 
     .PARAMETER InstanceName
         Only updates a specific instance(s).
@@ -205,7 +206,7 @@ function Update-DbaInstance {
         [ValidateNotNull()]
         [int]$Throttle = 50,
         [ValidateSet('Default', 'Basic', 'Negotiate', 'NegotiateWithImplicitCredential', 'Credssp', 'Digest', 'Kerberos')]
-        [string]$Authentication = @('CredSSP', 'Default')[$null -eq $Credential],
+        [string]$Authentication = @('Credssp', 'Default')[$null -eq $Credential],
         [string]$ExtractPath,
         [string[]]$ArgumentList,
         [switch]$Download,

--- a/internal/functions/Initialize-CredSSP.ps1
+++ b/internal/functions/Initialize-CredSSP.ps1
@@ -54,7 +54,7 @@ function Initialize-CredSSP {
     # The command Get-WSManCredSSP can only run in an elevated PowerShell session, so we test that to be able to fail with a suitable message
     $isElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if (-not $isElevated) {
-        Stop-Function -Message "Failed to configure CredSSP because the PowerShell session is not elevated" -ErrorRecord $_
+        Stop-Function -Message "Failed to configure CredSSP because the PowerShell session is not elevated"
     }
 
     # Get current config

--- a/internal/functions/Initialize-CredSSP.ps1
+++ b/internal/functions/Initialize-CredSSP.ps1
@@ -55,6 +55,7 @@ function Initialize-CredSSP {
     $isElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if (-not $isElevated) {
         Stop-Function -Message "Failed to configure CredSSP because the PowerShell session is not elevated"
+        return
     }
 
     # Get current config

--- a/internal/functions/Initialize-CredSSP.ps1
+++ b/internal/functions/Initialize-CredSSP.ps1
@@ -9,6 +9,7 @@ function Initialize-CredSSP {
         Remote computer will be configured to act as a server and accept client connections from local computer.
 
         This function can be disabled by setting the value of configuration item "commands.initialize-credssp.bypass" to $true.
+        Configuration of CredSSP can and will be done by this command only from an elevated PowerShell session.
 
     .PARAMETER ComputerName
         Remote computer name
@@ -37,32 +38,42 @@ function Initialize-CredSSP {
         [bool]$EnableException
     )
 
-    #Check to see if this function is bypassed
-    if ( ( Get-DbatoolsConfigValue -FullName 'commands.initialize-credssp.bypass') -eq $true ) {
-        Write-Message -Level Verbose -Message "CredSSP initialization bypass (commands.initialize-credssp.bypass) is set to $true";
-        return;
+    # Check to see if this function is bypassed
+    if (Get-DbatoolsConfigValue -FullName 'commands.initialize-credssp.bypass') {
+        Write-Message -Level Verbose -Message "CredSSP initialization bypass (commands.initialize-credssp.bypass) is set to $true"
+        return
     }
 
-    #Configure local machine
-    #Start local WinRM service
+    # Configure local machine
+    # Start local WinRM service
     if ((Get-Service WinRM).Status -ne 'Running') {
         $null = Get-Service WinRM -ErrorAction Stop | Start-Service -ErrorAction Stop
         Start-Sleep -Seconds 1
     }
-    #Get current config
+
+    # The command Get-WSManCredSSP can only run in an elevated PowerShell session, so we test that.
+    # We return this command without error if we are not able to configure CredSSP.
+    # The calling command has to test a successful connection anyway, so we don't do that here.
+    $isElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    if (-not $isElevated) {
+        Write-Message -Level Verbose -Message "PowerShell session is not elevated, so we can only hope that CredSSP is configured"
+        return
+    }
+
+    # Get current config
     try {
         $sspList = Get-WSManCredSSP -ErrorAction Stop
-
     } catch {
         Stop-Function -Message "Failed to get a list of CredSSP hosts" -ErrorRecord $_
         return
     }
-    #Enable delegation to a remote server if not declared already
+
+    # Enable delegation to a remote server if not declared already
     if ($sspList -and $sspList[0] -notmatch "wsman\/$([regex]::Escape($ComputerName))[\,$]") {
         Write-Message -Level Verbose -Message "Configuring local host to use CredSSP"
         try {
             # Enable client SSP on local machine
-            $null = Enable-WSManCredSSP -role Client -DelegateComputer $ComputerName -Force -ErrorAction Stop
+            $null = Enable-WSManCredSSP -Role Client -DelegateComputer $ComputerName -Force -ErrorAction Stop
         } catch {
             Stop-Function -Message "Failed to configure local CredSSP as a client" -ErrorRecord $_
         }

--- a/internal/functions/Initialize-CredSSP.ps1
+++ b/internal/functions/Initialize-CredSSP.ps1
@@ -51,13 +51,10 @@ function Initialize-CredSSP {
         Start-Sleep -Seconds 1
     }
 
-    # The command Get-WSManCredSSP can only run in an elevated PowerShell session, so we test that.
-    # We return this command without error if we are not able to configure CredSSP.
-    # The calling command has to test a successful connection anyway, so we don't do that here.
+    # The command Get-WSManCredSSP can only run in an elevated PowerShell session, so we test that to be able to fail with a suitable message
     $isElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if (-not $isElevated) {
-        Write-Message -Level Verbose -Message "PowerShell session is not elevated, so we can only hope that CredSSP is configured"
-        return
+        Stop-Function -Message "Failed to configure CredSSP because the PowerShell session is not elevated" -ErrorRecord $_
     }
 
     # Get current config

--- a/internal/functions/Restart-WinRMService.ps1
+++ b/internal/functions/Restart-WinRMService.ps1
@@ -33,7 +33,8 @@ function Restart-WinRMService {
             # Retrieve a session from the session cache, if available (it's unique per runspace)
             [array]$currentSessions = [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::PSSessionGet($runspaceId, $ComputerName)
             Write-Message -Level Debug -Message "Removing $($currentSessions.Count) sessions from $ComputerName in runspace $runspaceId"
-            $currentSessions | Remove-PSSession
+            # "$currentSessions | Remove-PSSession" would fail with "Remove-PSSession : Cannot bind argument to parameter 'Session' because it is null." if $currentSessions is empty.
+            foreach ($session in $currentSessions) { $session | Remove-PSSession }
             Write-Message -Level Debug "Waiting for the WinRM service to restart on $ComputerName"
             $waitCounter = 0
             while ($waitCounter -lt $Timeout * 5) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8117 )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Be able to run Install-DbaInstance and Update-DbaInstance in an unelevated PowerShell session, when CredSSP is already configured. No need to bypass Initialize-CredSSP with commands.initialize-credssp.bypass in this case.

### Approach
Test for elevated PowerShell session inside of Initialize-CredSSP

