### PR TITLE
Watch-DbaDbLogin - Only write to target and don't watch target

### DIFF
--- a/public/Watch-DbaDbLogin.ps1
+++ b/public/Watch-DbaDbLogin.ps1
@@ -95,6 +95,11 @@ function Watch-DbaDbLogin {
     )
 
     process {
+        if (Test-Bound 'SqlCms', 'ServersFromFile', 'InputObject' -Not) {
+            Stop-Function -Message "You must specify a server list source using -SqlCms or -ServersFromFile or pipe in connected instances. See the command documentation and examples for more details."
+            return
+        }
+
         try {
             $serverDest = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
         } catch {

--- a/public/Watch-DbaDbLogin.ps1
+++ b/public/Watch-DbaDbLogin.ps1
@@ -188,7 +188,7 @@ function Watch-DbaDbLogin {
             $procs = $procs | Where-Object { $systemdbs -notcontains $_.Database -and $excludedPrograms -notcontains $_.Program }
 
             if ($procs.Count -gt 0) {
-                $procs | Select-Object @{Label = "ComputerName"; Expression = { $instance.ComputerName } }, @{Label = "InstanceName"; Expression = { $instance.ServiceName } }, @{Label = "SqlInstance"; Expression = { $instance.DomainInstanceName } }, LoginTime, Login, Host, Program, DatabaseId, Database, IsSystem, CaptureTime | ConvertTo-DbaDataTable | Write-DbaDbTableData -SqlInstance $instance -Database $Database -Table $Table -AutoCreateTable
+                $procs | Select-Object @{Label = "ComputerName"; Expression = { $instance.ComputerName } }, @{Label = "InstanceName"; Expression = { $instance.ServiceName } }, @{Label = "SqlInstance"; Expression = { $instance.DomainInstanceName } }, LoginTime, Login, Host, Program, DatabaseId, Database, IsSystem, CaptureTime | ConvertTo-DbaDataTable | Write-DbaDbTableData -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -Table $Table -AutoCreateTable
 
                 Write-Message -Level Output -Message "Added process information for $instance to datatable."
             } else {

--- a/public/Watch-DbaDbLogin.ps1
+++ b/public/Watch-DbaDbLogin.ps1
@@ -82,7 +82,7 @@ function Watch-DbaDbLogin {
     param (
         [DbaInstance]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [object]$Database,
+        [string]$Database,
         [string]$Table = "DbaTools-WatchDbLogins",
         # Central Management Server
         [string]$SqlCms,

--- a/public/Watch-DbaDbLogin.ps1
+++ b/public/Watch-DbaDbLogin.ps1
@@ -125,14 +125,6 @@ function Watch-DbaDbLogin {
             }
         }
 
-        if ($SqlInstance) {
-            if ($servers) {
-                $servers += $SqlInstance
-            } else {
-                $servers = $SqlInstance
-            }
-        }
-
         <#
             Connect each server
         #>

--- a/public/Watch-DbaDbLogin.ps1
+++ b/public/Watch-DbaDbLogin.ps1
@@ -95,6 +95,13 @@ function Watch-DbaDbLogin {
     )
 
     process {
+        try {
+            $serverDest = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+        } catch {
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
+            return
+        }
+
         $systemdbs = "master", "msdb", "model", "tempdb"
         $excludedPrograms = "Microsoft SQL Server Management Studio - Query", "SQL Management"
 
@@ -188,7 +195,7 @@ function Watch-DbaDbLogin {
             $procs = $procs | Where-Object { $systemdbs -notcontains $_.Database -and $excludedPrograms -notcontains $_.Program }
 
             if ($procs.Count -gt 0) {
-                $procs | Select-Object @{Label = "ComputerName"; Expression = { $instance.ComputerName } }, @{Label = "InstanceName"; Expression = { $instance.ServiceName } }, @{Label = "SqlInstance"; Expression = { $instance.DomainInstanceName } }, LoginTime, Login, Host, Program, DatabaseId, Database, IsSystem, CaptureTime | ConvertTo-DbaDataTable | Write-DbaDbTableData -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -Table $Table -AutoCreateTable
+                $procs | Select-Object @{Label = "ComputerName"; Expression = { $instance.ComputerName } }, @{Label = "InstanceName"; Expression = { $instance.ServiceName } }, @{Label = "SqlInstance"; Expression = { $instance.DomainInstanceName } }, LoginTime, Login, Host, Program, DatabaseId, Database, IsSystem, CaptureTime | ConvertTo-DbaDataTable | Write-DbaDbTableData -SqlInstance $serverDest -Database $Database -Table $Table -AutoCreateTable
 
                 Write-Message -Level Output -Message "Added process information for $instance to datatable."
             } else {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8616 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Align code with documentation.

### Approach
Revert some of the changes made in #8323 and #8384. Removed some code.

### Commands to test
```
$instanceToStore = Connect-DbaInstance -SqlInstance SERV9\LAW7_0009
$instanceToWatch = Connect-DbaInstance -SqlInstance SERV5\LAW7_0001
$instanceToWatch | Watch-DbaDbLogin -SqlInstance $instanceToStore -Database Test
```

### Screenshots
![image](https://github.com/dataplat/dbatools/assets/66946165/6bf60a2d-9a7b-4b15-a6eb-a50bc7fd2fe6)


Test failes as it is excluded on AppVayor.
