### PR TITLE
Find-DbaInstance - Add SqlInstance to default output

### DIFF
--- a/xml/dbatools.Format.ps1xml
+++ b/xml/dbatools.Format.ps1xml
@@ -501,6 +501,7 @@
                     <TableColumnHeader/>
                     <TableColumnHeader/>
                     <TableColumnHeader/>
+                    <TableColumnHeader/>
                 </TableHeaders>
                 <TableRowEntries>
                     <TableRowEntry>
@@ -510,6 +511,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>InstanceName</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>SqlInstance</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Port</PropertyName>


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8187 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

As most of the commands output ComputerName, InstanceName and SqlInstance as the first three properties, Find-DbaInstance should do that as well.

![image](https://user-images.githubusercontent.com/66946165/154915889-20516e52-5e99-4aaa-b6bc-c495aeece27f.png)

