### PR TITLE
Set-DbatoolsInsecureConnection - Persist by default

### DIFF
--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set encryption values
         run: |
           Import-Module dbatools
-          Set-DbatoolsInsecureConnection -Register
+          Set-DbatoolsInsecureConnection
           Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Write-Warning
 
       - name:  Setup docker images

--- a/public/Set-DbatoolsInsecureConnection.ps1
+++ b/public/Set-DbatoolsInsecureConnection.ps1
@@ -20,6 +20,9 @@ function Set-DbatoolsInsecureConnection {
 
         Configuration scopes are the default locations configurations are being stored at.
 
+    .PARAMETER Register
+        Deprecated.
+
     .LINK
         https://dbatools.io/Set-DbatoolsInsecureConnection
         https://blog.netnerds.net/2023/03/new-defaults-for-sql-server-connections-encryption-trust-certificate/
@@ -40,9 +43,13 @@ function Set-DbatoolsInsecureConnection {
     [CmdletBinding()]
     param (
         [switch]$SessionOnly,
-        [Dataplat.Dbatools.Configuration.ConfigScope]$Scope = [Dataplat.Dbatools.Configuration.ConfigScope]::UserDefault
+        [Dataplat.Dbatools.Configuration.ConfigScope]$Scope = [Dataplat.Dbatools.Configuration.ConfigScope]::UserDefault,
+        [switch]$Register
     )
     process {
+        if ($Register) {
+            Write-Message -Level Warning -Message "The Register parameter is deprecated and will be removed in a future release."
+        }
         # Set these defaults for all future sessions on this machine
         Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Passthru
         Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -Passthru

--- a/public/Set-DbatoolsInsecureConnection.ps1
+++ b/public/Set-DbatoolsInsecureConnection.ps1
@@ -12,8 +12,8 @@ function Set-DbatoolsInsecureConnection {
 
         You can read more here: https://dbatools.io/newdefaults
 
-    .PARAMETER Register
-        Registers the settings to persist across sessions so they'll be used even if you close and reopen PowerShell.
+    .PARAMETER SessionOnly
+        Does not persist across sessions so the default will return if you close and reopen PowerShell.
 
     .PARAMETER Scope
         The configuration scope it should be registered under. Defaults to UserDefault.
@@ -30,16 +30,16 @@ function Set-DbatoolsInsecureConnection {
         Sets the default connection settings to trust all server certificates and not require encrypted connections.
 
     .EXAMPLE
-        PS C:\> Set-DbatoolsInsecureConnection -Register
+        PS C:\> Set-DbatoolsInsecureConnection -SessionOnly
 
         Sets the default connection settings to trust all server certificates and not require encrypted connections.
 
-        Registers the settings to persist across sessions so they'll be used even if you close and reopen PowerShell.
+        Does not persist across sessions so the default will return if you close and reopen PowerShell.
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     [CmdletBinding()]
     param (
-        [switch]$Register,
+        [switch]$SessionOnly,
         [Dataplat.Dbatools.Configuration.ConfigScope]$Scope = [Dataplat.Dbatools.Configuration.ConfigScope]::UserDefault
     )
     process {
@@ -47,7 +47,7 @@ function Set-DbatoolsInsecureConnection {
         Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Passthru
         Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -Passthru
 
-        if ($Register) {
+        if (-not $SessionOnly) {
             Register-DbatoolsConfig -FullName sql.connection.trustcert -Scope $Scope
             Register-DbatoolsConfig -FullName sql.connection.encrypt -Scope $Scope
         }

--- a/tests/Set-DbatoolsInsecureConnection.Tests.ps1
+++ b/tests/Set-DbatoolsInsecureConnection.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SessionOnly', 'Scope'
+        [object[]]$knownParameters = 'Register', 'SessionOnly', 'Scope'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Set-DbatoolsInsecureConnection.Tests.ps1
+++ b/tests/Set-DbatoolsInsecureConnection.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'Register', 'Scope'
+        [object[]]$knownParameters = 'SessionOnly', 'Scope'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
@@ -30,12 +30,6 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $null = Set-DbatoolsInsecureConnection
             Get-DbatoolsConfigValue -FullName sql.connection.trustcert | Should -BeTrue
             # sql.connection.encrypt is a string because it needs to be mandatory, optional, true or false
-            Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Should -Be 'False'
-        }
-
-        It "registers the settings to persist across sessions so they'll be used even if you close and reopen PowerShell" {
-            $null = Set-DbatoolsInsecureConnection -Register
-            Get-DbatoolsConfigValue -FullName sql.connection.trustcert | Should -BeTrue
             Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Should -Be 'False'
         }
     }


### PR DESCRIPTION
I don't wanna -Register each time. Especially since this command is mostly used for CI/CD in my case.