### PR TITLE
Format-DbaBackupInformation - fix path building for MacOS

### DIFF
--- a/functions/Format-DbaBackupInformation.ps1
+++ b/functions/Format-DbaBackupInformation.ps1
@@ -188,6 +188,8 @@ function Format-DbaBackupInformation {
                     Write-Message -Message " 1 PhysicalName = $($_.PhysicalName) " -Level Verbose
                     $Pname = [System.Io.FileInfo]$_.PhysicalName
                     $RestoreDir = $Pname.DirectoryName
+                    # Handle MacOS returning full path for BaseName
+                    $baseName = $Pname.BaseName.Split($PathSep)[-1]
                     if ($_.Type -eq 'D' -or $_.FileType -eq 'D') {
                         if ('' -ne $DataFileDirectory) {
                             $RestoreDir = $DataFileDirectory
@@ -206,7 +208,7 @@ function Format-DbaBackupInformation {
                         }
                     }
 
-                    $_.PhysicalName = $RestoreDir + $PathSep + $DatabaseFilePrefix + $Pname.BaseName + $DatabaseFileSuffix + $Pname.extension
+                    $_.PhysicalName = $RestoreDir + $PathSep + $DatabaseFilePrefix + $baseName + $DatabaseFileSuffix + $Pname.extension
                     Write-Message -Message "PhysicalName = $($_.PhysicalName) " -Level Verbose
                 }
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7961 <!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
BaseName behaves differently on PowerShell Core/MacOS in that it returns the full path of the base file, not just the base file name. This should fix that use case and have no effect on others.

This should provide a fix for Copy- and Restore-DbaDatabase on MacOS.

### Approach
<!-- How does this change solve that purpose -->
Split the value proactively before using the BaseName.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
* Format-DbaBackupInformation
* Restore-DbaDatabase
* Copy-DbaDatabase
