### PR TITLE
Copy-DbaDbMail - support for getting mail server passwords - fixes #7824

### DIFF
--- a/functions/Copy-DbaDbMail.ps1
+++ b/functions/Copy-DbaDbMail.ps1
@@ -264,6 +264,13 @@ function Copy-DbaDbMail {
             $sourceMailServers = $sourceServer.Mail.Accounts.MailServers
             $destMailServers = $destServer.Mail.Accounts.MailServers
 
+            Write-Message -Message "Getting mail server credentials." -Level Verbose
+            $credentialAccounts = @($sourceServer.Query("SELECT credentials.name AS credential_name, sysmail_server.account_id FROM sys.credentials
+            JOIN msdb.dbo.sysmail_server ON credentials.credential_id = sysmail_server.credential_id"))
+            if ($credentialAccounts.Count -gt 0) {
+                $decryptedCredentials = Get-DecryptedObject -SqlInstance $sourceServer -Type Credential | Where-Object { $_.Name -in $credentialAccounts.credential_name }
+            }
+
             Write-Message -Message "Migrating mail servers." -Level Verbose
             foreach ($mailServer in $sourceMailServers) {
                 $mailServerName = $mailServer.name
@@ -308,6 +315,16 @@ function Copy-DbaDbMail {
                         Write-Message -Message "Copying mail server $mailServerName." -Level Verbose
                         $sql = $mailServer.Script() | Out-String
                         $sql = $sql -replace "(?<=@account_name=N'[\d\w\s']*)$sourceRegEx(?=[\d\w\s']*',)", $destinstance
+                        $credentialName = ($credentialAccounts | Where-Object {$_.account_id -eq $mailServer.Parent.ID }).credential_name
+                        if ($credentialName) {
+                            $decryptedCred = $decryptedCredentials | Where-Object { $_.Name -eq $credentialName }
+                            if ($decryptedCred) {
+                                $password = $decryptedCred.Password.Replace("'", "''")
+                                $sql = $sql -replace "@password=N''", "@password=N'$($password)'"
+                            } else {
+                                Write-Message -Level Warning -Message "Failed to get mail server password, it will need to be entered manually on the destination."
+                            }
+                        }
                         Write-Message -Message $sql -Level Debug
                         $destServer.Query($sql) | Out-Null
                         $copyMailServerStatus.Status = "Successful"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #7824  )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Copies over basic authentic mail server passwords when possible, warns the user otherwise.

### Approach
First, the collection of credential_name and account_id is fetched from the source server. Credential_name (guid string) is the only unique value for credentials that is also in the Get-DecryptedObject output. Unfortunately, SMO does not expose this, so we must use a query. This is done before the foreach over MailServers, so that this call can be done once per source.
This $credentialName will be null for Windows Auth and Anonymous Auth accounts, so the whole next section is skipped if this is null.
Get-DecryptedObject is then used to fetch the password from the source, using similar code as Copy-DbaCredential. This is set to run without exception, so that failure will result in falling back to the old logic of a blank password. In this case, a warning message is added to inform the user.

### Commands to test
Copy-DbaDbMail -Source SQL1 -Destination SQL2

### Learning
In Database Mail, when the use picks the Basic Authentication for a mail account, this is stored as a Credential with a new GUID as its name. The email user/password are stored in the credential’s identity and secret. The credential_id is stored in msdb.dbo.sysmail_server which has a 1:1 relationship with msdb.dbo.sysmail_account.
I considered two ways to fix this. 
1) Get the decrypted value from the source with Get-DecryptedObject and insert it into the text that comes from the SMO MailServer.Script() command that is already being used.
2) Run a Copy-DbaCredential and then update the msdb.dbo.sysmail_server.credential_id to the new credential.

Option 2 seemed worse because sysmail_server has no stored procedures available that allow linking an existing credential, so you’d have to update a system table directly.
Option 1 follows the same pattern as Copy-DbaCredential (and this PR is heavily inspired by that code) so seemed like the better idea.

I have tested this on SQL 2012, 2014, 2016, 2017, and 2019, with remote DAC on and off, and with combinations of one and multiple servers.