### PR TITLE
Get-DbaDbRestoreHistory: new param to return history by restore type

### DIFF
--- a/tests/Get-DbaDbRestoreHistory.Tests.ps1
+++ b/tests/Get-DbaDbRestoreHistory.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Since', 'Force', 'Last', 'EnableException'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Since', 'RestoreType', 'Force', 'Last', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 
@@ -27,10 +27,17 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         $null = Restore-DbaDatabase -SqlInstance $script:instance2 -Path $script:appveyorlabrepo\singlerestore\singlerestore.bak -DatabaseName $dbname1 -DestinationFilePrefix $dbname1
         $null = Restore-DbaDatabase -SqlInstance $script:instance2 -Path $script:appveyorlabrepo\singlerestore\singlerestore.bak -DatabaseName $dbname2 -DestinationFilePrefix $dbname2
         $null = Restore-DbaDatabase -SqlInstance $script:instance2 -Path $script:appveyorlabrepo\singlerestore\singlerestore.bak -DatabaseName $dbname2 -DestinationFilePrefix "rsh_pre_$dbname2" -WithReplace
+        $fullBackup = Backup-DbaDatabase -SqlInstance $script:instance2 -Database $dbname1 -Type Full
+        $diffBackup = Backup-DbaDatabase -SqlInstance $script:instance2 -Database $dbname1 -Type Diff
+        $logBackup = Backup-DbaDatabase -SqlInstance $script:instance2 -Database $dbname1 -Type Log
+
+        $null = Restore-DbaDatabase -SqlInstance $script:instance2 -Path $diffBackup.BackupPath, $logBackup.BackupPath -DatabaseName $dbname1 -WithReplace
     }
 
     AfterAll {
-        $null = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname1, $dbname2 | Remove-DbaDatabase -Confirm:$false
+        $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname1, $dbname2 | Remove-DbaDatabase -Confirm:$false
+        Remove-Item -Path $fullBackup.BackupPath -Force
+        Remove-Item -Path $logBackup.BackupPath -Force
     }
     Context "Preparation" {
         It "Should have prepared" {
@@ -55,20 +62,20 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
         It "Should return the full restore with the correct properties" {
             $results[0].RestoreType | Should -Be "Database"
-            $results[1].RestoreType | Should -Be "Database"
+            $results[1].RestoreType | Should -Be "Log"
             $results[0].From | Should -Be $script:appveyorlabrepo\singlerestore\singlerestore.bak
-            $results[1].From | Should -Be $script:appveyorlabrepo\singlerestore\singlerestore.bak
+            $results[1].From | Should -Be $logBackup.BackupPath
             ($results | Where-Object Database -eq $dbname1).To | Should -Match "\\$dbname1"
             ($results | Where-Object Database -eq $dbname2).To | Should -Match "\\rsh_pre_$dbname2"
         }
     }
     Context "Get complete restore history for multiple database" {
         $results = @(Get-DbaDbRestoreHistory -SqlInstance $script:instance2 -Database $dbname1, $dbname2)
-        It "Results holds 3 objects" {
-            $results.Count | Should -Be 3
+        It "Results holds correct number of objects" {
+            $results.Count | Should -Be 6
         }
         It "Should return the full restore with the correct properties" {
-            @($results | Where-Object Database -eq $dbname1).Count | Should -Be 1
+            @($results | Where-Object Database -eq $dbname1).Count | Should -Be 4
             @($results | Where-Object Database -eq $dbname2).Count | Should -Be 2
         }
     }
@@ -80,6 +87,23 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             ($result.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
             $ExpectedPropsDefault = 'ComputerName,InstanceName,SqlInstance,Database,Username,RestoreType,Date,From,To,BackupFinishDate'.Split(',')
             ($result.PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames | Sort-Object) | Should Be ($ExpectedPropsDefault | Sort-Object)
+        }
+    }
+    Context "Get restore history by restore type" {
+        It "returns the correct history records for full db restore" {
+            $results = Get-DbaDbRestoreHistory -SqlInstance $script:instance2 -Database $dbname1, $dbname2 -RestoreType Database
+            $results.count | Should -Be 4
+            @($results | Where-Object RestoreType -eq Database).Count | Should -Be 4
+        }
+        It "returns the correct history records for diffential restore" {
+            $results = Get-DbaDbRestoreHistory -SqlInstance $script:instance2 -Database $dbname1 -RestoreType Differential
+            $results.Database | Should -Be $dbname1
+            $results.RestoreType | Should -Be Differential
+        }
+        It "returns the correct history records for log restore" {
+            $results = Get-DbaDbRestoreHistory -SqlInstance $script:instance2 -Database $dbname1 -RestoreType Log
+            $results.Database | Should -Be $dbname1
+            $results.RestoreType | Should -Be Log
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8110 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Added a new -RestoreType param as requested in #8110 to enhance filtering capabilities.

### Approach
<!-- How does this change solve that purpose -->
Minor change to the dynamic SQL used to obtain the restore history.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the new Pester tests.