### PR TITLE
Set-DbaResourceGovernor: reuse server object

### DIFF
--- a/functions/Set-DbaResourceGovernor.ps1
+++ b/functions/Set-DbaResourceGovernor.ps1
@@ -127,6 +127,7 @@ function Set-DbaResourceGovernor {
             # Execute
             if ($PSCmdlet.ShouldProcess($instance, "Changing Resource Governor")) {
                 $server.ResourceGovernor.Alter()
+                $server.ResourceGovernor.Refresh()
             }
 
             Get-DbaResourceGovernor -SqlInstance $server

--- a/functions/Set-DbaResourceGovernor.ps1
+++ b/functions/Set-DbaResourceGovernor.ps1
@@ -129,7 +129,7 @@ function Set-DbaResourceGovernor {
                 $server.ResourceGovernor.Alter()
             }
 
-            Get-DbaResourceGovernor -SqlInstance $instance
+            Get-DbaResourceGovernor -SqlInstance $server
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, https://github.com/dataplat/dbatools/pull/8171 was an incomplete fix for #8170 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The $server object needs to be used at the bottom, otherwise there may still be SqlCredential issues.