### PR TITLE
Add-DbaAgDatabase - New check for failure with automatic seeding

### DIFF
--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -250,9 +250,6 @@ function Add-DbaAgDatabase {
             $targetSynchronizationState = @{ }
             $output = @( )
 
-            # Needed in Step 5, but we need the time where everything started
-            $startTime = $server.Query("SELECT GETDATE() StartTime").StartTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss", [System.Globalization.CultureInfo]::InvariantCulture)
-
             $progress['Activity'] = "Adding database $($db.Name) to Availability Group $AvailabilityGroup."
 
             $progress['Status'] = "Step 1/5: Setting seeding mode if needed."
@@ -497,7 +494,7 @@ function Add-DbaAgDatabase {
                                 $syncProgress['SecondsRemaining'] = [int](($physicalSeedingStats.estimate_time_complete_utc - (Get-Date).ToUniversalTime()).TotalSeconds)
                                 $syncProgress['CurrentOperation'] = "Seeding state: $($physicalSeedingStats.internal_state_desc), $([int]($physicalSeedingStats.transferred_size_bytes/1024/1024)) out of $([int]($physicalSeedingStats.database_size_bytes/1024/1024)) MB transferred."
                             }
-                            $automaticSeeding = $server.Query("SELECT TOP 1 * FROM sys.dm_hadr_automatic_seeding WHERE ag_id = '$($ag.UniqueId.Guid.ToUpper())' AND ag_db_id = '$($ag.AvailabilityDatabases[$db.Name].UniqueId.Guid.ToUpper())' AND ag_remote_replica_id = '$($ag.AvailabilityReplicas[$replicaName].UniqueId.Guid.ToUpper())' AND start_time > CONVERT(datetime, '$startTime', 126) ORDER BY start_time DESC")
+                            $automaticSeeding = $server.Query("SELECT TOP 1 * FROM sys.dm_hadr_automatic_seeding WHERE ag_id = '$($ag.UniqueId.Guid.ToUpper())' AND ag_db_id = '$($ag.AvailabilityDatabases[$db.Name].UniqueId.Guid.ToUpper())' AND ag_remote_replica_id = '$($ag.AvailabilityReplicas[$replicaName].UniqueId.Guid.ToUpper())' ORDER BY start_time DESC")
                             Write-Message -Level Verbose -Message "Current automatic seeding state: $($automaticSeeding.current_state)"
                             if ($automaticSeeding.current_state -eq 'FAILED') {
                                 $failure = $true


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On October 2, 2022, [we removed some bloat from our repository](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or reset their repo using the following code:

```
git fetch
git reset --hard origin/master
```

You can also just delete your dbatools directory and have GitHub Desktop reclone it.

 - [s] Please confirm you have the smaller repo (110MB .git directory vs 275MB .git directory)

 Note this will likely have to happen once more in the future as we move the SMO and c# library to their own repository.

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8603 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

See issue for details.

Maybe we don't need the filter for start_time if the ag_db_id is a new guid every time.

I have renamed $seedingStats to $physicalSeedingStats to better align the variable name with the view name.