### PR TITLE
Remove ConvertTo-SecureString from Examples

### DIFF
--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -89,13 +89,13 @@ function Backup-DbaDbCertificate {
         Exports all certificates except those for AdventureWorks on the specified SQL Server to the default data path for the instance.
 
     .EXAMPLE
-        PS C:\> Backup-DbaDbCertificate -SqlInstance Server1 -Path \\Server1\Certificates -EncryptionPassword (ConvertTo-SecureString -force -AsPlainText GoodPass1234!!)
+        PS C:\> Backup-DbaDbCertificate -SqlInstance Server1 -Path \\Server1\Certificates -EncryptionPassword (Get-Credential nousernameneeded).Password
 
         Exports all the certificates and private keys on the specified SQL Server.
 
     .EXAMPLE
-        PS C:\> $EncryptionPassword = ConvertTo-SecureString -AsPlainText "GoodPass1234!!" -force
-        PS C:\> $DecryptionPassword = ConvertTo-SecureString -AsPlainText "Password4567!!" -force
+        PS C:\> $EncryptionPassword = (Get-Credential nousernameneeded).Password
+        PS C:\> $DecryptionPassword = (Get-Credential nousernameneeded).Password
         PS C:\> Backup-DbaDbCertificate -SqlInstance Server1 -EncryptionPassword $EncryptionPassword -DecryptionPassword $DecryptionPassword
 
         Exports all the certificates on the specified SQL Server using the supplied DecryptionPassword, since an EncryptionPassword is specified private keys are also exported.

--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -89,13 +89,13 @@ function Backup-DbaDbCertificate {
         Exports all certificates except those for AdventureWorks on the specified SQL Server to the default data path for the instance.
 
     .EXAMPLE
-        PS C:\> Backup-DbaDbCertificate -SqlInstance Server1 -Path \\Server1\Certificates -EncryptionPassword (Get-Credential nousernameneeded).Password
+        PS C:\> Backup-DbaDbCertificate -SqlInstance Server1 -Path \\Server1\Certificates -EncryptionPassword (Get-Credential NoUsernameNeeded).Password
 
         Exports all the certificates and private keys on the specified SQL Server.
 
     .EXAMPLE
-        PS C:\> $EncryptionPassword = (Get-Credential nousernameneeded).Password
-        PS C:\> $DecryptionPassword = (Get-Credential nousernameneeded).Password
+        PS C:\> $EncryptionPassword = (Get-Credential NoUsernameNeeded).Password
+        PS C:\> $DecryptionPassword = (Get-Credential NoUsernameNeeded).Password
         PS C:\> Backup-DbaDbCertificate -SqlInstance Server1 -EncryptionPassword $EncryptionPassword -DecryptionPassword $DecryptionPassword
 
         Exports all the certificates on the specified SQL Server using the supplied DecryptionPassword, since an EncryptionPassword is specified private keys are also exported.

--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -57,7 +57,7 @@ function New-DbaCredential {
         https://dbatools.io/New-DbaCredential
 
     .EXAMPLE
-        PS C:\> New-DbaCredential -SqlInstance Server1 -Name MyCredential -Identity "ad\user" -SecurePassword (ConvertTo-SecureString 'myStr0ngPwd' -AsPlainText -Force)
+        PS C:\> New-DbaCredential -SqlInstance Server1 -Name MyCredential -Identity "ad\user" -SecurePassword (Get-Credential nousernameneeded).Password
 
         It will create a credential named "MyCredential" that as "ad\user" as identity and a password on server1 if it does not exist.
 
@@ -71,7 +71,7 @@ function New-DbaCredential {
         >>SqlInstance = "Server1"
         >>Name = "AzureBackupBlobStore"
         >>Identity = "https://<Azure Storage Account Name>.blob.core.windows.net/<Blob Container Name>"
-        >>SecurePassword = (ConvertTo-SecureString '<Azure Storage Account Access Key>' -AsPlainText -Force)
+        >>SecurePassword = (Get-Credential nousernameneeded).Password # <Azure Storage Account Access Key>
         >>}
         PS C:\> New-DbaCredential @params
 
@@ -82,7 +82,7 @@ function New-DbaCredential {
         >>SqlInstance = "server1"
         >>Name = "https://<azure storage account name>.blob.core.windows.net/<blob container>"
         >>Identity = "SHARED ACCESS SIGNATURE"
-        >>SecurePassword = (ConvertTo-SecureString '<Shared Access Token>' -AsPlainText -Force)
+        >>SecurePassword = (Get-Credential nousernameneeded).Password # <Shared acccess token>
         >>}
         PS C:\> New-DbaCredential @sasParams
 

--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -57,7 +57,7 @@ function New-DbaCredential {
         https://dbatools.io/New-DbaCredential
 
     .EXAMPLE
-        PS C:\> New-DbaCredential -SqlInstance Server1 -Name MyCredential -Identity "ad\user" -SecurePassword (Get-Credential nousernameneeded).Password
+        PS C:\> New-DbaCredential -SqlInstance Server1 -Name MyCredential -Identity "ad\user" -SecurePassword (Get-Credential NoUsernameNeeded).Password
 
         It will create a credential named "MyCredential" that as "ad\user" as identity and a password on server1 if it does not exist.
 
@@ -71,7 +71,7 @@ function New-DbaCredential {
         >>SqlInstance = "Server1"
         >>Name = "AzureBackupBlobStore"
         >>Identity = "https://<Azure Storage Account Name>.blob.core.windows.net/<Blob Container Name>"
-        >>SecurePassword = (Get-Credential nousernameneeded).Password # <Azure Storage Account Access Key>
+        >>SecurePassword = (Get-Credential NoUsernameNeeded).Password # <Azure Storage Account Access Key>
         >>}
         PS C:\> New-DbaCredential @params
 
@@ -82,7 +82,7 @@ function New-DbaCredential {
         >>SqlInstance = "server1"
         >>Name = "https://<azure storage account name>.blob.core.windows.net/<blob container>"
         >>Identity = "SHARED ACCESS SIGNATURE"
-        >>SecurePassword = (Get-Credential nousernameneeded).Password # <Shared acccess token>
+        >>SecurePassword = (Get-Credential NoUsernameNeeded).Password # <Shared Access Token>
         >>}
         PS C:\> New-DbaCredential @sasParams
 

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -93,7 +93,7 @@ function Set-DbaLogin {
         https://dbatools.io/Set-DbaLogin
 
     .EXAMPLE
-        PS C:\> $SecurePassword = (Get-Credential nousernameneeded).Password
+        PS C:\> $SecurePassword = (Get-Credential NoUsernameNeeded).Password
         PS C:\> $cred = New-Object System.Management.Automation.PSCredential ("username", $SecurePassword)
         PS C:\> Set-DbaLogin -SqlInstance sql1 -Login login1 -SecurePassword $cred -Unlock -PasswordMustChange
 

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -93,7 +93,7 @@ function Set-DbaLogin {
         https://dbatools.io/Set-DbaLogin
 
     .EXAMPLE
-        PS C:\> $SecurePassword = ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force
+        PS C:\> $SecurePassword = (Get-Credential nousernameneeded).Password
         PS C:\> $cred = New-Object System.Management.Automation.PSCredential ("username", $SecurePassword)
         PS C:\> Set-DbaLogin -SqlInstance sql1 -Login login1 -SecurePassword $cred -Unlock -PasswordMustChange
 

--- a/functions/Update-DbaServiceAccount.ps1
+++ b/functions/Update-DbaServiceAccount.ps1
@@ -66,7 +66,7 @@ function Update-DbaServiceAccount {
         Requires Local Admin rights on destination computer(s).
 
     .EXAMPLE
-        PS C:\> $SecurePassword = (Get-Credential nousernameneeded).Password
+        PS C:\> $SecurePassword = (Get-Credential NoUsernameNeeded).Password
         PS C:\> Update-DbaServiceAccount -ComputerName sql1 -ServiceName 'MSSQL$MYINSTANCE' -SecurePassword $SecurePassword
 
         Changes the current service account's password of the service MSSQL$MYINSTANCE to 'Qwerty1234'

--- a/functions/Update-DbaServiceAccount.ps1
+++ b/functions/Update-DbaServiceAccount.ps1
@@ -66,7 +66,7 @@ function Update-DbaServiceAccount {
         Requires Local Admin rights on destination computer(s).
 
     .EXAMPLE
-        PS C:\> $SecurePassword = ConvertTo-SecureString 'Qwerty1234' -AsPlainText -Force
+        PS C:\> $SecurePassword = (Get-Credential nousernameneeded).Password
         PS C:\> Update-DbaServiceAccount -ComputerName sql1 -ServiceName 'MSSQL$MYINSTANCE' -SecurePassword $SecurePassword
 
         Changes the current service account's password of the service MSSQL$MYINSTANCE to 'Qwerty1234'

--- a/functions/Write-DbaDbTableData.ps1
+++ b/functions/Write-DbaDbTableData.ps1
@@ -143,7 +143,7 @@ function Write-DbaDbTableData {
         Performs a bulk insert of all the data in customers.csv into mydb.dbo.customers. Because Schema was not specified, dbo was used. NULL values in the destination table will be preserved.
 
     .EXAMPLE
-        PS C:\> $passwd = (Get-Credential nousernameneeded).Password
+        PS C:\> $passwd = (Get-Credential NoUsernameNeeded).Password
         PS C:\> $AzureCredential = New-Object System.Management.Automation.PSCredential("AzureAccount"),$passwd)
         PS C:\> $DataTable = Import-Csv C:\temp\customers.csv
         PS C:\> Write-DbaDbTableData -SqlInstance AzureDB.database.windows.net -InputObject $DataTable -Database mydb -Table customers -KeepNulls -SqlCredential $AzureCredential -BulkCopyTimeOut 300

--- a/functions/Write-DbaDbTableData.ps1
+++ b/functions/Write-DbaDbTableData.ps1
@@ -143,7 +143,7 @@ function Write-DbaDbTableData {
         Performs a bulk insert of all the data in customers.csv into mydb.dbo.customers. Because Schema was not specified, dbo was used. NULL values in the destination table will be preserved.
 
     .EXAMPLE
-        PS C:\> $passwd = ConvertTo-SecureString "P@ssw0rd" -AsPlainText -Force
+        PS C:\> $passwd = (Get-Credential nousernameneeded).Password
         PS C:\> $AzureCredential = New-Object System.Management.Automation.PSCredential("AzureAccount"),$passwd)
         PS C:\> $DataTable = Import-Csv C:\temp\customers.csv
         PS C:\> Write-DbaDbTableData -SqlInstance AzureDB.database.windows.net -InputObject $DataTable -Database mydb -Table customers -KeepNulls -SqlCredential $AzureCredential -BulkCopyTimeOut 300


### PR DESCRIPTION
I will be enforcing a new policy that all Examples must be secure.

I've never been a fan of showing people how to use ConvertTo-SecureString because it's basically suggesting it's okay to type out a plain-text password at the console. If people need it for CI/CD, they can figure it out how to do it securely on other blog sites. Maybe I'll do a dbatools specific guide at some point.

[Anyway, this Twitter thread is pure pain](https://twitter.com/Lee_Holmes/status/1570927313797419009).