### PR TITLE
Fix use of .\instance #8574

### DIFF
--- a/bin/projects/dbatools/dbatools.Tests/Parameter/DbaInstanceParamaterTest.cs
+++ b/bin/projects/dbatools/dbatools.Tests/Parameter/DbaInstanceParamaterTest.cs
@@ -103,6 +103,27 @@ namespace Sqlcollaborative.Dbatools.Parameter
         }
 
         /// <summary>
+        /// Checks that . is treated as a localhost connection
+        /// </summary>
+        [TestMethod]
+        public void TestDotHostnameWithInstance()
+        {
+            var dbaInstanceParamater = new DbaInstanceParameter(@".\instancename");
+
+            Assert.AreEqual(".", dbaInstanceParamater.ComputerName);
+            Assert.AreEqual("[.]", dbaInstanceParamater.SqlComputerName);
+            Assert.AreEqual(@".\instancename", dbaInstanceParamater.FullName);
+            Assert.IsTrue(dbaInstanceParamater.IsLocalHost);
+            Assert.AreEqual(@"NP:.\instancename", dbaInstanceParamater.FullSmoName);
+            Assert.AreEqual(@"instancename", dbaInstanceParamater.InstanceName);
+            Assert.AreEqual(@"[instancename]", dbaInstanceParamater.SqlInstanceName);
+            Assert.AreEqual(@"[.\instancename]", dbaInstanceParamater.SqlFullName);
+            Assert.AreEqual(SqlConnectionProtocol.NP, dbaInstanceParamater.NetworkProtocol);
+            Assert.IsTrue(dbaInstanceParamater.IsLocalHost);
+            Assert.IsFalse(dbaInstanceParamater.IsConnectionString);
+        }
+
+        /// <summary>
         /// Checks that localdb named instances
         /// </summary>
         [TestMethod]

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -269,7 +269,7 @@ namespace Sqlcollaborative.Dbatools.Parameter
 
             if (UtilityHost.IsLike(tempString, @".\*"))
             {
-                _ComputerName = Name;
+                _ComputerName = ".";
                 _NetworkProtocol = SqlConnectionProtocol.NP;
 
                 string instanceName = tempString.Substring(2);


### PR DESCRIPTION
You can also just delete your dbatools directory and have GitHub Desktop reclone it.

 - [x] Please confirm you have the smaller repo (110MB .git directory vs 275MB .git directory)

 Note this will likely have to happen once more in the future as we move the SMO and c# library to their own repository.

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [x] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Fix use of .\instance #8574

