### PR TITLE
Update dbatools-buildref-index.json

### DIFF
--- a/bin/dbatools-buildref-index.json
+++ b/bin/dbatools-buildref-index.json
@@ -1,5 +1,5 @@
 {
-    "LastUpdated": "2022-04-19T00:00:00",
+    "LastUpdated": "2022-06-05T00:00:00",
     "Data": [
         {
             "Version": "8.0.47",


### PR DESCRIPTION
Was last updated on 2022-04-19, so it got stale.