### PR TITLE
Get-DbaKbUpdate - Fix for new URL style in microsoft catalog

### DIFF
--- a/functions/Get-DbaKbUpdate.ps1
+++ b/functions/Get-DbaKbUpdate.ps1
@@ -188,7 +188,7 @@ function Get-DbaKbUpdate {
                         }
                     }
 
-                    $links = $downloaddialog | Select-String -AllMatches -Pattern "(http[s]?\://download\.windowsupdate\.com\/[^\'\""]*)" | Select-Object -Unique
+                    $links = $downloaddialog | Select-String -AllMatches -Pattern "(http[s]?\://[^/]*download\.windowsupdate\.com\/[^\'\""]*)" | Select-Object -Unique
 
                     foreach ($link in $links) {
                         $build = Get-DbaBuild -Kb "KB$kb" -WarningAction SilentlyContinue

--- a/functions/Get-DbaKbUpdate.ps1
+++ b/functions/Get-DbaKbUpdate.ps1
@@ -172,6 +172,9 @@ function Get-DbaKbUpdate {
                         Write-Message -Level Verbose -Message "Downloading detailed information for updateid=$updateid"
                         $detaildialog = Invoke-TlsWebRequest -Uri "https://www.catalog.update.microsoft.com/ScopedViewInline.aspx?updateid=$updateid" -UseBasicParsing -ErrorAction Stop
                         $description = Get-Info -Text $detaildialog -Pattern '<span id="ScopedViewHandler_desc">'
+                        if (-not $description) {
+                            Write-Message -Level Warning -Message "The response from the webserver did not include the expected information. Please try again later if you need the detailed information."
+                        }
                         $lastmodified = Get-Info -Text $detaildialog -Pattern '<span id="ScopedViewHandler_date">'
                         $size = Get-Info -Text $detaildialog -Pattern '<span id="ScopedViewHandler_size">'
                         $classification = Get-Info -Text $detaildialog -Pattern '<span id="ScopedViewHandler_labelClassification_Separator" class="labelTitle">'

--- a/functions/Get-DbaKbUpdate.ps1
+++ b/functions/Get-DbaKbUpdate.ps1
@@ -59,29 +59,37 @@ function Get-DbaKbUpdate {
     begin {
         # Wishing Microsoft offered an RSS feed. Since they don't, we are forced to parse webpages.
         function Get-Info ($Text, $Pattern) {
-            $info = $Text -Split $Pattern
-            if ($Pattern -match "labelTitle") {
-                $part = ($info[1] -Split '</span>')[1]
-                $part = $part.Replace("<div>", "")
-                ($part -Split '</div>')[0].Trim()
-            } elseif ($Pattern -match "span ") {
-                ($info[1] -Split '</span>')[0].Trim()
-            } else {
-                ($info[1] -Split ';')[0].Replace("'", "").Trim()
+            try {
+                $info = $Text -Split $Pattern
+                if ($Pattern -match "labelTitle") {
+                    $part = ($info[1] -Split '</span>')[1]
+                    $part = $part.Replace("<div>", "")
+                    ($part -Split '</div>')[0].Trim()
+                } elseif ($Pattern -match "span ") {
+                    ($info[1] -Split '</span>')[0].Trim()
+                } else {
+                    ($info[1] -Split ';')[0].Replace("'", "").Trim()
+                }
+            } catch {
+                Write-Message -Level Verbose -Message "Failed to get info with pattern '$Pattern'"
             }
         }
 
         function Get-SuperInfo ($Text, $Pattern) {
-            $info = $Text -Split $Pattern
-            if ($Pattern -match "supersededbyInfo") {
-                $part = ($info[1] -Split '<span id="ScopedViewHandler_labelSupersededUpdates_Separator" class="labelTitle">')[0]
-            } else {
-                $part = ($info[1] -Split '<div id="languageBox" style="display: none">')[0]
-            }
-            $nomarkup = ($part -replace '<[^>]+>', '').Trim() -split [Environment]::NewLine
-            foreach ($line in $nomarkup) {
-                $clean = $line.Trim()
-                if ($clean) { $clean }
+            try {
+                $info = $Text -Split $Pattern
+                if ($Pattern -match "supersededbyInfo") {
+                    $part = ($info[1] -Split '<span id="ScopedViewHandler_labelSupersededUpdates_Separator" class="labelTitle">')[0]
+                } else {
+                    $part = ($info[1] -Split '<div id="languageBox" style="display: none">')[0]
+                }
+                $nomarkup = ($part -replace '<[^>]+>', '').Trim() -split [Environment]::NewLine
+                foreach ($line in $nomarkup) {
+                    $clean = $line.Trim()
+                    if ($clean) { $clean }
+                }
+            } catch {
+                Write-Message -Level Verbose -Message "Failed to get superinfo with pattern '$Pattern'"
             }
         }
 
@@ -161,6 +169,7 @@ function Get-DbaKbUpdate {
                     }
 
                     if (-not $Simple) {
+                        Write-Message -Level Verbose -Message "Downloading detailed information for updateid=$updateid"
                         $detaildialog = Invoke-TlsWebRequest -Uri "https://www.catalog.update.microsoft.com/ScopedViewInline.aspx?updateid=$updateid" -UseBasicParsing -ErrorAction Stop
                         $description = Get-Info -Text $detaildialog -Pattern '<span id="ScopedViewHandler_desc">'
                         $lastmodified = Get-Info -Text $detaildialog -Pattern '<span id="ScopedViewHandler_date">'

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -67,9 +67,7 @@ $TestsRunGroups = @{
         'Get-DbaHelpIndex',
         'Get-DbaExternalProcess',
         # just fails too often
-        'Remove-DbaDbTableData',
-        'Get-DbaKbUpdate',
-        'Save-DbaKbUpdate'
+        'Remove-DbaDbTableData'
     )
     # do not run everywhere
     "disabled"          = @()


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8275 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

This is the new download-link for CU8 of SQL Server 2019:
https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/sqlserver2019-kb4577194-x64_a09e2537b854ae384d965e998e53ce33cdc34f16.exe

So it looks like they have added "catalog.s." in from of the URL.