### PR TITLE
Enable/Disable-DbaAgHadr - Get instance details from SQL Server

### DIFF
--- a/functions/Disable-DbaAgHadr.ps1
+++ b/functions/Disable-DbaAgHadr.ps1
@@ -76,8 +76,8 @@ function Disable-DbaAgHadr {
         foreach ($instance in $SqlInstance) {
             $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             if ($null -ne $server) {
-                $computer = $computerFullName = server.ComputerName
-                $instanceName = server.DomainInstanceName
+                $computer = $computerFullName = $server.ComputerName
+                $instanceName = $server.DomainInstanceName
             }
             else {
                 $computer = $computerFullName = $instance.ComputerName

--- a/functions/Disable-DbaAgHadr.ps1
+++ b/functions/Disable-DbaAgHadr.ps1
@@ -75,8 +75,14 @@ function Disable-DbaAgHadr {
     process {
         foreach ($instance in $SqlInstance) {
             $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
-            $computer = $computerFullName = server.ComputerName
-            $instanceName = server.DomainInstanceName
+            if ($null -ne $server) {
+                $computer = $computerFullName = server.ComputerName
+                $instanceName = server.DomainInstanceName
+            }
+            else {
+                $computer = $computerFullName = $instance.ComputerName
+                $instanceName = $instance.InstanceName
+            }
             if (-not (Test-ElevationRequirement -ComputerName $instance)) {
                 return
             }

--- a/functions/Disable-DbaAgHadr.ps1
+++ b/functions/Disable-DbaAgHadr.ps1
@@ -74,7 +74,7 @@ function Disable-DbaAgHadr {
     }
     process {
         foreach ($instance in $SqlInstance) {
-            $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -DisableException
             if ($null -ne $server) {
                 $computer = $computerFullName = $server.ComputerName
                 $instanceName = $server.DomainInstanceName

--- a/functions/Enable-DbaAgHadr.ps1
+++ b/functions/Enable-DbaAgHadr.ps1
@@ -75,9 +75,17 @@ function Enable-DbaAgHadr {
     }
     process {
         foreach ($instance in $SqlInstance) {
+            
             $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
-            $computer = $computerFullName = server.ComputerName
-            $instanceName = server.DomainInstanceName
+            if ($null -ne $server) {
+                $computer = $computerFullName = server.ComputerName
+                $instanceName = server.DomainInstanceName
+            }
+            else {
+                $computer = $computerFullName = $instance.ComputerName
+                $instanceName = $instance.InstanceName
+            }
+
             if (-not (Test-ElevationRequirement -ComputerName $instance)) {
                 return
             }

--- a/functions/Enable-DbaAgHadr.ps1
+++ b/functions/Enable-DbaAgHadr.ps1
@@ -76,7 +76,7 @@ function Enable-DbaAgHadr {
     process {
         foreach ($instance in $SqlInstance) {
 
-            $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -DisableException
             if ($null -ne $server) {
                 $computer = $computerFullName = $server.ComputerName
                 $instanceName = $server.DomainInstanceName

--- a/functions/Enable-DbaAgHadr.ps1
+++ b/functions/Enable-DbaAgHadr.ps1
@@ -10,6 +10,13 @@ function Enable-DbaAgHadr {
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
 
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
     .PARAMETER Credential
         Credential object used to connect to the Windows server as a different user
 
@@ -58,6 +65,7 @@ function Enable-DbaAgHadr {
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
         [PSCredential]$Credential,
         [switch]$Force,
         [switch]$EnableException
@@ -67,8 +75,9 @@ function Enable-DbaAgHadr {
     }
     process {
         foreach ($instance in $SqlInstance) {
-            $computer = $computerFullName = $instance.ComputerName
-            $instanceName = $instance.InstanceName
+            $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            $computer = $computerFullName = server.ComputerName
+            $instanceName = server.DomainInstanceName
             if (-not (Test-ElevationRequirement -ComputerName $instance)) {
                 return
             }
@@ -107,7 +116,7 @@ function Enable-DbaAgHadr {
             }
 
             if ($noChange -eq $false) {
-                if ($PSCmdlet.ShouldProcess($instance, "Changing Hadr from $isHadrEnabled to 1 for $instance")) {
+                if ($PSCmdlet.ShouldProcess($instance, "Changing Hadr from $isHadrEnabled to True for $instance")) {
                     try {
                         Invoke-ManagedComputerCommand -ComputerName $computerFullName -Credential $Credential -ScriptBlock $scriptBlock -ArgumentList $instanceName
                     } catch {

--- a/functions/Enable-DbaAgHadr.ps1
+++ b/functions/Enable-DbaAgHadr.ps1
@@ -75,11 +75,11 @@ function Enable-DbaAgHadr {
     }
     process {
         foreach ($instance in $SqlInstance) {
-            
+
             $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             if ($null -ne $server) {
-                $computer = $computerFullName = server.ComputerName
-                $instanceName = server.DomainInstanceName
+                $computer = $computerFullName = $server.ComputerName
+                $instanceName = $server.DomainInstanceName
             }
             else {
                 $computer = $computerFullName = $instance.ComputerName

--- a/functions/Get-DbaAgHadr.ps1
+++ b/functions/Get-DbaAgHadr.ps1
@@ -1,10 +1,10 @@
 function Get-DbaAgHadr {
     <#
     .SYNOPSIS
-        Gets the Hadr service setting on the specified SQL Server instance.
+        Gets the running Hadr setting on the specified SQL Server instance.
 
     .DESCRIPTION
-        Gets the Hadr setting, from the service level, and returns true or false for the specified SQL Server instance.
+        Gets the running Hadr setting, from the instance level, and returns true or false for the specified SQL Server instance.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.

--- a/tests/Disable-DbaAgHadr.Tests.ps1
+++ b/tests/Disable-DbaAgHadr.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag "UnitTests" {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Credential', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Enable-DbaAgHadr.Tests.ps1
+++ b/tests/Enable-DbaAgHadr.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag "UnitTests" {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Credential', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8295 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
While leaving out SqlCredential as a parameter was probably done since this function doesn't technically require connecting to the instance to function, by relying on the SqlInstance parameter alone it is susceptible to functioning incorrectly (see 'localhost' example in bug). 

I think the benefits of connecting to fetch the values outweighs not doing so.

### Approach
<!-- How does this change solve that purpose -->

- Connect to the instance to get ComputerName & InstanceName like most other functions. 
- Tweak ShouldProcess message to reflect Bool variable (i.e. "Changing Hadr from False to True" instead of "Changing Hadr from False to 1")

### Commands to test
<!-- if these are the examples in the help just note it as such -->

- Enable-DbaAgHadr
- Disable-DbaAgHadr

### Other
I didn't tackle the disparity between Get-DbaAgHadr and the other commands fetching the status in two different ways, but am happy to wrap that in here if folks agree it should be standardized one way or another across all three commands.
