### PR TITLE
Find-DbaDbDisabledIndex: Add DatabaseId to the return object

### DIFF
--- a/functions/Find-DbaDbDisabledIndex.ps1
+++ b/functions/Find-DbaDbDisabledIndex.ps1
@@ -87,6 +87,7 @@ function Find-DbaDbDisabledIndex {
     begin {
         $sql = "
         SELECT DB_NAME() AS 'DatabaseName'
+        ,d.database_id AS DatabaseId
         ,s.name AS 'SchemaName'
         ,t.name AS 'TableName'
         ,i.object_id AS ObjectId
@@ -98,6 +99,8 @@ function Find-DbaDbDisabledIndex {
             ON t.schema_id = s.schema_id
         JOIN sys.indexes i
             ON i.object_id = t.object_id
+        JOIN sys.databases d
+            ON d.name = DB_NAME()
         WHERE i.is_disabled = 1"
     }
     process {

--- a/tests/Find-DbaDbDisabledIndex.Tests.ps1
+++ b/tests/Find-DbaDbDisabledIndex.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'NoClobber', 'Append', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -18,29 +18,39 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         BeforeAll {
             $server = Connect-DbaInstance -SqlInstance $script:instance1
             $random = Get-Random
+            $databaseName1 = "dbatoolsci1_$random"
+            $databaseName2 = "dbatoolsci2_$random"
+            $db1 = New-DbaDatabase -SqlInstance $server -Name $databaseName1
+            $db2 = New-DbaDatabase -SqlInstance $server -Name $databaseName2
             $indexName = "dbatoolsci_index_$random"
             $tableName = "dbatoolsci_table_$random"
             $sql = "create table $tableName (col1 int)
                     create index $indexName on $tableName (col1)
                     ALTER INDEX $indexName ON $tableName DISABLE;"
-            $null = $server.Query($sql, 'tempdb')
+            $null = $db1.Query($sql)
+            $null = $db2.Query($sql)
         }
         AfterAll {
-            $sql = "drop table $tableName;"
-            $null = $server.Query($sql, 'tempdb')
+            $db1, $db2 | Remove-DbaDatabase -Confirm:$false
         }
 
         It "Should find disabled index: $indexName" {
             $results = Find-DbaDbDisabledIndex -SqlInstance $script:instance1
-            $results.IndexName -contains $indexName | Should Be $true
+            ($results | Where-Object { $_.IndexName -eq $indexName }).Count | Should -Be 2
+            ($results | Where-Object { $_.DatabaseName -in $databaseName1, $databaseName2 }).Count | Should -Be 2
+            ($results | Where-Object { $_.DatabaseId -in $db1.Id, $db2.Id }).Count | Should -Be 2
         }
         It "Should find disabled index: $indexName for specific database" {
-            $results = Find-DbaDbDisabledIndex -SqlInstance $script:instance1 -Database tempdb
-            $results.IndexName -contains $indexName | Should Be $true
+            $results = Find-DbaDbDisabledIndex -SqlInstance $script:instance1 -Database $databaseName1
+            $results.IndexName | Should -Be $indexName
+            $results.DatabaseName | Should -Be $databaseName1
+            $results.DatabaseId | Should -Be $db1.Id
         }
         It "Should exclude specific database" {
-            $results = Find-DbaDbDisabledIndex -SqlInstance $script:instance1 -ExcludeDatabase tempdb
-            $results.DatabaseName -contains 'tempdb' | Should Be $false
+            $results = Find-DbaDbDisabledIndex -SqlInstance $script:instance1 -ExcludeDatabase $databaseName1
+            $results.IndexName | Should -Be $indexName
+            $results.DatabaseName | Should -Be $databaseName2
+            $results.DatabaseId | Should -Be $db2.Id
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, relates to #8183  )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Minor change to add DatabaseId to the return object. In this case using 'DatabaseId' instead of 'Id' since the command returns an object specific to indexes.

### Approach
<!-- How does this change solve that purpose -->
Using sys.databases since [DB_ID() is not guaranteed in Azure](https://docs.microsoft.com/en-us/sql/t-sql/functions/db-id-transact-sql?view=sql-server-ver16#remarks).

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Updated the pester tests.