### PR TITLE
New Command - Test-DbaAgSpn

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -51,6 +51,7 @@
     # Specific functions to export for Core, etc are also found in psm1
     # FunctionsToExport specifically helps with AUTO-LOADING so do not remove
     FunctionsToExport  = @(
+        'Test-DbaAgSpn',
         'Install-DbaAgentAdminAlert',
         'Set-DbatoolsInsecureConnection',
         'Get-DbaDbServiceBrokerQueue',

--- a/public/Test-DbaAgSpn.ps1
+++ b/public/Test-DbaAgSpn.ps1
@@ -1,0 +1,203 @@
+function Test-DbaAgSpn {
+    <#
+    .SYNOPSIS
+        Tests the SPNs for an availability group listener
+
+    .DESCRIPTION
+        Tests the SPNs for an availability group listener
+
+        https://learn.microsoft.com/en-us/sql/database-engine/availability-groups/windows/listeners-client-connectivity-application-failover?view=sql-server-ver16#SPNs was used as a guide
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. Server version must be SQL Server version 2012 or higher.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Credential
+        Alternative credential for connecting to Active Directory.
+
+    .PARAMETER AvailabilityGroup
+        The availability group to test. If not specified, all availability groups will be tested.
+
+    .PARAMETER Listener
+        The availability group listener to test. If not specified, all listeners will be tested.
+
+    .PARAMETER InputObject
+        Enables piped input from Get-DbaAvailabilityGroup.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: AG, HA
+        Author: Chrissy LeMaire (@cl), netnerds.net
+
+        Website: https://dbatools.io
+        Copyright: (c) 2023 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Test-DbaAgSpn
+
+    .EXAMPLE
+        PS C:\> Get-DbaAvailabilityGroup -SqlInstance sql01 -AvailabilityGroup SharePoint | Test-DbaAgSpn
+
+        Tests the SPNs for the SharePoint availability group listeners on sql01
+
+    .EXAMPLE
+        PS C:\> Test-DbaAgSpn -SqlInstance sql01 -AvailabilityGroup SharePoint -Listener spag01
+
+        Tests the spag01 SPN for the SharePoint availability group listener on sql01
+
+    .EXAMPLE
+        PS C:\> Test-DbaAgSpn -SqlInstance sql01 | Set-DbaSpn
+
+        Tests the SPNs for all availability group listeners on sql01 and sets them if they are not set
+
+    #>
+    [CmdletBinding()]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [PSCredential]$Credential,
+        [string[]]$AvailabilityGroup,
+        [string[]]$Listener,
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.AvailabilityGroup[]]$InputObject,
+        [switch]$EnableException
+    )
+    begin {
+        # spare the cmdlet to search for the same account over and over
+        $resultCache = @{ }
+        $spns = @()
+    }
+    process {
+        if (Test-Bound -Not SqlInstance, InputObject) {
+            Stop-Function -Message "You must supply either -SqlInstance or an Input Object"
+            return
+        }
+
+        if ($SqlInstance) {
+            $InputObject += Get-DbaAvailabilityGroup -SqlInstance $SqlInstance -AvailabilityGroup $AvailabilityGroup -SqlCredential $SqlCredential
+        }
+
+        foreach ($ag in $InputObject) {
+            Write-Message -Level Verbose -Message "Processing $($ag.Name) on $($ag.Parent.Name)"
+            if (-not $Listener) {
+                $listeners = $ag | Get-DbaAgListener
+            } else {
+                write-warning poot
+                $listeners = $ag | Get-DbaAgListener -Listener $Listener
+            }
+
+            # ([System.Net.Dns]::GetHostEntry($hostEntry)).HostName
+            foreach ($aglistener in $listeners) {
+                Write-Message -Level Verbose -Message "Processing $($aglistener.Name) on $($aglistener.Parent.Name)"
+                $server = $aglistener.Parent.Parent
+                $platform = $server.Platform -split " " | Select-Object -Last 1
+                $version = $server.VersionString, $server.DatabaseEngineEdition, "Edition", $platform -join " "
+                $port = $aglistener.PortNumber
+
+                $fqdn = $server.Information.FullyQualifiedNetName
+                $dnsname = ($fqdn -split "\." | Select-Object -Skip 1) -join "."
+                $hostEntry = $aglistener.Name, $dnsname -join "."
+
+                if ($aglistener.InstanceName -eq "MSSQLSERVER") {
+                    $required = "MSSQLSvc/$hostEntry"
+                } else {
+                    $required = "MSSQLSvc/" + $hostEntry + ":" + $aglistener.InstanceName
+                }
+
+                $spns += [pscustomobject] @{
+                    ComputerName           = $server.Information.FullyQualifiedNetName
+                    SqlInstance            = $aglistener.SqlInstance
+                    InstanceName           = $aglistener.InstanceName
+                    SqlProduct             = $version
+                    InstanceServiceAccount = $server.ServiceAccount
+                    RequiredSPN            = $required
+                    IsSet                  = $false
+                    Cluster                = $server.IsClustered
+                    TcpEnabled             = $true
+                    Port                   = $port
+                    DynamicPort            = $false
+                    Warning                = "None"
+                    Error                  = "None"
+                    Credential             = $Credential
+                }
+
+                $spns += [pscustomobject] @{
+                    ComputerName           = $server.Information.FullyQualifiedNetName
+                    SqlInstance            = $aglistener.SqlInstance
+                    InstanceName           = $aglistener.InstanceName
+                    SqlProduct             = $version
+                    InstanceServiceAccount = $server.ServiceAccount
+                    RequiredSPN            = "MSSQLSvc/$hostEntry" + ":" + $port
+                    IsSet                  = $false
+                    Cluster                = $server.IsClustered
+                    TcpEnabled             = $true
+                    Port                   = $port
+                    DynamicPort            = $false
+                    Warning                = "None"
+                    Error                  = "None"
+                    Credential             = $Credential
+                }
+            }
+        }
+
+        foreach ($spn in $spns) {
+            Write-Message -Level Verbose -Message "Processing SPN on $($spn.SqlInstance)"
+            $searchfor = 'User'
+            if ($spn.InstanceServiceAccount -eq 'LocalSystem' -or $spn.InstanceServiceAccount -like 'NT SERVICE\*') {
+                Write-Message -Level Verbose -Message "Virtual account detected, changing target registration to computername"
+                $spn.InstanceServiceAccount = "$($resolved.Domain)\$($resolved.ComputerName)$"
+                $searchfor = 'Computer'
+            } elseif ($spn.InstanceServiceAccount -like '*\*$') {
+                Write-Message -Level Verbose -Message "Managed Service Account detected"
+                $searchfor = 'Computer'
+            }
+
+            $serviceAccount = $spn.InstanceServiceAccount
+            # spare the cmdlet to search for the same account over and over
+            if ($spn.InstanceServiceAccount -notin $resultCache.Keys) {
+                Write-Message -Message "Searching for $serviceAccount" -Level Verbose
+                try {
+                    $result = Get-DbaADObject -ADObject $serviceAccount -Type $searchfor -Credential $Credential -EnableException
+                    $resultCache[$spn.InstanceServiceAccount] = $result
+                } catch {
+                    if (![System.String]::IsNullOrEmpty($spn.InstanceServiceAccount)) {
+                        Write-Message -Message "AD lookup failure. This may be because the domain cannot be resolved for the SQL Server service account ($serviceAccount)." -Level Warning
+                    }
+                }
+            } else {
+                $result = $resultCache[$spn.InstanceServiceAccount]
+            }
+            if ($result.Count -gt 0) {
+                try {
+                    $results = $result.GetUnderlyingObject()
+                    if ($results.Properties.servicePrincipalName -contains $spn.RequiredSPN) {
+                        $spn.IsSet = $true
+                    }
+                } catch {
+                    Write-Message -Message "The SQL Service account ($serviceAccount) has been found, but you don't have enough permission to inspect its SPNs" -Level Warning
+                    continue
+                }
+            } else {
+                Write-Message -Level Warning -Message "SQL Service account not found. Results may not be accurate."
+                $spn
+                continue
+            }
+            if (!$spn.IsSet -and $spn.TcpEnabled) {
+                $spn.Error = "SPN missing"
+            }
+
+            $spn | Select-DefaultView -ExcludeProperty Credential, DomainName
+        }
+    }
+}

