### PR TITLE
New-DbaCredential - Able to create without password

### DIFF
--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -64,7 +64,7 @@ function New-DbaCredential {
     .EXAMPLE
         PS C:\> New-DbaCredential -SqlInstance Server1 -Identity "MyIdentity"
 
-        It will create a credential with identity value "MyIdentity" and same name without a passowrd on server1 if it does not exist.
+        It will create a credential with identity value "MyIdentity" and same name but without a passowrd on server1 if it does not exist.
 
     .EXAMPLE
         PS C:\> $params = @{

--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -174,9 +174,9 @@ function New-DbaCredential {
                         $credential.MappedClassType = $mappedClass
                         $credential.ProviderName = $ProviderName
                         if ($SecurePassword) {
-                            $credential.Create($Identity, $SecurePassword)
+                            $credential.Create($cred, $SecurePassword)
                         } else {
-                            $credential.Create($Identity)
+                            $credential.Create($cred)
                         }
 
                         Add-Member -Force -InputObject $credential -MemberType NoteProperty -Name ComputerName -value $server.ComputerName

--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -59,12 +59,12 @@ function New-DbaCredential {
     .EXAMPLE
         PS C:\> New-DbaCredential -SqlInstance Server1 -Name MyCredential -Identity "ad\user" -SecurePassword (ConvertTo-SecureString 'myStr0ngPwd' -AsPlainText -Force)
 
-        It will create a credential named "MyCredential" that as "ad\user" as identity and a passowrd on server1 if it does not exist.
+        It will create a credential named "MyCredential" that as "ad\user" as identity and a password on server1 if it does not exist.
 
     .EXAMPLE
         PS C:\> New-DbaCredential -SqlInstance Server1 -Identity "MyIdentity"
 
-        It will create a credential with identity value "MyIdentity" and same name but without a passowrd on server1 if it does not exist.
+        It will create a credential with identity value "MyIdentity" and same name but without a password on server1 if it does not exist.
 
     .EXAMPLE
         PS C:\> $params = @{

--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -57,14 +57,14 @@ function New-DbaCredential {
         https://dbatools.io/New-DbaCredential
 
     .EXAMPLE
-        PS C:\> New-DbaCredential -SqlInstance Server1
+        PS C:\> New-DbaCredential -SqlInstance Server1 -Name MyCredential -Identity "ad\user" -SecurePassword (ConvertTo-SecureString 'myStr0ngPwd' -AsPlainText -Force)
 
-        You will be prompted to securely enter your password, then a credential will be created in the master database on server1 if it does not exist.
+        It will create a credential named "MyCredential" that as "ad\user" as identity and a passowrd on server1 if it does not exist.
 
     .EXAMPLE
-        PS C:\> New-DbaCredential -SqlInstance Server1 -Confirm:$false
+        PS C:\> New-DbaCredential -SqlInstance Server1 -Identity "MyIdentity"
 
-        Suppresses all prompts to install but prompts to securely enter your password and creates a credential on Server1.
+        It will create a credential with identity value "MyIdentity" and same name without a passowrd on server1 if it does not exist.
 
     .EXAMPLE
         PS C:\> $params = @{
@@ -105,7 +105,7 @@ function New-DbaCredential {
         [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [object]$Name = $Identity,
+        [string]$Name = $Identity,
         [parameter(Mandatory)]
         [Alias("CredentialIdentity")]
         [string]$Identity,

--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -94,12 +94,11 @@ function New-DbaCredential {
         >>SqlInstance = "server1"
         >>Name = "https://<azure storage account name>.blob.core.windows.net/<blob container>"
         >>Identity = "Managed Identity"
-        >>NoPassword = $true
         >>}
         PS C:\> New-DbaCredential @managedIdentityParams
 
         Create a credential on Server1 using a Managed Identity for Backup To URL. The Name is the full URI for the blob container that will be the backup target.
-        As no password is needed in this case, we use the NoPassword parameter.
+        As no password is needed in this case, we just don't pass the -SecurePassword parameter.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Medium")]
     param (

--- a/tests/New-DbaCredential.Tests.ps1
+++ b/tests/New-DbaCredential.Tests.ps1
@@ -6,7 +6,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Identity', 'SecurePassword', 'NoPassword', 'MappedClassType', 'ProviderName', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Identity', 'SecurePassword', 'MappedClassType', 'ProviderName', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -58,7 +58,6 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
                 SqlInstance = $script:instance2
                 Name = "https://mystorageaccount.blob.core.windows.net/mycontainer"
                 Identity = 'Managed Identity'
-                NoPassword = $true
             }
             $results = New-DbaCredential @credentialParams
             $results.Name | Should Be "https://mystorageaccount.blob.core.windows.net/mycontainer"

--- a/tests/New-DbaCredential.Tests.ps1
+++ b/tests/New-DbaCredential.Tests.ps1
@@ -6,7 +6,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Identity', 'SecurePassword', '$NoPassword', 'MappedClassType', 'ProviderName', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Identity', 'SecurePassword', 'NoPassword', 'MappedClassType', 'ProviderName', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -60,7 +60,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
                 Identity = 'Managed Identity'
                 NoPassword = $true
             }
-            $results = New-DbaCredential $credentialParams
+            $results = New-DbaCredential @credentialParams
             $results.Name | Should Be "https://mystorageaccount.blob.core.windows.net/mycontainer"
             $results.Identity | Should Be "Managed Identity"
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Add support to Credentials without password.

Also removed the arrays from the parameters. The `-Name` of the credential is unique, so even if we passed to different `-Identity` only the last one will last.

### Approach
<!-- How does this change solve that purpose -->
I have removed the `Read-Host` that asked for a password.
Currently, if no password is passed, the credential is created anyway. The verbose message will mention that.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
``` powershell
$credentialParams = @{
    SqlInstance = "localhost"
    Name =  "https://mystorageaccount.blob.core.windows.net/mycontainer"
    Identity = 'Managed Identity'
    Force = $true
}

New-DbaCredential @credentialParams
```

### Screenshots
![image](https://user-images.githubusercontent.com/19521315/155127453-94493206-8c80-4854-a7e8-8fb26c3f8520.png)
