### PR TITLE
Get-DbaAgBackupHistory

### DIFF
--- a/functions/Get-DbaAgBackupHistory.ps1
+++ b/functions/Get-DbaAgBackupHistory.ps1
@@ -204,6 +204,7 @@ function Get-DbaAgBackupHistory {
         $null = $PSBoundParameters.Remove('SqlInstance')
         $null = $PSBoundParameters.Remove('AvailabilityGroup')
         $null = $PSBoundParameters.Remove('Last')
+        $null = $PSBoundParameters.Remove('LsnSort')
         $AgResults = Get-DbaDbBackupHistory -SqlInstance $serverList @PSBoundParameters
         foreach ($agr in $AgResults) {
             $agr.AvailabilityGroupName = $AvailabilityGroup


### PR DESCRIPTION
Fixing a bug, didn't remove the new parameter from the subsequent call to the underlying backup cmdlet

<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On October 2, 2022, [we removed some bloat from our repository](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or reset their repo using the following code:

```
git fetch
git reset --hard origin/master
```

You can also just delete your dbatools directory and have GitHub Desktop reclone it.

 - [x] Please confirm you have the smaller repo (110MB .git directory vs 275MB .git directory)

 Note this will likely have to happen once more in the future as we move the SMO and c# library to their own repository.

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Previous pull request introduced a bug as the new LsnSort parameter was being propagated to the underlying call to Get-DbaDbBackupHistory via @PSBoundParameters.  Removing from that.

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
