### PR TITLE
Supporting custm -Port parameter when using PSRemoting (WinRM)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+﻿coverage:
+  status:
+    project: off
+    patch: off
+comment: off
+
+fixes:
+  - "dbatools/::bin/projects/dbatools/dbatools/"
+

--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -222,6 +222,7 @@ function Invoke-DbaAdvancedInstall {
     $WinRMPort = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
     if (($null -ne $WinRMPort) -and ($WinRMPort -gt -1)) {
         $connectionParams.Port = $WinRMPort
+        Write-Message -Level Verbose -Message "Using Port: $($connectionParams.Port)"
     }
 
     if ($Credential) { $connectionParams.Credential = $Credential }

--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -218,6 +218,12 @@ function Invoke-DbaAdvancedInstall {
         ErrorAction  = "Stop"
         UseSSL       = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false)
     }
+
+    $Port = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
+    if (($null -ne $Port) -and ($Port -gt -1)) {
+        $connectionParams += @{ Port = $Port }
+    }
+
     if ($Credential) { $connectionParams.Credential = $Credential }
     # need to figure out where to store the config file
     if ($isLocalHost) {

--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -219,9 +219,9 @@ function Invoke-DbaAdvancedInstall {
         UseSSL       = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false)
     }
 
-    $Port = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
-    if (($null -ne $Port) -and ($Port -gt -1)) {
-        $connectionParams += @{ Port = $Port }
+    $WinRMPort = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
+    if (($null -ne $WinRMPort) -and ($WinRMPort -gt -1)) {
+        $connectionParams.Port = $WinRMPort
     }
 
     if ($Credential) { $connectionParams.Credential = $Credential }

--- a/functions/Reset-DbaAdmin.ps1
+++ b/functions/Reset-DbaAdmin.ps1
@@ -181,6 +181,12 @@ function Reset-DbaAdmin {
                         ErrorAction  = "Stop"
                         UseSSL       = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false)
                     }
