### PR TITLE
Test-DbaConnection - support usage of FQDN when testing TcpPort

### DIFF
--- a/functions/Test-DbaConnection.ps1
+++ b/functions/Test-DbaConnection.ps1
@@ -181,7 +181,7 @@ function Test-DbaConnection {
 
                 # TCP Port
                 try {
-                    $tcpport = (Get-DbaTcpPort -SqlInstance $server -SqlCredential $SqlCredential -Credential $Credential -EnableException).Port
+                    $tcpport = (Get-DbaTcpPort -SqlInstance $instance -SqlCredential $SqlCredential -Credential $Credential -EnableException).Port
                 } catch {
                     $tcpport = $_
                 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8116 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

As Get-DbaTcpPort opens a new connection anyway, we should call the command with $instance instead of $server, because $instance is the original input and can contain a FQDN.