### PR TITLE
Find-DbaOrphanedFile: Ensure that -Recurse returns the full file path

### DIFF
--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Path', 'FileType', 'LocalOnly', 'RemoteOnly', 'Recurse', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should -Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
@@ -16,25 +16,44 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Orphaned files are correctly identified" {
         BeforeAll {
-            $dbname = "dbatoolsci_orphanedfile"
+            $dbname = "dbatoolsci_orphanedfile_$(Get-Random)"
             $server = Connect-DbaInstance -SqlInstance $script:instance2
-            $null = $server.Query("CREATE DATABASE $dbname")
+            $db1 = New-DbaDatabase -SqlInstance $server -Name $dbname
+
+            $dbname2 = "dbatoolsci_orphanedfile_$(Get-Random)"
+            $db2 = New-DbaDatabase -SqlInstance $server -Name $dbname2
+
             $tmpdir = "c:\temp\orphan_$(Get-Random)"
             if (-not(Test-Path $tmpdir)) {
                 $null = New-Item -Path $tmpdir -type Container
             }
             $tmpdirInner = Join-Path $tmpdir "inner"
             $null = New-Item -Path $tmpdirInner -type Container
+            $tmpBackupPath = Join-Path $tmpdirInner "backup"
+            $null = New-Item -Path $tmpBackupPath -type Container
+
+            $tmpdir2 = "c:\temp\orphan_$(Get-Random)"
+            if (-not(Test-Path $tmpdir2)) {
+                $null = New-Item -Path $tmpdir2 -type Container
+            }
+            $tmpdirInner2 = Join-Path $tmpdir2 "inner"
+            $null = New-Item -Path $tmpdirInner2 -type Container
+            $tmpBackupPath2 = Join-Path $tmpdirInner2 "backup"
+            $null = New-Item -Path $tmpBackupPath2 -type Container
+
             $result = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname
             if ($result.count -eq 0) {
-                it "has failed setup" {
+                It "has failed setup" {
                     Set-TestInconclusive -message "Setup failed"
                 }
                 throw "has failed setup"
             }
+
+            $backupFile = Backup-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -Path $tmpBackupPath -Type Full
+            $backupFile2 = Backup-DbaDatabase -SqlInstance $script:instance2 -Database $dbname2 -Path $tmpBackupPath2 -Type Full
         }
         AfterAll {
-            Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
+            Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname, $dbname2 | Remove-DbaDatabase -Confirm:$false
             Remove-Item $tmpdir -Recurse -Force -ErrorAction SilentlyContinue
         }
         It "Has the correct properties" {
@@ -45,7 +64,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Filename,RemoteFilename,Server'.Split(',')
             ($results[0].PsObject.Properties.Name | Sort-Object) | Should -Be ($ExpectedProps | Sort-Object)
         }
-        
+
 
         It "Finds two files" {
             $results = Find-DbaOrphanedFile -SqlInstance $script:instance2
@@ -59,14 +78,20 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.Filename.Count | Should -Be 0
         }
         It "works with -Recurse" {
-            "a" | out-file (Join-Path $tmpdir "out.mdf")
+            "a" | Out-File (Join-Path $tmpdir "out.mdf")
             $results = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $tmpdir
             $results.Filename.Count | Should -Be 1
-            move-item "$tmpdir\out.mdf" -destination $tmpdirInner
+            Move-Item "$tmpdir\out.mdf" -destination $tmpdirInner
             $results = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $tmpdir
             $results.Filename.Count | Should -Be 0
             $results = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $tmpdir -Recurse
             $results.Filename.Count | Should -Be 1
+
+            $results = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $tmpdir, $tmpdir2 -Recurse -FileType bak
+            $results.Filename | Should -Contain $backupFile.BackupPath
+            $results.Filename | Should -Contain $backupFile2.BackupPath
+            $results.Filename | Should -Contain "$tmpdirInner\out.mdf"
+            $results.Count | Should -Be 3
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8400 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Ensure the command returns the full file path when -Recurse is used.

### Approach
<!-- How does this change solve that purpose -->
A recursive CTE is used to construct the full file paths. See the code comments in the new SQL added into the command.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the updated pester test.

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
Helpful posting: https://www.sqlservercentral.com/forums/topic/get-full-path-from-sys-xp_dirtree