+
+                    $Port = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
+                    if (($null -ne $Port) -and ($Port -gt -1)) {
+                        $connectionParams += @{ Port = $Port }
+                    }
+
                     $session = New-PSSession @connectionParams
                 } catch {
                     Stop-Function -Continue -ErrorRecord $_ -Message "Can't access $hostName using PSSession. Check your firewall settings and ensure Remoting is enabled or run the script locally."

--- a/internal/configurations/settings/remoting.ps1
+++ b/internal/configurations/settings/remoting.ps1
@@ -13,3 +13,4 @@ Set-DbatoolsConfig -FullName 'PSRemoting.PsSessionOption.SkipRevocationCheck' -V
 
 # New-PSSession
 Set-DbatoolsConfig -FullName 'PSRemoting.PsSession.UseSSL' -Value $false -Initialize -Validation bool -Description 'Changes the value of -UseSSL parameter used by New-PsSession which is used for dbatools internally when working with PSRemoting.'
+Set-DbatoolsConfig -FullName 'PSRemoting.PsSession.Port' -Value $null -Initialize -Validation integerpositive -Description 'Changes the -Port parameter value used by New-PsSession which is used for dbatools internally when working with PSRemoting. Use it when you don''t work with default port number. To reset, use Set-DbatoolsConfig -FullName ''PSRemoting.PsSession.Port'' -Value $null'

--- a/internal/functions/Invoke-Command2.ps1
+++ b/internal/functions/Invoke-Command2.ps1
@@ -99,7 +99,7 @@ function Invoke-Command2 {
                 UseSSL         = $UseSSL
             }
             if (($null -ne $Port) -and ($Port -gt -1)) {
-                $psSessionSplat += @{ Port = $Port }
+                $psSessionSplat.Port = $Port
             }
             if (Test-Windows -NoWarn) {
                 $psSessionOptionsSplat = @{

--- a/internal/functions/Invoke-Command2.ps1
+++ b/internal/functions/Invoke-Command2.ps1
@@ -33,6 +33,9 @@ function Invoke-Command2 {
         .PARAMETER UseSSL
             Enables SSL
 
+        .PARAMETER Port
+            Uses a specific Port to connect
+
         .PARAMETER ArgumentList
             Any arguments to pass to the scriptblock being run
 
@@ -62,6 +65,7 @@ function Invoke-Command2 {
         [string]$Authentication = 'Default',
         [string]$ConfigurationName,
         [switch]$UseSSL = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false),
+        [int]$Port = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null),
         [switch]$Raw,
         [version]$RequiredPSVersion
     )
@@ -93,6 +97,9 @@ function Invoke-Command2 {
                 Name           = $sessionName
                 ErrorAction    = 'Stop'
                 UseSSL         = $UseSSL
+            }
+            if (($null -ne $Port) -and ($Port -gt -1)) {
+                $psSessionSplat += @{ Port = $Port }
             }
             if (Test-Windows -NoWarn) {
                 $psSessionOptionsSplat = @{

--- a/internal/functions/Invoke-Command2.ps1
+++ b/internal/functions/Invoke-Command2.ps1
@@ -100,6 +100,7 @@ function Invoke-Command2 {
             }
             if (($null -ne $Port) -and ($Port -gt -1)) {
                 $psSessionSplat.Port = $Port
+                Write-Message -Level Verbose -Message "Using Port: $($psSessionSplat.Port)"
             }
             if (Test-Windows -NoWarn) {
                 $psSessionOptionsSplat = @{

--- a/internal/functions/Test-PSRemoting.ps1
+++ b/internal/functions/Test-PSRemoting.ps1
@@ -30,6 +30,7 @@ function Test-PSRemoting {
             }
             if (($null -ne $Port) -and ($Port -gt -1)) {
                 $psWSManSplat.Port = $Port
+                Write-Message -Level Verbose -Message "Test using Port: $($psWSManSplat.Port)"
             }
 
             $null = Test-WSMan @psWSManSplat

--- a/internal/functions/Test-PSRemoting.ps1
+++ b/internal/functions/Test-PSRemoting.ps1
@@ -16,11 +16,23 @@ function Test-PSRemoting {
 
     process {
         $UseSSL = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false
+        $Port = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
 
         Write-Message -Level VeryVerbose -Message "Testing $($ComputerName.Computername)"
 
         try {
-            $null = Test-WSMan -ComputerName $ComputerName.ComputerName -Credential $Credential -Authentication Default -UseSSL:$UseSSL -ErrorAction Stop
+            $psWSManSplat = @{
+                ComputerName   = $ComputerName.ComputerName
+                Authentication = Default
+                Credential     = $Credential
+                UseSSL         = $UseSSL
+                ErrorAction    = 'Stop'
+            }
+            if (($null -ne $Port) -and ($Port -gt -1)) {
+                $psWSManSplat += @{ Port = $Port }
+            }
+
+            $null = Test-WSMan @psWSManSplat
             $true
         } catch {
             $false

--- a/internal/functions/Test-PSRemoting.ps1
+++ b/internal/functions/Test-PSRemoting.ps1
@@ -29,7 +29,7 @@ function Test-PSRemoting {
                 ErrorAction    = 'Stop'
             }
             if (($null -ne $Port) -and ($Port -gt -1)) {
-                $psWSManSplat += @{ Port = $Port }
+                $psWSManSplat.Port = $Port
             }
 
             $null = Test-WSMan @psWSManSplat

--- a/internal/functions/Test-PSRemoting.ps1
+++ b/internal/functions/Test-PSRemoting.ps1
@@ -23,7 +23,7 @@ function Test-PSRemoting {
         try {
             $psWSManSplat = @{
                 ComputerName   = $ComputerName.ComputerName
-                Authentication = Default
+                Authentication = "Default"
                 Credential     = $Credential
                 UseSSL         = $UseSSL
                 ErrorAction    = 'Stop'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8480 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Support a custom port when using PSRemoting

### Approach
Made it configurable through `Set-DbatoolsConfig`.
Then it will be read when creating the parameter list to connect.

NOTE: Similar to the `-UseSSL` configuration.

### Commands to test
Users need to set the wanted value for the port using `Set-DbatoolsConfig` command

``` powershell
Set-DbatoolsConfig -FullName 'PSRemoting.PsSession.Port' -Value 1111
``` 

Call any command that uses PSRemoting (WinRM)

To reset it (also on the notes) use:

``` powershell
Set-DbatoolsConfig -FullName 'PSRemoting.PsSession.Port' -Value $null
``` 