--- a/tests/Test-DbaAgSpn.Tests.ps1
+++ b/tests/Test-DbaAgSpn.Tests.ps1
@@ -1,0 +1,14 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Credential', 'AvailabilityGroup', 'Listener', 'InputObject', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1005 

It worked on my lab.

```
PS> Test-DbaAgSpn -SqlInstance sqlag1

Cluster                : False
ComputerName           : sqlag1.ad.local
DynamicPort            : False
Error                  : None
InstanceName           : MSSQLSERVER
InstanceServiceAccount : ad\sqlserver
IsSet                  : True
Port                   : 1433
RequiredSPN            : MSSQLSvc/sqlag.ad.local
SqlInstance            : sqlag1
SqlProduct             : 16.0.1000.6 Enterprise Edition x64
TcpEnabled             : True
Warning                : None

Cluster                : False
ComputerName           : sqlag1.ad.local
DynamicPort            : False
Error                  : None
InstanceName           : MSSQLSERVER
InstanceServiceAccount : ad\sqlserver
IsSet                  : True
Port                   : 1433
RequiredSPN            : MSSQLSvc/sqlag.ad.local:1433
SqlInstance            : sqlag1
SqlProduct             : 16.0.1000.6 Enterprise Edition x64
TcpEnabled             : True
Warning                : None
```
Set the SPN this way

