### PR TITLE
Add more PsSessionOptions -Skip* (#8281)

### DIFF
--- a/internal/configurations/settings/remoting.ps1
+++ b/internal/configurations/settings/remoting.ps1
@@ -7,5 +7,9 @@ Set-DbatoolsConfig -FullName 'PSRemoting.Sessions.Enable' -Value $true -Initiali
 # New-PSSessionOption
 Set-DbatoolsConfig -FullName 'PSRemoting.PsSessionOption.IncludePortInSPN' -Value $false -Initialize -Validation bool -Description 'Changes the value of -IncludePortInSPN parameter used by New-PsSessionOption which is used for dbatools internally when working with PSRemoting.'
 
+Set-DbatoolsConfig -FullName 'PSRemoting.PsSessionOption.SkipCACheck' -Value $false -Initialize -Validation bool -Description 'Changes the value of -SkipCACheck parameter used by New-PsSessionOption which is used for dbatools internally when working with PSRemoting.'
+Set-DbatoolsConfig -FullName 'PSRemoting.PsSessionOption.SkipCNCheck' -Value $false -Initialize -Validation bool -Description 'Changes the value of -SkipCNCheck parameter used by New-PsSessionOption which is used for dbatools internally when working with PSRemoting.'
+Set-DbatoolsConfig -FullName 'PSRemoting.PsSessionOption.SkipRevocationCheck' -Value $false -Initialize -Validation bool -Description 'Changes the value of -SkipRevocationCheck parameter used by New-PsSessionOption which is used for dbatools internally when working with PSRemoting.'
+
 # New-PSSession
 Set-DbatoolsConfig -FullName 'PSRemoting.PsSession.UseSSL' -Value $false -Initialize -Validation bool -Description 'Changes the value of -UseSSL parameter used by New-PsSession which is used for dbatools internally when working with PSRemoting.'

--- a/internal/functions/Invoke-Command2.ps1
+++ b/internal/functions/Invoke-Command2.ps1
@@ -96,8 +96,11 @@ function Invoke-Command2 {
             }
             if (Test-Windows -NoWarn) {
                 $psSessionOptionsSplat = @{
-                    IdleTimeout      = (New-TimeSpan -Minutes 10).TotalMilliSeconds
-                    IncludePortInSPN = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSessionOption.IncludePortInSPN' -Fallback $false)
+                    IdleTimeout         = (New-TimeSpan -Minutes 10).TotalMilliSeconds
+                    IncludePortInSPN    = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSessionOption.IncludePortInSPN' -Fallback $false)
+                    SkipCACheck         = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSessionOption.SkipCACheck' -Fallback $false)
+                    SkipCNCheck         = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSessionOption.SkipCNCheck' -Fallback $false)
+                    SkipRevocationCheck = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSessionOption.SkipRevocationCheck' -Fallback $false)
                 }
                 $sessionOption = New-PSSessionOption @psSessionOptionsSplat
                 $psSessionSplat += @{ SessionOption = $sessionOption }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8281 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Support more options related to skip certificate checks when connecting remotely.

### Approach
Add three more possible configurations for the `PSSessionOption`.

They can be configured with `Set-DbaToolsConfig`

### Commands to test
Any that uses PSRemote

### Learning
<!-- Optional -->
``` powershell
-SkipCACheck
-SkipCNCheck
-SkipRevocationCheck
```
Are parameters available on the `New-PSSessionOption`