### PR TITLE
Convert-SIDToUserName was throwing an exception with orphaned SIDs

### DIFF
--- a/functions/Get-DbaPrivilege.ps1
+++ b/functions/Get-DbaPrivilege.ps1
@@ -58,9 +58,13 @@ function Get-DbaPrivilege {
     begin {
         $ResolveSID = @"
     function Convert-SIDToUserName ([string] `$SID ) {
-      `$objSID = New-Object System.Security.Principal.SecurityIdentifier (`"`$SID`")
-      `$objUser = `$objSID.Translate( [System.Security.Principal.NTAccount])
-      `$objUser.Value
+      try {
+        `$objSID = New-Object System.Security.Principal.SecurityIdentifier (`"`$SID`")
+        `$objUser = `$objSID.Translate( [System.Security.Principal.NTAccount])
+        `$objUser.Value
+      } catch {
+        `$null
+      }
     }
 "@
         $ComputerName = $ComputerName.ComputerName | Select-Object -Unique

--- a/functions/Get-DbaPrivilege.ps1
+++ b/functions/Get-DbaPrivilege.ps1
@@ -56,17 +56,17 @@ function Get-DbaPrivilege {
     )
 
     begin {
-        $ResolveSID = @"
-    function Convert-SIDToUserName ([string] `$SID ) {
+        $ResolveSID = @'
+    function Convert-SIDToUserName ([string] $SID ) {
       try {
-        `$objSID = New-Object System.Security.Principal.SecurityIdentifier (`"`$SID`")
-        `$objUser = `$objSID.Translate( [System.Security.Principal.NTAccount])
-        `$objUser.Value
+        $objSID = New-Object System.Security.Principal.SecurityIdentifier ($SID)
+        $objUser = $objSID.Translate([System.Security.Principal.NTAccount])
+        $objUser.Value
       } catch {
-        `$null
+        $SID
       }
     }
-"@
+'@
         $ComputerName = $ComputerName.ComputerName | Select-Object -Unique
     }
     process {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8118 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Resolve error when running command locally and not from a remote session.

```
Some or all identity references could not be translated.
+ CategoryInfo : NotSpecified: (MYCOMPUTERNAME:String) [], Exception
+ FullyQualifiedErrorId : dbatools_Get-DbaPrivilege
```

### Approach
Wrap SID translation in try/catch. If an error is thrown, return no username.

### Commands to test
Get-DbaPrivilege on a computer with an orphaned SID.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
