### PR TITLE
Support new user from external provider

### DIFF
--- a/functions/New-DbaDbUser.ps1
+++ b/functions/New-DbaDbUser.ps1
@@ -197,7 +197,7 @@ function New-DbaDbUser {
                         if ($ExternalProvider) {
                             # Due to a bug at the time of writing, the user is created using T-SQL
                             # More info at: https://github.com/microsoft/sqlmanagementobjects/issues/112
-                            $sql = "CREATE USER [$Username] FROM EXTERNAL PROVIDER"
+                            $sql = "CREATE USER [$Username] FROM EXTERNAL PROVIDER WITH DEFAULT_SCHEMA = [$DefaultSchema]"
                             $db.Query($sql)
                             # Refresh the user list otherwise won't appear in the list
                             $db.Users.Refresh()

--- a/functions/New-DbaDbUser.ps1
+++ b/functions/New-DbaDbUser.ps1
@@ -34,6 +34,10 @@ function New-DbaDbUser {
     .PARAMETER DefaultSchema
         The default database schema for the user. If not specified this value will default to dbo.
 
+    .PARAMETER ExternalProvider
+        Specifies that the user is for Azure AD Authentication.
+        Equivalent to T-SQL: 'CREATE USER [claudio@********.onmicrosoft.com] FROM EXTERNAL PROVIDER`
+
     .PARAMETER Force
         If user exists, drop and recreate.
 
@@ -79,6 +83,11 @@ function New-DbaDbUser {
 
         Creates a new sql user named user1 mapped to Login1 in the specified database and specifies the default schema to be schema1.
 
+    .EXAMPLE
+        PS C:\> New-DbaDbUser -SqlInstance sqlserver2014 -Database DB1 -Username "claudio@********.onmicrosoft.com" -ExternalProvider
+
+        Creates a new sql user named 'claudio@********.onmicrosoft.com' mapped to Azure Active Directory (AAD) in the specified database.
+
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Medium")]
     param(
@@ -91,6 +100,7 @@ function New-DbaDbUser {
         [string]$Login,
         [string]$Username = $Login,
         [string]$DefaultSchema = 'dbo',
+        [switch]$ExternalProvider,
         [switch]$Force,
         [switch]$EnableException
     )
@@ -165,7 +175,10 @@ function New-DbaDbUser {
                     Remove-User -User $existingUser
                 }
 
-                if ($Login) {
+                if ($ExternalProvider) {
+                    Write-Message -Level Verbose -Message "Using UserType: External"
+                    $userType = [Microsoft.SqlServer.Management.Smo.UserType]::External
+                } elseif ($Login) {
                     # Does a user exist with same login?
                     $existingUser = $db.Users | Where-Object Login -eq $Login
                     if ($existingUser) {
@@ -181,14 +194,23 @@ function New-DbaDbUser {
 
                 if ($Pscmdlet.ShouldProcess($db, "Creating user $Username")) {
                     try {
-                        $smoUser = New-Object Microsoft.SqlServer.Management.Smo.User
-                        $smoUser.Parent = $db
-                        $smoUser.Name = $Username
-                        $smoUser.Login = $Login
-                        $smoUser.UserType = $userType
-                        $smoUser.DefaultSchema = $DefaultSchema
+                        if ($ExternalProvider) {
+                            # Due to a bug at the time of writing, the user is created using T-SQL
+                            # More info at: https://github.com/microsoft/sqlmanagementobjects/issues/112
+                            $sql = "CREATE USER [$Username] FROM EXTERNAL PROVIDER"
+                            $db.Query($sql)
+                            # Refresh the user list otherwise won't appear in the list
+                            $db.Users.Refresh()
+                        } else {
+                            $smoUser = New-Object Microsoft.SqlServer.Management.Smo.User
+                            $smoUser.Parent = $db
+                            $smoUser.Name = $Username
+                            $smoUser.Login = $Login
+                            $smoUser.UserType = $userType
+                            $smoUser.DefaultSchema = $DefaultSchema
 
-                        $smoUser.Create()
+                            $smoUser.Create()
+                        }
                         Write-Message -Level Verbose -Message "Successfully added $Username in $db to $instance."
 
                         # Display Results

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IncludeSystem', 'Login', 'Username', 'DefaultSchema', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IncludeSystem', 'Login', 'Username', 'DefaultSchema', 'ExternalProvider', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8557)
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [x] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Make possible the creation of database users with `EXTERNAL PROVIDER`.

### Approach
Added a new parameter of type `switch` called `-ExternalProvider` that needs to be passed to say that the contained user maps to the AAD.

### Commands to test
``` powershell
New-DbaDbUser -SqlInstance <AzureSQLManagedInstance> -Database dbatools -ExternalProvider -Username "claudio@********.onmicrosoft.com"
```

### Screenshots
![image](https://user-images.githubusercontent.com/19521315/193128807-1cd8fccf-3ac9-4a62-84f9-effaf11b46dd.png)

### Learning
Keep in mind that for the time being this will be done using T-SQL as SMO has a BUG that prevents the creation of EXTERNAL PROVIDER on Azure SQL Managed Instance.
More info: https://github.com/microsoft/sqlmanagementobjects/issues/112

Will be updating to pure SMO when a new version with the fix is released.
