### PR TITLE
Remove warnings/errors running update-dbatools on non-Windows systems

### DIFF
--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -2,20 +2,23 @@
 param(
     $module = "dbatools"
 )
-
-$isElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-
 # Which process should we be looking for?
 if ($psedition -eq 'Core') {
     $process = "pwsh"
 } else {
     $process = "powershell"
 }
-$ise = Get-Process powershell_ise -ErrorAction SilentlyContinue
-if ($ise) {
-    return "PowerShell ISE found in use. Please close this program before using this script."
-}
+if (($PSVersionTable.PSVersion.Major -le 5) -or ($PSVersionTable.PSVersion.Major -gt 6 -and $PSVersionTable.OS -contains "Windows")) {
+    $isElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
+    $ise = Get-Process powershell_ise -ErrorAction SilentlyContinue
+    if ($ise) {
+        return "PowerShell ISE found in use. Please close this program before using this script."
+    }
+} else {
+    $isElevated = $null;
+    $ise = $null;
+}
 $installedVersion = Get-InstalledModule $module -AllVersions | Select-Object Version, InstalledLocation
 Write-Output "The currently installed version(s) of $module is/are: "
 $installedVersion.Version


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #8564 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->

Eliminates warning resulting from looking for Windows-specific objects or applications on non-Windows OSes.

### Approach
Check `$PSVersionTable` for version and host OS

### Commands to test
`Update-DbaTools`