### PR TITLE
Install-DbaInstance - Support installation of Failover Cluster Instance

### DIFF
--- a/functions/Install-DbaInstance.ps1
+++ b/functions/Install-DbaInstance.ps1
@@ -579,6 +579,15 @@ function Install-DbaInstance {
                 } catch {
                     Stop-Function -Message "Failed to read config file $ConfigurationFile" -ErrorRecord $_
                 }
+            } elseif ($Configuration.ACTION) {
+                # build minimal config if a custom ACTION is provided
+                $config = @{
+                    $mainKey = @{
+                        INSTANCENAME = $instance
+                        FEATURES     = $featureList
+                        QUIET        = "True"
+                    }
+                }
             } else {
                 # determine a default user to assign sqladmin permissions
                 if ($Credential) {

--- a/functions/Install-DbaInstance.ps1
+++ b/functions/Install-DbaInstance.ps1
@@ -58,6 +58,13 @@ function Install-DbaInstance {
         For example, to define a custom server collation you can use the following parameter:
         PS> Install-DbaInstance -Version 2017 -Configuration @{ SQLCOLLATION = 'Latin1_General_BIN' }
 
+        As long as you don't specify the item ACTION, some items are already set by the command, like SQLSYSADMINACCOUNTS or *SVCSTARTUPTYPE.
+        If you specify the item ACTION, only INSTANCENAME and FEATURES are set based on the corresponding parameters and QUIET is set to True.
+        You will have to set all other needed items for your specific ACTION.
+        But this way it is possible to use the command so install a Failover Cluster Instance or even to remove a SQL Server instance.
+
+        More information about how to install a Failover Cluster Instance can be found here: https://github.com/dataplat/dbatools/discussions/7447
+
         Full list of parameters can be found here: https://docs.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server-from-the-command-prompt#Install
 
     .PARAMETER Authentication


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Support a different ACTION than just "Install". This way, a cluster installation is supported without the need for a configuration file.

### Approach
Check for the existance of the key "ACTION" in the hashtable provided with the parameter Configuration.

### Commands to test
Will be provided later...
To see how a cluster installation is possible now: https://github.com/dataplat/dbatools/discussions/7447

### Screenshots
Will be provided later...
