### PR TITLE
fixed Description/example in Invoke-DbaDbLogShipping

### DIFF
--- a/functions/Invoke-DbaDbLogShipping.ps1
+++ b/functions/Invoke-DbaDbLogShipping.ps1
@@ -23,7 +23,7 @@ function Invoke-DbaDbLogShipping {
         ** NTFS permissions
         The backup destination must have at least read/write permissions for the primary instance agent account.
         The backup destination must have at least read permissions for the secondary instance agent account.
-        The copy destination must have at least read/write permission for the secondary instance agent acount.
+        The copy destination must have at least read/write permission for the secondary instance agent account.
 
     .PARAMETER SourceSqlInstance
         Source SQL Server instance which contains the databases to be log shipped.
@@ -374,7 +374,7 @@ function Invoke-DbaDbLogShipping {
         >> GenerateFullBackup = $true
         >> RestoreScheduleFrequencyType = 'daily'
         >> RestoreScheduleFrequencyInterval = 1
-        >> SecondaryDatabaseSuffix = 'DR'
+        >> SecondaryDatabaseSuffix = 'LS'
         >> CopyDestinationFolder = '\\sql2\logshippingdest'
         >> Force = $true
         >> }


### PR DESCRIPTION


<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
One typo in the Description is fixed. Also fixed first example regarding "SecondaryDatabaseSuffix" parameter
![example](https://user-images.githubusercontent.com/27739194/191301545-9ef1447f-ec18-4ffe-8570-e47e550340fa.png)


