### PR TITLE
Adding -Property parameter to New-DbaDacOption

### DIFF
--- a/functions/New-DbaDacOption.ps1
+++ b/functions/New-DbaDacOption.ps1
@@ -99,10 +99,10 @@ function New-DbaDacOption {
                 }
             }
             function New-DacObject {
-                Param ([String]$TypeName, [hashtable]$Property=$Property)
+                Param ([String]$TypeName, [hashtable]$Property = $Property)
 
-                $dacOptionSplat = @{TypeName = $TypeName}
-                if ($Property) { $dacOptionSplat.Property = $Property}
+                $dacOptionSplat = @{TypeName = $TypeName }
+                if ($Property) { $dacOptionSplat.Property = $Property }
                 try {
                     New-Object @dacOptionSplat -ErrorAction Stop
                 } catch {
@@ -132,7 +132,7 @@ function New-DbaDacOption {
                         $output.DeployOptions = if ($Property -and 'DeployOptions' -in $Property.Keys) {
                             New-DacObject -TypeName Microsoft.SqlServer.Dac.DacDeployOptions -Property $Property.DeployOptions
                         } else {
-                            New-DacObject -TypeName Microsoft.SqlServer.Dac.DacDeployOptions -Property @{}
+                            New-DacObject -TypeName Microsoft.SqlServer.Dac.DacDeployOptions -Property @{ }
                         }
                     }
                     $output.GenerateDeploymentScript = $false

--- a/tests/New-DbaDacOption.Tests.ps1
+++ b/tests/New-DbaDacOption.Tests.ps1
@@ -14,7 +14,10 @@ Describe "$commandname Unit Tests" -Tag "UnitTests" {
 }
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
-        $publishprofile = New-DbaDacProfile -SqlInstance $script:instance1 -Database whatever -Path TestDrive:\
+        $publishprofile = New-DbaDacProfile -SqlInstance $script:instance1 -Database whatever -Path C:\temp
+    }
+    AfterAll {
+        Remove-Item -Confirm:$false -Path $publishprofile.FileName -ErrorAction SilentlyContinue
     }
     It "Returns dacpac export options" {
         New-DbaDacOption -Action Export | Should -Not -BeNullOrEmpty

--- a/tests/New-DbaDacOption.Tests.ps1
+++ b/tests/New-DbaDacOption.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$commandname Unit Tests" -Tag "UnitTests" {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'Type', 'Action', 'PublishXml', 'EnableException'
+        [object[]]$knownParameters = 'Type', 'Action', 'PublishXml', 'Property', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -14,10 +14,7 @@ Describe "$commandname Unit Tests" -Tag "UnitTests" {
 }
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
-        $publishprofile = New-DbaDacProfile -SqlInstance $script:instance1 -Database whatever -Path C:\temp
-    }
-    AfterAll {
-        Remove-Item -Confirm:$false -Path $publishprofile.FileName -ErrorAction SilentlyContinue
+        $publishprofile = New-DbaDacProfile -SqlInstance $script:instance1 -Database whatever -Path TestDrive:\
     }
     It "Returns dacpac export options" {
         New-DbaDacOption -Action Export | Should -Not -BeNullOrEmpty
@@ -26,12 +23,24 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         New-DbaDacOption -Action Export -Type Bacpac | Should -Not -BeNullOrEmpty
     }
     It "Returns dacpac publish options" {
-        New-DbaDacOption -Action Publish  | Should -Not -BeNullOrEmpty
+        New-DbaDacOption -Action Publish | Should -Not -BeNullOrEmpty
     }
     It "Returns dacpac publish options from an xml" {
         New-DbaDacOption -Action Publish -PublishXml $publishprofile.FileName -EnableException | Should -Not -BeNullOrEmpty
     }
     It "Returns bacpac publish options" {
         New-DbaDacOption -Action Publish -Type Bacpac | Should -Not -BeNullOrEmpty
+    }
+    It "Properly sets a property value when specified" {
+        (New-DbaDacOption -Action Export -Property @{CommandTimeout = 5 }).CommandTimeout | Should -Be 5
+        (New-DbaDacOption -Action Export -Type Bacpac -Property @{CommandTimeout = 5 }).CommandTimeout | Should -Be 5
+        (New-DbaDacOption -Action Publish -Property @{GenerateDeploymentReport = $true }).GenerateDeploymentReport | Should -BeTrue
+        (New-DbaDacOption -Action Publish -Type Bacpac -Property @{CommandTimeout = 5 }).CommandTimeout | Should -Be 5
+        $result = (New-DbaDacOption -Action Publish -Property @{
+                GenerateDeploymentReport = $true; DeployOptions = @{CommandTimeout = 5 }
+            }
+        )
+        $result.GenerateDeploymentReport | Should -BeTrue
+        $result.DeployOptions.CommandTimeout | Should -Be 5
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [] Bug fix (non-breaking change, fixes # )
 - [x] New feature (non-breaking change, adds functionality, fixes #8463 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Add ability to initialize object properties on a function call

### Approach
Re-using -Property parameter of New-Object

### Commands to test
New-DbaDacOption

### Screenshots
![image](https://user-images.githubusercontent.com/30303784/181394836-ed77b999-8bfa-4d04-b147-f8ac8329a890.png)

