### PR TITLE
Fix JobCount returned on schedule creation

### DIFF
--- a/public/New-DbaAgentSchedule.ps1
+++ b/public/New-DbaAgentSchedule.ps1
@@ -534,6 +534,7 @@ function New-DbaAgentSchedule {
                     if ($PSCmdlet.ShouldProcess($instance, "Adding the schedule $schedule to job $($j.Name)")) {
                         Write-Message -Message "Adding schedule $Schedule to job $($j.Name)" -Level Verbose
                         $j.AddSharedSchedule($jobschedule.Id)
+                        $jobschedule.Refresh()
                     }
                 }
             }

--- a/tests/New-DbaAgentSchedule.Tests.ps1
+++ b/tests/New-DbaAgentSchedule.Tests.ps1
@@ -63,7 +63,8 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $jobId = (Get-DbaAgentJob -SqlInstance $script:instance2 -Job dbatoolsci_newschedule).JobID
             foreach ($key in $results.keys) {
                 $results[$key].EnumJobReferences() | Should -Contain $jobId
-                $results[$key].FrequencyTypes   | Should -BeIn $scheduleOptions
+                $results[$key].FrequencyTypes | Should -BeIn $scheduleOptions
+                $results[$key].JobCount | Should -Be 1
 
                 if ($key -in @('IdleComputer', 'OnIdle')) {
                     $results[$key].FrequencyTypes   | Should -Be "OnIdle"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8933  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Adds a refresh on the schedule object so the JobCount is properly updated before returning results

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
New-DbaAgentSchedule

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
