### PR TITLE
Install-DbaMultiTool: add sp_help_revlogin to script list

### DIFF
--- a/public/Install-DbaMultiTool.ps1
+++ b/public/Install-DbaMultiTool.ps1
@@ -140,6 +140,7 @@ function Install-DbaMultiTool {
                 $sqlScripts += Get-ChildItem $localCachedCopy -Filter "sp_doc.sql" -Recurse
                 $sqlScripts += Get-ChildItem $localCachedCopy -Filter "sp_sizeoptimiser.sql" -Recurse
                 $sqlScripts += Get-ChildItem $localCachedCopy -Filter "sp_estindex.sql" -Recurse
+                $sqlScripts += Get-ChildItem $localCachedCopy -Filter "sp_help_revlogin.sql" -Recurse
 
                 foreach ($script in $sqlScripts) {
                     $scriptName = $script.Name


### PR DESCRIPTION
 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8803  )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
None of the community script installers include the useful sp_help_revlogin by Microsoft. Since it's an MIT license, I've included it in dba-multitool and with this change it will be easy to programmatically add it to systems.

### Approach
<!-- How does this change solve that purpose -->
Add the new script name to the list of explicit scripts to install

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Install-DbaMultiTool
