### PR TITLE
Availability Groups: Some more fixes for granting permissions

### DIFF
--- a/functions/Add-DbaAgReplica.ps1
+++ b/functions/Add-DbaAgReplica.ps1
@@ -347,7 +347,7 @@ function Add-DbaAgReplica {
                                 try {
                                     $null = Grant-DbaAgPermission -SqlInstance $server -Type AvailabilityGroup -AvailabilityGroup $InputObject.Name -Permission CreateAnyDatabase -EnableException
                                 } catch {
-                                    Stop-Function -Message "Failure" -ErrorRecord $_
+                                    Stop-Function -Message "Failure granting CreateAnyDatabase permission to the availability group" -ErrorRecord $_
                                 }
                             }
                         }
@@ -355,7 +355,7 @@ function Add-DbaAgReplica {
                             try {
                                 $null = Grant-DbaAgPermission -SqlInstance $server -Type Endpoint -Login $serviceAccount -Permission Connect -EnableException
                             } catch {
-                                Stop-Function -Message "Failure" -ErrorRecord $_
+                                Stop-Function -Message "Failure granting Connect permission for the endpoint to service account $serviceAccount" -ErrorRecord $_
                             }
                         }
                     }

--- a/functions/Grant-DbaAgPermission.ps1
+++ b/functions/Grant-DbaAgPermission.ps1
@@ -180,7 +180,7 @@ function Grant-DbaAgPermission {
                                 Status       = "Success"
                             }
                         } catch {
-                            Stop-Function -Message "Failure" -ErrorRecord $_ -Target $ag -Continue
+                            Stop-Function -Message "Failure granting $perm to $($account.Name)" -ErrorRecord $_ -Target $ag -Continue
                         }
                     }
                 }

--- a/functions/Grant-DbaAgPermission.ps1
+++ b/functions/Grant-DbaAgPermission.ps1
@@ -75,14 +75,14 @@ function Grant-DbaAgPermission {
         https://dbatools.io/Grant-DbaAgPermission
 
     .EXAMPLE
-        PS C:\> Grant-DbaAgPermission -SqlInstance sql2017a -Type AvailabilityGroup -AvailabilityGroup SharePoint -Login ad\spservice -Permission CreateAnyDatabase
+        PS C:\> Grant-DbaAgPermission -SqlInstance sql2017a -Type AvailabilityGroup -AvailabilityGroup SharePoint -Permission CreateAnyDatabase
 
-        Adds CreateAnyDatabase permissions to ad\spservice on the SharePoint availability group on sql2017a. Does not prompt for confirmation.
+        Adds CreateAnyDatabase permissions to the SharePoint availability group on sql2017a. Does not prompt for confirmation.
 
     .EXAMPLE
-        PS C:\> Grant-DbaAgPermission -SqlInstance sql2017a -Type AvailabilityGroup -AvailabilityGroup ag1, ag2 -Login ad\spservice -Permission CreateAnyDatabase -Confirm
+        PS C:\> Grant-DbaAgPermission -SqlInstance sql2017a -Type AvailabilityGroup -AvailabilityGroup ag1, ag2 -Permission CreateAnyDatabase -Confirm
 
-        Adds CreateAnyDatabase permissions to ad\spservice on the ag1 and ag2 availability groups on sql2017a. Prompts for confirmation.
+        Adds CreateAnyDatabase permissions to the ag1 and ag2 availability groups on sql2017a. Prompts for confirmation.
 
     .EXAMPLE
         PS C:\> Get-DbaLogin -SqlInstance sql2017a | Out-GridView -Passthru | Grant-DbaAgPermission -Type EndPoint
@@ -106,12 +106,12 @@ function Grant-DbaAgPermission {
     )
     process {
         if (Test-Bound -Not SqlInstance, InputObject) {
-            Stop-Function -Message "You must supply either -SqlInstance or an Input Object"\
+            Stop-Function -Message "You must supply either -SqlInstance or an Input Object"
             return
         }
 
-        if ($SqlInstance -and -not $Login -and -not $AvailabilityGroup) {
-            Stop-Function -Message "You must specify one or more logins when using the SqlInstance parameter."
+        if ($Type -contains "Endpoint" -and $SqlInstance -and -not $Login) {
+            Stop-Function -Message "You must specify one or more logins when using the Endpoint type together with the SqlInstance parameter."
             return
         }
 

--- a/functions/Grant-DbaAgPermission.ps1
+++ b/functions/Grant-DbaAgPermission.ps1
@@ -132,7 +132,7 @@ function Grant-DbaAgPermission {
                         $server.GrantAvailabilityGroupCreateDatabasePrivilege($ag)
                         $server.Alter()
                     } catch {
-                        Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance
+                        Stop-Function -Message "Failure executing GrantAvailabilityGroupCreateDatabasePrivilege for Availability Group $ag" -ErrorRecord $_ -Target $instance
                         return
                     }
                 }
@@ -144,7 +144,7 @@ function Grant-DbaAgPermission {
                         try {
                             $InputObject += New-DbaLogin -SqlInstance $server -Login $account -EnableException
                         } catch {
-                            Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance
+                            Stop-Function -Message "Failure creating login $account" -ErrorRecord $_ -Target $instance
                             return
                         }
                     }
@@ -180,7 +180,7 @@ function Grant-DbaAgPermission {
                                 Status       = "Success"
                             }
                         } catch {
-                            Stop-Function -Message "Failure granting $perm to $($account.Name)" -ErrorRecord $_ -Target $ag -Continue
+                            Stop-Function -Message "Failure granting $perm on endpoint to $($account.Name)" -ErrorRecord $_ -Target $account -Continue
                         }
                     }
                 }
@@ -207,7 +207,7 @@ function Grant-DbaAgPermission {
                                     Status       = "Success"
                                 }
                             } catch {
-                                Stop-Function -Message "Failure" -ErrorRecord $_ -Target $ag -Continue
+                                Stop-Function -Message "Failure granting $perm on availability group $($ag.Name) to $($account.Name)" -ErrorRecord $_ -Target $ag -Continue
                             }
                         }
                     }

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -625,6 +625,20 @@ function New-DbaAvailabilityGroup {
 
         $wait = 0
 
+        # This can not be moved to Add-DbaAgReplica, as the AG has to be existing to grant this permission
+        if ($SeedingMode -eq "Automatic") {
+            if ($Pscmdlet.ShouldProcess($second.Name, "Granting CreateAnyDatabase permission to the availability group on every replica")) {
+                try {
+                    $null = Grant-DbaAgPermission -SqlInstance $server -Type AvailabilityGroup -AvailabilityGroup $Name -Permission CreateAnyDatabase -EnableException
+                    foreach ($second in $secondaries) {
+                        $null = Grant-DbaAgPermission -SqlInstance $second -Type AvailabilityGroup -AvailabilityGroup $Name -Permission CreateAnyDatabase -EnableException
+                    }
+                } catch {
+                    Stop-Function -Message "Failure" -ErrorRecord $_
+                }
+            }
+        }
+
         # Add databases
         Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Adding databases"
         if ($Database) {


### PR DESCRIPTION
Fixes some issues introduced or not solved by #8181 and #8182.

Mainly moved the grants to a position where the objects are already created.

Also changed Grant-DbaAgPermission as CreateAnyDatabase is granted to the AG and not a specific Login (Or am I wrong? But we only use "$server.GrantAvailabilityGroupCreateDatabasePrivilege($ag)").