### PR TITLE
New-DbaDbUser: Refactor and added contained user creation

### DIFF
--- a/public/New-DbaDbUser.ps1
+++ b/public/New-DbaDbUser.ps1
@@ -107,7 +107,7 @@ function New-DbaDbUser {
         [Parameter(Mandatory, ParameterSetName = "Login")]
         [string]$Login,
         [Parameter(ParameterSetName = "Login", Mandatory = $False)]
-        [Parameter(ParameterSetName = "NoLogin", Mandatory = $True)]
+        [Parameter(Mandatory, ParameterSetName = "NoLogin")]
         [Parameter(ParameterSetName = "ContainedSQLUser", Mandatory = $True)]
         [Parameter(ParameterSetName = "ContainedAADUser", Mandatory = $True)]
         [string]$Username,

--- a/public/New-DbaDbUser.ps1
+++ b/public/New-DbaDbUser.ps1
@@ -104,7 +104,7 @@ function New-DbaDbUser {
         [string[]]$Database,
         [string[]]$ExcludeDatabase,
         [switch]$IncludeSystem = $False,
-        [Parameter(ParameterSetName = "Login", Mandatory = $True)]
+        [Parameter(Mandatory, ParameterSetName = "Login")]
         [string]$Login,
         [Parameter(ParameterSetName = "Login", Mandatory = $False)]
         [Parameter(ParameterSetName = "NoLogin", Mandatory = $True)]

--- a/public/New-DbaDbUser.ps1
+++ b/public/New-DbaDbUser.ps1
@@ -124,7 +124,6 @@ function New-DbaDbUser {
         $connParam = @{ }
         if ($SqlCredential) { $connParam.SqlCredential = $SqlCredential }
 
-        # is this required?
         if ($Force) { $ConfirmPreference = 'none' }
 
         # When user is created from login and no user name is provided then login name will be used as the user name

--- a/public/New-DbaDbUser.ps1
+++ b/public/New-DbaDbUser.ps1
@@ -104,7 +104,7 @@ function New-DbaDbUser {
         [string[]]$Database,
         [string[]]$ExcludeDatabase,
         [switch]$IncludeSystem = $False,
-        [Parameter(ParameterSetName = "NoLogin", Mandatory = $True)]
+        [Parameter(ParameterSetName = "NoLogin", Mandatory = $False)]
         [Parameter(ParameterSetName = "Login", Mandatory = $True)]
         [string]$Login,
         [Parameter(ParameterSetName = "Login", Mandatory = $False)]
@@ -209,9 +209,9 @@ function New-DbaDbUser {
                             Stop-Function -Message "Failed to add user $Username in $db to $instance" -Category InvalidOperation -ErrorRecord $_ -Target $instance -Continue
                         }
 
-                    } else {
-                        Stop-Function -Message "Invalid DefaultSchema: $DefaultSchema is not found in the database $db on $instance, skipping." -Continue
                     }
+                } else {
+                    Stop-Function -Message "Invalid DefaultSchema: $DefaultSchema is not found in the database $db on $instance, skipping." -Continue
                 }
             }
         }

