### PR TITLE
Import-DbaCsv - Unlock CSV file after import

### DIFF
--- a/bin/projects/dbatools/dbatools/IO/ProgressStream.cs
+++ b/bin/projects/dbatools/dbatools/IO/ProgressStream.cs
@@ -119,5 +119,14 @@ namespace Sqlcollaborative.Dbatools.IO
         {
             inner.Write(buffer, offset, count);
         }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                inner.Dispose();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Type of Change

 - [x ] Bug fix (non-breaking change, fixes #8593)

### Purpose
Fixes a bug I introduced in a previous contribution, where the CSV file remained locked after the import-dbacsv operation.

### Approach
The underlying file stream was not being disposed properly, due to a wrapper stream I introduced to report progress. The disposal operation is now passed down to the wrapped stream.

### Commands to test
See linked bug.
