### PR TITLE
Issue #8208 - Query Store tests for msdb and Trace Flags

### DIFF
--- a/functions/Test-DbaDbQueryStore.ps1
+++ b/functions/Test-DbaDbQueryStore.ps1
@@ -120,7 +120,7 @@ function Test-DbaDbQueryStore {
                 }
                 'Microsoft.SqlServer.Management.Smo.Database' {
                     Write-Message -Level Verbose -Message "Processing Database through InputObject"
-                    $dbDatabases = $input | Where-Object { -not $_.IsSystemObject }
+                    $dbDatabases = $input | Where-Object { -not $ExcludeDatabase }
                 }
                 default {
                     Stop-Function -Message "InputObject is not a server or database."

--- a/functions/Test-DbaDbQueryStore.ps1
+++ b/functions/Test-DbaDbQueryStore.ps1
@@ -228,7 +228,7 @@ function Test-DbaDbQueryStore {
                 }
                 try {
                     foreach ($tf in $queryStoreTF) {
-                        if (($server.MajorVersion -gt 15 -and $tf.TraceFlag -eq 7752) -or $tf.TraceFlag -eq 7745) {
+                        if (($server.MajorVersion -lt 15 -and $tf.TraceFlag -eq 7752) -or $tf.TraceFlag -eq 7745) {
                             $tfEnabled = Get-DbaTraceFlag -SqlInstance $server -TraceFlag $tf.TraceFlag
                             [PSCustomObject]@{
                                 ComputerName     = $server.ComputerName

--- a/functions/Test-DbaDbQueryStore.ps1
+++ b/functions/Test-DbaDbQueryStore.ps1
@@ -120,7 +120,7 @@ function Test-DbaDbQueryStore {
                 }
                 'Microsoft.SqlServer.Management.Smo.Database' {
                     Write-Message -Level Verbose -Message "Processing Database through InputObject"
-                    $dbDatabases = $input | Where-Object { -not $ExcludeDatabase }
+                    $dbDatabases = $input | Where-Object { $_.Name -notin $ExcludeDatabase }
                 }
                 default {
                     Stop-Function -Message "InputObject is not a server or database."


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #8208 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`) - but it says there was no test to run
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To allow for testing of the msdb database since Query Store can be enabled on it.
To skip testing for trace flags on Azure SQL DB and testing for trace flag 7752 on 2019 and above.

### Approach
Testing to DatabaseEdition and MajorVersion of server where it applied.

### Commands to test
Test-DbaDbQueryStore -SQLInstance . -Database "msdb"

### Screenshots
![image](https://user-images.githubusercontent.com/26776763/156833942-7540af1b-e00d-4dcb-a1cc-5be3ea758375.png)