--- a/public/New-DbaDbUser.ps1
+++ b/public/New-DbaDbUser.ps1
@@ -98,7 +98,7 @@ function New-DbaDbUser {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Medium")]
     param(
-        [parameter(Mandatory = $True, Position = 1)]
+        [parameter(Mandatory, Position = 1)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$Database,

--- a/public/New-DbaDbUser.ps1
+++ b/public/New-DbaDbUser.ps1
@@ -28,7 +28,7 @@ function New-DbaDbUser {
     .PARAMETER Login
         When specified, the user will be associated to this SQL login and have the same name as the Login.
 
-    .PARAMETER UserName
+    .PARAMETER Username
         When specified, the user will have this name.
 
     .PARAMETER Password
@@ -110,7 +110,7 @@ function New-DbaDbUser {
         [Parameter(ParameterSetName = "NoLogin", Mandatory = $True)]
         [Parameter(ParameterSetName = "ContainedSQLUser", Mandatory = $True)]
         [Parameter(ParameterSetName = "ContainedAADUser", Mandatory = $True)]
-        [string]$UserName,
+        [string]$Username,
         [string]$DefaultSchema = 'dbo',
         [Parameter(ParameterSetName = "ContainedSQLUser", Mandatory = $True)]
         [securestring]$Password,
@@ -128,8 +128,8 @@ function New-DbaDbUser {
         if ($Force) { $ConfirmPreference = 'none' }
 
         # When user is created from login and no user name is provided then login name will be used as the user name
-        if ($Login -and -not($UserName)) {
-            $UserName = $Login
+        if ($Login -and -not($Username)) {
+            $Username = $Login
         }
 
         #Set appropriate user type
@@ -175,17 +175,17 @@ function New-DbaDbUser {
                 #prepare user query param
                 $userParam = $connParam.Clone()
                 $userParam.Database = $dbSmo.name
-                $userParam.User = $UserName
+                $userParam.User = $Username
 
                 #check if the schema exists
                 if ($dbSmo.Name -in ($getValidSchema).Parent.Name) {
-                    if ($Pscmdlet.ShouldProcess($dbSmo, "Creating user $UserName")) {
-                        Write-Message -Level Verbose -Message "Add user [$UserName] to database [$dbSmo] on [$instance]"
+                    if ($Pscmdlet.ShouldProcess($dbSmo, "Creating user $Username")) {
+                        Write-Message -Level Verbose -Message "Add user [$Username] to database [$dbSmo] on [$instance]"
 
                         #smo param builder
                         $smoUser = New-Object Microsoft.SqlServer.Management.Smo.User
                         $smoUser.Parent = $dbSmo
-                        $smoUser.Name = $UserName
+                        $smoUser.Name = $Username
                         if ($Login) { $smoUser.Login = $Login }
                         $smoUser.UserType = $userType
                         $smoUser.DefaultSchema = $DefaultSchema
@@ -193,13 +193,13 @@ function New-DbaDbUser {
                         #Check if the user exists already
                         $userExists = Get-DbaDbUser @userParam
                         if ($userExists -and -not($Force)) {
-                            Stop-Function -Message "User [$UserName] already exists in the database $dbSmo on [$instance] and -Force was not specified, skipping." -Target $UserName -Continue -EnableException $False
+                            Stop-Function -Message "User [$Username] already exists in the database $dbSmo on [$instance] and -Force was not specified, skipping." -Target $Username -Continue -EnableException $False
                         } elseif ($userExists -and $Force) {
                             try {
-                                Write-Message -Level Verbose -Message "FORCE is used, user [$UserName] will be dropped in the database $dbSmo on [$instance]"
+                                Write-Message -Level Verbose -Message "FORCE is used, user [$Username] will be dropped in the database $dbSmo on [$instance]"
                                 Remove-DbaDbUser @userParam -Force
                             } catch {
-                                Stop-Function -Message "Could not remove existing user [$UserName] in the database $dbSmo on [$instance], skipping." -Target $User -ErrorRecord $_ -Continue
+                                Stop-Function -Message "Could not remove existing user [$Username] in the database $dbSmo on [$instance], skipping." -Target $User -ErrorRecord $_ -Continue
                             }
                         }
 

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -24,12 +24,14 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
         $null = New-DbaLogin -SqlInstance $script:instance2 -Login $userName -Password $securePassword -Force
         $null = New-DbaDatabase -SqlInstance $script:instance2 -Name $dbname
+        $dbContainmentSpValue = (Get-DbaSpConfigure -SqlInstance $script:instance2 -Name ContainmentEnabled).ConfiguredValue
         $null = Set-DbaSpConfigure -SqlInstance $script:instance2 -Name ContainmentEnabled -Value 1
         $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "ALTER DATABASE [$dbname] SET CONTAINMENT = PARTIAL WITH NO_WAIT"
     }
     AfterAll {
         $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -Confirm:$false
         $null = Remove-DbaLogin -SqlInstance $script:instance2 -Login $userName -Confirm:$false
+        $null = Set-DbaSpConfigure -SqlInstance $script:instance2 -Name ContainmentEnabled -Value $dbContainmentSpValue
     }
     Context "Test error handling" {
         It "Tries to create the user with an invalid default schema" {

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -24,7 +24,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
         $null = New-DbaLogin -SqlInstance $script:instance2 -Login $userName -Password $securePassword -Force
         $null = New-DbaDatabase -SqlInstance $script:instance2 -Name $dbname
-        Invoke-DbaQuery -SqlInstance $script:instance2 -Query "ALTER DATABASE [$dbname] SET CONTAINMENT = PARTIAL WITH NO_WAIT"
+        $null = Set-DbaSpConfigure -SqlInstance $script:instance2 -Name ContainmentEnabled -Value 1
+        $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "ALTER DATABASE [$dbname] SET CONTAINMENT = PARTIAL WITH NO_WAIT"
     }
     AfterAll {
         $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -Confirm:$false

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -24,7 +24,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
         $null = New-DbaLogin -SqlInstance $script:instance2 -Login $userName -Password $securePassword -Force
         $null = New-DbaDatabase -SqlInstance $script:instance2 -Name $dbname
-        $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "ALTER DATABASE [$dbname] SET CONTAINMENT = PARTIAL WITH NO_WAIT"
+        Invoke-DbaQuery -SqlInstance $script:instance2 -Query "ALTER DATABASE [$dbname] SET CONTAINMENT = PARTIAL WITH NO_WAIT"
     }
     AfterAll {
         $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -Confirm:$false
@@ -46,10 +46,10 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
     }
     Context "Should create the user with password" {
-        It "Creates the user and get it" {
+        It "Creates the contained sql user and get it." {
             New-DbaDbUser -SqlInstance $script:instance2 -Database $dbname -Username $userNameWithPassword -Password $securePassword -DefaultSchema guest
             $newDbUser = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname | Where-Object Name -eq $userNameWithPassword
-            $newDbUser.Name | Should Be $userNameWithPassword
+            $newDbUser.Name | Should -Be $userNameWithPassword
             $newDbUser.DefaultSchema | Should -Be 'guest'
         }
     }

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IncludeSystem', 'Login', 'Username', 'DefaultSchema', 'ExternalProvider', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IncludeSystem', 'Login', 'Username', 'Password', 'DefaultSchema', 'ExternalProvider', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
@@ -17,12 +17,14 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $dbname = "dbatoolscidb_$(Get-Random)"
         $userName = "dbatoolscidb_UserWithLogin"
+        $userNameWithPassword = "dbatoolscidb_UserWithPassword"
         $userNameWithoutLogin = "dbatoolscidb_UserWithoutLogin"
 
         $password = 'MyV3ry$ecur3P@ssw0rd'
         $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
         $null = New-DbaLogin -SqlInstance $script:instance2 -Login $userName -Password $securePassword -Force
         $null = New-DbaDatabase -SqlInstance $script:instance2 -Name $dbname
+        $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "ALTER DATABASE [$dbname] SET CONTAINMENT = PARTIAL WITH NO_WAIT"
     }
     AfterAll {
         $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -Confirm:$false
@@ -40,6 +42,14 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             New-DbaDbUser -SqlInstance $script:instance2 -Database $dbname -Login $userName -DefaultSchema guest
             $newDbUser = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname | Where-Object Name -eq $userName
             $newDbUser.Name | Should Be $userName
+            $newDbUser.DefaultSchema | Should -Be 'guest'
+        }
+    }
+    Context "Should create the user with password" {
+        It "Creates the user and get it" {
+            New-DbaDbUser -SqlInstance $script:instance2 -Database $dbname -Username $userNameWithPassword -Password $securePassword -DefaultSchema guest
+            $newDbUser = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname | Where-Object Name -eq $userNameWithPassword
+            $newDbUser.Name | Should Be $userNameWithPassword
             $newDbUser.DefaultSchema | Should -Be 'guest'
         }
     }


### PR DESCRIPTION
## Type of Change
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8815
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
- Refactored the code a bit to use `dbatools` public functions.
- Added parameter sets based on the type of user
- Added functionality to create contained users
- Added functionality to return an warning when the given database doesn't exists
- Removed deprecated `SqlLogin` user type
- Updated integration test

### Approach
Included a new parameter (Password) to the function and also used parameter sets. Depends on which parameter the user choose then action will be taken. In this case if they use `Password` parameter then it will create a SQL user with password in the database. SQL User with password is supported only in contained database and from SQL 2012 onwards. This check is not done , if the database is not enabled partial containment then at the time of execution a error will be thrown.

### Commands to test
`New-DbaDbUser -SqlInstance sqlserver2016 -Database DB1 -Username user1 -Password (ConvertTo-SecureString -String "DBATools" -AsPlainText)`
