### PR TITLE
Get-DbaDatabase / Compare-DbaCollationSensitiveObject - Removed mandatory from value parameter

### DIFF
--- a/functions/Test-DbaDbQueryStore.ps1
+++ b/functions/Test-DbaDbQueryStore.ps1
@@ -89,6 +89,11 @@ function Test-DbaDbQueryStore {
         [object[]]$InputObject,
         [switch]$EnableException
     )
+
+    begin {
+        $ExcludeDatabase += "master", "model", "tempdb"
+    }
+
     process {
         if (Test-FunctionInterrupt) { return }
 
@@ -107,15 +112,15 @@ function Test-DbaDbQueryStore {
             switch ($inputType) {
                 'Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter' {
                     Write-Message -Level Verbose -Message "Processing DbaInstanceParameter through InputObject"
-                    $dbDatabases = Get-DbaDatabase -SqlInstance $input -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -ExcludeSystem -OnlyAccessible
+                    $dbDatabases = Get-DbaDatabase -SqlInstance $input -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -OnlyAccessible
                 }
                 'Microsoft.SqlServer.Management.Smo.Server' {
                     Write-Message -Level Verbose -Message "Processing Server through InputObject"
-                    $dbDatabases = Get-DbaDatabase -SqlInstance $input -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -ExcludeSystem -OnlyAccessible
+                    $dbDatabases = Get-DbaDatabase -SqlInstance $input -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -OnlyAccessible
                 }
                 'Microsoft.SqlServer.Management.Smo.Database' {
                     Write-Message -Level Verbose -Message "Processing Database through InputObject"
-                    $dbDatabases = $input | Where-Object { -not $_.IsSystemObject }
+                    $dbDatabases = $input | Where-Object { $_.Name -notin $ExcludeDatabase }
                 }
                 default {
                     Stop-Function -Message "InputObject is not a server or database."
@@ -127,6 +132,10 @@ function Test-DbaDbQueryStore {
                 $server = Connect-DbaInstance -SqlInstance $dbDatabases[0].Parent -SqlCredential $SqlCredential -MinimumVersion 13
             } catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            if ($server.DatabaseEngineType -eq "SqlAzureDatabase") {
+                $ExcludeDatabase += "msdb"
             }
 
             if ($Database) {
@@ -207,32 +216,36 @@ function Test-DbaDbQueryStore {
                 Stop-Function -Message "Unable to get Query Store data $server" -Target $server -ErrorRecord $_
             }
 
-            # Trace flags
-            $queryStoreTF = [PSCustomObject]@{
-                TraceFlag     = '7745'
-                Justification = 'SQL Server will not wait to write Query Store data to disk on shutdown\failover (can cause lose of Query Store data).'
-            },
-            [PSCustomObject]@{
-                TraceFlag     = '7752'
-                Justification = 'Load Query Store data asynchronously on SQL Server startup.'
-            }
-            try {
-                foreach ($tf in $queryStoreTF) {
-                    $tfEnabled = Get-DbaTraceFlag -SqlInstance $server -TraceFlag $tf.TraceFlag
-                    [PSCustomObject]@{
-                        ComputerName     = $server.ComputerName
-                        InstanceName     = $server.DbaInstanceName
-                        SqlInstance      = $server.Name
-                        Name             = ('Trace Flag {0} Enabled' -f $tf.TraceFlag)
-                        Value            = if ($tfEnabled) { 'Enabled' } else { 'Disabled' }
-                        RecommendedValue = $tf.TraceFlag
-                        IsBestPractice   = ($tfEnabled.TraceFlag -eq $tf.TraceFlag)
-                        Justification    = $tf.Justification
-                    }
-                    $tfEnabled = $null
+            if ($server.DatabaseEngineType -ne "SqlAzureDatabase") {
+                # Trace flags
+                $queryStoreTF = [PSCustomObject]@{
+                    TraceFlag     = '7745'
+                    Justification = 'SQL Server will not wait to write Query Store data to disk on shutdown\failover (can cause lose of Query Store data).'
+                },
+                [PSCustomObject]@{
+                    TraceFlag     = '7752'
+                    Justification = 'Load Query Store data asynchronously on SQL Server startup.'
                 }
-            } catch {
-                Stop-Function -Message "Unable to get Trace Flag data $server" -Target $server -ErrorRecord $_
+                try {
+                    foreach ($tf in $queryStoreTF) {
+                        if (($server.MajorVersion -lt 15 -and $tf.TraceFlag -eq 7752) -or $tf.TraceFlag -eq 7745) {
+                            $tfEnabled = Get-DbaTraceFlag -SqlInstance $server -TraceFlag $tf.TraceFlag
+                            [PSCustomObject]@{
+                                ComputerName     = $server.ComputerName
+                                InstanceName     = $server.DbaInstanceName
+                                SqlInstance      = $server.Name
+                                Name             = ('Trace Flag {0} Enabled' -f $tf.TraceFlag)
+                                Value            = if ($tfEnabled) { 'Enabled' } else { 'Disabled' }
+                                RecommendedValue = $tf.TraceFlag
+                                IsBestPractice   = ($tfEnabled.TraceFlag -eq $tf.TraceFlag)
+                                Justification    = $tf.Justification
+                            }
+                            $tfEnabled = $null
+                        }
+                    }
+                } catch {
+                    Stop-Function -Message "Unable to get Trace Flag data $server" -Target $server -ErrorRecord $_
+                }
             }
         }
     }

--- a/internal/functions/Compare-DbaCollationSensitiveObject.ps1
+++ b/internal/functions/Compare-DbaCollationSensitiveObject.ps1
@@ -67,7 +67,6 @@ Function Compare-DbaCollationSensitiveObject {
         [switch]$Eq,
         [parameter(Mandatory, ParameterSetName = 'Ne')]
         [switch]$Ne,
-        [parameter(Mandatory)]
         [object]$Value,
         [parameter(Mandatory)]
         [String]$Collation)

--- a/tests/Get-DbaDatabase.Tests.ps1
+++ b/tests/Get-DbaDatabase.Tests.ps1
@@ -45,7 +45,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $dbname1 = "dbatoolsci_Backup_$random"
         $dbname2 = "dbatoolsci_NoBackup_$random"
         New-DbaDatabase -SqlInstance $script:instance1 -name $dbname1 ,$dbname2
-        $dbname1 | Backup-DbaDatabase -Type Full -FilePath NUL
+        $NULL = Backup-DbaDatabase -SqlInstance . -Type Full -FilePath nul -Database $dbname1  
     }
     AfterAll {
         $null = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname1, $dbname2 | Remove-DbaDatabase -Confirm:$false

--- a/tests/Get-DbaDatabase.Tests.ps1
+++ b/tests/Get-DbaDatabase.Tests.ps1
@@ -58,7 +58,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
         $results = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname2 -NoFullBackup
         It "Should report 1 database with no full backup" {
-            ($results | Where-Object Database -match "master").Count | Should Be 1
+            ($results).Count | Should Be 1
         }
     }
 }

--- a/tests/Get-DbaDatabase.Tests.ps1
+++ b/tests/Get-DbaDatabase.Tests.ps1
@@ -35,6 +35,32 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.IsAccessible | Should Be $true
         }
     }
+    
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+    BeforeAll {
+
+        $random = Get-Random
+        $dbname1 = "dbatoolsci_Backup_$random"
+        $dbname2 = "dbatoolsci_NoBackup_$random"
+        New-DbaDatabase -SqlInstance $script:instance1 -name $dbname1 ,$dbname2
+        $dbname1 | Backup-DbaDatabase -Type Full -FilePath NUL
+    }
+    AfterAll {
+        $null = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname1, $dbname2 | Remove-DbaDatabase -Confirm:$false
+    }
+
+    Context "Results return if no backup" {
+        $results = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname1 -NoFullBackup
+        It "Should not report as database has full backup" {
+            ($results).Count | Should Be 0
+        }
+        $results = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname2 -NoFullBackup
+        It "Should report 1 database with no full backup" {
+            ($results | Where-Object Database -match "master").Count | Should Be 1
+        }
+    }
 }
 
 Describe "$commandname Unit Tests" -Tags "UnitTests", Get-DBADatabase {

--- a/tests/Get-DbaDatabase.Tests.ps1
+++ b/tests/Get-DbaDatabase.Tests.ps1
@@ -45,7 +45,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $dbname1 = "dbatoolsci_Backup_$random"
         $dbname2 = "dbatoolsci_NoBackup_$random"
         New-DbaDatabase -SqlInstance $script:instance1 -name $dbname1 ,$dbname2
-        $NULL = Backup-DbaDatabase -SqlInstance . -Type Full -FilePath nul -Database $dbname1  
+        $NULL = Backup-DbaDatabase -SqlInstance $script:instance1 -Type Full -FilePath nul -Database $dbname1  
     }
     AfterAll {
         $null = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname1, $dbname2 | Remove-DbaDatabase -Confirm:$false

--- a/tests/Get-DbaDatabase.Tests.ps1
+++ b/tests/Get-DbaDatabase.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'ExcludeUser', 'ExcludeSystem', 'Owner', 'Encrypted', 'Status', 'Access', 'RecoveryModel', 'NoFullBackup', 'NoFullBackupSince', 'NoLogBackup', 'NoLogBackupSince', 'EnableException', 'IncludeLastUsed', 'OnlyAccessible'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -35,7 +35,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.IsAccessible | Should Be $true
         }
     }
-    
+
 }
 
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
@@ -44,8 +44,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $random = Get-Random
         $dbname1 = "dbatoolsci_Backup_$random"
         $dbname2 = "dbatoolsci_NoBackup_$random"
-        New-DbaDatabase -SqlInstance $script:instance1 -name $dbname1 ,$dbname2
-        $NULL = Backup-DbaDatabase -SqlInstance $script:instance1 -Type Full -FilePath nul -Database $dbname1  
+        New-DbaDatabase -SqlInstance $script:instance1 -name $dbname1 , $dbname2
+        $NULL = Backup-DbaDatabase -SqlInstance $script:instance1 -Type Full -FilePath nul -Database $dbname1
     }
     AfterAll {
         $null = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname1, $dbname2 | Remove-DbaDatabase -Confirm:$false


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #8225  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Prevent null error when no full backups returned

### Approach
Compare-DbaCollationSensitiveObject now allows null and returns a result set. I think this is a valid approach over testing for $null before calling the function as you still need the results of the null comparison.

Function is not used anywhere else making this a safe change

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
