### PR TITLE
Get-DbaAgentSchedule - Use better switch syntax

### DIFF
--- a/public/Get-DbaAgentSchedule.ps1
+++ b/public/Get-DbaAgentSchedule.ps1
@@ -135,7 +135,7 @@ function Get-DbaAgentSchedule {
                     # Loop through the days
                     while ($frequencyInterval -gt 0) {
 
-                        switch ($FrequenctInterval) {
+                        switch (1) {
                             { ($frequencyInterval - 64) -ge 0 } {
                                 $days[5] = "Saturday"
                                 $frequencyInterval -= 64


### PR DESCRIPTION
As the switch statement never tests against the input this is not a change in execution, but better for readability.