### PR TITLE
Enable Set-DbaDbCompatibility to support SQL Server 2022

### DIFF
--- a/functions/Set-DbaDbCompatibility.ps1
+++ b/functions/Set-DbaDbCompatibility.ps1
@@ -28,6 +28,7 @@ function Set-DbaDbCompatibility {
         Version130 = SQL Server 2016
         Version140 = SQL Server 2017
         Version150 = SQL Server 2019
+        Version160 = SQL Server 2022
 
     .PARAMETER TargetCompatibility
         Deprecated parameter. Please use Compatibility instead.
@@ -41,6 +42,7 @@ function Set-DbaDbCompatibility {
         13 = SQL Server 2016
         14 = SQL Server 2017
         15 = SQL Server 2019
+        16 = SQL Server 2022
 
     .PARAMETER InputObject
         A collection of databases (such as returned by Get-DbaDatabase)
@@ -92,7 +94,7 @@ function Set-DbaDbCompatibility {
         [PSCredential]$SqlCredential,
         [string[]]$Database,
         [Microsoft.SqlServer.Management.Smo.CompatibilityLevel]$Compatibility,
-        [ValidateSet(9, 10, 11, 12, 13, 14, 15)]
+        [ValidateSet(9, 10, 11, 12, 13, 14, 15, 16)]
         [int]$TargetCompatibility,
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
@@ -116,6 +118,7 @@ function Set-DbaDbCompatibility {
                     13 { "Version130" } # SQL Server 2016
                     14 { "Version140" } # SQL Server 2017
                     15 { "Version150" } # SQL Server 2019
+                    16 { "Version160" } # SQL Server 2022
                 }
             }
             Write-Message -Level Verbose -Message "TargetCompatibility $TargetCompatibility was converted to Compatibility $Compatibility."


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [X] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The command Set-DbaDbCompatibility does not support SQL Server 2022

### Approach
I added the versions for SQL Server 2022

### Commands to test
Set-DbaDbCompatibility

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
