### PR TITLE
Get-DbaUserPermission - Fix collation conflict

### DIFF
--- a/bin/stig.sql
+++ b/bin/stig.sql
@@ -475,7 +475,7 @@ USE tempdb;
                         P.[Source View]
                     FROM
                         STIG.database_permissions P
-                        INNER JOIN Targets T ON T.[Principal] = P.[Grantee]
+                        INNER JOIN Targets T ON T.[Principal] COLLATE DATABASE_DEFAULT = P.[Grantee] COLLATE DATABASE_DEFAULT
                     ORDER BY
                         P.[Securable Type or Class],
                         P.[Schema/Owner],

--- a/tests/Get-DbaUserPermission.Tests.ps1
+++ b/tests/Get-DbaUserPermission.Tests.ps1
@@ -46,4 +46,21 @@ exec sp_addrolemember 'userrole','bob';
             }
         }
     }
+
+    Context "Command do not return error when database as different collation" {
+        $dbName = "dbatoolsci_UserPermissionDiffCollation"
+        $dbCollation = "Latin1_General_CI_AI"
+
+        $null = New-DbaDatabase -SqlInstance $script:instance1 -Name $dbName -Collation $dbCollation
+
+        $results = Get-DbaUserPermission -SqlInstance $script:instance1 -Database $dbName -WarningVariable warnvar
+        It "Should not warn about collation conflict" {
+            $warnvar | Should -Be $null
+        }
+        It "returns results" {
+            $results.Count -gt 0 | Should Be $true
+        }
+
+        $null = Remove-DbaDatabase -SqlInstance $script:instance1 -Database $dbName -Confirm:$false
+    }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8366 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix collation conflict issue (#8366)

### Approach
Need to run the comparison with the same collation.
Used `COLLATE DATABASE_DEFAULT` on L478 of `stig.sql` script

### Commands to test
Get-DbaUserPermission
