### PR TITLE
Invoke-DbaDbMirroring - remove db restore to witness

### DIFF
--- a/functions/Invoke-DbaDbMirroring.ps1
+++ b/functions/Invoke-DbaDbMirroring.ps1
@@ -272,6 +272,7 @@ function Invoke-DbaDbMirroring {
                     }
                 }
 
+                $currentmirrordb = Get-DbaDatabase -SqlInstance $dest -Database $dbName
                 $primaryendpoint = Get-DbaEndpoint -SqlInstance $source | Where-Object EndpointType -eq DatabaseMirroring
                 $currentmirrorendpoint = Get-DbaEndpoint -SqlInstance $dest | Where-Object EndpointType -eq DatabaseMirroring
 


### PR DESCRIPTION
Fixes #8573 

I thought I fixed this already 🤔  Guess not. Neverthless, no dbs need to exist on witness. https://learn.microsoft.com/en-us/sql/database-engine/database-mirroring/database-mirroring-witness?view=sql-server-ver16