### PR TITLE
Improve WinRM Port - Make int nullable and check if gt 0

### DIFF
--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -219,8 +219,8 @@ function Invoke-DbaAdvancedInstall {
         UseSSL       = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false)
     }
 
-    $WinRMPort = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
-    if (($null -ne $WinRMPort) -and ($WinRMPort -gt -1)) {
+    [nullable[int]]$WinRMPort = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
+    if (($null -ne $WinRMPort) -and ($WinRMPort -gt 0)) {
         $connectionParams.Port = $WinRMPort
         Write-Message -Level Verbose -Message "Using Port: $($connectionParams.Port)"
     }

--- a/functions/Reset-DbaAdmin.ps1
+++ b/functions/Reset-DbaAdmin.ps1
@@ -182,8 +182,8 @@ function Reset-DbaAdmin {
                         UseSSL       = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false)
                     }
 
-                    $Port = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
-                    if (($null -ne $Port) -and ($Port -gt -1)) {
+                    [nullable[int]]$Port = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
+                    if (($null -ne $Port) -and ($Port -gt 0)) {
                         $connectionParams += @{ Port = $Port }
                     }
 

--- a/internal/functions/Invoke-Command2.ps1
+++ b/internal/functions/Invoke-Command2.ps1
@@ -65,7 +65,7 @@ function Invoke-Command2 {
         [string]$Authentication = 'Default',
         [string]$ConfigurationName,
         [switch]$UseSSL = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false),
-        [int]$Port = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null),
+        [nullable[int]]$Port = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null),
         [switch]$Raw,
         [version]$RequiredPSVersion
     )
@@ -98,7 +98,7 @@ function Invoke-Command2 {
                 ErrorAction    = 'Stop'
                 UseSSL         = $UseSSL
             }
-            if (($null -ne $Port) -and ($Port -gt -1)) {
+            if (($null -ne $Port) -and ($Port -gt 0)) {
                 $psSessionSplat.Port = $Port
                 Write-Message -Level Verbose -Message "Using Port: $($psSessionSplat.Port)"
             }

--- a/internal/functions/Test-PSRemoting.ps1
+++ b/internal/functions/Test-PSRemoting.ps1
@@ -16,7 +16,7 @@ function Test-PSRemoting {
 
     process {
         $UseSSL = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false
-        $Port = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
+        [nullable[int]]$Port = Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.Port' -Fallback $null
 
         Write-Message -Level VeryVerbose -Message "Testing $($ComputerName.Computername)"
 
@@ -28,7 +28,7 @@ function Test-PSRemoting {
                 UseSSL         = $UseSSL
                 ErrorAction    = 'Stop'
             }
-            if (($null -ne $Port) -and ($Port -gt -1)) {
+            if (($null -ne $Port) -and ($Port -gt 0)) {
                 $psWSManSplat.Port = $Port
                 Write-Message -Level Verbose -Message "Test using Port: $($psWSManSplat.Port)"
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8501 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Make `[int]` variable accept `$null` values to keep the behaviour when we don't specific any port to PSRemoting.

More about the problem on the issue and here: https://github.com/dataplat/dbatools/discussions/8500

### Approach
Problem is that variable was set of type `[int]` instead of `[nullable[int]]` so it defaults to `0` instead of `$null`

### Commands to test
Any invoking `Invoke-Command2`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
This happens because `[int]$null` is `0`.