### PR TITLE
Fix/8860

### DIFF
--- a/bin/dbatools-buildref-index.json
+++ b/bin/dbatools-buildref-index.json
@@ -4370,7 +4370,7 @@
         {
             "Version": "15.0.2000",
             "SP": "RTM",
-			"SupportedUntil": "2030-01-08"
+            "SupportedUntil": "2030-01-08"
         },
         {
             "Version": "15.0.2070",
@@ -4520,7 +4520,7 @@
         {
             "Version": "16.0.1000",
             "SP": "RTM",
-			"SupportedUntil": "2033-01-11"
+            "SupportedUntil": "2033-01-11"
         },
         {
             "Version": "16.0.1050",

--- a/bin/dbatools-buildref-index.json
+++ b/bin/dbatools-buildref-index.json
@@ -4370,7 +4370,7 @@
         {
             "Version": "15.0.2000",
             "SP": "RTM",
-            "SupportedUntil": "2025-01-07"
+			"SupportedUntil": "2030-01-08"
         },
         {
             "Version": "15.0.2070",
@@ -4519,7 +4519,8 @@
         },
         {
             "Version": "16.0.1000",
-            "SP": "RTM"
+            "SP": "RTM",
+			"SupportedUntil": "2033-01-11"
         },
         {
             "Version": "16.0.1050",

--- a/bin/dbatools-buildref-index.json
+++ b/bin/dbatools-buildref-index.json
@@ -1,5 +1,5 @@
 {
-    "LastUpdated": "2023-04-13T00:00:00",
+    "LastUpdated": "2023-04-14T00:00:00",
     "Data": [
         {
             "Version": "8.0.47",


### PR DESCRIPTION
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8860 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
Show correct support extended end date

### Approach
Took from MS official lifecycle:
- 2019, https://learn.microsoft.com/en-us/lifecycle/products/sql-server-2019
- 2022, https://learn.microsoft.com/en-us/lifecycle/products/sql-server-2022

