### PR TITLE
Add DatabaseID to the return object for backup commands

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -756,6 +756,7 @@ function Backup-DbaDatabase {
                             $HeaderInfo | Add-Member -Type NoteProperty -Name BackupFolder -Value $pathresult
                             $HeaderInfo | Add-Member -Type NoteProperty -Name BackupPath -Value ($FinalBackupPath | Sort-Object -Unique)
                             $HeaderInfo | Add-Member -Type NoteProperty -Name DatabaseName -Value $dbName
+                            $HeaderInfo | Add-Member -Type NoteProperty -Name DatabaseId -Value $db.ID
                             $HeaderInfo | Add-Member -Type NoteProperty -Name Notes -Value ($failures -join (','))
                             $HeaderInfo | Add-Member -Type NoteProperty -Name Script -Value $script
                             $HeaderInfo | Add-Member -Type NoteProperty -Name Verified -Value $Verified

--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -213,6 +213,7 @@ function Backup-DbaDbCertificate {
                         InstanceName   = $server.ServiceName
                         SqlInstance    = $server.DomainInstanceName
                         Database       = $db.Name
+                        DatabaseID     = $db.ID
                         Certificate    = $certName
                         Path           = $exportPathCert
                         Key            = $exportPathKey
@@ -235,6 +236,7 @@ function Backup-DbaDbCertificate {
                         InstanceName   = $server.ServiceName
                         SqlInstance    = $server.DomainInstanceName
                         Database       = $db.Name
+                        DatabaseID     = $db.ID
                         Certificate    = $certName
                         Path           = $exportPathCert
                         Key            = $exportPathKey

--- a/functions/Backup-DbaDbMasterKey.ps1
+++ b/functions/Backup-DbaDbMasterKey.ps1
@@ -164,6 +164,7 @@ function Backup-DbaDbMasterKey {
                 Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                 Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name Database -value $dbName
+                Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name DatabaseID -value $db.ID
                 Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name Filename -value $fullKeyName
                 Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name Status -value $status
 

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -65,6 +65,9 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $results.DatabaseName.Count | Should -Be 1
             $results.BackupComplete | Should -Be $true
         }
+        It "Database ID should be returned" {
+            $results.DatabaseID | Should -Be (Get-DbaDatabase -SqlInstance $script:instance1 -Database master).ID
+        }
     }
 
     Context "Database should backup 2 databases" {
@@ -152,7 +155,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
     Context "Should stripe if multiple backupfolders specified" {
         $backupPaths = "$DestBackupDir\stripe1", "$DestBackupDir\stripe2", "$DestBackupDir\stripe3"
-        $null = New-item -Path $backupPaths -ItemType Directory
+        $null = New-Item -Path $backupPaths -ItemType Directory
 
 
         $results = Backup-DbaDatabase -SqlInstance $script:instance1 -Database master -BackupDirectory $backupPaths
@@ -319,7 +322,7 @@ go
     }
 
     Context "Test Backup templating" {
-        $results = Backup-DbaDatabase -SqlInstance $script:instance1 -Database master,msdb -BackupDirectory $DestBackupDir\dbname\instancename\backuptype\  -BackupFileName dbname-backuptype.bak -ReplaceInName -BuildPath
+        $results = Backup-DbaDatabase -SqlInstance $script:instance1 -Database master, msdb -BackupDirectory $DestBackupDir\dbname\instancename\backuptype\  -BackupFileName dbname-backuptype.bak -ReplaceInName -BuildPath
         It "Should have replaced the markers" {
             $results[0].BackupPath | Should -BeLike "$DestBackupDir\master\$(($script:instance1).split('\')[1])\Full\master-Full.bak"
             $results[1].BackupPath | Should -BeLike "$DestBackupDir\msdb\$(($script:instance1).split('\')[1])\Full\msdb-Full.bak"

--- a/tests/Backup-DbaDbCertificate.Tests.ps1
+++ b/tests/Backup-DbaDbCertificate.Tests.ps1
@@ -37,6 +37,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $null = Remove-Item -Path $results.Path -ErrorAction SilentlyContinue -Confirm:$false
             $results.Certificate | Should -Be $cert.Name
             $results.Status -match "Success"
+            $results.DatabaseID | Should -Be (Get-DbaDatabase -SqlInstance $script:instance1 -Database $db1Name).ID
         }
 
         It "warns the caller if the cert cannot be found" {

--- a/tests/Backup-DbaDbMasterKey.Tests.ps1
+++ b/tests/Backup-DbaDbMasterKey.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Credential', 'Database', 'ExcludeDatabase', 'SecurePassword', 'Path', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -30,6 +30,10 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It "backs up the db cert" {
             $results.Database -eq 'tempdb'
             $results.Status -eq "Success"
+        }
+
+        It "Database ID should be returned" {
+            $results.DatabaseID | Should -Be (Get-DbaDatabase -SqlInstance $script:instance1 -Database tempdb).ID
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, related to #8183 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Minor changes to include the DatabaseID as part of the return object for the relevant backup commands. This is part 2 of a series of PRs related to #8183.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Minor changes added into the Pester tests.
