### PR TITLE
Get-DbaTraceFlag - fix issue with loop\piping

### DIFF
--- a/functions/Get-DbaTraceFlag.ps1
+++ b/functions/Get-DbaTraceFlag.ps1
@@ -74,8 +74,8 @@ function Get-DbaTraceFlag {
             $tflags = $server.EnumActiveGlobalTraceFlags()
 
             if ($tFlags.Rows.Count -eq 0) {
-                Write-Message -Level Output -Message "No global trace flags enabled"
-                return
+                Write-Message -Level Verbose -Message "No global trace flags enabled"
+                continue
             }
 
             if ($TraceFlag) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Running the following, it stops getting trace flags when it finds a server without any
```
Get-DbaTraceFlag -sqlinstance $servers | ft
```

### Approach
Change from return to continue in the loop
Also changed from `output` to `verbose` for the message about not finding trace flags

### Commands to test
Get-DbaTraceFlag -sqlinstance $servers | ft
