### PR TITLE
Changed Instance Count Logic to handle SQL 2019 SSRS 

### DIFF
--- a/functions/Test-DbaMaxMemory.ps1
+++ b/functions/Test-DbaMaxMemory.ps1
@@ -83,7 +83,7 @@ function Test-DbaMaxMemory {
                     } else {
                         $serverService = Get-DbaService -ComputerName $instance -EnableException
                     }
-                    $instanceCount = ($serverService | Where-Object State -Like Running | Where-Object InstanceName | Group-Object InstanceName | Measure-Object Count).Count
+                    $instanceCount = ($serverService | Where-Object { ($_.State -Like 'Running') -and ($_.ServiceType -eq 'Engine') } | Group-Object InstanceName | Measure-Object Count).Count
                 }
             } catch {
                 Write-Message -Level Warning -Message "Couldn't get accurate SQL Server instance count on $instance. Defaulting to 1." -Target $instance -ErrorRecord $_


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
For SQL 2019, SSRS is installed as a separate feature and is causing Test-DbaMaxMemory to see it as its own instance.  This causes issues when testing and applying max memory values.
### Approach
<!-- How does this change solve that purpose -->
I modified the logic to only count the "Engine" object for each instance to prevent the instance count from picking up the SSRS instance which is not an actual engine instance.
### Commands to test
<!-- if these are the examples in the help just note it as such -->
Run Test-DbaMaxMemory on a server with SQL 2019 Engine and SSRS installed and you will see 2 instances returned which is not correct.
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/169602/161780125-fd227849-80ab-4777-ac00-b9de3ca7fc31.png)
![image](https://user-images.githubusercontent.com/169602/161780162-b08da744-59bf-4f79-94b7-9f007a88c531.png)
![image](https://user-images.githubusercontent.com/169602/161780185-97a05cd5-f9f3-4445-b8ea-06909a0de49e.png)
![image](https://user-images.githubusercontent.com/169602/161780195-c1ffbd20-410f-491a-9685-58c8c5694690.png)

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
