### PR TITLE
Export-DbaInstance - Catch Replication Errors

### DIFF
--- a/functions/Export-DbaInstance.ps1
+++ b/functions/Export-DbaInstance.ps1
@@ -383,8 +383,13 @@ function Export-DbaInstance {
             if ($Exclude -notcontains 'ReplicationSettings') {
                 Write-Message -Level Verbose -Message "Exporting replication settings"
                 Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Exporting replication settings"
-                $null = Export-DbaRepServerSetting -SqlInstance $instance -SqlCredential $SqlCredential -FilePath "$exportPath\replication.sql"
-                Get-ChildItem -ErrorAction Ignore -Path "$exportPath\replication.sql"
+
+                try {
+                    $null = Export-DbaRepServerSetting -SqlInstance $instance -SqlCredential $SqlCredential -FilePath "$exportPath\replication.sql" -EnableException
+                    Get-ChildItem -ErrorAction Ignore -Path "$exportPath\replication.sql"
+                } catch {
+                    Write-Message -Level Verbose -Message "Replication failed, skipping"
+                }
             }
 
             if ($Exclude -notcontains 'SysDbUserObjects') {


### PR DESCRIPTION
Replication can't run in many scenarios. Make it quiet if this is the case.