### PR TITLE
Invoke-ManagedComputerCommand - Fix to enable retry again

### DIFF
--- a/functions/Set-DbaNetworkConfiguration.ps1
+++ b/functions/Set-DbaNetworkConfiguration.ps1
@@ -143,9 +143,15 @@ function Set-DbaNetworkConfiguration {
             $targetConf = $args[0]
             $changes = @()
             $verbose = @()
+            $verbose += $setupVerbose
             $exception = $null
 
             try {
+                $verbose += "Starting code from Set-DbaNetworkConfiguration"
+
+                # If WMI object is empty, there are no client protocols - so we test for that to see if initialization was successful
+                $verbose += "Found $($wmi.ServerInstances.Count) instances and $($wmi.ClientProtocols.Count) client protocols inside of WMI object"
+
                 $verbose += "Getting server protocols for $($targetConf.InstanceName)"
                 $wmiServerProtocols = ($wmi.ServerInstances | Where-Object { $_.Name -eq $targetConf.InstanceName } ).ServerProtocols
 

--- a/internal/functions/Invoke-ManagedComputerCommand.ps1
+++ b/internal/functions/Invoke-ManagedComputerCommand.ps1
@@ -72,7 +72,7 @@ function Invoke-ManagedComputerCommand {
             foreach ($msg in $result.Verbose) {
                 Write-Message -Level Verbose -Message $msg
             }
-            Stop-Function -Message "Execution against $computer failed." -Target $computer -ErrorRecord $result.Exception
+            Stop-Function -Message "Execution against $computer failed." -Target $computer -ErrorRecord $result.Exception -EnableException $true
         } else {
             # The old code pattern is used or no exception was catched, so just return the result
             $result

--- a/internal/functions/Invoke-ManagedComputerCommand.ps1
+++ b/internal/functions/Invoke-ManagedComputerCommand.ps1
@@ -72,7 +72,8 @@ function Invoke-ManagedComputerCommand {
             foreach ($msg in $result.Verbose) {
                 Write-Message -Level Verbose -Message $msg
             }
-            Stop-Function -Message "Execution against $computer failed." -Target $computer -ErrorRecord $result.Exception -EnableException $true
+            Write-Message -Level Verbose -Message "Execution against $computer failed with: $($result.Exception)"
+            Stop-Function -Message "Failed." -Target $computer -ErrorRecord $result.Exception -EnableException $true
         } else {
             # The old code pattern is used or no exception was catched, so just return the result
             $result


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
When the new code pattern like in Set-DbaNetworkConfiguration, the Invoke-Command2 does not throw an exception and thus the retry dows not work.

### Approach
This is just a quick fix to enable the retry again. I will have a deeper look later and change all the scriptblocks executed with Invoke-ManagedComputerCommand to follow the new code pattern like in Set-DbaNetworkConfiguration. This way we have verbose mesages from the remote execution and can analyse issues more easily.

### Commands to test
I've seen this with this command, but only because the direct wmi call produced an empty WMI object.
```
Set-DbaNetworkConfiguration -SqlInstance SQL01\SQLINST01 -IpAddress 192.168.3.41:1433 -RestartService -Confirm:$false
```

### Screenshots
![image](https://user-images.githubusercontent.com/66946165/157859228-809429e6-a8ea-43ff-ae39-2296bf8d35cb.png)
