### PR TITLE
chore(ci): add informational Codecov status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,11 @@
-﻿coverage:
+coverage:
   status:
-    project: off
-    patch: off
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
 comment: off
 
 fixes:


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [x] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Hi, Tom from Codecov here. I noticed that you were using Codecov but weren't actually getting any notifications on pull requests. I figured it would be useful to get some idea if code being changed is being tested, but also not blocking CI/merging. Let me know if this makes sense or if we can do something that would be helpful.

### Approach
This change adds informational status checks to commits. This prevents them from being blocking but continues to provide some feedback.

### Commands to test
N/A

### Screenshots
N/A

### Learning
[Informational status checks](https://docs.codecov.com/docs/commit-status#informational)
