### PR TITLE
Set-DbaNetworkConfiguration - Add parameter IpAddress

### DIFF
--- a/functions/Set-DbaNetworkConfiguration.ps1
+++ b/functions/Set-DbaNetworkConfiguration.ps1
@@ -97,7 +97,7 @@ function Set-DbaNetworkConfiguration {
         Does not prompt for confirmation.
 
     .EXAMPLE
-        PS C:\> Set-DbaNetworkConfiguration -SqlInstance sql2016\test -ListenOnIPAddressOnly 192.168.3.41:1433 -RestartService
+        PS C:\> Set-DbaNetworkConfiguration -SqlInstance sql2016\test -IpAddress 192.168.3.41:1433 -RestartService
 
         Ensures that the TCP/IP network protocol is enabled and configured to only listen on port 1433 of IP address 192.168.3.41.
         Restarts the service if needed.
@@ -292,12 +292,12 @@ function Set-DbaNetworkConfiguration {
     }
 
     process {
-        if ($SqlInstance -and (Test-Bound -Not -ParameterName EnableProtocol, DisableProtocol, DynamicPortForIPAll, StaticPortForIPAll, ListenOnIPAddressOnly)) {
+        if ($SqlInstance -and (Test-Bound -Not -ParameterName EnableProtocol, DisableProtocol, DynamicPortForIPAll, StaticPortForIPAll, IpAddress)) {
             Stop-Function -Message "You must choose an action if SqlInstance is used."
             return
         }
 
-        if ($SqlInstance -and (Test-Bound -ParameterName EnableProtocol, DisableProtocol, DynamicPortForIPAll, StaticPortForIPAll, ListenOnIPAddressOnly -Not -Max 1)) {
+        if ($SqlInstance -and (Test-Bound -ParameterName EnableProtocol, DisableProtocol, DynamicPortForIPAll, StaticPortForIPAll, IpAddress -Not -Max 1)) {
             Stop-Function -Message "Only one action is allowed at a time."
             return
         }

--- a/tests/Set-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Set-DbaNetworkConfiguration.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'EnableProtocol', 'DisableProtocol', 'DynamicPortForIPAll', 'StaticPortForIPAll', 'ListenOnIPAddressOnly', 'RestartService', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'EnableProtocol', 'DisableProtocol', 'DynamicPortForIPAll', 'StaticPortForIPAll', 'IpAddress', 'RestartService', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Set-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Set-DbaNetworkConfiguration.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'EnableProtocol', 'DisableProtocol', 'DynamicPortForIPAll', 'StaticPortForIPAll', 'RestartService', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'EnableProtocol', 'DisableProtocol', 'DynamicPortForIPAll', 'StaticPortForIPAll', 'ListenOnIPAddressOnly', 'RestartService', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
In addition to configure IPAll, I would like to be able to configure the instance to listen on specific IP addresses only. This could be used to have multiple instances on one maschine listening all on port 1433 but on individual ip addresses.

### Approach
I added the parameter ListenOnIPAddressOnly.

### Commands to test
```
Set-DbaNetworkConfiguration -SqlInstance sql01\sqlin01 -ListenOnIPAddressOnly 192.168.3.31:1433
```
