### PR TITLE
Get-DbaServerRoleMember - Fix Login parameter being overwritten

### DIFF
--- a/functions/Get-DbaServerRoleMember.ps1
+++ b/functions/Get-DbaServerRoleMember.ps1
@@ -146,7 +146,7 @@ function Get-DbaServerRoleMember {
                 }
 
                 foreach ($member in $members) {
-                    $login = $server.Logins | Where-Object { $_.Name -eq $member }
+                    $loginList = $server.Logins | Where-Object { $_.Name -eq $member }
 
                     if ($login) {
                         [PSCustomObject]@{
@@ -154,9 +154,9 @@ function Get-DbaServerRoleMember {
                             InstanceName = $server.ServiceName
                             SqlInstance  = $server.DomainInstanceName
                             Role         = $role.Name
-                            Name         = $login.Name
+                            Name         = $loginList.Name
                             SmoRole      = $role
-                            SmoLogin     = $login
+                            SmoLogin     = $loginList
                         }
                     }
                 }

--- a/functions/Get-DbaServerRoleMember.ps1
+++ b/functions/Get-DbaServerRoleMember.ps1
@@ -148,7 +148,7 @@ function Get-DbaServerRoleMember {
                 foreach ($member in $members) {
                     $loginList = $server.Logins | Where-Object { $_.Name -eq $member }
 
-                    if ($login) {
+                    if ($loginList) {
                         [PSCustomObject]@{
                             ComputerName = $server.ComputerName
                             InstanceName = $server.ServiceName

--- a/tests/Get-DbaServerRoleMember.Tests.ps1
+++ b/tests/Get-DbaServerRoleMember.Tests.ps1
@@ -74,5 +74,6 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
     AfterAll {
         Remove-DbaLogin -SqlInstance $instance -Login $testLogin -Force -Confirm:$false
+        Remove-DbaLogin -SqlInstance $instance1 -Login $testLogin -Force -Confirm:$false
     }
 }

--- a/tests/Get-DbaServerRoleMember.Tests.ps1
+++ b/tests/Get-DbaServerRoleMember.Tests.ps1
@@ -21,6 +21,10 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $testLogin = 'getDbaInstanceRoleMemberLogin'
         $null = New-DbaLogin -SqlInstance $instance -Login $testLogin -Password $password1
         $null = Set-DbaLogin -SqlInstance $instance -Login $testLogin -AddRole 'dbcreator'
+
+        $instance1 = Connect-DbaInstance -SqlInstance $script:instance1
+        $null = New-DbaLogin -SqlInstance $instance1 -Login $testLogin -Password $password1
+        $null = Set-DbaLogin -SqlInstance $instance1 -Login $testLogin -AddRole 'dbcreator'
     }
 
     Context "Functionality" {
@@ -58,6 +62,13 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $uniqueLogins = $result.Name | Select-Object -Unique
             $uniqueLogins.Count | Should -BeExactly 1
             $uniqueLogins | Should -Contain $testLogin
+        }
+
+        It 'Returns results for all instances' {
+            $result = Get-DbaServerRoleMember -SqlInstance $instance, $instance1 -Login $testLogin
+
+            $uniqueInstances = $result.SqlInstance | Select-Object -Unique
+            $uniqueInstances.Count | Should -BeExactly 2
         }
     }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8495)
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
When using more than one instance and the `-Login` parameter, the latter is overwritten and the filter won't work for the 2nd and subsequent instances on the collection of instances.

### Approach
Rename the variable that holds the final list of logins per instance.

### Commands to test
Get-DbaServerRoleMember -SqlInstance "localhost:14333", "localhost:14334" -Login "sqladmin"

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/19521315/185375013-d4fc6e34-70db-4c5a-9717-464d35b68c88.png)

After:
![image](https://user-images.githubusercontent.com/19521315/185375673-76174443-9462-4628-a83d-ace83eee12ba.png)


### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
