### PR TITLE
fix/centralize ag 'create any database' perms

### DIFF
--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -269,8 +269,7 @@ function Add-DbaAgDatabase {
                                 $replica.Alter()
                                 if ($SeedingMode -eq 'Automatic') {
                                     Write-Message -Level Verbose -Message "Setting GrantAvailabilityGroupCreateDatabasePrivilege on server $($replicaServerSMO[$replicaName]) for Availability Group $AvailabilityGroup."
-                                    $replicaServerSMO[$replicaName].GrantAvailabilityGroupCreateDatabasePrivilege($AvailabilityGroup)
-                                    $replicaServerSMO[$replicaName].Alter()
+                                    $null = Grant-DbaAgPermission -SqlInstance $replicaServerSMO[$replicaName] -Type AvailabilityGroup -AvailabilityGroup $AvailabilityGroup -Permission CreateAnyDatabase
                                 }
                             } catch {
                                 $failure = $true

--- a/functions/Add-DbaAgReplica.ps1
+++ b/functions/Add-DbaAgReplica.ps1
@@ -279,7 +279,9 @@ function Add-DbaAgReplica {
 
                     if ($server.HostPlatform -ne "Linux") {
                         if ($Pscmdlet.ShouldProcess($second.Name, "Granting Connect permission to service account: $serviceAccount")) {
-                            $null = Grant-DbaAgPermission -SqlInstance $server -Type AvailabilityGroup -AvailabilityGroup $InputObject.Name -Login $serviceAccount -Permission CreateAnyDatabase
+                            if ($SeedingMode -eq "Automatic") {
+                                $null = Grant-DbaAgPermission -SqlInstance $server -Type AvailabilityGroup -AvailabilityGroup $InputObject.Name -Login $serviceAccount -Permission CreateAnyDatabase
+                            }
                             $null = Grant-DbaAgPermission -SqlInstance $server -Login $serviceAccount -Type Endpoint -Permission Connect
                         }
                     }

--- a/functions/Grant-DbaAgPermission.ps1
+++ b/functions/Grant-DbaAgPermission.ps1
@@ -126,10 +126,11 @@ function Grant-DbaAgPermission {
             } catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-            if ($perm -contains "CreateAnyDatabase") {
+            if ($Permission -contains "CreateAnyDatabase") {
                 foreach ($ag in $AvailabilityGroup) {
                     try {
-                        $server.Query("ALTER AVAILABILITY GROUP $ag GRANT CREATE ANY DATABASE")
+                        $server.GrantAvailabilityGroupCreateDatabasePrivilege($ag)
+                        $server.Alter()
                     } catch {
                         Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance
                         return

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -624,22 +624,6 @@ function New-DbaAvailabilityGroup {
             }
         }
 
-        Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Granting permissions on availability group, this may take a moment"
-        if ($SeedingMode -eq 'Automatic') {
-            try {
-                if ($Pscmdlet.ShouldProcess($server.Name, "Seeding mode is automatic. Adding CreateAnyDatabase permissions to availability group.")) {
-                    $sql = "ALTER AVAILABILITY GROUP [$Name] GRANT CREATE ANY DATABASE"
-                    $null = $server.Query($sql)
-                    foreach ($second in $secondaries) {
-                        $null = $second.Query($sql)
-                    }
-                }
-            } catch {
-                # Log the exception but keep going
-                Stop-Function -Message "Failure" -ErrorRecord $_
-            }
-        }
-
         # Wait for the availability group to be ready
         Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Waiting for replicas to be connected and ready"
         do {


### PR DESCRIPTION
- Not needed in New-DbaAvailabilityGroup since it is handled in both Replica and Database AG Adders
- Utilize Grant-DbaAgPermission as the route to do this perm via SMO, and only if automatic seeding
- Fix Grant-DbaAgPermission parameter parsing so it actually works

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8178 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Followup from #8181 
Fixes & standardizes the create database permission required by AGs for automatic seeding.

### Approach
- Make Grant-DbaAgPermission use SMO
- Make all other functions use Grant-DbaAgPermission
- Remove the granting from New-DbaAgAvailabilityGroup since it calls both the Add-Replica and Add-Database functions already
- 
### Commands to test

- Add-DbaAgDatabase
- New-DbaAvailabilityGroup
- Add-DbaAgReplica
- Grant-DbaAgPermission
