### PR TITLE
Connect-DbaInstance: Use parameter or config for TrustServerCertificate for connections from registered servers

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -573,7 +573,10 @@ function Connect-DbaInstance {
                     Write-Message -Level Warning -Message "Additional parameters are passed in, but they will be ignored"
                 }
             } elseif ($inputObjectType -in 'RegisteredServer', 'ConnectionString' ) {
-                if (Test-Bound -ParameterName $ignoredParameters, 'ApplicationIntent', 'StatementTimeout') {
+                # Parameter TrustServerCertificate changes the connection string be allow connections to instances with the default self-signed certificate
+                if (Test-Bound -ParameterName 'TrustServerCertificate') {
+                    Write-Message -Level Verbose -Message "Additional parameter TrustServerCertificate is passed in and will override other settings"
+                } elseif (Test-Bound -ParameterName $ignoredParameters, 'ApplicationIntent', 'StatementTimeout') {
                     Write-Message -Level Warning -Message "Additional parameters are passed in, but they will be ignored"
                 }
             } elseif ($inputObjectType -in 'SqlConnection' ) {
@@ -643,6 +646,13 @@ function Connect-DbaInstance {
                 $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $inputObject
             } elseif ($inputObjectType -in 'RegisteredServer', 'ConnectionString') {
                 $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $serverName
+                # Parameter TrustServerCertificate changes the connection string be allow connections to instances with the default self-signed certificate
+                if ($TrustServerCertificate) {
+                    Write-Message -Level Verbose -Message "TrustServerCertificate will be set to 'True'"
+                    $csb = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnectionStringBuilder -ArgumentList $connectionString
+                    $csb.TrustServerCertificate = $true
+                    $connectionString = $csb.ConnectionString
+                }
                 $server.ConnectionContext.ConnectionString = $connectionString
             } elseif ($inputObjectType -eq 'String') {
                 # Identify authentication method

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -80,6 +80,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
         It "connects using a connection string without 'Encrypt' and 'Trust Server Certificate'" {
             $trustcertValue = Get-DbatoolsConfigValue -FullName sql.connection.trustcert
+            Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $false
             # Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true
             $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True;"
             Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $trustcertValue

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -74,7 +74,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "connects using a connection string" {
-            $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True;"
+            $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True"
             $server.Databases.Name.Count -gt 0 | Should Be $true
         }
 
@@ -87,7 +87,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
         It "connects using a connection object" {
             Set-DbatoolsConfig -FullName commands.connect-dbainstance.smo.computername.source -Value 'instance.ComputerName'
-            [Microsoft.Data.SqlClient.SqlConnection]$sqlconnection = "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True;"
+            [Microsoft.Data.SqlClient.SqlConnection]$sqlconnection = "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True;Encrypt=False;Trust Server Certificate=True"
             $server = Connect-DbaInstance -SqlInstance $sqlconnection
             $server.ComputerName | Should Be ([DbaInstance]$script:instance1).ComputerName
             $server.Databases.Name.Count -gt 0 | Should Be $true
@@ -100,13 +100,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "connects using a connection string - instance2" {
-            $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance2;Initial Catalog=tempdb;Integrated Security=True;"
+            $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance2;Initial Catalog=tempdb;Integrated Security=True"
             $server.Databases.Name.Count -gt 0 | Should Be $true
         }
 
         It "connects using a connection object - instance2" {
             Set-DbatoolsConfig -FullName commands.connect-dbainstance.smo.computername.source -Value 'instance.ComputerName'
-            [Microsoft.Data.SqlClient.SqlConnection]$sqlconnection = "Data Source=$script:instance2;Initial Catalog=tempdb;Integrated Security=True;"
+            [Microsoft.Data.SqlClient.SqlConnection]$sqlconnection = "Data Source=$script:instance2;Initial Catalog=tempdb;Integrated Security=True;Encrypt=False;Trust Server Certificate=True"
             $server = Connect-DbaInstance -SqlInstance $sqlconnection
             $server.ComputerName | Should Be ([DbaInstance]$script:instance2).ComputerName
             $server.Databases.Name.Count -gt 0 | Should Be $true

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -78,6 +78,14 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $server.Databases.Name.Count -gt 0 | Should Be $true
         }
 
+        It "connects using a connection string without 'Encrypt' and 'Trust Server Certificate'" {
+            $trustcertValue = Get-DbatoolsConfigValue -FullName sql.connection.trustcert
+            # Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true
+            $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True;"
+            Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $trustcertValue
+            $server.Databases.Name.Count -gt 0 | Should Be $true
+        }
+
         It "connects using a dot" {
             $newinstance = $script:instance1.Replace("localhost", ".")
             Write-Warning "Connecting to $newinstance"

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -74,16 +74,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "connects using a connection string" {
-            $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True;Encrypt=False;Trust Server Certificate=True;"
-            $server.Databases.Name.Count -gt 0 | Should Be $true
-        }
-
-        It "connects using a connection string without 'Encrypt' and 'Trust Server Certificate'" {
-            $trustcertValue = Get-DbatoolsConfigValue -FullName sql.connection.trustcert
-            Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $false
-            # Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true
             $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True;"
-            Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $trustcertValue
             $server.Databases.Name.Count -gt 0 | Should Be $true
         }
 
@@ -96,7 +87,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
         It "connects using a connection object" {
             Set-DbatoolsConfig -FullName commands.connect-dbainstance.smo.computername.source -Value 'instance.ComputerName'
-            [Microsoft.Data.SqlClient.SqlConnection]$sqlconnection = "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True;Encrypt=False;Trust Server Certificate=True"
+            [Microsoft.Data.SqlClient.SqlConnection]$sqlconnection = "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True;"
             $server = Connect-DbaInstance -SqlInstance $sqlconnection
             $server.ComputerName | Should Be ([DbaInstance]$script:instance1).ComputerName
             $server.Databases.Name.Count -gt 0 | Should Be $true
@@ -109,13 +100,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "connects using a connection string - instance2" {
-            $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance2;Initial Catalog=tempdb;Integrated Security=True;Encrypt=False;Trust Server Certificate=True"
+            $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance2;Initial Catalog=tempdb;Integrated Security=True;"
             $server.Databases.Name.Count -gt 0 | Should Be $true
         }
 
         It "connects using a connection object - instance2" {
             Set-DbatoolsConfig -FullName commands.connect-dbainstance.smo.computername.source -Value 'instance.ComputerName'
-            [Microsoft.Data.SqlClient.SqlConnection]$sqlconnection = "Data Source=$script:instance2;Initial Catalog=tempdb;Integrated Security=True;Encrypt=False;Trust Server Certificate=True"
+            [Microsoft.Data.SqlClient.SqlConnection]$sqlconnection = "Data Source=$script:instance2;Initial Catalog=tempdb;Integrated Security=True;"
             $server = Connect-DbaInstance -SqlInstance $sqlconnection
             $server.ComputerName | Should Be ([DbaInstance]$script:instance2).ComputerName
             $server.Databases.Name.Count -gt 0 | Should Be $true


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [ ] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
When using `Get-DbaRegisteredServer -SqlInstance xyz | Connect-DbaInstance` only the connection string is used and connections to instances with the default self-signed certificate fail with dbatools 2.0.

### Approach
If $TrustServerCertificate is true either by using the parameter or by changing the config, the connection string will be changed before opening the connection.
