### PR TITLE
Set-DbaResourceGovernor: use SqlCredential, not Credential

### DIFF
--- a/functions/Set-DbaResourceGovernor.ps1
+++ b/functions/Set-DbaResourceGovernor.ps1
@@ -12,7 +12,7 @@ function Set-DbaResourceGovernor {
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
 
-    .PARAMETER Credential
+    .PARAMETER SqlCredential
         Credential object used to connect to the Windows server as a different user
 
     .PARAMETER Enabled
@@ -71,7 +71,8 @@ function Set-DbaResourceGovernor {
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
-        [PSCredential]$Credential,
+        [Alias("Credential")]
+        [PSCredential]$SqlCredential,
         [switch]$Enabled,
         [switch]$Disabled,
         [string]$ClassifierFunction,

--- a/tests/Set-DbaResourceGovernor.Tests.ps1
+++ b/tests/Set-DbaResourceGovernor.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag "UnitTests" {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'Enabled', 'Disabled', 'ClassifierFunction', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Enabled', 'Disabled', 'ClassifierFunction', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8170 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Standardize the param name.

### Approach
Alias the old one for backwards compatibility, but set the name to the standard SqlCredential.

### Commands to test
Set-DbaResourceGovernor
