### PR TITLE
Update PR template with updated final pruning date (today -- repo is now 85MB)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Below information IS REQUIRED with every PR -->
 ## Please read -- recent changes to our repo
-On October 2, 2022, [we removed some bloat from our repository](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or reset their repo using the following code:
+On November 10, 2022, [we removed some bloat from our repository (for a second time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or reset their repo using the following code:
 
 ```
 git fetch
@@ -9,7 +9,7 @@ git reset --hard origin/master
 
 You can also just delete your dbatools directory and have GitHub Desktop reclone it.
 
- - [ ] Please confirm you have the smaller repo (110MB .git directory vs 275MB .git directory)
+ - [ ] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB .git directory)
 
  Note this will likely have to happen once more in the future as we move the SMO and c# library to their own repository.
 

--- a/.github/workflows/reposize.yml
+++ b/.github/workflows/reposize.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Repository size should be less than 90MB
         shell: pwsh
         run: |
+          cd /tmp
           gh repo clone dataplat/dbatools
+          cd /tmp/dbatools
           $objects = git count-objects -v
           $sizepack = $objects -split '`n' | Where-Object { $PSItem -match "size-pack" }
           $size = $sizepack -split " " | Select-Object -Last 1

--- a/.github/workflows/reposize.yml
+++ b/.github/workflows/reposize.yml
@@ -8,15 +8,22 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     steps:
+      - uses: actions/checkout@v1
       - uses: jwalton/gh-find-current-pr@v1
+        id: findpr
+        with:
+          state: all
+
       - name: Repository size should be less than 90MB
+        env:
+          PR: ${{ steps.findpr.outputs.pr }}
         shell: pwsh
         run: |
           cd /tmp
           gh repo clone dataplat/dbatools
           cd /tmp/dbatools
-          Write-Output "Checking out ${{PR}}"
-          gh pr checkout ${{PR}}
+          Write-Output "Checking out $env:PR"
+          gh pr checkout $env:PR
           $objects = git count-objects -v
           $sizepack = $objects -split '`n' | Where-Object { $PSItem -match "size-pack" }
           $size = $sizepack -split " " | Select-Object -Last 1

--- a/.github/workflows/reposize.yml
+++ b/.github/workflows/reposize.yml
@@ -6,14 +6,15 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
       - name: Repository size should be less than 90MB
         shell: pwsh
         run: |
+          gh repo clone dataplat/dbatools
           $objects = git count-objects -v
           $sizepack = $objects -split '`n' | Where-Object { $PSItem -match "size-pack" }
           $size = $sizepack -split " " | Select-Object -Last 1

--- a/.github/workflows/reposize.yml
+++ b/.github/workflows/reposize.yml
@@ -1,0 +1,24 @@
+name: Check repo size
+on: [pull_request]
+
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: Repository size should be less than 90MB
+        shell: pwsh
+        run: |
+          $objects = git count-objects -v
+          $sizepack = $objects -split '`n' | Where-Object { $PSItem -match "size-pack" }
+          $size = $sizepack -split " " | Select-Object -Last 1
+          Write-Output "Repo size is $size"
+          # old size = 110299 or 250000+
+          if ($size -gt 95000) { # Size is 89836, so 95000 should last a while
+            throw "This clone is outdated. Please reclone your repo and resubmit with the slimmed down repo. See https://github.com/dataplat/dbatools/pull/8637 for more information."
+          }

--- a/.github/workflows/reposize.yml
+++ b/.github/workflows/reposize.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  clone:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/reposize.yml
+++ b/.github/workflows/reposize.yml
@@ -15,8 +15,8 @@ jobs:
           cd /tmp
           gh repo clone dataplat/dbatools
           cd /tmp/dbatools
-          Write-Output "Checking out ${PR}"
-          gh pr checkout ${PR}
+          Write-Output "Checking out ${{PR}}"
+          gh pr checkout ${{PR}}
           $objects = git count-objects -v
           $sizepack = $objects -split '`n' | Where-Object { $PSItem -match "size-pack" }
           $size = $sizepack -split " " | Select-Object -Last 1

--- a/.github/workflows/reposize.yml
+++ b/.github/workflows/reposize.yml
@@ -2,21 +2,21 @@ name: Check repo size
 on: [pull_request]
 
 jobs:
-  # This workflow contains a single job called "build"
   clone:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - uses: jwalton/gh-find-current-pr@v1
       - name: Repository size should be less than 90MB
         shell: pwsh
         run: |
           cd /tmp
           gh repo clone dataplat/dbatools
           cd /tmp/dbatools
+          Write-Output "Checking out ${PR}"
+          gh pr checkout ${PR}
           $objects = git count-objects -v
           $sizepack = $objects -split '`n' | Where-Object { $PSItem -match "size-pack" }
           $size = $sizepack -split " " | Select-Object -Last 1


### PR DESCRIPTION
I could have committed directly to Dev but I wanted everyone to know that I have performed the final pruning, removing the SMO DLLs from our repository. Now, our repo is 85MB and takes 14-30 seconds to clone instead of minutes.

![image](https://user-images.githubusercontent.com/8278033/201030145-ccb6960e-4016-400d-86c9-6b26f2328866.png)

I just deleted my dbatools directory and had GH Desktop reclone it, but if you want to do it from the command line, I believe this works:

```
git fetch
git reset --hard origin/master
```

This is the last time you'll have to do this. I'll also add a PR check to ensure I don't accidentally merge the old size.