### PR TITLE
Get-DbaBackupInformation - Fix size information for striped backups

### DIFF
--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -323,8 +323,8 @@ function Get-DbaBackupInformation {
                         Name       = "Size"
                         Expression = { [dbasize]$PSItem.Size }
                     } -Unique)
-                $historyObject.TotalSize = ($group.Group.BackupSize.Byte | Measure-Object -Sum).Sum
-                $HistoryObject.CompressedBackupSize = ($group.Group.CompressedBackupSize.Byte | Measure-Object -Sum).Sum
+                $historyObject.TotalSize = $group.Group[0].BackupSize.Byte
+                $HistoryObject.CompressedBackupSize = $group.Group[0].CompressedBackupSize.Byte
                 $historyObject.Type = $description
                 $historyObject.BackupSetId = $group.group[0].BackupSetGUID
                 $historyObject.DeviceType = 'Disk'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8302 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Every file of a striped backup contains the size information about the backup itself, not the individual file. So the size can just be fetched from the first backup file like most other information.

Before:

![image](https://user-images.githubusercontent.com/66946165/166102244-7f690952-aea6-4216-9699-671eb744b7db.png)


After: 
![image](https://user-images.githubusercontent.com/66946165/166102263-c91c7efa-a64a-436a-b028-223e8b20f0c2.png)

