### PR TITLE
Find-DbaInstance - Correct SqlConnect check, update test to not be Appveyor specific

### DIFF
--- a/functions/Find-DbaInstance.ps1
+++ b/functions/Find-DbaInstance.ps1
@@ -236,9 +236,7 @@ function Find-DbaInstance {
         [Dataplat.Dbatools.Discovery.DbaInstanceConfidenceLevel]$MinimumConfidence = 'Low',
         [switch]$EnableException
     )
-
     begin {
-
         #region Utility Functions
         function Test-SqlInstance {
             <#
@@ -257,7 +255,8 @@ function Find-DbaInstance {
         #>
             [CmdletBinding()]
             param (
-                [Parameter(ValueFromPipeline)][DbaInstance[]]$Target,
+                [Parameter(ValueFromPipeline)]
+                [DbaInstance[]]$Target,
                 [PSCredential]$Credential,
                 [PSCredential]$SqlCredential,
                 [Dataplat.Dbatools.Discovery.DbaInstanceScanType]$ScanType,
@@ -266,11 +265,9 @@ function Find-DbaInstance {
                 [Dataplat.Dbatools.Discovery.DbaInstanceConfidenceLevel]$MinimumConfidence,
                 [switch]$EnableException
             )
-
             begin {
                 [System.Collections.ArrayList]$computersScanned = @()
             }
-
             process {
                 foreach ($computer in $Target) {
                     $stepCounter = 0
@@ -501,7 +498,7 @@ function Find-DbaInstance {
                         $toDelete = @()
                         foreach ($dataSet in $masterList) {
                             try {
-                                $server = Connect-DbaInstance -SqlInstance $dataSet.FullSmoName -SqlCredential $SqlCredential
+                                $server = Connect-DbaInstance -SqlInstance $dataSet.SqlInstance -SqlCredential $SqlCredential
                                 $dataSet.SqlConnected = $true
                                 $dataSet.Confidence = 'High'
 

--- a/tests/Find-DbaInstance.Tests.ps1
+++ b/tests/Find-DbaInstance.Tests.ps1
@@ -4,9 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'ComputerName', 'DiscoveryType', 'Credential', 'SqlCredential', 'ScanType', 'IpAddress', 'DomainController', 'TCPPort', 'MinimumConfidence', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        BeforeAll {
+            [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+            [object[]]$knownParameters = 'ComputerName', 'DiscoveryType', 'Credential', 'SqlCredential', 'ScanType', 'IpAddress', 'DomainController', 'TCPPort', 'MinimumConfidence', 'EnableException'
+            $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        }
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
         }
@@ -15,7 +17,9 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "Command finds appveyor instances" {
-        $results = Find-DbaInstance -ComputerName $env:COMPUTERNAME
+        BeforeAll {
+            $results = Find-DbaInstance -ComputerName $env:COMPUTERNAME -ScanType Browser, SqlConnect
+        }
         It "finds more than one SQL instance" {
             $results.count -gt 1
         }
@@ -27,6 +31,9 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
         It "finds the SQL2017 instance" {
             $results.InstanceName -contains 'SQL2017' | Should -Be $true
+        }
+        It "successfully connects" {
+            $results.SqlConnected | Should -Be $true
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.
 -->

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8678 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
- Remove reference to property that does not exist on the object type.
- Cleanup test to not be Appveyor specific
- Add parameter input to allow users to run locally

### Approach
Replaced the `FullSmoName` with the correct property from class `Dataplat.Dbatools.Discovery.DbaInstanceReport`, `SqlInstance`

### Commands to test

Pester execution locally can now be done, passing in number of computer names.

```powershell
Invoke-Pester @{Path = '.\tests\Find-DbaInstance.Tests.ps1'; Parameters = @{TestServer = 'labsql201901','labsql202201'}}
```

Command specific execution:

```powershell
❯ Find-DbaInstance -ComputerName labsql201901 -ScanType Browser, SqlConnect | select *

MachineName    : labsql201901
ComputerName   : labsql201901
InstanceName   : 
FullName       : labsql201901
SqlInstance    : labsql201901
Port           : 1433
TcpConnected   : True
SqlConnected   : True
DnsResolution  : 
Ping           : False
BrowseReply    : 
Services       : 
SystemServices : 
SPNs           : {}
PortsScanned   : {labsql201901:1433 - True}
Availability   : Unknown
Confidence     : High
ScanTypes      : SqlConnect, Browser
Timestamp      : 1/15/2023 7:22:41 PM
```

### Screenshots

![image](https://user-images.githubusercontent.com/11204251/212581369-9ef2fd4f-4838-46a9-a81d-8cc621e99c37.png)

![image](https://user-images.githubusercontent.com/11204251/212581305-d918e629-32fa-4928-91ba-ddc38727e72e.png)

