### PR TITLE
Implementing Test-DbaPath for Testing Copy Folder for Log Shipping Secondary

### DIFF
--- a/private/functions/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/private/functions/New-DbaLogShippingPrimaryDatabase.ps1
@@ -134,7 +134,7 @@ function New-DbaLogShippingPrimaryDatabase {
         Stop-Function -Message "The backup share path $BackupShare should be formatted in the form \\server\share." -Target $SqlInstance
         return
     } else {
-        if (-not ((Test-Path $BackupShare -PathType Container -IsValid) -and ((Get-Item $BackupShare).PSProvider.Name -eq 'FileSystem'))) {
+        if (-not ((Test-DbaPath $BackupShare -SqlInstance $SqlInstance -SqlCredential $SqlCredential) -and ((Get-Item $BackupShare).PSProvider.Name -eq 'FileSystem'))) {
             Stop-Function -Message "The backup share path $BackupShare is not valid or can't be reached." -Target $SqlInstance
             return
         }

--- a/private/functions/New-DbaLogShippingSecondaryPrimary.ps1
+++ b/private/functions/New-DbaLogShippingSecondaryPrimary.ps1
@@ -131,7 +131,7 @@ function New-DbaLogShippingSecondaryPrimary {
         Stop-Function -Message "The backup destination path should be formatted in the form \\server\share." -Target $SqlInstance
         return
     } else {
-        if (-not ((Test-Path $BackupDestinationDirectory -PathType Container -IsValid) -and ((Get-Item $BackupDestinationDirectory).PSProvider.Name -eq 'FileSystem'))) {
+        if (-not ((Test-DbaPath $BackupDestinationDirectory -SqlInstance $SqlInstance -SqlCredential $SqlCredential) -and ((Get-Item $BackupDestinationDirectory).PSProvider.Name -eq 'FileSystem'))) {
             Stop-Function -Message "The backup destination path is not valid or can't be reached." -Target $SqlInstance
             return
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [X] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Minor fix for issue where the copy-to location is local to the secondary server in log shipping. Currently the function tests the path relative to the machine where the script is run. When I attempted to configure log shipping with the folder for log files that was local to the secondary server DbaTools would fail to find that local drive (it only existed on the secondary) and fail to set up the secondary server because the folder path failed the check. In our environment the initial backup location is a UNC share but I did notice that `Test-Path` was used there and updated it as well.

### Approach
<!-- How does this change solve that purpose -->
Changing `Test-Path` to `Test-DbaPath` ensures the path is checked in the context of the server rather than locally to the where the script is being run.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Invoke-DbaDbLogShipping`