### PR TITLE
Set-DbaDbOwner - Fill owner before change to work around a bug in SMO

### DIFF
--- a/functions/Set-DbaDbOwner.ps1
+++ b/functions/Set-DbaDbOwner.ps1
@@ -145,6 +145,8 @@ function Set-DbaDbOwner {
                     elseif ($db.Users.name -contains $TargetLogin) {
                         Write-Message -Level Warning -Message "$dbName on $instance has $TargetLogin as a mapped user. Mapped users can not be database owners."
                     } else {
+                        # Make sure the Owner property in the SMO is filled befor the change. See #8528 for details.
+                        $null = $db.Owner
                         $db.SetOwner($TargetLogin)
                         # The used version of the SMO does not update the .Owner property, so we have to force this:
                         $db.Alter()


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8528  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

See #8528 for details.