### PR TITLE
Get-DbaDbCompression: Add DatabaseId to the return object

### DIFF
--- a/public/Get-DbaDbCompression.ps1
+++ b/public/Get-DbaDbCompression.ps1
@@ -111,6 +111,7 @@ function Get-DbaDbCompression {
                                     InstanceName    = $server.ServiceName
                                     SqlInstance     = $server.DomainInstanceName
                                     Database        = $db.Name
+                                    DatabaseId      = $db.Id
                                     Schema          = $obj.Schema
                                     TableName       = $obj.Name
                                     IndexName       = $null
@@ -131,6 +132,7 @@ function Get-DbaDbCompression {
                                     InstanceName    = $server.ServiceName
                                     SqlInstance     = $server.DomainInstanceName
                                     Database        = $db.Name
+                                    DatabaseId      = $db.Id
                                     Schema          = $obj.Schema
                                     TableName       = $obj.Name
                                     IndexName       = $index.Name


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, related to #8183 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Minor change to add DatabaseId to the return object.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See current Pester tests for this command.