### PR TITLE
Set-DbaNetworkCertificate: Try to determine key algorithm and use appropriate extension class

### DIFF
--- a/public/Set-DbaNetworkCertificate.ps1
+++ b/public/Set-DbaNetworkCertificate.ps1
@@ -182,8 +182,24 @@ function Set-DbaNetworkCertificate {
                     $keyFullPath = $keyPath + $keyName
                 } else {
                     $keyPath = $env:ProgramData + '\Microsoft\Crypto\Keys\'
-                    $rsaKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($cert)
-                    $keyName = $rsaKey.Key.UniqueName
+                    $algorithm = $cert.GetKeyAlgorithm()
+
+                    if ($algorithm.StartsWith("1.2.840.10045")){
+                        $ecdsaKey = [System.Security.Cryptography.X509Certificates.ECDsaCertificateExtensions]::GetECDsaPrivateKey($cert)
+                        $keyName = $ecdsaKey.Key.UniqueName
+                    }
+                    elseif($algorithm.StartsWith("1.2.840.113549")) {
+                        $rsaKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($cert)
+                        $keyName = $rsaKey.Key.UniqueName
+                    }
+                    elseif($algorithm.StartsWith("1.3.14.3.2.12")) {
+                        $rsaKey = [System.Security.Cryptography.X509Certificates.DSACertificateExtensions]::GetDSAPrivateKey($cert)
+                        $keyName = $rsaKey.Key.UniqueName
+                    }
+                    else {
+                        Write-Warning "Unknown certificate key algorithm OID ""$algorithm""."
+                    }
+
                     $KeyFullPath = $keyPath + $keyName
                 }
 

--- a/public/Set-DbaNetworkCertificate.ps1
+++ b/public/Set-DbaNetworkCertificate.ps1
@@ -184,19 +184,16 @@ function Set-DbaNetworkCertificate {
                     $keyPath = $env:ProgramData + '\Microsoft\Crypto\Keys\'
                     $algorithm = $cert.GetKeyAlgorithm()
 
-                    if ($algorithm.StartsWith("1.2.840.10045")){
+                    if ($algorithm.StartsWith("1.2.840.10045")) {
                         $ecdsaKey = [System.Security.Cryptography.X509Certificates.ECDsaCertificateExtensions]::GetECDsaPrivateKey($cert)
                         $keyName = $ecdsaKey.Key.UniqueName
-                    }
-                    elseif($algorithm.StartsWith("1.2.840.113549")) {
+                    } elseif ($algorithm.StartsWith("1.2.840.113549")) {
                         $rsaKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($cert)
                         $keyName = $rsaKey.Key.UniqueName
-                    }
-                    elseif($algorithm.StartsWith("1.3.14.3.2.12")) {
+                    } elseif ($algorithm.StartsWith("1.3.14.3.2.12")) {
                         $rsaKey = [System.Security.Cryptography.X509Certificates.DSACertificateExtensions]::GetDSAPrivateKey($cert)
                         $keyName = $rsaKey.Key.UniqueName
-                    }
-                    else {
+                    } else {
                         Write-Warning "Unknown certificate key algorithm OID ""$algorithm""."
                     }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
*Set-DbaNetworkCertificate* currently fails to grant read permissions to certificates using the ECDsa key algorithm due to the way it determines the path to the key file.

### Approach
Changed the key discovery part of *Set-DbaNetworkCertificate* to determine the key algorithm using the OID value returned by `$cert.GetKeyAlgorithm()`. Can handle certificates using `RSA`, `ECDsa` and `DSA`  key algorithms now (only tested with `RSA` and `ECDsa`).
