### PR TITLE
Get-DbaUserPermission - Exclude non-accessible databases

### DIFF
--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -204,15 +204,19 @@ function Get-DbaUserPermission {
             $tempdb = $server.Databases['tempdb']
 
             if ($Database) {
-                $dbs = $dbs | Where-Object { $Database -contains $_.Name }
+                $dbs = $dbs | Where-Object { $Database -contains $_.Name -and $_.IsAccessible -eq $true }
             }
 
             if ($ExcludeDatabase) {
-                $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
+                $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase -and $_.IsAccessible -eq $true
             }
 
             if ($ExcludeSystemDatabase) {
-                $dbs = $dbs | Where-Object IsSystemObject -eq $false
+                $dbs = $dbs | Where-Object IsSystemObject -eq $false -and IsAccessible -eq $true
+            }
+
+            if ($null -eq $Database) {
+                Stop-Function -Message "Failure: Database is not accessible." -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             #reset $serverDT

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -200,23 +200,23 @@ function Get-DbaUserPermission {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            $dbs = $server.Databases
+            $dbs = $server.Databases | Where-Object { $_.IsAccessible -eq $true }
             $tempdb = $server.Databases['tempdb']
 
             if ($Database) {
-                $dbs = $dbs | Where-Object { $Database -contains $_.Name -and $_.IsAccessible -eq $true }
+                $dbs = $dbs | Where-Object { $Database -contains $_.Name }
+
+                if ($null -eq $dbs) {
+                    Write-Message -Message "Database is not available!" -Level Warning
+                }
             }
 
             if ($ExcludeDatabase) {
-                $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase -and $_.IsAccessible -eq $true
+                $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
             }
 
             if ($ExcludeSystemDatabase) {
-                $dbs = $dbs | Where-Object IsSystemObject -eq $false -and IsAccessible -eq $true
-            }
-
-            if ($null -eq $Database) {
-                Stop-Function -Message "Failure: No accessible databases selected." -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                $dbs = $dbs | Where-Object IsSystemObject -eq $false
             }
 
             #reset $serverDT

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -200,7 +200,7 @@ function Get-DbaUserPermission {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            $dbs = $server.Databases | Where-Object { $_.IsAccessible -eq $true }
+            $dbs = $server.Databases
             $tempdb = $server.Databases['tempdb']
 
             if ($Database) {

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -205,10 +205,6 @@ function Get-DbaUserPermission {
 
             if ($Database) {
                 $dbs = $dbs | Where-Object { $Database -contains $_.Name }
-
-                if ($null -eq $dbs) {
-                    Write-Message -Message "Database is not available!" -Level Warning
-                }
             }
 
             if ($ExcludeDatabase) {
@@ -225,7 +221,12 @@ function Get-DbaUserPermission {
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $db on $instance"
 
-                $db.ExecuteNonQuery($endSQL)
+                try {
+                    $db.ExecuteNonQuery($endSQL)
+                } catch {
+                    # here to avoid empty catch
+                    $null = 1
+                } # this will fail if the database is not accessible (i.e. restoring etc.)
 
                 if ($db.IsAccessible -eq $false) {
                     Stop-Function -Message "The database $db is not accessible" -Continue

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -216,7 +216,7 @@ function Get-DbaUserPermission {
             }
 
             if ($null -eq $Database) {
-                Stop-Function -Message "Failure: Database is not accessible." -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure: No accessible databases selected." -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             #reset $serverDT


### PR DESCRIPTION
If someone (me) is going to query all the servers and all the databases indiscriminately then maybe we should proactively ignore databases that are inaccessible.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Get-DbaUserPermission throws errors when attempting to get permissions for a database that is not online (i.e. restoring etc.) This change will ensure the function ignores any databases where IsAccessible is False.

### Approach
<!-- How does this change solve that purpose -->
Added a filter to the Where-Object statement when populating the $dbs array.