```
Test-DbaAgSpn -SqlInstance sqlag1 -Verbose | Set-DbaSpn -WhatIf
```

```
Test-DbaAgSpn -SqlInstance sqlag1 -Verbose | Set-DbaSpn -Verbose
VERBOSE: [12:35:03][Connect-DbaInstance] String is passed in, will build server object from instance object and other parameters, do some checks and then return the server object
VERBOSE: [12:35:03][Connect-DbaInstance] authentication method is 'local integrated'
VERBOSE: [12:35:03][Test-DbaAgSpn] Processing test-ag on sqlag1
VERBOSE: [12:35:03][Test-DbaAgSpn] Processing sqlag on test-ag
VERBOSE: [12:35:03][Test-DbaAgSpn] Processing SPN on sqlag1
VERBOSE: [12:35:03][Test-DbaAgSpn] Searching for ad\sqlserver
VERBOSE: [12:35:03][Get-DbaADObject] Searching for sqlserver under domain ad in SamAccountName format
VERBOSE: [12:35:03][Set-DbaSpn] Looking for account ad\sqlserver...
VERBOSE: [12:35:03][Get-DbaADObject] Searching for sqlserver under domain ad in SamAccountName format
VERBOSE: Performing the operation "Adding SPN to service account" on target "MSSQLSvc/sqlag.ad.local".
VERBOSE: [12:35:03][Set-DbaSpn] Added SPN MSSQLSvc/sqlag.ad.local to ad\sqlserver


Name           : MSSQLSvc/sqlag.ad.local
ServiceAccount : ad\sqlserver
Property       : servicePrincipalName
IsSet          : True
Notes          : Successfully added SPN

VERBOSE: Performing the operation "Adding constrained delegation to service account for SPN" on target "MSSQLSvc/sqlag.ad.local".
VERBOSE: [12:35:03][Set-DbaSpn] Added kerberos delegation to MSSQLSvc/sqlag.ad.local for ad\sqlserver
Name           : MSSQLSvc/sqlag.ad.local
ServiceAccount : ad\sqlserver
Property       : msDS-AllowedToDelegateTo
IsSet          : True
Notes          : Successfully added constrained delegation

VERBOSE: [12:35:03][Test-DbaAgSpn] Processing SPN on sqlag1
VERBOSE: [12:35:03][Set-DbaSpn] Looking for account ad\sqlserver...
VERBOSE: [12:35:03][Get-DbaADObject] Searching for sqlserver under domain ad in SamAccountName format
VERBOSE: Performing the operation "Adding SPN to service account" on target "MSSQLSvc/sqlag.ad.local:1433".
VERBOSE: [12:35:03][Set-DbaSpn] Added SPN MSSQLSvc/sqlag.ad.local:1433 to ad\sqlserver
Name           : MSSQLSvc/sqlag.ad.local:1433
ServiceAccount : ad\sqlserver
Property       : servicePrincipalName
IsSet          : True
Notes          : Successfully added SPN

VERBOSE: Performing the operation "Adding constrained delegation to service account for SPN" on target "MSSQLSvc/sqlag.ad.local:1433".
VERBOSE: [12:35:03][Set-DbaSpn] Added kerberos delegation to MSSQLSvc/sqlag.ad.local:1433 for ad\sqlserver
Name           : MSSQLSvc/sqlag.ad.local:1433
ServiceAccount : ad\sqlserver
Property       : msDS-AllowedToDelegateTo
IsSet          : True
Notes          : Successfully added constrained delegation

```