### PR TITLE
Fully qualify Read-SqlXEvent to SqlServer.XEvent\Read-SqlXEvent

### DIFF
--- a/functions/Read-DbaAuditFile.ps1
+++ b/functions/Read-DbaAuditFile.ps1
@@ -91,14 +91,14 @@ function Read-DbaAuditFile {
             }
 
             if ($Raw) {
-                return (Read-SqlXEvent -FileName $currentfile)
+                return (SqlServer.XEvent\Read-SqlXEvent -FileName $currentfile)
             }
 
-            # use the Read-SqlXEvent cmdlet from Microsoft
+            # use the SqlServer.XEvent\Read-SqlXEvent cmdlet from Microsoft
             # because the underlying Class uses Tasks
             # which is hard to handle in PowerShell
 
-            $enum = Read-SqlXEvent -FileName $currentfile
+            $enum = SqlServer.XEvent\Read-SqlXEvent -FileName $currentfile
             $newcolumns = ($enum.Fields.Name | Select-Object -Unique)
 
             $actions = ($enum.Actions.Name | Select-Object -Unique)

--- a/functions/Read-DbaXEFile.ps1
+++ b/functions/Read-DbaXEFile.ps1
@@ -96,14 +96,14 @@ function Read-DbaXEFile {
             }
 
             if ($Raw) {
-                return (Read-SqlXEvent -FileName $currentfile)
+                return (SqlServer.XEvent\Read-SqlXEvent -FileName $currentfile)
             }
 
-            # use the Read-SqlXEvent cmdlet from Microsoft
+            # use the SqlServer.XEvent\Read-SqlXEvent cmdlet from Microsoft
             # because the underlying Class uses Tasks
             # which is hard to handle in PowerShell
 
-            $enum = Read-SqlXEvent -FileName $currentfile
+            $enum = SqlServer.XEvent\Read-SqlXEvent -FileName $currentfile
             $newcolumns = ($enum.Fields.Name | Select-Object -Unique)
 
             $actions = ($enum.Actions.Name | Select-Object -Unique)

--- a/functions/Watch-DbaXESession.ps1
+++ b/functions/Watch-DbaXESession.ps1
@@ -103,13 +103,13 @@ function Watch-DbaXESession {
 
             try {
                 if ($raw) {
-                    return (Read-SqlXEvent -ConnectionString $server.ConnectionContext.ConnectionString -SessionName $sessionname -ErrorAction Stop)
+                    return (SqlServer.XEvent\Read-SqlXEvent -ConnectionString $server.ConnectionContext.ConnectionString -SessionName $sessionname -ErrorAction Stop)
                 }
 
-                # use the Read-SqlXEvent cmdlet from Microsoft
+                # use the SqlServer.XEvent\Read-SqlXEvent cmdlet from Microsoft
                 # because the underlying Class uses Tasks
                 # which is hard to handle in PowerShell
-                Read-SqlXEvent -ConnectionString $server.ConnectionContext.ConnectionString -SessionName $sessionname -ErrorAction Stop | ForEach-Object -Process {
+                SqlServer.XEvent\Read-SqlXEvent -ConnectionString $server.ConnectionContext.ConnectionString -SessionName $sessionname -ErrorAction Stop | ForEach-Object -Process {
 
                     $hash = [ordered]@{ }
 


### PR DESCRIPTION
We load an isolated DLL to get this command. Fully qualify it so there's no confusion with the `SqlServer` module.

```
Import-Module "C:\github\dbatools\bin\smo\SqlServer.XEvent.dll"
Get-command Read-SqlXEvent

CommandType     Name                                               Version    Source
-----------     ----                                               -------    ------
Cmdlet          Read-SqlXEvent                                     1.0.0.0    SqlServer.XEvent
Cmdlet          Read-SqlXEvent                                     21.1.18256 SqlServer
```

May help fix https://github.com/dataplat/dbatools/issues/8478