### PR TITLE
Get-DbaDbCheckConstraint: Add DatabaseId to the return object

### DIFF
--- a/functions/Get-DbaDbCheckConstraint.ps1
+++ b/functions/Get-DbaDbCheckConstraint.ps1
@@ -116,6 +116,7 @@ function Get-DbaDbCheckConstraint {
                         Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                         Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                         Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name Database -value $db.Name
+                        Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name DatabaseId -value $db.Id
 
                         $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Parent', 'ID', 'CreateDate',
                         'DateLastModified', 'Name', 'IsEnabled', 'IsChecked', 'NotForReplication', 'Text', 'State'

--- a/tests/Get-DbaDbCheckConstraint.Tests.ps1
+++ b/tests/Get-DbaDbCheckConstraint.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'ExcludeSystemTable', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -34,11 +34,12 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "Command actually works" {
         It "returns no check constraints from excluded DB with -ExcludeDatabase" {
             $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -ExcludeDatabase master
-            $results.where( {$_.Database -eq 'master'}).count | Should Be 0
+            $results.where( { $_.Database -eq 'master' }).count | Should Be 0
         }
         It "returns only check constraints from selected DB with -Database" {
             $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -Database $dbname
-            $results.where( {$_.Database -ne 'master'}).count | Should Be 1
+            $results.where( { $_.Database -ne 'master' }).count | Should Be 1
+            $results.DatabaseId | Get-Unique | Should -Be (Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname).Id
         }
         It "Should include test check constraint: $ckName" {
             $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -Database $dbname -ExcludeSystemTable


### PR DESCRIPTION
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, relates to #8183 <!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Minor change to add DatabaseId to the return object.

### Approach
<!-- How does this change solve that purpose -->
Added a NoteProperty.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the changes to the pester tests.