### PR TITLE
New-DbaLinkedServer: allow for updates to the security context setting

### DIFF
--- a/tests/New-DbaLinkedServer.Tests.ps1
+++ b/tests/New-DbaLinkedServer.Tests.ps1
@@ -5,10 +5,10 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'LinkedServer', 'ServerProduct', 'Provider', 'DataSource', 'Location', 'ProviderString', 'Catalog', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'LinkedServer', 'ServerProduct', 'Provider', 'DataSource', 'Location', 'ProviderString', 'Catalog', 'SecurityContext', 'SecurityContextRemoteUser', 'SecurityContextRemoteUserPassword', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
@@ -17,23 +17,29 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
         $random = Get-Random
         $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
+        $instance3 = Connect-DbaInstance -SqlInstance $script:instance3
+
+        $securePassword = ConvertTo-SecureString -String 'securePassword!' -AsPlainText -Force
+        $loginName = "dbatoolscli_test_$random"
+        New-DbaLogin -SqlInstance $instance3 -Login $loginName -SecurePassword $securePassword
     }
     AfterAll {
-        if ($instance2.LinkedServers.Name -contains "LS1_$random") {
-            $instance2.LinkedServers["LS1_$random"].Drop()
-        }
+        Remove-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS1_$random" -Confirm:$false -Force
+        Remove-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS2_$random" -Confirm:$false -Force
+        Remove-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS3_$random" -Confirm:$false -Force
+        Remove-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS4_$random" -Confirm:$false -Force
+        Remove-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS5_$random" -Confirm:$false -Force
+        Remove-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS6_$random" -Confirm:$false -Force
 
-        if ($instance2.LinkedServers.Name -contains "LS2_$random") {
-            $instance2.LinkedServers["LS2_$random"].Drop()
-        }
+        Remove-DbaLogin -SqlInstance $instance3 -Login $loginName -Confirm:$false
     }
 
     Context "ensure command works" {
 
         It "Creates a linked server" {
-            $results = New-DbaLinkedServer -SqlInstance $script:instance2 -LinkedServer "LS1_$random" -ServerProduct product1 -Provider provider1 -DataSource dataSource1 -Location location1 -ProviderString providerString1 -Catalog catalog1
+            $results = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS1_$random" -ServerProduct product1 -Provider provider1 -DataSource dataSource1 -Location location1 -ProviderString providerString1 -Catalog catalog1
             $results.Parent.Name | Should -Be $instance2.Name
-            $results.Name | Should -Be "LS1_$random"
+            $results.Name | Should -Be "dbatoolscli_LS1_$random"
             $results.ProductName | Should -Be product1
             $results.ProviderName | Should -Be provider1
             $results.DataSource | Should -Be dataSource1
@@ -43,20 +49,57 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "Check the validation for duplicate linked servers" {
-            $results = New-DbaLinkedServer -SqlInstance $script:instance2 -LinkedServer "LS1_$random"
+            $results = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS1_$random" -WarningVariable warnings
             $results | Should -BeNullOrEmpty
+            $warnings | Should -BeLike "*Linked server dbatoolscli_LS1_$random already exists on *"
+        }
+
+        It "Check the validation when the linked server param is not provided" {
+            $results = New-DbaLinkedServer -SqlInstance $instance2 -WarningVariable warnings
+            $results | Should -BeNullOrEmpty
+            $warnings | Should -BeLike "*LinkedServer is required*"
         }
 
         It "Creates a linked server using a server from a pipeline" {
-            $results = $instance2 | New-DbaLinkedServer -LinkedServer "LS2_$random" -ServerProduct product2 -Provider provider2 -DataSource dataSource2 -Location location2 -ProviderString providerString2 -Catalog catalog2
+            $results = $instance2 | New-DbaLinkedServer -LinkedServer "dbatoolscli_LS2_$random" -ServerProduct product2 -Provider provider2 -DataSource dataSource2 -Location location2 -ProviderString providerString2 -Catalog catalog2
             $results.Parent.Name | Should -Be $instance2.Name
-            $results.Name | Should -Be "LS2_$random"
+            $results.Name | Should -Be "dbatoolscli_LS2_$random"
             $results.ProductName | Should -Be product2
             $results.ProviderName | Should -Be provider2
             $results.DataSource | Should -Be dataSource2
             $results.Location | Should -Be location2
             $results.ProviderString | Should -Be providerString2
             $results.Catalog | Should -Be catalog2
+        }
+
+        It "Creates a linked server with the different security context options" {
+            $results = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS3_$random" -ServerProduct mssql -Provider sqlncli -DataSource $instance3 -SecurityContext NoConnection
+
+            $results.RemoteUser | Should -BeNullOrEmpty
+            $results.Impersonate | Should -BeNullOrEmpty
+
+            $results = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS4_$random" -ServerProduct mssql -Provider sqlncli -DataSource $instance3 -SecurityContext WithoutSecurityContext
+
+            $results.RemoteUser | Should -BeNullOrEmpty
+            $results.Impersonate | Should -Be $false
+
+            $results = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS5_$random" -ServerProduct mssql -Provider sqlncli -DataSource $instance3 -SecurityContext CurrentSecurityContext
+
+            $results.RemoteUser | Should -BeNullOrEmpty
+            $results.Impersonate | Should -Be $true
+
+            $results = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS6_$random" -ServerProduct mssql -Provider sqlncli -DataSource $instance3 -SecurityContext SpecifiedSecurityContext -WarningVariable warnings
+
+            $warnings | Should -BeLike "*SecurityContextRemoteUser is required when SpecifiedSecurityContext is used*"
+
+            $results = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS6_$random" -ServerProduct mssql -Provider sqlncli -DataSource $instance3 -SecurityContext SpecifiedSecurityContext -SecurityContextRemoteUser $loginName -WarningVariable warnings
+
+            $warnings | Should -BeLike "*SecurityContextRemoteUserPassword is required when SpecifiedSecurityContext is used*"
+
+            $results = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "dbatoolscli_LS6_$random" -ServerProduct mssql -Provider sqlncli -DataSource $instance3 -SecurityContext SpecifiedSecurityContext -SecurityContextRemoteUser $loginName -SecurityContextRemoteUserPassword $securePassword
+
+            $results.RemoteUser | Should -Be $loginName
+            $results.Impersonate | Should -Be $false
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8112 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Allow the caller to specify the security context setting for a new linked server.

### Approach
<!-- How does this change solve that purpose -->
There does not seem to be a way to update the security context setting using SMO. The sp_addlinkedsrvlogin and sp_droplinkedsrvlogin procs are invoked using the different combination of params for each security context.

Part of a series of PRs related to linked servers:

1. Update for Remove-DbaLinkedServer (#7952)
2. New command for Get-DbaLinkedServerLogin (#7965)
3. New command for New-DbaLinkedServerLogin (#7983)
4. New command for Remove-DbaLinkedServerLogin (#8027)
5. Update for New-DbaLinkedServer (This PR)
6. New command for Set-DbaLinkedServer

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the new Pester tests and examples section of the command.

Note: the help page for New-DbaLinkedServer needs to be added to https://docs.dbatools.io/