### PR TITLE
Add support for geometry/geography/hierarchyid types

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -29,6 +29,7 @@ if ($PSVersionTable.PSEdition -ne "Core") {
                         "System.Diagnostics.DiagnosticSource",
                         "Microsoft.IdentityModel.Abstractions",
                         "Microsoft.Data.SqlClient",
+                        "Microsoft.SqlServer.Types",
                         "System.Configuration.ConfigurationManager",
                         "Microsoft.SqlServer.Replication",
                         "Microsoft.SqlServer.Rmo",

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -310,4 +310,15 @@ SELECT 2
                 go"
         { Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query $sql -EnableException } | Should -Not -Throw
     }
+
+    It "supports geography types (#8541)" {
+        $results = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "select cast(null as geometry)"
+        $results.Column1 | Should -Be "Null"
+        $results = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "select cast(null as geography)"
+        $results.Column1 | Should -Be "Null"
+        $results = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "select cast(null as hierarchyid)"
+        $results.Column1 | Should -Be "NULL"
+    }
+
+
 }


### PR DESCRIPTION
Fixes #8541 and includes tests

Figured it out from SO https://stackoverflow.com/questions/6569624/datareader-getfieldtype-returned-null