### PR TITLE
Invoke-DbaDbShrink: Ensure correct usage of the dbasize type for accurate verbose messages

### DIFF
--- a/tests/Invoke-DbaDbShrink.Tests.ps1
+++ b/tests/Invoke-DbaDbShrink.Tests.ps1
@@ -97,5 +97,18 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $db.LogFiles[0].Size | Should BeLessThan $oldLogSize
             $db.FileGroups[0].Files[0].Size | Should BeLessThan $oldDataSize
         }
+
+        It "Shrinks just the data file(s) when FileType is Data and uses the StepSize" {
+            $result = Invoke-DbaDbShrink $server -Database $db.Name -FileType Data -StepSize 2MB -Verbose
+            $result.Database | Should -Be $db.Name
+            $result.File | Should -Be $db.Name
+            $result.Success | Should -Be $true
+            $db.Refresh()
+            $db.RecalculateSpaceUsage()
+            $db.FileGroups[0].Files[0].Refresh()
+            $db.LogFiles[0].Refresh()
+            $db.FileGroups[0].Files[0].Size | Should BeLessThan $oldDataSize
+            $db.LogFiles[0].Size | Should Be $oldLogSize
+        }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, relates to #7241 and #8314   ) )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Ensuring correct usage of the dbasize datatype and that the verbose messages report the sizes accurately. See #8314 for the implementation discussion.

### Approach
<!-- How does this change solve that purpose -->
Converting the file sizes to be used correctly in the dbasize datatype.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the pester tests.

### Sample output from pester tests
Describing Invoke-DbaDbShrink Unit Tests

  Context Validate parameters
    [+] Should only contain our specific parameters 409ms

Describing Invoke-DbaDbShrink Integration Tests

  Context Verifying Database is shrunk
    [+] Shrinks just the log file when FileType is Log 2.7s
    [+] Shrinks just the data file(s) when FileType is Data 1.48s
    [+] Shrinks the entire database when FileType is All 6.31s
VERBOSE: [09:50:31][Connect-DbaInstance] Server object passed in, will do some checks and then return the original object
VERBOSE: [09:50:31][Invoke-DbaDbShrink] Connection timeout set to 0
VERBOSE: [09:50:31][Invoke-DbaDbShrink] Processing [dbatoolsci_shrinktest] on localhost
VERBOSE: [09:50:31][Invoke-DbaDbShrink] File: dbatoolsci_shrinktest
VERBOSE: [09:50:31][Invoke-DbaDbShrink] Initial Size: 16.00 MB
VERBOSE: [09:50:31][Invoke-DbaDbShrink] Space Used: 2.69 MB
VERBOSE: [09:50:31][Invoke-DbaDbShrink] Initial Freespace: 13.31 MB
VERBOSE: [09:50:31][Invoke-DbaDbShrink] Target Freespace: 0 B
VERBOSE: [09:50:31][Invoke-DbaDbShrink] Target FileSize: 2.69 MB
VERBOSE: Performing the operation "Shrinking from 16.00 MB to 2.69 MB" on target "[dbatoolsci_shrinktest] on localhost".
VERBOSE: [09:50:31][Invoke-DbaDbShrink] Getting starting average fragmentation
VERBOSE: [09:50:31][Invoke-DbaDbShrink] Beginning shrink of files
VERBOSE: [09:50:31][Invoke-DbaDbShrink] ShrinkGap: 13.31 MB
VERBOSE: [09:50:31][Invoke-DbaDbShrink] Step Size: 2048 KB
VERBOSE: [09:50:32][Invoke-DbaDbShrink] Step: 1 of 7
VERBOSE: [09:50:32][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 14.00 MB
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Step: 2 of 7
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 12.00 MB
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Step: 3 of 7
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 10.00 MB
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Step: 4 of 7
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 8.00 MB
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Step: 5 of 7
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 6.00 MB
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Step: 6 of 7
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 4.00 MB
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Step: 7 of 7
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Shrinking dbatoolsci_shrinktest to 2.69 MB
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Final file size: 3.00 MB
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Final file space available: 320.00 KB
VERBOSE: [09:50:37][Invoke-DbaDbShrink] Getting ending average fragmentation
    [+] Shrinks just the data file(s) when FileType is Data and uses the StepSize 6.34s