### PR TITLE
Export-DbaUser Bug Fix 8626 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Below information IS REQUIRED with every PR -->
 ## Please read -- recent changes to our repo
-On November 10, 2022, [we removed some bloat from our repository (for a second time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or reset their repo using the following code:
+On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or reset their repo using the following code:
 
 ```
 git fetch
@@ -10,8 +10,6 @@ git reset --hard origin/master
 You can also just delete your dbatools directory and have GitHub Desktop reclone it.
 
  - [ ] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB .git directory)
-
- Note this will likely have to happen once more in the future as we move the SMO and c# library to their own repository.
 
 ## Type of Change
 <!-- What type of change does your code introduce -->

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -477,7 +477,7 @@ function Export-DbaUser {
                         if ($Template) {
                             $grantee = "{templateUser}"
                         } else {
-                            $grantee = $databasePermission.Grantee
+                            $grantee = $objectPermission.Grantee
                         }
 
                         $outsql += "$grantObjectPermission $($objectPermission.PermissionType) ON $object TO [$grantee]$withGrant AS [$($objectPermission.Grantor)];"


### PR DESCRIPTION
switched to objectPermissions instead of databasePermissions, previous was resulting in missing value.

<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for a second time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or reset their repo using the following code:

```
git fetch
git reset --hard origin/master
```

You can also just delete your dbatools directory and have GitHub Desktop reclone it.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB .git directory)

 Note this will likely have to happen once more in the future as we move the SMO and c# library to their own repository.

## Type of Change
<!-- What type of change does your code introduce -->
 - [ x] Bug fix (non-breaking change, fixes #8626 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix to resolve empty grantee field in the scripts that were output for object level permissions. Attempting to apply the script created would fail since no grantee was present. 



