### PR TITLE
Remove dbatools.core.library dependency, use only dbatools.library

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install and cache PowerShell modules
         uses: potatoqualitee/psmodulecache@v5.2
         with:
-          modules-to-cache: dbatools.library:2023.1.28
+          modules-to-cache: dbatools.library:2023.1.29
 
       - name: Set encryption values
         run: |
@@ -64,7 +64,7 @@ jobs:
         uses: potatoqualitee/psmodulecache@v5.2
         with:
           shell: powershell, pwsh
-          modules-to-cache: dbatools.library:2023.1.28
+          modules-to-cache: dbatools.library:2023.1.29
 
       - name: Install SQL Server localdb
         uses: potatoqualitee/mssqlsuite@v1.3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install and cache PowerShell modules
         uses: potatoqualitee/psmodulecache@v5.2
         with:
-          modules-to-cache: dbatools.library:2023.1.28, dbatools.core.library:2023.1.28
+          modules-to-cache: dbatools.library:2023.1.28
 
       - name: Set encryption values
         run: |
@@ -64,7 +64,7 @@ jobs:
         uses: potatoqualitee/psmodulecache@v5.2
         with:
           shell: powershell, pwsh
-          modules-to-cache: dbatools.library:2023.1.28, dbatools.core.library:2023.1.28
+          modules-to-cache: dbatools.library:2023.1.28
 
       - name: Install SQL Server localdb
         uses: potatoqualitee/mssqlsuite@v1.3

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -15,13 +15,11 @@ jobs:
       - name: Install dbatools prerelease
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module dbatools.core.library -AllowClobber
-          Install-Module dbatools -AllowPrerelease -AllowClobber
+          Install-Module dbatools -AllowPrerelease
           Set-DbatoolsConfig -Name Import.EncryptionMessageCheck -Value $false -PassThru | Register-DbatoolsConfig
 
       - name: Measure import speed on pwsh
         run: |
-          Import-Module dbatools.core.library
           Measure-Command { Import-Module dbatools }
           Get-Module dbatools
 
@@ -71,19 +69,17 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module dbatools.core.library -AllowClobber
-          Install-Module dbatools -AllowPrerelease -AllowClobber
+          Install-Module dbatools -AllowPrerelease
 
       - name: Install dbatools prerelease on powershell
         shell: powershell
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module dbatools.library -AllowClobber
-          Install-Module dbatools -AllowPrerelease -AllowClobber
+          Install-Module dbatools.library
+          Install-Module dbatools -AllowPrerelease
 
       - name: Measure import speed on pwsh
         run: |
-          Import-Module dbatools.core.library
           Measure-Command { Import-Module dbatools }
           Get-Module dbatools
 

--- a/.github/workflows/xplat-import.yml
+++ b/.github/workflows/xplat-import.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install and cache PowerShell modules
       uses: potatoqualitee/psmodulecache@v5.1
       with:
-          modules-to-cache: dbatools.library:2023.1.28
+          modules-to-cache: dbatools.library:2023.1.29
 
     - name: Perform the import
       shell: pwsh

--- a/.github/workflows/xplat-import.yml
+++ b/.github/workflows/xplat-import.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install and cache PowerShell modules
       uses: potatoqualitee/psmodulecache@v5.1
       with:
-          modules-to-cache: dbatools.library:2023.1.28, dbatools.core.library:2023.1.28
+          modules-to-cache: dbatools.library:2023.1.28
 
     - name: Perform the import
       shell: pwsh

