### PR TITLE
Add ARM64 Self-Hosted Runner

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,7 +5,11 @@ defaults:
     shell: pwsh
 jobs:
   linux-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, arm64]
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/xplat-import.yml
+++ b/.github/workflows/xplat-import.yml
@@ -8,13 +8,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest, arm64]
 
     steps:
     - uses: actions/checkout@v3
 
     - name: Install and cache PowerShell modules
-      uses: potatoqualitee/psmodulecache@v5.1
+      uses: potatoqualitee/psmodulecache@v5.2
       with:
           modules-to-cache: dbatools.library:2023.1.29
 

--- a/tests/gh-actions.ps1
+++ b/tests/gh-actions.ps1
@@ -225,8 +225,10 @@ exec sp_addrolemember 'userrole','bob';
         (Test-DbaTempDbConfig).Rule | Should -Contain "File Growth in Percent"
     }
 
-    It "creates a snapshot" {
-        (New-DbaDbSnapshot -Database pubs).SnapshotOf | Should -Be "pubs"
+    if ((dpkg --print-architecture) -notmatch "arm") {
+        It "creates a snapshot" {
+            (New-DbaDbSnapshot -Database pubs).SnapshotOf | Should -Be "pubs"
+        }
     }
 
     It "gets an XE template on Linux" {


### PR DESCRIPTION
This workflow uses a self-hosted runner that is 100% dedicated to dbatools. It's actually a VM in the Oracle Cloud Free Tier which I heard may just disappear one day then Oracle Cloud Support won't return our calls. But until then....

ARM64 tests are important because it's so different from x64 and SMO assemblies (XE stuff in particular) has been known to fail in the past.