### PR TITLE
Set-DbaAgentSchedule - Support all FrequencySubdayType options

### DIFF
--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -56,7 +56,7 @@ function Set-DbaAgentSchedule {
 
     .PARAMETER FrequencySubdayType
         Specifies the units for the subday FrequencyInterval.
-        Allowed values are 1, "Time", 2, "Seconds", 4, "Minutes", 8 or "Hours"
+        Allowed values are 1, 'Once', 'Time', 2, 'Seconds', 'Second', 4, 'Minutes', 'Minute', 8, 'Hours', 'Hour'
 
     .PARAMETER FrequencySubdayInterval
         The number of subday type periods to occur between each execution of a job.
@@ -152,7 +152,7 @@ function Set-DbaAgentSchedule {
         [ValidateSet('Once', 'OneTime', 'Daily', 'Weekly', 'Monthly', 'MonthlyRelative', 'AgentStart', 'AutoStart', 'IdleComputer', 'OnIdle', 1, 4, 8, 16, 32, 64, 128)]
         [object]$FrequencyType,
         [object[]]$FrequencyInterval,
-        [ValidateSet(1, "Time", 2, "Seconds", 4, "Minutes", 8, "Hours")]
+        [ValidateSet(1, 'Once', 'Time', 2, 'Seconds', 'Second', 4, 'Minutes', 'Minute', 8, 'Hours', 'Hour')]
         [object]$FrequencySubdayType,
         [int]$FrequencySubdayInterval,
         [ValidateSet('Unused', 'First', 'Second', 'Third', 'Fourth', 'Last')]
@@ -191,10 +191,14 @@ function Set-DbaAgentSchedule {
         if ($FrequencySubdayType -notin 0, 1, 2, 4, 8) {
             [int]$FrequencySubdayType =
             switch ($FrequencySubdayType) {
+                "Once" { 1 }
                 "Time" { 1 }
                 "Seconds" { 2 }
+                "Second" { 2 }
                 "Minutes" { 4 }
+                "Minute" { 4 }
                 "Hours" { 8 }
+                "Hour" { 8 }
                 default { 0 }
             }
         }
@@ -217,14 +221,13 @@ function Set-DbaAgentSchedule {
         }
 
         # Check the subday interval
-        if (($FrequencySubdayType -in 2, 4) -and (-not ($FrequencySubdayInterval -ge 1 -or $FrequencySubdayInterval -le 59))) {
-            Stop-Function -Message "Subday interval $FrequencySubdayInterval must be between 1 and 59 when subday type is 2, 'Seconds', 4 or 'Minutes'" -Target $SqlInstance
+        if (($FrequencySubdayType -in 2, "Seconds", 4, "Minutes") -and (-not ($FrequencySubdayInterval -ge 1 -or $FrequencySubdayInterval -le 59))) {
+            Stop-Function -Message "Subday interval $FrequencySubdayInterval must be between 1 and 59 when subday type is 'Seconds' or 'Minutes'" -Target $SqlInstance
             return
-        } elseif (($FrequencySubdayType -eq 8) -and (-not ($FrequencySubdayInterval -ge 1 -and $FrequencySubdayInterval -le 23))) {
-            Stop-Function -Message "Subday interval $FrequencySubdayInterval must be between 1 and 23 when subday type is 8 or 'Hours" -Target $SqlInstance
+        } elseif (($FrequencySubdayType -eq 8, "Hours") -and (-not ($FrequencySubdayInterval -ge 1 -and $FrequencySubdayInterval -le 23))) {
+            Stop-Function -Message "Subday interval $FrequencySubdayInterval must be between 1 and 23 when subday type is 'Hours'" -Target $SqlInstance
             return
         }
-
 
         # Check of the FrequencyInterval value is of type string and set the integer value
         if (($null -ne $FrequencyType)) {

--- a/tests/Set-DbaAgentSchedule.Tests.ps1
+++ b/tests/Set-DbaAgentSchedule.Tests.ps1
@@ -188,7 +188,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
     Context "Should set schedules with various frequency subday type" {
         BeforeAll {
-            foreach ($FrequencySubdayType in ('Time', 'Seconds', 'Minutes', 'Hours')) {
+            foreach ($FrequencySubdayType in ('1', 'Once', 'Time', '2', 'Seconds', 'Second', '4', 'Minutes', 'Minute', '8', 'Hours', 'Hour')) {
                 $variables = @{SqlInstance    = $script:instance2
                     Schedule                  = "dbatoolsci_$FrequencySubdayType"
                     Job                       = 'dbatoolsci_setschedule1'
@@ -211,7 +211,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
         $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
         foreach ($schedule in $schedules) {
-            foreach ($FrequencySubdayType in ('Time', '1', 'Seconds', '2', 'Minutes', '4', 'Hours', '8')) {
+            foreach ($FrequencySubdayType in ('1', 'Once', 'Time', '2', 'Seconds', 'Second', '4', 'Minutes', 'Minute', '8', 'Hours', 'Hour')) {
                 $variables = @{SqlInstance    = $script:instance2
                     Schedule                  = "$schedule"
                     Job                       = 'dbatoolsci_setschedule1'

--- a/tests/Set-DbaAgentSchedule.Tests.ps1
+++ b/tests/Set-DbaAgentSchedule.Tests.ps1
@@ -188,7 +188,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
     Context "Should set schedules with various frequency subday type" {
         BeforeAll {
-            foreach ($FrequencySubdayType in ('1', 'Once', 'Time', '2', 'Seconds', 'Second', '4', 'Minutes', 'Minute', '8', 'Hours', 'Hour')) {
+            foreach ($FrequencySubdayType in ('Once', 'Time', 'Seconds', 'Second', 'Minutes', 'Minute', 'Hours', 'Hour')) {
                 $variables = @{SqlInstance    = $script:instance2
                     Schedule                  = "dbatoolsci_$FrequencySubdayType"
                     Job                       = 'dbatoolsci_setschedule1'
@@ -211,7 +211,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
         $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
         foreach ($schedule in $schedules) {
-            foreach ($FrequencySubdayType in ('1', 'Once', 'Time', '2', 'Seconds', 'Second', '4', 'Minutes', 'Minute', '8', 'Hours', 'Hour')) {
+            foreach ($FrequencySubdayType in ('Once', 'Time', 'Seconds', 'Second', 'Minutes', 'Minute', 'Hours', 'Hour')) {
                 $variables = @{SqlInstance    = $script:instance2
                     Schedule                  = "$schedule"
                     Job                       = 'dbatoolsci_setschedule1'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8349 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [x] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Full coverage of `FrequencySubdayType` options across all commands. This one was missing

### Approach
Same as https://github.com/dataplat/dbatools/pull/6872

### Commands to test
Set-DbaAgentSchedule