### PR TITLE
Bug Fix 8626 Export-DbaUser

### DIFF
--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -477,7 +477,7 @@ function Export-DbaUser {
                         if ($Template) {
                             $grantee = "{templateUser}"
                         } else {
-                            $grantee = $databasePermission.Grantee
+                            $grantee = $objectPermission.Grantee
                         }
 
                         $outsql += "$grantObjectPermission $($objectPermission.PermissionType) ON $object TO [$grantee]$withGrant AS [$($objectPermission.Grantor)];"


### PR DESCRIPTION
PR on behalf of @MrTCS until I can figure out the code to slim down remote repos. Fixes #8626

> switched to objectPermissions instead of databasePermissions, previous was resulting in missing value.

> Fix to resolve empty grantee field in the scripts that were output for object level permissions. Attempting to apply the script created would fail since no grantee was present.
