### PR TITLE
Add/New-DbaComputerCertificate - Add Flag support

### DIFF
--- a/functions/Add-DbaComputerCertificate.ps1
+++ b/functions/Add-DbaComputerCertificate.ps1
@@ -145,7 +145,7 @@ function Add-DbaComputerCertificate {
 
             $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
             $cert.Import($CertificateData, $SecurePassword, $flags)
-            Write-Verbose -Message "Importing cert to $Folder\$Store"
+            Write-Verbose -Message "Importing cert to $Folder\$Store using flags: $flags"
             $tempStore = New-Object System.Security.Cryptography.X509Certificates.X509Store($Folder, $Store)
             $tempStore.Open('ReadWrite')
             $tempStore.Add($cert)

--- a/functions/Add-DbaComputerCertificate.ps1
+++ b/functions/Add-DbaComputerCertificate.ps1
@@ -113,7 +113,7 @@ function Add-DbaComputerCertificate {
                 # import the cert to memory but don't store it to persist to the store
                 $bytes = [System.IO.File]::ReadAllBytes($Path)
                 $Certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
-                $Certificate.Import($bytes, $SecurePassword, "Exportable, EphemeralKeySet")
+                $null = $Certificate.Import($bytes, $SecurePassword, "Exportable, EphemeralKeySet")
             } catch {
                 Stop-Function -Message "Can't import certificate." -ErrorRecord $_
                 return

--- a/functions/Add-DbaComputerCertificate.ps1
+++ b/functions/Add-DbaComputerCertificate.ps1
@@ -45,7 +45,7 @@ function Add-DbaComputerCertificate {
             The key associated with a PFX file is persisted when importing a certificate.
 
             UserProtected
-            Notify the user through a dialog box or other method that the key is accessed. The Cryptographic Service Provider (CSP) in use defines the precise behavior.
+            Notify the user through a dialog box or other method that the key is accessed. The Cryptographic Service Provider (CSP) in use defines the precise behavior. NOTE: This can only be used when you add a certificate to localhost, as it causes a prompt to appear.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -84,11 +84,10 @@ function Add-DbaComputerCertificate {
 
         Adds the local C:\temp\cert.cer to the local computer's LocalMachine\My (Personal) certificate store.
 
-
     .EXAMPLE
         PS C:\> Add-DbaComputerCertificate -ComputerName sql01 -Path C:\temp\sql01.pfx -Confirm:$false -Flag NonExportable
 
-        Adds the local C:\temp\sql01.pfx to sql01's LocalMachine\My (Personal) certificate store and marks the private key as non-exportable.
+        Adds the local C:\temp\sql01.pfx to sql01's LocalMachine\My (Personal) certificate store and marks the private key as non-exportable. Skips confirmation prompt.
 
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]

--- a/functions/New-DbaComputerCertificate.ps1
+++ b/functions/New-DbaComputerCertificate.ps1
@@ -52,6 +52,26 @@ function New-DbaComputerCertificate {
     .PARAMETER Folder
         Certificate folder - defaults to My (Personal)
 
+    .PARAMETER Flag
+        Defines where and how to import the private key of an X.509 certificate.
+
+        Defaults to: Exportable, PersistKeySet
+
+            EphemeralKeySet
+            The key associated with a PFX file is created in memory and not persisted on disk when importing a certificate.
+
+            Exportable
+            Imported keys are marked as exportable.
+
+            NonExportable
+            Expliictly mark keys as nonexportable.
+
+            PersistKeySet
+            The key associated with a PFX file is persisted when importing a certificate.
+
+            UserProtected
+            Notify the user through a dialog box or other method that the key is accessed. The Cryptographic Service Provider (CSP) in use defines the precise behavior.
+
     .PARAMETER Dns
         Specify the Dns entries listed in SAN. By default, it will be ComputerName + FQDN, or in the case of clusters, clustername + cluster FQDN.
 
@@ -126,11 +146,28 @@ function New-DbaComputerCertificate {
         [int]$KeyLength = 1024,
         [string]$Store = "LocalMachine",
         [string]$Folder = "My",
+        [ValidateSet("EphemeralKeySet", "Exportable", "PersistKeySet", "UserProtected", "NonExportable")]
+        [string[]]$Flag = @("Exportable", "PersistKeySet"),
         [string[]]$Dns,
         [switch]$SelfSigned,
         [switch]$EnableException
     )
     begin {
+        if ("NonExportable" -in $Flag) {
+            $flags = ($Flag | Where-Object { $PSItem -ne "Exportable" -and $PSItem -ne "NonExportable" } ) -join ","
+
+            # It needs at least one flag
+            if (-not $flags) {
+                if ($Store -eq "LocalMachine") {
+                    $flags = "MachineKeySet"
+                } else {
+                    $flags = "UserKeySet"
+                }
+            }
+        } else {
+            $flags = $Flag -join ","
+        }
+
         $englishCodes = 9, 1033, 2057, 3081, 4105, 5129, 6153, 7177, 8201, 9225
         if ($englishCodes -notcontains (Get-DbaCmObject -ClassName Win32_OperatingSystem).OSLanguage) {
             Stop-Function -Message "Currently, this command is only supported in English OS locales. OS Locale detected: $([System.Globalization.CultureInfo]::GetCultureInfo([int](Get-DbaCmObject Win32_OperatingSystem).OSLanguage).DisplayName)`nWe apologize for the inconvenience and look into providing universal language support in future releases."
@@ -362,19 +399,27 @@ function New-DbaComputerCertificate {
                 }
 
                 $scriptBlock = {
-                    $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
-                    $cert.Import($args[0], $args[1], "Exportable,PersistKeySet")
+                    param (
+                        $CertificateData,
+                        [SecureString]$SecurePassword,
+                        $Store,
+                        $Folder,
+                        $flags
+                    )
+                    Write-Verbose -Message "Importing cert to $Folder\$Store using flags: $flags"
 
-                    $certstore = New-Object System.Security.Cryptography.X509Certificates.X509Store($args[3], $args[2])
+                    $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+                    $cert.Import($CertificateData, $SecurePassword, $flags)
+                    $certstore = New-Object System.Security.Cryptography.X509Certificates.X509Store($Folder, $Store)
                     $certstore.Open('ReadWrite')
                     $certstore.Add($cert)
                     $certstore.Close()
-                    Get-ChildItem "Cert:\$($args[2])\$($args[3])" -Recurse | Where-Object { $_.Thumbprint -eq $cert.Thumbprint }
+                    Get-ChildItem "Cert:\$($Store)\$($Folder)" -Recurse | Where-Object { $_.Thumbprint -eq $cert.Thumbprint }
                 }
 
-                if ($PScmdlet.ShouldProcess("local", "Connecting to $computer to import new cert")) {
+                if ($PScmdlet.ShouldProcess($computer, "Attempting to import new cert")) {
                     try {
-                        $thumbprint = (Invoke-Command2 -ComputerName $computer -Credential $Credential -ArgumentList $certdata, $SecurePassword, $Store, $Folder -ScriptBlock $scriptBlock -ErrorAction Stop).Thumbprint
+                        $thumbprint = (Invoke-Command2 -ComputerName $computer -Credential $Credential -ArgumentList $certdata, $SecurePassword, $Store, $Folder, $flags -ScriptBlock $scriptBlock -ErrorAction Stop -Verbose).Thumbprint
                         Get-DbaComputerCertificate -ComputerName $computer -Credential $Credential -Thumbprint $thumbprint
                     } catch {
                         Stop-Function -Message "Issue importing new cert on $computer" -ErrorRecord $_ -Target $computer -Continue

--- a/functions/New-DbaComputerCertificate.ps1
+++ b/functions/New-DbaComputerCertificate.ps1
@@ -58,6 +58,23 @@ function New-DbaComputerCertificate {
     .PARAMETER SelfSigned
         Creates a self-signed certificate. All other parameters can still apply except CaServer and CaName because the command does not go and get the certificate signed.
 
+    .PARAMETER Flag
+        Defines where and how to import the private key of an X.509 certificate.
+
+        Defaults to: Exportable, PersistKeySet
+
+            EphemeralKeySet
+            The key associated with a PFX file is created in memory and not persisted on disk when importing a certificate.
+
+            Exportable
+            Imported keys are marked as exportable.
+
+            PersistKeySet
+            The key associated with a PFX file is persisted when importing a certificate.
+
+            UserProtected
+            Notify the user through a dialog box or other method that the key is accessed. The Cryptographic Service Provider (CSP) in use defines the precise behavior.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -126,6 +143,8 @@ function New-DbaComputerCertificate {
         [int]$KeyLength = 1024,
         [string]$Store = "LocalMachine",
         [string]$Folder = "My",
+        [ValidateSet("DefaultKeySet", "EphemeralKeySet", "Exportable", "PersistKeySet", "UserProtected")]
+        [string[]]$Flag = @("Exportable", "PersistKeySet"),
         [string[]]$Dns,
         [switch]$SelfSigned,
         [switch]$EnableException
@@ -363,7 +382,8 @@ function New-DbaComputerCertificate {
 
                 $scriptBlock = {
                     $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
-                    $cert.Import($args[0], $args[1], "Exportable,PersistKeySet")
+                    $flags = $Flag -join ","
+                    $cert.Import($args[0], $args[1], $flags)
 
                     $certstore = New-Object System.Security.Cryptography.X509Certificates.X509Store($args[3], $args[2])
                     $certstore.Open('ReadWrite')

--- a/functions/New-DbaComputerCertificate.ps1
+++ b/functions/New-DbaComputerCertificate.ps1
@@ -58,23 +58,6 @@ function New-DbaComputerCertificate {
     .PARAMETER SelfSigned
         Creates a self-signed certificate. All other parameters can still apply except CaServer and CaName because the command does not go and get the certificate signed.
 
-    .PARAMETER Flag
-        Defines where and how to import the private key of an X.509 certificate.
-
-        Defaults to: Exportable, PersistKeySet
-
-            EphemeralKeySet
-            The key associated with a PFX file is created in memory and not persisted on disk when importing a certificate.
-
-            Exportable
-            Imported keys are marked as exportable.
-
-            PersistKeySet
-            The key associated with a PFX file is persisted when importing a certificate.
-
-            UserProtected
-            Notify the user through a dialog box or other method that the key is accessed. The Cryptographic Service Provider (CSP) in use defines the precise behavior.
-
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -143,8 +126,6 @@ function New-DbaComputerCertificate {
         [int]$KeyLength = 1024,
         [string]$Store = "LocalMachine",
         [string]$Folder = "My",
-        [ValidateSet("DefaultKeySet", "EphemeralKeySet", "Exportable", "PersistKeySet", "UserProtected")]
-        [string[]]$Flag = @("Exportable", "PersistKeySet"),
         [string[]]$Dns,
         [switch]$SelfSigned,
         [switch]$EnableException
@@ -382,8 +363,7 @@ function New-DbaComputerCertificate {
 
                 $scriptBlock = {
                     $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
-                    $flags = $Flag -join ","
-                    $cert.Import($args[0], $args[1], $flags)
+                    $cert.Import($args[0], $args[1], "Exportable,PersistKeySet")
 
                     $certstore = New-Object System.Security.Cryptography.X509Certificates.X509Store($args[3], $args[2])
                     $certstore.Open('ReadWrite')

--- a/tests/Add-DbaComputerCertificate.Tests.ps1
+++ b/tests/Add-DbaComputerCertificate.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'ComputerName', 'Credential', 'SecurePassword', 'Certificate', 'Path', 'Store', 'Folder', 'EnableException'
+        [object[]]$knownParameters = 'ComputerName', 'Credential', 'SecurePassword', 'Certificate', 'Path', 'Store', 'Folder', 'Flag', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/New-DbaComputerCertificate.Tests.ps1
+++ b/tests/New-DbaComputerCertificate.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'ComputerName', 'Credential', 'CaServer', 'CaName', 'ClusterInstanceName', 'SecurePassword', 'FriendlyName', 'CertificateTemplate', 'KeyLength', 'Store', 'Folder', 'Dns', 'SelfSigned', 'EnableException'
+        [object[]]$knownParameters = 'ComputerName', 'Credential', 'CaServer', 'CaName', 'ClusterInstanceName', 'SecurePassword', 'FriendlyName', 'CertificateTemplate', 'KeyLength', 'Store', 'Folder', 'Flag', 'Dns', 'SelfSigned', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
Now I understand more about certs 💯 

Fixes #8245 and #8252

Tested successfully with the following commands:

```
New-DbaComputerCertificate -ComputerName sql01, sql02 -ClusterInstanceName deleteme -FriendlyName "Delete me" -Verbose -Flag NonExportable
```

```
 Add-DbaComputerCertificate -Path C:\temp\test.pfx -Confirm:$false -ComputerName sql01 -Verbose
``` 

I never did use the UserProtected flag. It pops this up.

![image](https://user-images.githubusercontent.com/8278033/168569284-89de301a-5608-433a-8dc4-a445c1ce71ae.png)

Since that can only be accepted on localhost, I limited the flag usage to localhost.
