### PR TITLE
Get-DbaRegServerStore - Use correct object while connecting

### DIFF
--- a/functions/Get-DbaRegServerStore.ps1
+++ b/functions/Get-DbaRegServerStore.ps1
@@ -60,7 +60,7 @@ function Get-DbaRegServerStore {
             }
 
             try {
-                $store = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($server.ConnectionContext.SqlConnectionObject)
+                $store = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($server.ConnectionContext)
             } catch {
                 Stop-Function -Message "Cannot access Central Management Server on $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8338 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Dokumentation (https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.registeredservers.registeredserversstore?view=sql-smo-160) says that parameter should be of type ServerConnection, so we should use $server.ConnectionContext (which is of type ServerConection).