### PR TITLE
Allow Get-DbaDbBackupHistory to take a TimeSpan for -Since

### DIFF
--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -158,7 +158,7 @@ function Get-DbaDbBackupHistory {
         [switch]$IncludeCopyOnly,
         [Parameter(ParameterSetName = "NoLast")]
         [switch]$Force,
-        [DateTime]$Since = (Get-Date '01/01/1970'),
+        [object]$Since = (Get-Date '01/01/1970'),
         [ValidateScript( { ($_ -match '^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$') -or ('' -eq $_) })]
         [string]$RecoveryFork,
         [switch]$Last,
@@ -211,12 +211,18 @@ function Get-DbaDbBackupHistory {
         foreach ($typeFilter in $Type) {
             $backupTypeFilter += $backupTypeMapping[$typeFilter]
         }
-
     }
 
     process {
         if ($AgCheck) {
             Stop-Function -Message "Parameter AGCheck is deprecated. This command does not check for history from replicas even if this paramater is not provided. The functionality to also get the history from all replicas if SqlInstance is part on an availability group has been moved to Get-DbaAgBackupHistory."
+            return
+        }
+
+        if ($Since -is [timespan]) {
+            $Since = (Get-Date).add($Since);
+        } elseif (-not ($Since -is [datetime])) {
+            Stop-Function -Message "-Since must be either a DateTime or TimeSpan object."
             return
         }
 

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -32,6 +32,7 @@ function Get-DbaDbBackupHistory {
 
     .PARAMETER Since
         Specifies a starting point for the search for backups. If a DateTime object is passed, that will be used. If a TimeSpan object is passed, that will be added to Get-Date and the resulting value will be used.
+        
     .PARAMETER RecoveryFork
         Specifies the Recovery Fork you want backup history for.
 

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -31,8 +31,7 @@ function Get-DbaDbBackupHistory {
         If this switch is enabled, a large amount of information is returned, similar to what SQL Server itself returns.
 
     .PARAMETER Since
-        Specifies a DateTime object to use as the starting point for the search for backups.
-
+        Specifies a starting point for the search for backups. If a DateTime object is passed, that will be used. If a TimeSpan object is passed, that will be added to Get-Date and the resulting value will be used.
     .PARAMETER RecoveryFork
         Specifies the Recovery Fork you want backup history for.
 

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -221,7 +221,7 @@ function Get-DbaDbBackupHistory {
 
         if ($Since -is [timespan]) {
             $Since = (Get-Date).add($Since);
-        } elseif (-not ($Since -is [datetime])) {
+        } elseif ($Since -isnot [datetime]) {
             Stop-Function -Message "-Since must be either a DateTime or TimeSpan object."
             return
         }

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -158,7 +158,7 @@ function Get-DbaDbBackupHistory {
         [switch]$IncludeCopyOnly,
         [Parameter(ParameterSetName = "NoLast")]
         [switch]$Force,
-        [object]$Since = (Get-Date '01/01/1970'),
+        [psobject]$Since = (Get-Date '01/01/1970'),
         [ValidateScript( { ($_ -match '^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$') -or ('' -eq $_) })]
         [string]$RecoveryFork,
         [switch]$Last,

--- a/tests/Get-DbaDbBackupHistory.Tests.ps1
+++ b/tests/Get-DbaDbBackupHistory.Tests.ps1
@@ -159,4 +159,22 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             ($Ignore | Where-Object Type -like '*diff*').count | Should -Be 0
         }
     }
+
+    Context "Testing the Since parameter" {
+        It "DateTime for -Since" {
+            $results = Get-DbaDbBackupHistory -SqlInstance $script:instance1 -Database $dbname -Since (Get-Date).AddMinutes(-5)
+            $results.count | Should -BeGreaterThan 0
+        }
+
+        It "TimeSpan for -Since" {
+            $results = Get-DbaDbBackupHistory -SqlInstance $script:instance1 -Database $dbname -Since (New-TimeSpan -Minutes -5)
+            $results.count | Should -BeGreaterThan 0
+        }
+
+        It "Invalid type for -Since" {
+            $results = Get-DbaDbBackupHistory -SqlInstance $script:instance1 -Database $dbname -Since "-" -WarningVariable warning
+            $results | Should -BeNullOrEmpty
+            $warning | Should -BeLike "*-Since must be either a DateTime or TimeSpan object*"
+        }
+    }
 }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8599 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Minor change to support TimeSpan values for the -Since param as @ben-thul suggested in #8599 

### Approach
<!-- How does this change solve that purpose -->
Update to param type and conditional logic to ensure $Since is set.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the new pester tests added.