### PR TITLE
Fix Copy-DbaSysDbUserObject to include indexes

### DIFF
--- a/functions/Copy-DbaSysDbUserObject.ps1
+++ b/functions/Copy-DbaSysDbUserObject.ps1
@@ -220,6 +220,7 @@ function Copy-DbaSysDbUserObject {
                             $transfer = New-Object Microsoft.SqlServer.Management.Smo.Transfer $smodb
                             $null = $transfer.CopyAllObjects = $false
                             $null = $transfer.Options.WithDependencies = $true
+                            $null = $transfer.Options.Indexes = $true
                             $null = $transfer.ObjectList.Add($table)
                             if ($PSCmdlet.ShouldProcess($destServer, "Attempting to add table $table to $systemDb")) {
                                 try {


### PR DESCRIPTION
The Copy-DbaSysDbUserObject function was missing the Indexes = true option when the -Classic switch is not on.

<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [X] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #8667 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

