### PR TITLE
Invoke-DbaDbShrink: Adjusting the verbose messages to account for the usage of the dbasize type

### DIFF
--- a/tests/Invoke-DbaDbShrink.Tests.ps1
+++ b/tests/Invoke-DbaDbShrink.Tests.ps1
@@ -97,5 +97,18 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $db.LogFiles[0].Size | Should BeLessThan $oldLogSize
             $db.FileGroups[0].Files[0].Size | Should BeLessThan $oldDataSize
         }
+
+        It "Shrinks just the data file(s) when FileType is Data and uses the StepSize" {
+            $result = Invoke-DbaDbShrink $server -Database $db.Name -FileType Data -StepSize 2MB -Verbose
+            $result.Database | Should -Be $db.Name
+            $result.File | Should -Be $db.Name
+            $result.Success | Should -Be $true
+            $db.Refresh()
+            $db.RecalculateSpaceUsage()
+            $db.FileGroups[0].Files[0].Refresh()
+            $db.LogFiles[0].Refresh()
+            $db.FileGroups[0].Files[0].Size | Should BeLessThan $oldDataSize
+            $db.LogFiles[0].Size | Should Be $oldLogSize
+        }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, relates to #7241  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Fixing the verbose messages to display the correct sizes per the findings from @miguelmolgar and @andreasjordan.

### Approach
<!-- How does this change solve that purpose -->
Ensuring the verbose messages are multiplied by 1024 similar to how the result object is being done.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
A new test was added.

### Sample output with this fix
VERBOSE: [08:31:59][Connect-DbaInstance] Server object passed in, will do some checks and then return the original object
VERBOSE: [08:31:59][Invoke-DbaDbShrink] Connection timeout set to 0
VERBOSE: [08:31:59][Invoke-DbaDbShrink] Processing [dbatoolsci_shrinktest] on []
VERBOSE: [08:31:59][Invoke-DbaDbShrink] File: dbatoolsci_shrinktest
**VERBOSE: [08:31:59][Invoke-DbaDbShrink] Initial Size: 16.00 MB
VERBOSE: [08:31:59][Invoke-DbaDbShrink] Space Used: 2.63 MB
VERBOSE: [08:31:59][Invoke-DbaDbShrink] Initial Freespace: 13.38 MB
VERBOSE: [08:31:59][Invoke-DbaDbShrink] Target Freespace: 0 B
VERBOSE: [08:31:59][Invoke-DbaDbShrink] Target FileSize: 2.63 MB**
VERBOSE: Performing the operation "Shrinking from 16.00 MB to 2.63 MB" on target "[dbatoolsci_shrinktest] on []".
VERBOSE: [08:31:59][Invoke-DbaDbShrink] Getting starting average fragmentation
VERBOSE: [08:31:59][Invoke-DbaDbShrink] Beginning shrink of files
VERBOSE: [08:31:59][Invoke-DbaDbShrink] ShrinkGap: 13.38 MB
VERBOSE: [08:31:59][Invoke-DbaDbShrink] Step Size: 2.00 MB
**VERBOSE: [08:31:59][Invoke-DbaDbShrink] Step: 1 of 6
VERBOSE: [08:31:59][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 14.00 MB
VERBOSE: [08:32:04][Invoke-DbaDbShrink] Step: 2 of 6
VERBOSE: [08:32:04][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 12.00 MB
VERBOSE: [08:32:04][Invoke-DbaDbShrink] Step: 3 of 6
VERBOSE: [08:32:04][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 10.00 MB
VERBOSE: [08:32:04][Invoke-DbaDbShrink] Step: 4 of 6
VERBOSE: [08:32:04][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 8.00 MB
VERBOSE: [08:32:05][Invoke-DbaDbShrink] Step: 5 of 6
VERBOSE: [08:32:05][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 6.00 MB
VERBOSE: [08:32:05][Invoke-DbaDbShrink] Step: 6 of 6
VERBOSE: [08:32:05][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 4.00 MB**
VERBOSE: [08:32:05][Invoke-DbaDbShrink] Final file size: 4.00 MB
VERBOSE: [08:32:05][Invoke-DbaDbShrink] Final file space available: 1.38 MB
VERBOSE: [08:32:05][Invoke-DbaDbShrink] Getting ending average fragmentation

