### PR TITLE
Find-DbaDbUnusedIndex: Add DatabaseId to the return object

### DIFF
--- a/tests/Find-DbaDbUnusedIndex.Tests.ps1
+++ b/tests/Find-DbaDbUnusedIndex.Tests.ps1
@@ -33,7 +33,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
             Write-Message -Level Warning -Message "Find-DbaDbUnusedIndex setting up the new database $dbName"
             Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbName -Confirm:$false
-            New-DbaDatabase -SqlInstance $script:instance2 -Name $dbName
+            $newDB = New-DbaDatabase -SqlInstance $script:instance2 -Name $dbName
 
             $indexName = "dbatoolsci_index_$random"
             $tableName = "dbatoolsci_table_$random"
@@ -54,6 +54,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
         It "Should find the 'unused' index on each test sql instance" {
             $results = Find-DbaDbUnusedIndex -SqlInstance $script:instance2 -Database $dbName -IgnoreUptime -Seeks 10 -Scans 10 -Lookups 10
+            $results.Database | Should -Be $dbName
+            $results.DatabaseId | Should -Be $newDB.Id
 
             $testSQLinstance = $false
 
@@ -71,7 +73,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
 
         It "Should return the expected columns on each test sql instance" {
-            [object[]]$expectedColumnArray = 'CompressionDescription', 'ComputerName', 'Database', 'IndexId', 'IndexName', 'IndexSizeMB', 'InstanceName', 'LastSystemLookup', 'LastSystemScan', 'LastSystemSeek', 'LastSystemUpdate', 'LastUserLookup', 'LastUserScan', 'LastUserSeek', 'LastUserUpdate', 'ObjectId', 'RowCount', 'Schema', 'SqlInstance', 'SystemLookup', 'SystemScans', 'SystemSeeks', 'SystemUpdates', 'Table', 'TypeDesc', 'UserLookups', 'UserScans', 'UserSeeks', 'UserUpdates'
+            [object[]]$expectedColumnArray = 'CompressionDescription', 'ComputerName', 'Database', 'DatabaseId', 'IndexId', 'IndexName', 'IndexSizeMB', 'InstanceName', 'LastSystemLookup', 'LastSystemScan', 'LastSystemSeek', 'LastSystemUpdate', 'LastUserLookup', 'LastUserScan', 'LastUserSeek', 'LastUserUpdate', 'ObjectId', 'RowCount', 'Schema', 'SqlInstance', 'SystemLookup', 'SystemScans', 'SystemSeeks', 'SystemUpdates', 'Table', 'TypeDesc', 'UserLookups', 'UserScans', 'UserSeeks', 'UserUpdates'
 
             $testSQLinstance = $false
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, relates to #8183  )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Return the DatabaseId per #8183 

### Approach
<!-- How does this change solve that purpose -->
Minor refactoring of the query in the command due to the limitation in Azure for DB_ID noted at: https://docs.microsoft.com/en-us/sql/t-sql/functions/db-id-transact-sql#remarks

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the pester tests.