### PR TITLE
Get-DbaDbCertificate: Add DatabaseId to the return object

### DIFF
--- a/functions/Get-DbaDbCertificate.ps1
+++ b/functions/Get-DbaDbCertificate.ps1
@@ -111,6 +111,7 @@ function Get-DbaDbCertificate {
                 Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name InstanceName -value $db.InstanceName
                 Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name SqlInstance -value $db.SqlInstance
                 Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name Database -value $db.Name
+                Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name DatabaseId -value $db.Id
 
                 Select-DefaultView -InputObject $cert -Property ComputerName, InstanceName, SqlInstance, Database, Name, Subject, StartDate, ActiveForServiceBrokerDialog, ExpirationDate, Issuer, LastBackupDate, Owner, PrivateKeyEncryptionType, Serial
             }

--- a/tests/Get-DbaDbCertificate.Tests.ps1
+++ b/tests/Get-DbaDbCertificate.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Certificate', 'Subject', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -21,8 +21,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             }
 
             $tempdbmasterkey = New-DbaDbMasterKey -SqlInstance $script:instance1 -Database tempdb -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
-            $certificateName1 = "Cert_$(Get-random)"
-            $certificateName2 = "Cert_$(Get-random)"
+            $certificateName1 = "Cert_$(Get-Random)"
+            $certificateName2 = "Cert_$(Get-Random)"
             $cert1 = New-DbaDbCertificate -SqlInstance $script:instance1 -Name $certificateName1 -Confirm:$false
             $cert2 = New-DbaDbCertificate -SqlInstance $script:instance1 -Name $certificateName2 -Database "tempdb" -Confirm:$false
         }
@@ -36,11 +36,13 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $cert = Get-DbaDbCertificate -SqlInstance $script:instance1 -Certificate $certificateName1
         It "returns database certificate created in default, master database" {
             "$($cert.Database)" -match 'master' | Should Be $true
+            $cert.DatabaseId | Should -Be (Get-DbaDatabase -SqlInstance $script:instance1 -Database master).Id
         }
 
         $cert = Get-DbaDbCertificate -SqlInstance $script:instance1 -Database tempdb
         It "returns database certificate created in tempdb database, looked up by certificate name" {
             "$($cert.Name)" -match $certificateName2 | Should Be $true
+            $cert.DatabaseId | Should -Be (Get-DbaDatabase -SqlInstance $script:instance1 -Database tempdb).Id
         }
 
         $cert = Get-DbaDbCertificate -SqlInstance $script:instance1 -ExcludeDatabase master


### PR DESCRIPTION
 - [x] Please confirm you have the smaller repo (110MB .git directory vs 275MB .git directory)


## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, relates to #8183<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Minor change to add DatabaseId to the return object.

### Approach
<!-- How does this change solve that purpose -->
Added a NoteProperty on the return object.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the updated Pester tests.