### PR TITLE
New function to get latest sql version

### DIFF
--- a/public/Get-DbaLatestSQLVersion.ps1
+++ b/public/Get-DbaLatestSQLVersion.ps1
@@ -1,0 +1,105 @@
+function Get-DbaLatestSQLVersion {
+    <#
+        .SYNOPSIS
+            Get latest version of SQL Server SP & CU
+        .DESCRIPTION
+            Function to get the latest version of SQL server. Source from online dbatools Github community
+        .PARAMETER ServerMajorVersion
+            [OPTIONAL] When provided the output result will only contain latest version for that SQL Server
+        .PARAMETER WebVersionUrl
+            [OPTIONAL] Override the default URL for fetching all SQL Server Versions. Default points to dbatools repository.
+        .PARAMETER OfflineOnly
+            [OPTIONAL] When enabled, the function will use the local version of the reference data that's bundled with dbatools module. Using this parameter might result in outdated dataset. Use only when no internet connection is available.
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+        .EXAMPLE
+            Get-LatestSQLVersion
+            Get-LatestSQLVersion -OfflineOnly
+            Get-LatestSQLVersion -ServerMajorVersion "10.50"
+
+        .NOTES
+        Tags: Version
+        Author: Vidhya Sagar (@sqlarticles)
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaLatestSQLVersion
+    #>
+    param(
+        [ValidateSet("8", "9", "10", "10.50", "11", "12", "13", "14", "15", "16")]
+        [parameter(Mandatory = $false)]
+        [string]$ServerMajorVersion,
+        [parameter(Mandatory = $false)]
+        [Uri]$WebVersionUrl = "https://raw.githubusercontent.com/dataplat/dbatools/development/bin/dbatools-buildref-index.json",
+        [switch]$OfflineOnly = $false,
+        [switch]$EnableException = $false
+    )
+
+    begin {
+
+        $moduleReferenceFile = Join-DbaPath -Path $PSScriptRoot -Child ..\bin\dbatools-buildref-index.json
+
+        $latestVersion = New-Object System.Collections.Generic.List[Object]
+
+        $sqlMajorVersions = @("8", "9", "10.0", "10.50", "11", "12", "13", "14", "15", "16")
+
+        if ($OfflineOnly -eq $false) {
+            try {
+                $allSqlVersion = (Invoke-WebRequest -Uri $WebVersionUrl).Content | ConvertFrom-Json
+            } catch {
+                Write-Message -Level Warning -Message "Unable to read from online reference file [$WebVersionUrl]. Using local reference file (might not have the latest releases)"
+            }
+        }
+
+        if (-not($allSqlVersion) ) {
+            try {
+                $allSqlVersion = Get-Content -Path $moduleReferenceFile | ConvertFrom-Json
+            } catch {
+                Stop-Function -Message "Unable to read the reference file online and also locally." -ErrorRecord $_ -Target $moduleReferenceFile -EnableException $EnableException
+            }
+        }
+
+    }
+    process {
+        if ($null -ne $allSqlVersion) {
+            foreach ($version in $sqlMajorVersions) {
+                $wildVersion = "$version*"
+                $lastestSP = $allSqlVersion.Data | Select-Object Version, CU, SP, KBList | Where-Object { $_.Version -like $wildVersion -and $null -ne $_.SP } | Sort-Object -Bottom 1
+                $latestPatch = $allSqlVersion.Data | Select-Object Version, CU, SP, KBList | Where-Object { $_.Version -like $wildVersion -and $null -eq $_.SP } | Sort-Object -Bottom 1
+                $latestVersionObject = [PSCustomObject]@{
+                    SQLName            = switch ($version) {
+                        "8" { "SQL 2000" }
+                        "9" { "SQL 2005" }
+                        "10.0" { "SQL 2008" }
+                        "10.50" { "SQL 2008 R2" }
+                        "11" { "SQL 2012" }
+                        "12" { "SQL 2014" }
+                        "13" { "SQL 2016" }
+                        "14" { "SQL 2017" }
+                        "15" { "SQL 2019" }
+                        "16" { "SQL 2022" }
+                    }
+                    SQLMajorVersion    = if ($version -eq "10.0") { "10" } else { $version }
+                    LatestSP           = $lastestSP.SP
+                    LatestSPVersion    = $lastestSP.Version
+                    LatestSPKB         = $lastestSP.KBList
+                    LatestPatch        = $latestPatch.CU
+                    LatestPatchVersion = $latestPatch.Version
+                    LatestPatchKB      = $latestPatch.KBList
+                }
+                $latestVersion.Add($latestVersionObject)
+            }
+        }
+    }
+    end {
+        if ($ServerMajorVersion) {
+            $latestVersion = $latestVersion | Where-Object { $_.SQLMajorVersion -eq $ServerMajorVersion }
+        }
+        return $latestVersion
+    }
+}

--- a/tests/Get-DbaLatestSQLVersion.Tests.ps1
+++ b/tests/Get-DbaLatestSQLVersion.Tests.ps1
@@ -1,0 +1,40 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'ServerMajorVersion', 'WebVersionUrl', 'OfflineOnly', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+
+    Context "Should fetch the version locally" {
+        It "Gets latest version for all SQL versions starting from SQL 2000" {
+            $results = Get-DbaLatestSQLVersion -OfflineOnly
+            $results | Should -Not -Be $null
+            $results.count | Should -Be 10
+        }
+
+        It "Get the latest version for SQL 2014" {
+            $results = Get-DbaLatestSQLVersion -ServerMajorVersion 12 -OfflineOnly
+            $results | Should -Not -Be $null
+            $results.LatestSP | Should -Be "SP3"
+        }
+    }
+
+    Context "Should fetch the version from online" {
+        It "Failure to read online data, fall back to local" {
+            $results = Get-DbaLatestSQLVersion -WebVersionUrl "https://dbatools.dummy/dummy-reference.json" -Verbose -WarningVariable warningMessage
+            $results | Should -Not -Be $null
+            $warningMessage | Should -BeLike "*Unable to read from online reference file*"
+        }
+    }
+
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
This function will provide the latest version of SQL Server details based on the reference data from dbatools(https://github.com/dataplat/dbatools/blob/development/bin/dbatools-buildref-index.json). Hope this function can be useful in the scenarios below
- Automatically check if the current version of SQL Server is out of date
- Versioning details are hardcoded in some of the functions and requires a change every time a new version is released. Now this function can be used instead. As long as the reference data is up to date then no changes is required at the code level.

### Approach
Uses the reference dataset from dbatools online community (https://github.com/dataplat/dbatools/blob/development/bin/dbatools-buildref-index.json)
This data is also bundled with dbatools module.
User is provided with two options, by default the reference data is looked up online. When that ends in failure, it will fall back to the local reference data set. Also the end user can provide `OfflineOnly` parameter to force the function to use only offline version of the reference data.

### Commands to test
            Get-LatestSQLVersion
            Get-LatestSQLVersion -OfflineOnly
            Get-LatestSQLVersion -ServerMajorVersion "10.50"
