### PR TITLE
New-DbaDbTable - Drop table if creation fails and change DefaultEx to DefaultExpression

### DIFF
--- a/functions/New-DbaDbTable.ps1
+++ b/functions/New-DbaDbTable.ps1
@@ -505,14 +505,13 @@ function New-DbaDbTable {
                     $db | Get-DbaDbTable -Table "[$Schema].[$Name]"
                 } catch {
                     $exception = $_
-                    Write-Message -Level Warning -Message "Failed to create table or failure while adding constraints. Will try to remove table."
+                    Write-Message -Level Verbose -Message "Failed to create table or failure while adding constraints. Will try to remove table (and schema)."
                     try {
-                        # If creation of a constraint fails, the table is already created - so it has to be droped.
-                        # But $object.Drop() or $object.DropIfExists() don't work as expected.
-                        # Maybe try again in a later version of the SMO...
-                        $db.Tables | Where-Object { $_.Schema -eq $Schema -and $_.Name -eq $Name } | ForEach-Object { $_.Drop() }
+                        $object.Refresh()
+                        $object.DropIfExists()
                         if ($schemaObject) {
-                            $db.Schemas[$Schema].Drop()
+                            $schemaObject.Refresh()
+                            $schemaObject.DropIfExists()
                         }
                     } catch {
                         Write-Message -Level Warning -Message "Failed to drop table: $_. Maybe table still exists."

--- a/functions/New-DbaDbTable.ps1
+++ b/functions/New-DbaDbTable.ps1
@@ -215,14 +215,14 @@ function New-DbaDbTable {
 
     .EXAMPLE
        PS C:\> $col = @{
-       >> Name      = 'Id'
-       >> Type      = 'varchar'
-       >> MaxLength = 36
-       >> DefaultEx = 'NEWID()'
+       >> Name              = 'Id'
+       >> Type              = 'varchar'
+       >> MaxLength         = 36
+       >> DefaultExpression = 'NEWID()'
        >> }
        PS C:\> New-DbaDbTable -SqlInstance sql2017 -Database tempdb -Name testtable -ColumnMap $col
 
-       Creates a new table on sql2017 in tempdb with the name testtable and one column. Uses "DefaultEx" to interpret the value as an expression and not as a string.
+       Creates a new table on sql2017 in tempdb with the name testtable and one column. Uses "DefaultExpression" to interpret the value as an expression and not as a string.
 
     .EXAMPLE
         PS C:\> # Create collection
@@ -443,14 +443,14 @@ function New-DbaDbTable {
                         $sqlColumn = New-Object Microsoft.SqlServer.Management.Smo.Column $object, $column.Name, $dataType
                         $sqlColumn.Nullable = $column.Nullable
 
-                        if ($column.DefaultEx) {
+                        if ($column.DefaultExpression) {
                             # override the default that would add quotes to an expression
                             if ($column.DefaultName) {
                                 $dfName = $column.DefaultName
                             } else {
                                 $dfName = "DF_$name`_$($column.Name)"
                             }
-                            $sqlColumn.AddDefaultConstraint($dfName).Text = $column.DefaultEx
+                            $sqlColumn.AddDefaultConstraint($dfName).Text = $column.DefaultExpression
                         } elseif ($column.Default) {
                             if ($column.DefaultName) {
                                 $dfName = $column.DefaultName

--- a/tests/New-DbaDbTable.Tests.ps1
+++ b/tests/New-DbaDbTable.Tests.ps1
@@ -99,7 +99,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             }
         }
         It "Creates the table" {
-            $null = New-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Name $tablename4 -ColumnMap $map -EnableException | Should Not Throw
+            { $null = New-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Name $tablename4 -ColumnMap $map -EnableException } | Should Not Throw
         }
     }
     Context "Should create the schema if it doesn't exist" {

--- a/tests/New-DbaDbTable.Tests.ps1
+++ b/tests/New-DbaDbTable.Tests.ps1
@@ -20,6 +20,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $tablename = "dbatoolssci_$(Get-Random)"
         $tablename2 = "dbatoolssci2_$(Get-Random)"
         $tablename3 = "dbatoolssci2_$(Get-Random)"
+        $tablename4 = "dbatoolssci2_$(Get-Random)"
     }
     AfterAll {
         $null = Invoke-DbaQuery -SqlInstance $script:instance1 -Database $dbname -Query "drop table $tablename, $tablename2"
@@ -82,7 +83,25 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $table.Columns.IdentityIncrement | Should -Be $map.IdentityIncrement
         }
     }
-
+    Context "Should create the table with using DefaultExpression and DefaultString" {
+        BeforeEach {
+            $map = @( )
+            $map += @{
+                Name              = 'Id'
+                Type              = 'varchar'
+                MaxLength         = 36
+                DefaultExpression = 'NEWID()'
+            }
+            $map += @{
+                Name          = 'Since'
+                Type          = 'datetime2'
+                DefaultString = '2021-12-31'
+            }
+        }
+        It "Creates the table" {
+            $null = New-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Name $tablename4 -ColumnMap $map -EnableException | Should Not Throw
+        }
+    }
     Context "Should create the schema if it doesn't exist" {
 
         It "schema created" {

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -61,7 +61,6 @@ $TestsRunGroups = @{
         'Export-DbaDacPackage',
         'New-DbaDbTransfer',
         'Remove-DbaAgDatabase',
-        'New-DbaDbTable',
         'Get-DbaDbSynonym',
         'Get-DbaDbVirtualLogFile',
         'Get-DbaFile',


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system
