### PR TITLE
Add parameter Language to Get-DbaKbUpdate

### DIFF
--- a/functions/Get-DbaKbUpdate.ps1
+++ b/functions/Get-DbaKbUpdate.ps1
@@ -18,8 +18,10 @@ function Get-DbaKbUpdate {
 
     .PARAMETER Language
         Cumulative Updates come in one file for all languages, but Service Packs have a file for every language.
+
         If you want to get only a specific language, use this parameter.
-        You have to use the two letter code that is used for Accept-Language HTTP header, e. g. "en" for english or "de" for german.
+
+        You you can press tab for auto-complete or use the two letter code that is used for Accept-Language HTTP header, e. g. "en" for English or "de" for German.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.

--- a/tests/Get-DbaKbUpdate.Tests.ps1
+++ b/tests/Get-DbaKbUpdate.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'Name', 'Simple', 'EnableException'
+        [object[]]$knownParameters = 'Name', 'Simple', 'Language', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
@@ -51,5 +51,19 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $results.KBLevel | Should -Contain 4057119
         $results.KBLevel | Should -Contain 4577194
         $results.KBLevel | Should -Contain 4564903
+    }
+
+    It "Call without specific language" {
+        $results = Get-DbaKbUpdate -Name KB5003279
+        $results.KBLevel | Should -Be 5003279
+        $results.Classification -match 'Service Pack'
+        $results.Link -match '-enu_'
+    }
+
+    It "Call with specific language" {
+        $results = Get-DbaKbUpdate -Name KB5003279 -Language ja
+        $results.KBLevel | Should -Be 5003279
+        $results.Classification -match 'Service Pack'
+        $results.Link -match '-jpn_'
     }
 }

--- a/tests/Get-DbaKbUpdate.Tests.ps1
+++ b/tests/Get-DbaKbUpdate.Tests.ps1
@@ -56,14 +56,14 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     It "Call without specific language" {
         $results = Get-DbaKbUpdate -Name KB5003279
         $results.KBLevel | Should -Be 5003279
-        $results.Classification -match 'Service Pack'
+        $results.Classification -match 'Service Packs'
         $results.Link -match '-enu_'
     }
 
     It "Call with specific language" {
         $results = Get-DbaKbUpdate -Name KB5003279 -Language ja
         $results.KBLevel | Should -Be 5003279
-        $results.Classification -match 'Service Pack'
+        $results.Classification -match 'Service Packs'
         $results.Link -match '-jpn_'
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8469  )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->

I want to be able to download only the specific language of the SQL Server Service Pack.

It is made available by #7825, but Microsoft Update Catalog behavior is changed between 2021-10-26 and 2022-07-29.
UC no longer returned all language version of SQL Server Service Pack.

### Approach
<!-- How does this change solve that purpose -->

New parameter Language to be able to obtain the download link for specific language version of Service Pack.

More specifically, Add Accept-Language HTTP Header to HTTP request if `-Language` option was specified.

### Commands to test
<!-- if these are the examples in the help just note it as such -->

See screenshots.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

![screenshot 2022-07-30 194748](https://user-images.githubusercontent.com/4245957/181907649-4e795c3b-75e6-4acd-9138-3e91d1e01b8f.png)

![screenshot 2022-07-30 194749](https://user-images.githubusercontent.com/4245957/181907654-2f015479-4ec7-44d8-8bfb-dce44d2769eb.png)

![screenshot 2022-07-30 194750](https://user-images.githubusercontent.com/4245957/181907660-004e8682-5a5c-424a-8a80-9b859c9db228.png)

