### PR TITLE
Do not load XEvents DLLs on ARM64

### DIFF
--- a/internal/scripts/libraryimport.ps1
+++ b/internal/scripts/libraryimport.ps1
@@ -94,6 +94,10 @@ $scriptBlock = {
             'SqlServer.XEvent'
         )
     }
+    # XEvent stuff kills CI/CD
+    if ($PSVersionTable.OS -match "ARM64") {
+        $names = $names | Where-Object { $PSItem -notmatch "XE" }
+    }
     #endregion Names
 
     $basePath = $dllRoot


### PR DESCRIPTION
Not sure what's up. I can import from the command line, but not within an arm64 runner. Still working through this.

```
ParentContainsErrorRecordException: /Users/runneradmin/.local/share/powershell/Modules/dbatools/1.1.62/internal/scripts/libraryimport.ps1:151
Line |
 151 |  … Invoke($script:PSModuleRoot, "$(Join-Path $script:DllRoot smo)", $scr …
     |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "Invoke" with "3" argument(s): "The running
     | command stopped because the preference variable
     | "ErrorActionPreference" or common parameter is set to Stop:
     | Could not import
     | /Users/runneradmin/.local/share/powershell/Modules/dbatools/1.1.62/bin/smo/coreclr/Microsoft.SqlServer.XEvent.Linq.dll :  MethodInvocationException: /Users/runneradmin/.local/share/powershell/Modules/dbatools/1.1.62/internal/scripts/libraryimport.ps1:140 Line |  140 |                      [Reflection.Assembly]::LoadFrom($assemblyPath)      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~      | Exception calling "LoadFrom" with "1" argument(s): "Could not      | load file or assembly 'Microsoft.SqlServer.XEvent.Linq,      | Version=14.0.0.0, Culture=neutral,      | PublicKeyToken=89845dcd8080cc91'."  "
```