### PR TITLE
Add DatabaseId to the return object for Find-DbaDbGrowthEvent

### DIFF
--- a/functions/Find-DbaDbGrowthEvent.ps1
+++ b/functions/Find-DbaDbGrowthEvent.ps1
@@ -162,6 +162,7 @@ function Find-DbaDbGrowthEvent {
                             CONVERT(INT,(DENSE_RANK() OVER (ORDER BY [StartTime] DESC))%2) AS OrderRank,
                                 CONVERT(INT, [EventClass]) AS EventClass,
                             [DatabaseName],
+                            (SELECT database_id FROM sys.databases WHERE Name = [DatabaseName]) AS DatabaseId,
                             [Filename],
                             CONVERT(INT,(Duration/1000)) AS Duration,
                             $(if (-not $UseLocalTime) { "
@@ -202,7 +203,7 @@ function Find-DbaDbGrowthEvent {
                         0 AS [HostName],
                         0 AS [SessionLoginName],
                         0 AS [SPID]
-            END	TRY
+            END    TRY
             BEGIN CATCH
                 SELECT
                     SERVERPROPERTY('MachineName') AS ComputerName,

--- a/tests/Find-DbaDbGrowthEvent.Tests.ps1
+++ b/tests/Find-DbaDbGrowthEvent.Tests.ps1
@@ -4,16 +4,62 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'EventType', 'FileType', 'UseLocalTime', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/dataplat/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Command actually works" {
+        BeforeAll {
+            $server = Connect-DbaInstance -SqlInstance $script:instance3
+            $random = Get-Random
+            $databaseName1 = "dbatoolsci1_$random"
+            $db1 = New-DbaDatabase -SqlInstance $server -Name $databaseName1
+
+            $sqlGrowthAndShrink =
+            "CREATE TABLE Tab1 (ID INTEGER);
+
+            INSERT INTO Tab1 (ID)
+            SELECT
+                1
+            FROM
+                sys.all_objects a
+            CROSS JOIN
+                sys.all_objects b;
+
+            TRUNCATE TABLE Tab1;
+            DBCC SHRINKFILE ($databaseName1, TRUNCATEONLY);
+            DBCC SHRINKFILE ($($databaseName1)_Log, TRUNCATEONLY);
+            "
+
+            $null = $db1.Query($sqlGrowthAndShrink)
+        }
+        AfterAll {
+            $db1 | Remove-DbaDatabase -Confirm:$false
+        }
+
+        It "Should find auto growth events in the default trace" {
+            $results = Find-DbaDbGrowthEvent -SqlInstance $server -Database $databaseName1 -EventType Growth
+            $results.EventClass | Should -Contain 92 # data file growth
+            $results.EventClass | Should -Contain 93 # log file growth
+            $results.DatabaseName | unique | Should -Be $databaseName1
+            $results.DatabaseId | unique | Should -Be $db1.ID
+        }
+
+        <# Leaving this commented out since the background process for auto shrink cannot be triggered
+
+        It "Should find auto shrink events in the default trace" {
+            $results = Find-DbaDbGrowthEvent -SqlInstance $server -Database $databaseName1 -EventType Shrink
+            $results.EventClass | Should -Contain 94 # data file shrink
+            $results.EventClass | Should -Contain 95 # log file shrink
+            $results.DatabaseName | unique | Should -Be $databaseName1
+            $results.DatabaseId | unique | Should -Be $db1.ID
+        }
+        #>
+    }
+}

--- a/tests/Find-DbaDbGrowthEvent.Tests.ps1
+++ b/tests/Find-DbaDbGrowthEvent.Tests.ps1
@@ -16,7 +16,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Command actually works" {
         BeforeAll {
-            $server = Connect-DbaInstance -SqlInstance $script:instance3
+            $server = Connect-DbaInstance -SqlInstance $script:instance1
             $random = Get-Random
             $databaseName1 = "dbatoolsci1_$random"
             $db1 = New-DbaDatabase -SqlInstance $server -Name $databaseName1

--- a/tests/Find-DbaDbGrowthEvent.Tests.ps1
+++ b/tests/Find-DbaDbGrowthEvent.Tests.ps1
@@ -45,8 +45,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
         It "Should find auto growth events in the default trace" {
             $results = Find-DbaDbGrowthEvent -SqlInstance $server -Database $databaseName1 -EventType Growth
-            $results.EventClass | Should -Contain 92 # data file growth
-            $results.EventClass | Should -Contain 93 # log file growth
+            ($results | Where-Object { $_.EventClass -in (92, 93) }).count | Should -BeGreaterThan 0
             $results.DatabaseName | unique | Should -Be $databaseName1
             $results.DatabaseId | unique | Should -Be $db1.ID
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, relates to #8183 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Minor change to add DatabaseId to the return object.

### Approach
<!-- How does this change solve that purpose -->
Inline query in the select clause

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the new pester test

### Learning
I explored the option of adding support for Extended Events to this command, but the challenge that came up was that the dba would need to setup the XE session ahead of time. This limits the value of what this command could do with Extended Events other than provide a means to query a specified XE session, for which there are already dbatools commands available.