### PR TITLE
Added Filter functionality to Get-DbaDbUserDefinedTableType

### DIFF
--- a/public/Get-DbaDbUserDefinedTableType.ps1
+++ b/public/Get-DbaDbUserDefinedTableType.ps1
@@ -85,7 +85,7 @@ function Get-DbaDbUserDefinedTableType {
 
             if ($Type) {
                 $userDefinedTableTypes = $db.UserDefinedTableTypes | Where-Object Name -in $Type
-            } else { 
+            } else {
                 $userDefinedTableTypes = $db.UserDefinedTableTypes
             }
 

--- a/public/Get-DbaDbUserDefinedTableType.ps1
+++ b/public/Get-DbaDbUserDefinedTableType.ps1
@@ -22,6 +22,9 @@ function Get-DbaDbUserDefinedTableType {
     .PARAMETER ExcludeDatabase
         The database(s) to exclude - this list is auto populated from the server
 
+    .PARAMETER Type
+        [OPTIONAL] When provided, the output will be filtered to return only the types given otherwise returns all the table types.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -56,6 +59,7 @@ function Get-DbaDbUserDefinedTableType {
         [PSCredential]$SqlCredential,
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
+        [string[]]$Type,
         [switch]$EnableException
     )
 
@@ -74,7 +78,11 @@ function Get-DbaDbUserDefinedTableType {
                 continue
             }
 
-            foreach ($tabletype in $db.UserDefinedTableTypes) {
+            if ($Type) {
+                $userDefinedTableTypes = $db.UserDefinedTableTypes | Where-Object Name -in $Type
+            } else { $userDefinedTableTypes = $db.UserDefinedTableTypes }
+
+            foreach ($tabletype in $userDefinedTableTypes) {
                 if ( $tabletype.IsSystemObject ) {
                     continue
                 }
@@ -84,7 +92,7 @@ function Get-DbaDbUserDefinedTableType {
                 Add-Member -Force -InputObject $tabletype -MemberType NoteProperty -Name SqlInstance -value $tabletype.Parent.SqlInstance
                 Add-Member -Force -InputObject $tabletype -MemberType NoteProperty -Name Database -value $db.Name
 
-                $defaults = 'ComputerName, InstanceName, SqlInstance, Database, ID, Name, Columns, Owner, CreateDate, IsSystemObject, Version'
+                $defaults = ('ComputerName', 'InstanceName', 'SqlInstance' , 'Database' , 'ID', 'Name', 'Columns', 'Owner', 'CreateDate', 'IsSystemObject', 'Version')
 
                 Select-DefaultView -InputObject $tabletype -Property $defaults
             }

--- a/public/Get-DbaDbUserDefinedTableType.ps1
+++ b/public/Get-DbaDbUserDefinedTableType.ps1
@@ -44,12 +44,17 @@ function Get-DbaDbUserDefinedTableType {
     .EXAMPLE
         PS C:\> Get-DbaDbUserDefinedTableType -SqlInstance sql2016
 
-        Gets all database Stored Procedures
+        Gets all database user defined table types in all the databases
 
     .EXAMPLE
         PS C:\> Get-DbaDbUserDefinedTableType -SqlInstance Server1 -Database db1
 
-        Gets the Stored Procedures for the db1 database
+        Gets all the user defined table types for the db1 database
+
+    .EXAMPLE
+        PS C:\> Get-DbaDbUserDefinedTableType -SqlInstance Server1 -Database db1 -Type type1
+
+        Gets type1 user defined table type from db1 database
 
     #>
     [CmdletBinding()]

--- a/public/Get-DbaDbUserDefinedTableType.ps1
+++ b/public/Get-DbaDbUserDefinedTableType.ps1
@@ -85,7 +85,9 @@ function Get-DbaDbUserDefinedTableType {
 
             if ($Type) {
                 $userDefinedTableTypes = $db.UserDefinedTableTypes | Where-Object Name -in $Type
-            } else { $userDefinedTableTypes = $db.UserDefinedTableTypes }
+            } else { 
+                $userDefinedTableTypes = $db.UserDefinedTableTypes
+            }
 
             foreach ($tabletype in $userDefinedTableTypes) {
                 if ( $tabletype.IsSystemObject ) {

--- a/tests/Get-DbaDbUserDefinedTableType.Tests.ps1
+++ b/tests/Get-DbaDbUserDefinedTableType.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'Database', 'ExcludeDatabase'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'Database', 'ExcludeDatabase', 'Type'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
@@ -17,14 +17,17 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
         $server = Connect-DbaInstance -SqlInstance $script:instance2
         $tabletypename = ("dbatools_{0}" -f $(Get-Random))
+        $tabletypename1 = ("dbatools_{0}" -f $(Get-Random))
         $server.Query("CREATE TYPE $tabletypename AS TABLE([column1] INT NULL)", 'tempdb')
+        $server.Query("CREATE TYPE $tabletypename1 AS TABLE([column1] INT NULL)", 'tempdb')
     }
     AfterAll {
         $null = $server.Query("DROP TYPE $tabletypename", 'tempdb')
+        $null = $server.Query("DROP TYPE $tabletypename1", 'tempdb')
     }
 
-    Context "Gets the Db User Defined Table Type" {
-        $results = Get-DbaDbUserDefinedTableType -SqlInstance $script:instance2 -database tempdb
+    Context "Gets a Db User Defined Table Type" {
+        $results = Get-DbaDbUserDefinedTableType -SqlInstance $script:instance2 -database tempdb -Type $tabletypename
         It "Gets results" {
             $results | Should Not Be $Null
         }
@@ -34,5 +37,19 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It "Should have an owner of dbo" {
             $results.owner | Should Be "dbo"
         }
+        It "Should have a count of 1" {
+            $results.Count | Should Be 1
+        }
+    }
+
+    Context "Gets all the Db User Defined Table Type" {
+        $results = Get-DbaDbUserDefinedTableType -SqlInstance $script:instance2 -database tempdb
+        It "Gets results" {
+            $results | Should Not Be $Null
+        }
+        It "Should have a count of 2" {
+            $results.Count | Should Be 2
+        }
+
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #8690
 - [x] New feature (non-breaking change, adds functionality, fixes #8691
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
This change will allow the users to filter the output by table type names.

### Approach
Followed standard pattern. Added a new parameter to the function which accepts an array of type names, the same is then used within the code to filter the output

### Commands to test
`Get-DbaDbUserDefinedTableType -SqlInstance Host1 -database DB1 -Type TableType1`
