### PR TITLE
Set-DbaLogin: use PasswordMustChange instead of MustChange param name

### DIFF
--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -30,7 +30,7 @@ function Set-DbaLogin {
         Switch to unlock an account. This can be used in conjunction with the -SecurePassword or -Force parameters.
         The default is false.
 
-    .PARAMETER MustChange
+    .PARAMETER PasswordMustChange
         Does the user need to change his/her password. This will only be used in conjunction with the -SecurePassword parameter.
         It is required that the login have both PasswordPolicyEnforced (check_policy) and PasswordExpirationEnabled (check_expiration) enabled for the login. See the Microsoft documentation for ALTER LOGIN for more details.
         The default is false.
@@ -95,7 +95,7 @@ function Set-DbaLogin {
     .EXAMPLE
         PS C:\> $SecurePassword = ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force
         PS C:\> $cred = New-Object System.Management.Automation.PSCredential ("username", $SecurePassword)
-        PS C:\> Set-DbaLogin -SqlInstance sql1 -Login login1 -SecurePassword $cred -Unlock -MustChange
+        PS C:\> Set-DbaLogin -SqlInstance sql1 -Login login1 -SecurePassword $cred -Unlock -PasswordMustChange
 
         Set the new password for login1 using a credential, unlock the account and set the option
         that the user must change password at next logon.
@@ -178,7 +178,8 @@ function Set-DbaLogin {
         [Alias("DefaultDB")]
         [string]$DefaultDatabase,
         [switch]$Unlock,
-        [switch]$MustChange,
+        [Alias("MustChange")]
+        [switch]PasswordMustChange,
         [string]$NewName,
         [switch]$Disable,
         [switch]$Enable,
@@ -228,8 +229,8 @@ function Set-DbaLogin {
             Stop-Function -Message 'You must specify a password when using the -Unlock parameter or use the -Force parameter. See the help documentation for this command.'
         }
 
-        if ((Test-Bound MustChange) -and (Test-Bound SecurePassword -Not)) {
-            Stop-Function -Message 'You must specify a password when using the -MustChange parameter. See the command help for more details.'
+        if ((Test-Bound PasswordMustChange) -and (Test-Bound SecurePassword -Not)) {
+            Stop-Function -Message 'You must specify a password when using the -PasswordMustChange parameter. See the command help for more details.'
         }
     }
 
@@ -420,7 +421,7 @@ function Set-DbaLogin {
 
                 # Change the password after the Alter() because the must_change requires the policy settings to be enabled first.
                 if (Test-bound -ParameterName 'SecurePassword') {
-                    if (Test-Bound MustChange) {
+                    if (Test-Bound PasswordMustChange) {
                         # Validate if the check_policy and check_expiration options are enabled on the login. These are required for the must_change option for alter login.
                         if ((-not $l.PasswordPolicyEnforced) -or (-not $l.PasswordExpirationEnabled)) {
                             Stop-Function -Message "Unable to change the password and set the must_change option for $l because check_policy = $($l.PasswordPolicyEnforced) and check_expiration = $($l.PasswordExpirationEnabled). See the command help for additional information on the -MustChange parameter." -Target $l -Continue
@@ -428,11 +429,11 @@ function Set-DbaLogin {
                     }
 
                     try {
-                        $l.ChangePassword($NewSecurePassword, $Unlock, $MustChange)
+                        $l.ChangePassword($NewSecurePassword, $Unlock, PasswordMustChange)
                         $passwordChanged = $true
 
-                        if (Test-Bound MustChange) {
-                            $l.Refresh()  # necessary so that the read only property MustChangePassword is updated
+                        if (Test-Bound PasswordMustChange) {
+                            $l.Refresh()  # necessary so that the read only property PasswordMustChange is updated
                         }
                     } catch {
                         $notes += "Couldn't change password"

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -179,7 +179,7 @@ function Set-DbaLogin {
         [string]$DefaultDatabase,
         [switch]$Unlock,
         [Alias("MustChange")]
-        [switch]PasswordMustChange,
+        [switch]$PasswordMustChange,
         [string]$NewName,
         [switch]$Disable,
         [switch]$Enable,
@@ -429,7 +429,7 @@ function Set-DbaLogin {
                     }
 
                     try {
-                        $l.ChangePassword($NewSecurePassword, $Unlock, PasswordMustChange)
+                        $l.ChangePassword($NewSecurePassword, $Unlock, $PasswordMustChange)
                         $passwordChanged = $true
 
                         if (Test-Bound PasswordMustChange) {

--- a/tests/Set-DbaLogin.Tests.ps1
+++ b/tests/Set-DbaLogin.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'SecurePassword', 'DefaultDatabase', 'Unlock', 'MustChange', 'NewName', 'Disable', 'Enable', 'DenyLogin', 'GrantLogin', 'PasswordPolicyEnforced', 'PasswordExpirationEnabled', 'AddRole', 'RemoveRole', 'Force', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'SecurePassword', 'DefaultDatabase', 'Unlock', 'PasswordMustChange', 'NewName', 'Disable', 'Enable', 'DenyLogin', 'GrantLogin', 'PasswordPolicyEnforced', 'PasswordExpirationEnabled', 'AddRole', 'RemoveRole', 'Force', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
@@ -266,11 +266,11 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
             $results.IsLocked | Should -Be $false
         }
 
-        It "MustChange" {
+        It "PasswordMustChange" {
             # password is required
-            $changeResult = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -MustChange -ErrorVariable error
+            $changeResult = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -PasswordMustChange -ErrorVariable error
             $changeResult | Should -BeNullOrEmpty
-            $error.Exception | Should -Match "You must specify a password when using the -MustChange parameter"
+            $error.Exception | Should -Match "You must specify a password when using the -PasswordMustChange parameter"
 
             # ensure the policy settings are off
             $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced:$false -PasswordExpirationEnabled:$false
@@ -283,19 +283,19 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
             $changeResult.PasswordExpirationEnabled | Should Be $true
 
             # check_policy and check_expiration must be set on the login
-            $changeResult = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random", "testlogin2_$random" -MustChange -Password $password1 -ErrorVariable error
+            $changeResult = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random", "testlogin2_$random" -PasswordMustChange -Password $password1 -ErrorVariable error
             $changeResult.Count | Should -Be 1
             $changeResult.LoginName | Should -Be "testlogin2_$random"
             $error.Exception | Should -Match "Unable to change the password and set the must_change option for \[testlogin1_$random\] because check_policy = False and check_expiration = False"
 
-            $changeResult = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -MustChange -Password $password1 -PasswordPolicyEnforced -PasswordExpirationEnabled
+            $changeResult = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -PasswordMustChange -Password $password1 -PasswordPolicyEnforced -PasswordExpirationEnabled
             $changeResult.MustChangePassword | Should -Be $true
             $changeResult.PasswordChanged | Should -Be $true
             $changeResult.PasswordPolicyEnforced | Should Be $true
             $changeResult.PasswordExpirationEnabled | Should Be $true
 
             # now change the password and set the must_change
-            $changeResult = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin2_$random" -MustChange -Password $password1
+            $changeResult = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin2_$random" -PasswordMustChange -Password $password1
             $changeResult.MustChangePassword | Should -Be $true
             $changeResult.PasswordChanged | Should -Be $true
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Have `Set-DbaLogin` use `PasswordMustChange` instead of `MustChange` so that it matches the same parameter in `New-DbaLogin`.

### Approach
<!-- How does this change solve that purpose -->
Alias old param name, use one that matches existing.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
* Set-DbaLogin

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
