### PR TITLE
Csv progress

### DIFF
--- a/bin/projects/dbatools/dbatools/IO/ProgressStream.cs
+++ b/bin/projects/dbatools/dbatools/IO/ProgressStream.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+
+namespace Sqlcollaborative.Dbatools.IO
+{
+    /// <summary>
+    /// Provides progress callbacks for a stream being read.
+    /// </summary>
+    public class ProgressStream : Stream
+    {
+        readonly Stream inner;
+        readonly Action<double> callback;
+        readonly long progressSize;
+        long length;
+        long progressAccumulator;
+
+        public ProgressStream(Stream inner, Action<double> callback, double factor)
+        {
+            this.inner = inner;
+            this.callback = callback;
+
+            this.length = inner.Length;
+            this.progressSize = (long)(length * factor);
+        }
+
+        public override bool CanRead
+        {
+            get { return inner.CanRead; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return inner.CanSeek; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return inner.CanWrite; }
+        }
+
+        public override long Length
+        {
+            get { return inner.Length; }
+        }
+
+        public override long Position
+        {
+            get { return inner.Position; }
+            set { inner.Position = value; }
+        }
+
+        public override void Flush()
+        {
+            inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var l = inner.Read(buffer, offset, count);
+            progressAccumulator += l;
+            bool needsUpdate = false;
+            while (progressSize > 0 && progressAccumulator > progressSize)
+            {
+                progressAccumulator -= progressSize;
+                needsUpdate = true;
+            }
+            if (needsUpdate)
+            {
+                callback((double)inner.Position / inner.Length);
+            }
+            return l;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return inner.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            inner.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            inner.Write(buffer, offset, count);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Adds percent complete progress report to Import-DbaCsv.

### Approach
<!-- How does this change solve that purpose -->
Uses the file size to determine percent complete by counting bytes read by the underlying data stream.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Import-DbaCsv

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![progress](https://user-images.githubusercontent.com/7776174/172438979-2eb781cd-4e83-4818-a99e-1e13b6c6b27e.png)

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
This change was inspired by the @potatoqualitee blog about CSV performance. I've used this technique before in other projects to report import progress, and thought it might be a nice enhancement for dbatools.

:warning: This PR is incomplete! I does not include the a newly compiled dll at `bin/netcoreapp3.1/dbatools.dll`, which carries the ProgressStream implementation. It isn't clear to me if there is an official build step to make this happen, as I'd manually copied it there to get things working.