### PR TITLE
Start-DbaMigration - Remove KeepCDC and KeepReplication parameters from detach method

### DIFF
--- a/public/Start-DbaMigration.ps1
+++ b/public/Start-DbaMigration.ps1
@@ -383,8 +383,6 @@ function Start-DbaMigration {
                 AllDatabases = $true;
                 Force = $Force;
                 IncludeSupportDbs = $IncludeSupportDbs;
-                KeepCDC = $KeepCDC;
-                KeepReplication = $KeepReplication;
             }
 
             if ($BackupRestore) {
@@ -392,6 +390,8 @@ function Start-DbaMigration {
                     BackupRestore = $true;
                     NoRecovery = $NoRecovery;
                     WithReplace = $WithReplace;
+                    KeepCDC = $KeepCDC;
+                    KeepReplication = $KeepReplication;
                 }
                 if ($UseLastBackup) {
                     $CopyDatabaseSplat += @{

--- a/public/Start-DbaMigration.ps1
+++ b/public/Start-DbaMigration.ps1
@@ -375,39 +375,39 @@ function Start-DbaMigration {
             Write-Message -Level Verbose -Message "Migrating databases"
 
             $CopyDatabaseSplat = @{
-                Source = $sourceserver;
-                Destination = $Destination;
-                DestinationSqlCredential = $DestinationSqlCredential;
-                SetSourceReadOnly = $SetSourceReadOnly;
-                ReuseSourceFolderStructure = $ReuseSourceFolderStructure;
-                AllDatabases = $true;
-                Force = $Force;
-                IncludeSupportDbs = $IncludeSupportDbs;
+                Source                     = $sourceserver
+                Destination                = $Destination
+                DestinationSqlCredential   = $DestinationSqlCredential
+                SetSourceReadOnly          = $SetSourceReadOnly
+                ReuseSourceFolderStructure = $ReuseSourceFolderStructure
+                AllDatabases               = $true
+                Force                      = $Force
+                IncludeSupportDbs          = $IncludeSupportDbs
             }
 
             if ($BackupRestore) {
                 $CopyDatabaseSplat += @{
-                    BackupRestore = $true;
-                    NoRecovery = $NoRecovery;
-                    WithReplace = $WithReplace;
-                    KeepCDC = $KeepCDC;
-                    KeepReplication = $KeepReplication;
+                    BackupRestore   = $true
+                    NoRecovery      = $NoRecovery
+                    WithReplace     = $WithReplace
+                    KeepCDC         = $KeepCDC
+                    KeepReplication = $KeepReplication
                 }
                 if ($UseLastBackup) {
                     $CopyDatabaseSplat += @{
-                        UseLastBackup = $UseLastBackup;
-                        Continue = $Continue;
+                        UseLastBackup = $UseLastBackup
+                        Continue      = $Continue
                     }
                 } else {
                     $CopyDatabaseSplat += @{
-                        SharedPath = $SharedPath;
-                        AzureCredential = $AzureCredential;
+                        SharedPath      = $SharedPath
+                        AzureCredential = $AzureCredential
                     }
                 }
             } else {
                 $CopyDatabaseSplat += @{
-                    DetachAttach = $DetachAttach;
-                    Reattach = $Reattach;
+                    DetachAttach = $DetachAttach
+                    Reattach     = $Reattach
                 }
             }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8870 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixes a bug with detach-based server migrations through `Start-DbaMigration`.

### Approach
Ultimately removes KeepCDC and KeepReplication parameters from detach call to `Copy-DbaDatabase`.

### Commands to test
`Start-DbaMigration`