--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -8,79 +8,49 @@
 @{
 
     # Script module or binary module file associated with this manifest.
-    RootModule            = 'dbatools.psm1'
+    RootModule         = 'dbatools.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.0.0'
+    ModuleVersion      = '2.0.0'
 
     # ID used to uniquely identify this module
-    GUID                  = '9d139310-ce45-41ce-8e8b-d76335aa1789'
+    GUID               = '9d139310-ce45-41ce-8e8b-d76335aa1789'
 
     # Author of this module
-    Author                = 'the dbatools team'
+    Author             = 'the dbatools team'
 
     # Company or vendor of this module
-    CompanyName           = 'dbatools.io'
+    CompanyName        = 'dbatools.io'
 
     # Copyright statement for this module
-    Copyright             = 'Copyright (c) 2021 by dbatools, licensed under MIT'
+    Copyright          = 'Copyright (c) 2023 by dbatools, licensed under MIT'
 
     # Description of the functionality provided by this module
-    Description           = "The community module that enables SQL Server Pros to automate database development and server administration"
-
-    # Minimum version of the Windows PowerShell engine required by this module
-    # This is because of the way RequiredModules checks to see if its Core or not
-    # dbatools.legacy will still work on PowerShell 3.0 and 4.0
-    PowerShellVersion     = '5.1'
-
-    # Name of the Windows PowerShell host required by this module
-    PowerShellHostName    = ''
-
-    # Minimum version of the Windows PowerShell host required by this module
-    PowerShellHostVersion = ''
-
-    # Minimum version of the .NET Framework required by this module
-    # DotNetFrameworkVersion = '4.6.2'
-
-    # Minimum version of the common language runtime (CLR) required by this module
-    CLRVersion            = ''
-
-    # Processor architecture (None, X86, Amd64, IA64) required by this module
-    ProcessorArchitecture = ''
+    Description        = "The community module that enables SQL Server Pros to automate database development and server administration"
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules       = @(
-        if ($PSEdition -eq 'Core') {
-            @(
-                @{ ModuleName = 'dbatools.core.library'; ModuleVersion = '2023.1.28' }
-            )
-        } else {
-            @(
-                @{ ModuleName = 'dbatools.library'; ModuleVersion = '2023.1.28' }
-            )
-        }
-    )
+    RequiredModules    = @{ ModuleName = 'dbatools.library'; ModuleVersion = '2023.1.28' }
 
     # Assemblies that must be loaded prior to importing this module
-    RequiredAssemblies    = @()
+    RequiredAssemblies = @()
 
     # Script files () that are run in the caller's environment prior to importing this module
-    ScriptsToProcess      = @()
+    ScriptsToProcess   = @()
 
     # Type files (xml) to be loaded when importing this module
-    TypesToProcess        = @("xml\dbatools.Types.ps1xml")
+    TypesToProcess     = @("xml\dbatools.Types.ps1xml")
 
     # Format files (xml) to be loaded when importing this module
     # "xml\dbatools.Format.ps1xml"
-    FormatsToProcess      = @("xml\dbatools.Format.ps1xml")
+    FormatsToProcess   = @("xml\dbatools.Format.ps1xml")
 
     # Modules to import as nested modules of the module specified in ModuleToProcess
-    NestedModules         = @()
+    NestedModules      = @()
 
     # Functions to export from this module
     # Specific functions to export for Core, etc are also found in psm1
     # FunctionsToExport specifically helps with AUTO-LOADING so do not remove
-    FunctionsToExport     = @(
+    FunctionsToExport  = @(
         'Get-DbaDbServiceBrokerQueue',
         'New-DbaLinkedServer',
         'Add-DbaAgDatabase',
@@ -754,18 +724,18 @@
     )
 
     # Cmdlets to export from this module
-    CmdletsToExport       = @(
+    CmdletsToExport    = @(
         'Select-DbaObject',
         'Set-DbatoolsConfig'
     )
 
     # Variables to export from this module
-    VariablesToExport     = ''
+    VariablesToExport  = ''
 
     # Aliases to export from this module
     # Aliases are stored in dbatools.psm1
     # The five listed below are intentional
-    AliasesToExport       = @(
+    AliasesToExport    = @(
         'Get-DbaRegisteredServer',
         'Attach-DbaDatabase',
         'Detach-DbaDatabase',
@@ -776,12 +746,12 @@
     )
 
     # List of all modules packaged with this module
-    ModuleList            = @()
+    ModuleList         = @()
 
     # List of all files packaged with this module
-    FileList              = ''
+    FileList           = ''
 
-    PrivateData           = @{
+    PrivateData        = @{
         # PSData is module packaging and gallery metadata embedded in PrivateData
         # It's for rebuilding PowerShellGet (and PoshCode) NuGet-style packages
         # We had to do this because it's the only place we're allowed to extend the manifest
@@ -810,7 +780,7 @@
 
             # Indicates this is a pre-release/testing version of the module.
             IsPrerelease = 'true'
-            Prerelease   = 'preview'
+            Prerelease   = 'preview-2'
         }
     }
 }

--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -29,7 +29,7 @@
     Description        = "The community module that enables SQL Server Pros to automate database development and server administration"
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules    = @{ ModuleName = 'dbatools.library'; ModuleVersion = '2023.1.28' }
+    RequiredModules    = @{ ModuleName = 'dbatools.library'; ModuleVersion = '2023.1.29' }
 
     # Assemblies that must be loaded prior to importing this module
     RequiredAssemblies = @()
@@ -780,7 +780,7 @@
 
             # Indicates this is a pre-release/testing version of the module.
             IsPrerelease = 'true'
-            Prerelease   = 'preview-2'
+            Prerelease   = 'preview1'
         }
     }
 }

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -42,16 +42,11 @@ $script:libraryroot = Get-DbatoolsLibraryPath -ErrorAction Ignore
 
 if (-not $script:libraryroot) {
     # for the people who bypass the psd1
-    if ($PSVersionTable.PSEdition -eq "Core") {
-        Import-Module dbatools.core.library -ErrorAction Ignore
-        $script:libraryroot = Get-DbatoolsLibraryPath -ErrorAction Ignore
-    } else {
-        Import-Module dbatools.library -ErrorAction Ignore
-        $script:libraryroot = Get-DbatoolsLibraryPath -ErrorAction Ignore
-    }
+    Import-Module dbatools.library -ErrorAction Ignore
+    $script:libraryroot = Get-DbatoolsLibraryPath -ErrorAction Ignore
 
     if (-not $script:libraryroot) {
-        throw "dbatools library module not found, please install it from the PowerShell Gallery. dbatools.library if you're using PS Desktop or dbatools.core.library if you're using PS Core"
+        throw "The dbatools library, dbatools.library, was module not found. Please install it from the PowerShell Gallery."
     }
     Write-ImportTime -Text "Couldn't find location for dbatools library module, loading it up"
 }

