### PR TITLE
Find-DbaOrphanedFile - Do not trim file name

### DIFF
--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -129,7 +129,6 @@ function Find-DbaOrphanedFile {
 
                 UPDATE #enum
                 SET parent = @dir,
-                fs_filename = ltrim(rtrim(e.fs_filename)),
                 parent_id = (SELECT MAX(i.id) FROM #enum i WHERE i.id < e.id AND i.depth = e.depth-1 AND i.is_file = 0)
                 FROM #enum e
                 WHERE e.parent IS NULL;


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8362 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Remove the deletion of the lead/trailing spaces when getting the file name.

### Approach
<!-- How does this change solve that purpose -->
Remove the following line on the update on the temporary table

https://github.com/dataplat/dbatools/blob/39edb63d6d8808230f282a4c8b4d1a4d3c6feb15/functions/Find-DbaOrphanedFile.ps1#L132

### Commands to test
Find-DbaOrphanedFile
