### PR TITLE
Module Import: add dotnet version warning/throw

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -7,6 +7,14 @@ param(
 
 $start = [DateTime]::Now
 
+If ($PSVersionTable.PSEdition -in "Desktop", $null) {
+    $netversion = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP' -Recurse | Get-ItemProperty -Name version -ErrorAction SilentlyContinue | Where-Object PSChildName -eq Full | Select-Object -First 1 -ExpandProperty Version
+    if ($netversion -lt [version]"4.6") {
+        # it actually works with 4.6 somehow, but 4.6.2 and above is recommended
+        throw "Modern versions of dbatools require at least .NET 4.6.2. Please update your .NET Framework or downgrade to dbatools 1.0.173"
+    }
+}
+
 if (($PSVersionTable.PSVersion.Major -lt 6) -or ($PSVersionTable.Platform -and $PSVersionTable.Platform -eq 'Win32NT')) {
     $script:isWindows = $true
 } else {


### PR DESCRIPTION
No idea why the psd1 `DotNetFrameworkVersion = '4.6.2'` doesn't work but this addresses it