### PR TITLE
Import-DbaCsv - Fix ColumnMapper bug

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,25 +67,3 @@ jobs:
           CLIENTSECRET: ${{secrets.CLIENTSECRET}}
         shell: pwsh
         run: $null = Invoke-Pester ./tests/gh-winactions.ps1 -Output Detailed -PassThru
-
-  macos-tests:
-    runs-on: macos-latest
-    env:
-      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install SQL Server
-        uses: potatoqualitee/mssqlsuite@v1.3
-        with:
-          sa-password: dbatools.I0
-          install: sqlengine
-
-      - name: Run pwsh tests
-        env:
-          TENANTID: ${{secrets.TENANTID}}
-          CLIENTID: ${{secrets.CLIENTID}}
-          CLIENTSECRET: ${{secrets.CLIENTSECRET}}
-        shell: pwsh
-        run: $null = Invoke-Pester ./tests/gh-macactions.ps1 -Output Detailed -PassThru

--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -548,7 +548,7 @@ function Import-DbaCsv {
                         $quotematch = (Get-Content -Path $file -TotalCount 1 -ErrorAction Stop).ToString()
 
                         if ((-not $KeepOrdinalOrder -and -not $AutoCreateTable) -or ($quotematch -match "'" -or $quotematch -match '"')) {
-                            if ($PSBoundParameters.ColumnMap) {
+                            if ($ColumnMap) {
                                 Write-Message -Level Verbose -Message "ColumnMap was supplied. Additional auto-mapping will not be attempted."
                             } elseif ($NoHeaderRow) {
                                 Write-Message -Level Verbose -Message "NoHeaderRow was supplied. Additional auto-mapping will not be attempted."
@@ -569,7 +569,7 @@ function Import-DbaCsv {
                             }
                         }
 
-                        if ($ColumnMap) {
+                        if ($PSBoundParameters.ColumnMap) {
                             foreach ($columnname in $ColumnMap) {
                                 foreach ($key in $columnname.Keys) {
                                     $null = $bulkcopy.ColumnMappings.Add($key, $columnname[$key])

--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -548,7 +548,7 @@ function Import-DbaCsv {
                         $quotematch = (Get-Content -Path $file -TotalCount 1 -ErrorAction Stop).ToString()
 
                         if ((-not $KeepOrdinalOrder -and -not $AutoCreateTable) -or ($quotematch -match "'" -or $quotematch -match '"')) {
-                            if ($ColumnMap) {
+                            if ($PSBoundParameters.ColumnMap) {
                                 Write-Message -Level Verbose -Message "ColumnMap was supplied. Additional auto-mapping will not be attempted."
                             } elseif ($NoHeaderRow) {
                                 Write-Message -Level Verbose -Message "NoHeaderRow was supplied. Additional auto-mapping will not be attempted."
@@ -569,7 +569,7 @@ function Import-DbaCsv {
                             }
                         }
 
-                        if ($ColumnMap) {
+                        if ($PSBoundParameters.ColumnMap) {
                             foreach ($columnname in $ColumnMap) {
                                 foreach ($key in $columnname.Keys) {
                                     $null = $bulkcopy.ColumnMappings.Add($key, $columnname[$key])

--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -569,7 +569,7 @@ function Import-DbaCsv {
                             }
                         }
 
-                        if ($PSBoundParameters.ColumnMap) {
+                        if ($ColumnMap) {
                             foreach ($columnname in $ColumnMap) {
                                 foreach ($key in $columnname.Keys) {
                                     $null = $bulkcopy.ColumnMappings.Add($key, $columnname[$key])

--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -379,6 +379,9 @@ function Import-DbaCsv {
     }
     process {
         foreach ($filename in $Path) {
+            if (-not $PSBoundParameters.ColumnMap) {
+                $ColumnMap = $null
+            }
 
             if ($filename.FullName) {
                 $filename = $filename.FullName
@@ -569,7 +572,7 @@ function Import-DbaCsv {
                             }
                         }
 
-                        if ($PSBoundParameters.ColumnMap) {
+                        if ($ColumnMap) {
                             foreach ($columnname in $ColumnMap) {
                                 foreach ($key in $columnname.Keys) {
                                     $null = $bulkcopy.ColumnMappings.Add($key, $columnname[$key])


### PR DESCRIPTION
Not sure what the trigger is but I could import like 5 csv files, but not 8. The error suggested it was a column mapping error and sure enough, seems sometimes it would reuse the column mapper. Now it all works.

```
Get-ChildItem C:\temp\csv | Import-DbaCsv -SqlInstance sql01 -Database tempdb -AutoCreateTable -Verbose
```