### PR TITLE
New-DbaConnectionString - Support older compatibility

### DIFF
--- a/private/functions/utility/Hide-ConnectionString.ps1
+++ b/private/functions/utility/Hide-ConnectionString.ps1
@@ -10,6 +10,6 @@ function Hide-ConnectionString {
         }
         return $connStringBuilder.ConnectionString
     } catch {
-        return "Failed to mask the connection string`: $($_.Exception.Message)"
+        return "Failed to mask the connection string"
     }
 }

--- a/public/New-DbaConnectionString.ps1
+++ b/public/New-DbaConnectionString.ps1
@@ -196,7 +196,7 @@ function New-DbaConnectionString {
         [string]$ClientName = "custom connection",
         [int]$ConnectTimeout,
         [string]$Database,
-        [ValidateSet('Mandatory', 'Optional', 'Strict')]
+        [ValidateSet('Mandatory', 'Optional', 'Strict', 'True', 'False')]
         [string]$EncryptConnection = (Get-DbatoolsConfigValue -FullName 'sql.connection.encrypt'),
         [string]$FailoverPartner,
         [switch]$IsActiveDirectoryUniversalAuth,


### PR DESCRIPTION
True/False was set by some users in the past and this helps support previously applied settings