### PR TITLE
Get-DbaUserPermissions Exclude Securables

### DIFF
--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -37,7 +37,6 @@ function Get-DbaUserPermission {
 
     .PARAMETER ExcludeSecurables
         Allow you to exclude object-level permissions from the output, and only return role permission(s).
-        switch will exclude specific object level permissions and simply return roles for users.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -45,7 +45,7 @@ function Get-DbaUserPermission {
 
     .NOTES
         Tags: Security, User
-        Author: Brandon Abshire, netnerds.net, josh smith
+        Author: Brandon Abshire, netnerds.net | Josh Smith
 
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -86,7 +86,7 @@ function Get-DbaUserPermission {
     )
 
     begin {
-        $endSQL = "	   BEGIN TRY DROP FUNCTION STIG.server_effective_permissions END TRY BEGIN CATCH END CATCH;
+        $endSQL = "       BEGIN TRY DROP FUNCTION STIG.server_effective_permissions END TRY BEGIN CATCH END CATCH;
                        GO
                        BEGIN TRY DROP VIEW STIG.server_permissions END TRY BEGIN CATCH END CATCH;
                        GO
@@ -163,7 +163,7 @@ function Get-DbaUserPermission {
                             WHERE   sl.name NOT LIKE 'NT %'
                                     AND sl.name NOT LIKE '##%';"
 
-            $dbSQL =  $dbSQL + "
+            $dbSQL = $dbSQL + "
                         UNION
                         SELECT DISTINCT
                                 'DB SECURABLES' AS Type ,
@@ -182,7 +182,7 @@ function Get-DbaUserPermission {
                                 FULL JOIN tempdb.[STIG].[database_permissions] dp ON ( drm.Member = dp.Grantee
                                                                                       OR drm.Role = dp.Grantee
                                                                                      )
-                        WHERE	dp.Grantor IS NOT NULL
+                        WHERE    dp.Grantor IS NOT NULL
                                 AND dp.Grantee NOT IN ('public', 'guest')
                                 AND [Schema/Owner] <> 'sys'"
         }

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -36,7 +36,7 @@ function Get-DbaUserPermission {
         Allows you to include output on sys schema objects.
 
     .PARAMETER ExcludeSecurables
-        For databases with a large number of objects getting object level permissions can be undesirable. Including this
+        Allow you to exclude object-level permissions from the output, and only return role permission(s).
         switch will exclude specific object level permissions and simply return roles for users.
 
     .PARAMETER EnableException

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -82,7 +82,7 @@ function Get-DbaUserPermission {
         [switch]$ExcludeSystemDatabase,
         [switch]$IncludePublicGuest,
         [switch]$IncludeSystemObjects,
-        [switch]$ExcludeSecurables
+        [switch]$ExcludeSecurables,
         [switch]$EnableException
     )
 
@@ -127,7 +127,7 @@ function Get-DbaUserPermission {
                                     LEFT JOIN tempdb.[STIG].[server_role_members] srm ON sl.name = srm.Member
                             WHERE   sl.name NOT LIKE 'NT %'
                                     AND sl.name NOT LIKE '##%'"
-        if -not ($ExcludeSecurables) {
+        if (-not $ExcludeSecurables) {
 
             $serverSQL = $serverSQL + "
                             UNION
@@ -163,7 +163,7 @@ function Get-DbaUserPermission {
                                 ' ' AS [Source View]
                         FROM    tempdb.[STIG].[database_role_members]"
 
-        if -not ($ExcludeSecurables) {
+        if (-not $ExcludeSecurables) {
 
             $dbSQL =  $dbSQL + "
                         UNION

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -126,6 +126,22 @@ function Get-DbaUserPermission {
                                     LEFT JOIN tempdb.[STIG].[server_role_members] srm ON sl.name = srm.Member
                             WHERE   sl.name NOT LIKE 'NT %'
                                     AND sl.name NOT LIKE '##%'"
+
+        $dbSQL = "SELECT  'DB ROLE MEMBERS' AS type ,
+                                Member ,
+                                ISNULL(Role, 'None') AS [Role/Securable/Class],
+                                ' ' AS [Schema/Owner] ,
+                                ' ' AS [Securable] ,
+                                ' ' AS [Grantee Type] ,
+                                ' ' AS [Grantee] ,
+                                ' ' AS [Permission] ,
+                                ' ' AS [State] ,
+                                ' ' AS [Grantor] ,
+                                ' ' AS [Grantor Type] ,
+                                ' ' AS [Source View]
+                        FROM    tempdb.[STIG].[database_role_members]"
+
+        # append unions to get securables if not excluded:
         if (-not $ExcludeSecurables) {
 
             $serverSQL = $serverSQL + "
@@ -146,23 +162,6 @@ function Get-DbaUserPermission {
                                     LEFT JOIN tempdb.[STIG].[server_permissions] sp ON sl.name = sp.Grantee
                             WHERE   sl.name NOT LIKE 'NT %'
                                     AND sl.name NOT LIKE '##%';"
-        }
-
-        $dbSQL = "SELECT  'DB ROLE MEMBERS' AS type ,
-                                Member ,
-                                ISNULL(Role, 'None') AS [Role/Securable/Class],
-                                ' ' AS [Schema/Owner] ,
-                                ' ' AS [Securable] ,
-                                ' ' AS [Grantee Type] ,
-                                ' ' AS [Grantee] ,
-                                ' ' AS [Permission] ,
-                                ' ' AS [State] ,
-                                ' ' AS [Grantor] ,
-                                ' ' AS [Grantor Type] ,
-                                ' ' AS [Source View]
-                        FROM    tempdb.[STIG].[database_role_members]"
-
-        if (-not $ExcludeSecurables) {
 
             $dbSQL =  $dbSQL + "
                         UNION

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -36,7 +36,7 @@ function Get-DbaUserPermission {
         Allows you to include output on sys schema objects.
 
     .PARAMETER ExcludeSecurables
-        Allow you to exclude object-level permissions from the output, and only return role permission(s).
+        Allows you to exclude object-level permissions from the output, and only return role permission(s).
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.

--- a/tests/Get-DbaUserPermission.Tests.ps1
+++ b/tests/Get-DbaUserPermission.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'ExcludeSystemDatabase', 'IncludePublicGuest', 'IncludeSystemObjects', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'ExcludeSystemDatabase', 'IncludePublicGuest', 'IncludeSystemObjects', 'ExcludeSecurables', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
This commit updates the function to accept a switch to ignore
securables at the database and server level. This is useful
when a database has an excessive number of users and objects
and/or the user is simply interested in role memberships.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
Ran into an issue with a 3rd party vendor db where the full roles and db securables returned over 4 million rows and function never returned. Adding a switch to return just role memberships would be keep this function useful in this case as role memberships are the only permissions I am actually concerned with at this point.

### Approach
Added a switch to the function that excludes the second half of the server and db queries when they are not desired.