### PR TITLE
Set-DbaTcpPort - add force switch

### DIFF
--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -129,7 +129,7 @@ function Set-DbaTcpPort {
                             $null = Stop-DbaService -ComputerName $computerFullName -InstanceName $instanceName -Type Agent, Engine
                             $null = Start-DbaService -ComputerName $computerFullName -InstanceName $instanceName -Type Agent, Engine
                         } catch {
-                            Stop-Function -Message "Issue restarting $instance" -Target $instance -Continue
+                            Stop-Function -Message "Issue restarting $instance on $computerFullName" -Target $instance -Continue -ErrorRecord $_
                         }
                     }
                 }

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -126,8 +126,7 @@ function Set-DbaTcpPort {
                 if (Test-Bound -ParameterName Force) {
                     if ($PSCmdlet.ShouldProcess($instance, "Force provided, restarting Engine and Agent service for $instance on $computerFullName")) {
                         try {
-                            $null = Stop-DbaService -ComputerName $computerFullName -InstanceName $instanceName -Type Agent, Engine
-                            $null = Start-DbaService -ComputerName $computerFullName -InstanceName $instanceName -Type Agent, Engine
+                            $null = Restart-DbaService -ComputerName $computerFullName -InstanceName $instanceName -Type Agent, Engine
                         } catch {
                             Stop-Function -Message "Issue restarting $instance on $computerFullName" -Target $instance -Continue -ErrorRecord $_
                         }

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -126,7 +126,7 @@ function Set-DbaTcpPort {
                 if (Test-Bound -ParameterName Force) {
                     if ($PSCmdlet.ShouldProcess($instance, "Force provided, restarting Engine and Agent service for $instance on $computerFullName")) {
                         try {
-                            $null = Restart-DbaService -ComputerName $computerFullName -InstanceName $instanceName -Type Agent, Engine
+                            $null = Restart-DbaService -SqlInstance $instance -Type Engine -Force -EnableException
                         } catch {
                             Stop-Function -Message "Issue restarting $instance on $computerFullName" -Target $instance -Continue -ErrorRecord $_
                         }

--- a/tests/Set-DbaTcpPort.Tests.ps1
+++ b/tests/Set-DbaTcpPort.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'Port', 'IpAddress', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'Port', 'IpAddress', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8402  )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Adds the `-Force` switch to allow service restarts as part of the command.

### Approach
Copy & pasted from `Enable-DbaAgHadr`'s implementation

### Commands to test
* Set-DbaTcpPort

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
