### PR TITLE
Invoke-DbaQuery, introduce noexec

### DIFF
--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -61,6 +61,10 @@ function Invoke-DbaQuery {
         Specifies the type of command represented by the query string. Valid options for this parameter are 'Text', 'TableDirect', and 'StoredProcedure'.
         Default is 'Text'. Further information: https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.commandtype
 
+    .PARAMETER NoExec
+        Use this switch to prepend SET NOEXEC ON and append SET NOEXEC OFF to each statement, useful for checking query formal errors
+
+
     .NOTES
         Tags: Database, Query, Utility
         Author: Friedrich Weinmann (@FredWeinmann)
@@ -176,6 +180,7 @@ function Invoke-DbaQuery {
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
         [switch]$ReadOnly,
+        [switch]$NoExec,
         [switch]$EnableException
     )
 
@@ -213,7 +218,9 @@ function Invoke-DbaQuery {
         if (Test-Bound -ParameterName "Verbose") {
             $splatInvokeDbaSqlAsync["Verbose"] = $Verbose
         }
-
+        if (Test-Bound -ParameterName "NoExec") {
+            $splatInvokeDbaSqlAsync["NoExec"] = $NoExec
+        }
 
         if (Test-Bound -ParameterName "File") {
             $files = @()
@@ -349,6 +356,7 @@ function Invoke-DbaQuery {
             Stop-Function -Category InvalidArgument -Message "Please provide either SqlInstance or InputObject"
             return
         }
+
 
         foreach ($db in $InputObject) {
             if (!$db.IsAccessible) {

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -184,7 +184,7 @@ function Invoke-DbaAsync {
         foreach ($piece in $Pieces) {
             $runningStatement = $piece
             if ($NoExec) {
-                $runningStatement = "SET NOEXEC ON; " + $piece + " SET NOEXEC OFF;"
+                $runningStatement = "SET NOEXEC ON; " + $piece + " ;SET NOEXEC OFF;"
             }
             $cmd = New-Object Microsoft.Data.SqlClient.SqlCommand($runningStatement, $conn)
             $cmd.CommandType = $CommandType

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -31,9 +31,11 @@ function Invoke-DbaAsync {
         .PARAMETER AppendServerInstance
             If this switch is enabled, the SQL Server instance will be appended to PSObject and DataRow output.
 
-
         .PARAMETER MessagesToOutput
             Use this switch to have on the output stream messages too (e.g. PRINT statements). Output will hold the resultset too. See examples for detail
+
+        .PARAMETER NoExec
+            Use this switch to prepend SET NOEXEC ON and append SET NOEXEC OFF to each statement
 
         .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -68,6 +70,9 @@ function Invoke-DbaAsync {
 
         [switch]
         $MessagesToOutput,
+
+        [switch]
+        $NoExec,
 
         [switch]$EnableException
     )
@@ -177,7 +182,11 @@ function Invoke-DbaAsync {
         # Only execute non-empty statements
         $Pieces = $Pieces | Where-Object { $_.Trim().Length -gt 0 }
         foreach ($piece in $Pieces) {
-            $cmd = New-Object Microsoft.Data.SqlClient.SqlCommand($piece, $conn)
+            $runningStatement = $piece
+            if ($NoExec) {
+                $runningStatement = "SET NOEXEC ON; " + $piece + " SET NOEXEC OFF;"
+            }
+            $cmd = New-Object Microsoft.Data.SqlClient.SqlCommand($runningStatement, $conn)
             $cmd.CommandType = $CommandType
             $cmd.CommandTimeout = $QueryTimeout
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8158 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [x] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Support NOEXEC "out of the box"

### Approach
In order to keep the Verbose stream unlittered/untouched by Confirm/Whatif, a new switch needed to be added.
See the new tests to see what it can/should be useful for, albeit @lowlydba can chime in and request some changes.
So let's see if everyone agrees on the "interface" before merging  ^_^