--- a/private/scripts/libraryimport.ps1
+++ b/private/scripts/libraryimport.ps1
@@ -1,5 +1,16 @@
 if ($PSVersionTable.PSEdition -eq "Core") {
     $names = @(
+        'Microsoft.SqlServer.Server',
+        'Microsoft.SqlServer.Dac',
+        'Microsoft.SqlServer.Smo',
+        'Microsoft.SqlServer.SmoExtended',
+        'Microsoft.SqlServer.SqlWmiManagement',
+        'Microsoft.SqlServer.Management.RegisteredServers',
+        'Microsoft.SqlServer.Management.Collector',
+        'Microsoft.SqlServer.Management.XEvent',
+        'Microsoft.SqlServer.Management.XEventDbScoped',
+        'Microsoft.SqlServer.XEvent.XELite',
+        '../third-party/LumenWorks/LumenWorks.Framework.IO'
         'Azure.Core',
         'Azure.Identity',
         'Microsoft.IdentityModel.Abstractions'
@@ -32,7 +43,7 @@ if ($PSVersionTable.OS -match "ARM64") {
 $assemblies = [System.AppDomain]::CurrentDomain.GetAssemblies()
 
 try {
-    $null = Import-Module ([IO.Path]::Combine($script:libraryroot,"third-party", "bogus", "bogus.dll"))
+    $null = Import-Module ([IO.Path]::Combine($script:libraryroot, "third-party", "bogus", "bogus.dll"))
 } catch {
     Write-Error "Could not import $assemblyPath : $($_ | Out-String)"
 }

--- a/tests/InModule.Help.Tests.ps1
+++ b/tests/InModule.Help.Tests.ps1
@@ -23,7 +23,8 @@ if ($env:appveyor) {
 
     foreach ($name in $names) {
         $library = Split-Path -Path (Get-Module dbatools*library).Path
-        $path = Join-DbaPath -Path $library -ChildPath lib
+        $path = Join-DbaPath -Path $library -ChildPath desktop
+        $path = Join-DbaPath -Path $path -ChildPath lib
         Add-Type -Path (Join-Path -path $path -ChildPath "$name.dll") -ErrorAction SilentlyContinue
     }
 }

--- a/tests/gh-actions.ps1
+++ b/tests/gh-actions.ps1
@@ -22,7 +22,7 @@ Describe "Integration Tests" -Tag "IntegrationTests" {
         # load dbatools-lib
         if (-not (Get-Module dbatools)) {
             Write-Warning "Importing dbatools from source"
-            Import-Module dbatools.core.library
+            Import-Module dbatools.library
             Import-Module ./dbatools.psd1 -Force
         }
     }

--- a/tests/gh-macactions.ps1
+++ b/tests/gh-macactions.ps1
@@ -11,7 +11,7 @@ Describe "Integration Tests" -Tag "IntegrationTests" {
 
         if (-not (Get-Module dbatools)) {
             Write-Warning "Importing dbatools from source"
-            Import-Module dbatools.core.library
+            Import-Module dbatools.library
             Import-Module ./dbatools.psd1 -Force
         }
     }

--- a/tests/gh-winactions.ps1
+++ b/tests/gh-winactions.ps1
@@ -7,11 +7,7 @@ Describe "Integration Tests" -Tag "IntegrationTests" {
 
         if (-not (Get-Module dbatools)) {
             Write-Warning "Importing dbatools from source"
-            if ($isWindows) {
-                Import-Module dbatools.core.library
-            } else {
-                Import-Module dbatools.library
-            }
+            Import-Module dbatools.library
             Import-Module ./dbatools.psd1 -Force
         }
     }


### PR DESCRIPTION
Turns out, supporting different required modules for Core is half-baked. PowerShell Gallery does not support it which is not acceptable. So now dbatools.library is just one big module.

![image](https://user-images.githubusercontent.com/8278033/215298815-81322439-b8e9-49d2-9c30-1384ea7da47c.png)
