### PR TITLE
Invoke-ManagedComputerCommand - Remove code that is not needed

### DIFF
--- a/internal/functions/Invoke-ManagedComputerCommand.ps1
+++ b/internal/functions/Invoke-ManagedComputerCommand.ps1
@@ -66,18 +66,7 @@ function Invoke-ManagedComputerCommand {
     Write-Message -Level Verbose -Message "Connecting to SQL WMI on $computer."
 
     try {
-        $result = Invoke-Command2 -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -Credential $Credential -ErrorAction Stop
-        if ($result.Exception) {
-            # The new code pattern for WMI calls like in Set-DbaNetworkConfiguration is used where all exceptions are catched and return as part of an object.
-            foreach ($msg in $result.Verbose) {
-                Write-Message -Level Verbose -Message $msg
-            }
-            Write-Message -Level Verbose -Message "Execution against $computer failed with: $($result.Exception)"
-            Stop-Function -Message "Failed." -Target $computer -ErrorRecord $result.Exception -EnableException $true
-        } else {
-            # The old code pattern is used or no exception was catched, so just return the result
-            $result
-        }
+        Invoke-Command2 -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -Credential $Credential -ErrorAction Stop
     } catch {
         Write-Message -Level Verbose -Message "Local connection attempt to $computer failed. Connecting remotely."
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On October 2, 2022, [we removed some bloat from our repository](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or reset their repo using the following code:

```
git fetch
git reset --hard origin/master
```

You can also just delete your dbatools directory and have GitHub Desktop reclone it.

 - [x] Please confirm you have the smaller repo (110MB .git directory vs 275MB .git directory)

 Note this will likely have to happen once more in the future as we move the SMO and c# library to their own repository.

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8444 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

The removed code was intended for Set-DbaNetworkConfiguration, but then Set-DbaNetworkConfiguration used Invoke-Command2 directly. Currently there is not command that uses the "new code pattern" where we catch execptions in the scriptblock and support verbose messages.

I still would like to change all the scriptblocks that commands pass to Invoke-ManagedComputerCommand, but I would have to change them all at once. 

So for now - just fixing this bug...