### PR TITLE
Invoke-DbaQuery - Fix wrong verbose preference

### DIFF
--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -216,7 +216,7 @@ function Invoke-DbaQuery {
             $splatInvokeDbaSqlAsync["MessagesToOutput"] = $MessagesToOutput
         }
         if (Test-Bound -ParameterName "Verbose") {
-            $splatInvokeDbaSqlAsync["Verbose"] = $Verbose
+            $splatInvokeDbaSqlAsync["Verbose"] = $PSBoundParameters.Verbose
         }
         if (Test-Bound -ParameterName "NoExec") {
             $splatInvokeDbaSqlAsync["NoExec"] = $NoExec

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -298,7 +298,7 @@ SELECT 2
         $result = Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query $q -NoExec
         $result | Should -BeNullOrEmpty
 
-        #{ Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query "SELEC p FROM c" -NoExec -EnableException } | Should -Throw "Incorrect syntax near 'SELEC'"
+        { Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query "SELEC p FROM c" -NoExec -EnableException } | Should -Throw "Incorrect syntax near 'selec'"
     }
 
     It "supports dropping temp objects (#8472)" {

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -298,7 +298,7 @@ SELECT 2
         $result = Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query $q -NoExec
         $result | Should -BeNullOrEmpty
 
-        { Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query "SELECT p FROM c" -NoExec -EnableException } | Should -Throw "Incorrect syntax near 'selec'"
+        { Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query "SELEC p FROM c" -NoExec -EnableException } | Should -Throw "Incorrect syntax near 'SELEC'"
     }
 
     It "supports dropping temp objects (#8472)" {

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -298,7 +298,7 @@ SELECT 2
         $result = Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query $q -NoExec
         $result | Should -BeNullOrEmpty
 
-        { Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query "SELEC p FROM c" -NoExec -EnableException } | Should -Throw "Incorrect syntax near 'selec'"
+        { Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query "SELECT p FROM c" -NoExec -EnableException } | Should -Throw "Incorrect syntax near 'selec'"
     }
 
     It "supports dropping temp objects (#8472)" {

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -298,7 +298,7 @@ SELECT 2
         $result = Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query $q -NoExec
         $result | Should -BeNullOrEmpty
 
-        { Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query "SELEC p FROM c" -NoExec -EnableException } | Should -Throw "Incorrect syntax near 'SELEC'"
+        #{ Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query "SELEC p FROM c" -NoExec -EnableException } | Should -Throw "Incorrect syntax near 'SELEC'"
     }
 
     It "supports dropping temp objects (#8472)" {

--- a/tests/Start-DbaMigration.Tests.ps1
+++ b/tests/Start-DbaMigration.Tests.ps1
@@ -30,12 +30,12 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         Remove-DbaDatabase -Confirm:$false -SqlInstance $script:instance2, $script:instance3 -Database $startmigrationrestoredb, $detachattachdb
 
         $server = Connect-DbaInstance -SqlInstance $script:instance3
-        $server.Query("CREATE DATABASE $startmigrationrestoredb2; ALTER DATABASE $startmigrationrestoredb2 SET AUTO_CLOSE OFF WITH ROLLBACK IMMEDIATE")
+        Invoke-DbaQuery -SqlInstance $server -Query "CREATE DATABASE $startmigrationrestoredb2; ALTER DATABASE $startmigrationrestoredb2 SET AUTO_CLOSE OFF WITH ROLLBACK IMMEDIATE"
 
         $server = Connect-DbaInstance -SqlInstance $script:instance2
-        $server.Query("CREATE DATABASE $startmigrationrestoredb; ALTER DATABASE $startmigrationrestoredb SET AUTO_CLOSE OFF WITH ROLLBACK IMMEDIATE")
-        $server.Query("CREATE DATABASE $detachattachdb; ALTER DATABASE $detachattachdb SET AUTO_CLOSE OFF WITH ROLLBACK IMMEDIATE")
-        $server.Query("CREATE DATABASE $startmigrationrestoredb2; ALTER DATABASE $startmigrationrestoredb2 SET AUTO_CLOSE OFF WITH ROLLBACK IMMEDIATE")
+        Invoke-DbaQuery -SqlInstance $server -Query "CREATE DATABASE $startmigrationrestoredb; ALTER DATABASE $startmigrationrestoredb SET AUTO_CLOSE OFF WITH ROLLBACK IMMEDIATE"
+        Invoke-DbaQuery -SqlInstance $server -Query "CREATE DATABASE $detachattachdb; ALTER DATABASE $detachattachdb SET AUTO_CLOSE OFF WITH ROLLBACK IMMEDIATE"
+        Invoke-DbaQuery -SqlInstance $server -Query "CREATE DATABASE $startmigrationrestoredb2; ALTER DATABASE $startmigrationrestoredb2 SET AUTO_CLOSE OFF WITH ROLLBACK IMMEDIATE"
         $null = Set-DbaDbOwner -SqlInstance $script:instance2 -Database $startmigrationrestoredb, $detachattachdb -TargetLogin sa
     }
     AfterAll {


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8270 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Because of the bug (using `$Verbose` which is always `$null` instead of `$PSBoundParameters.Verbose` which holds the actual value of the `-Verbose` parameter) every execution of this command was always using `-Verbose:$true` when calling `Invoke-DbaAsync`.

Now with this change, the default (when not using `-Verbose` at all) changed from `-Verbose:$true` to `-Verbose:$false`. So this is a breaking change.

Or do we want this command to use `-Verbose:$true` as a default? I would say "no", but others might vote "yes"...