### PR TITLE
Get/Test-DbaBuild, handle version "aliases"

### DIFF
--- a/public/Get-DbaBuild.ps1
+++ b/public/Get-DbaBuild.ps1
@@ -277,15 +277,19 @@ function Get-DbaBuild {
             )
 
             if ($Build) {
+                if ($Build.Minor -notin (0, 50)) {
+                    Write-Message -Level Debug -Message "Normalized Minor Version to account version aliases"
+                    $Build = New-Object -TypeName System.Version -ArgumentList ($Build.Major , ($Build.Minor - $Build.Minor % 10), $Build.Build)
+                }
                 Write-Message -Level Verbose -Message "Looking for $Build"
 
-                $IdxVersion = $Data | Where-Object Version -like "$($Build.Major).$($Build.Minor).*"
+                $IdxVersion = $Data | Where-Object Version -Like "$($Build.Major).$($Build.Minor).*"
             } elseif ($Kb) {
                 Write-Message -Level Verbose -Message "Looking for KB $Kb"
                 if ($Kb -match '^(KB)?(\d+)$') {
                     $currentKb = $Matches[2]
-                    $kbVersion = $Data | Where-Object KBList -contains $currentKb
-                    $IdxVersion = $Data | Where-Object Version -like "$($kbVersion.VersionObject.Major).$($kbVersion.VersionObject.Minor).*"
+                    $kbVersion = $Data | Where-Object KBList -Contains $currentKb
+                    $IdxVersion = $Data | Where-Object Version -Like "$($kbVersion.VersionObject.Major).$($kbVersion.VersionObject.Minor).*"
                 } else {
                     Stop-Function -Message "Wrong KB name $kb"
                     return
@@ -293,7 +297,7 @@ function Get-DbaBuild {
             } elseif ($MajorVersion) {
                 Write-Message -Level Verbose -Message "Looking for SQL $MajorVersion SP $ServicePack CU $CumulativeUpdate"
                 $kbVersion = $Data | Where-Object Name -eq $MajorVersion
-                $IdxVersion = $Data | Where-Object Version -like "$($kbVersion.VersionObject.Major).$($kbVersion.VersionObject.Minor).*"
+                $IdxVersion = $Data | Where-Object Version -Like "$($kbVersion.VersionObject.Major).$($kbVersion.VersionObject.Minor).*"
             }
 
             $Detected = @{ }
@@ -325,7 +329,7 @@ function Get-DbaBuild {
                     $Detected.CU = $el.CU
                 }
                 if ($null -ne $el.SupportedUntil) {
-                    $Detected.SupportedUntil = (Get-Date -date $el.SupportedUntil)
+                    $Detected.SupportedUntil = (Get-Date -Date $el.SupportedUntil)
                 }
                 $Detected.Build = $el.Version
                 $Detected.KB = $el.KBList

--- a/tests/Get-DbaBuild.Tests.ps1
+++ b/tests/Get-DbaBuild.Tests.ps1
@@ -15,7 +15,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$CommandName Unit Test" -Tags Unittest {
     BeforeAll {
-        $ModuleBase = (Get-Module -Name dbatools | Where-Object ModuleBase -notmatch net).ModuleBase
+        $ModuleBase = (Get-Module -Name dbatools | Where-Object ModuleBase -NotMatch net).ModuleBase
         $idxfile = "$ModuleBase\bin\dbatools-buildref-index.json"
     }
 
@@ -25,13 +25,13 @@ Describe "$CommandName Unit Test" -Tags Unittest {
             $result | Should -Be $true
         }
         It "the json can be parsed" {
-            $IdxRef = Get-Content $idxfile -raw | ConvertFrom-Json
+            $IdxRef = Get-Content $idxfile -Raw | ConvertFrom-Json
             $IdxRef | Should -BeOfType System.Object
         }
     }
     Context 'Validate LastUpdated property' {
         BeforeAll {
-            $IdxRef = Get-Content $idxfile -raw | ConvertFrom-Json
+            $IdxRef = Get-Content $idxfile -Raw | ConvertFrom-Json
         }
         It "Has a proper LastUpdated property" {
             $lastupdate = Get-Date -Date $IdxRef.LastUpdated
@@ -48,7 +48,7 @@ Describe "$CommandName Unit Test" -Tags Unittest {
     }
     Context 'Validate Data property' {
         BeforeAll {
-            $IdxRef = Get-Content $idxfile -raw | ConvertFrom-Json
+            $IdxRef = Get-Content $idxfile -Raw | ConvertFrom-Json
             $Groups = @{ }
             $OrderedKeys = @()
             foreach ($el in $IdxRef.Data) {
@@ -145,7 +145,20 @@ Describe "$CommandName Unit Test" -Tags Unittest {
             $result.Warning | Should -Be 'This version has been officially retired by Microsoft'
         }
     }
+    
+    Context "Recognizes version 'aliases', see #8915" {
+        It 'works with versions with the minor being either not 0 or 50' {
+            $result2016 = Get-DbaBuild -Build '13.3.6300'
+            $result2016.Build | Should -Be '13.3.6300'
+            $result2016.BuildLevel | Should -Be '13.0.6300'
+            $result2016.MatchType | Should -Be 'Exact'
 
+            $result2008R2 = Get-DbaBuild -Build '10.53.6220'
+            $result2008R2.Build | Should -Be '10.53.6220'
+            $result2008R2.BuildLevel | Should -Be '10.50.6220'
+            $result2008R2.MatchType | Should -Be 'Exact'
+        }
+    }
     # These are groups by major release (aka "Name")
     foreach ($g in $OrderedKeys) {
         $Versions = $Groups[$g]

--- a/tests/Test-DbaBuild.Tests.ps1
+++ b/tests/Test-DbaBuild.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'Build', 'MinimumBuild', 'MaxBehind', 'Latest', 'SqlInstance', 'SqlCredential', 'Update', 'Quiet', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
     Context "Retired KBs" {
@@ -21,6 +21,20 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             $goBackTo = "$($behindforCU7)CU"
             $result = Test-DbaBuild -Build '15.0.4003' -MaxBehind $goBackTo
             $result.CUTarget | Should -Be 'CU6'
+        }
+    }
+
+    Context "Recognizes version 'aliases', see #8915" {
+        It 'works with versions with the minor being either not 0 or 50' {
+            $result2016 = Test-DbaBuild -Build '13.3.6300' -Latest
+            $result2016.Build | Should -Be '13.3.6300'
+            $result2016.BuildLevel | Should -Be '13.0.6300'
+            $result2016.MatchType | Should -Be 'Exact'
+
+            $result2008R2 = Test-DbaBuild -Build '10.53.6220'  -Latest
+            $result2008R2.Build | Should -Be '10.53.6220'
+            $result2008R2.BuildLevel | Should -Be '10.50.6220'
+            $result2008R2.MatchType | Should -Be 'Exact'
         }
     }
 }


### PR DESCRIPTION
Handles version "aliases" such as 13.3.6300 or 10.53.6220.0

<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8915 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [x] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Handle valid versions passed in when they are "aliases" of "normalized" versions. 
i.e. 2008 has 4 SPs, and:
- 10.1.2531 is, in fact 10.0.2531
- 10.2.4000 is, in fact 10.2.4000
- ...

2016 has 3 SPs and:
- 13.1.4001 is, in fact, 13.0.4001
- 13.2.5026 is, in fact, 13.0.5026
and so on.


To make things ... funny, this happens for versions from 2008 to 2016 only. And of course 2008R2 has 50,51,52 instead of 0, 1, 2.
Dunno if we wanna make things more strict, because right now we just "normalize away" the minor if it's not either 50 or 0, leaving the door open for parsing a non-existant 9.1.2047 and that at the moment "matches" 9.0.2047 (2005 SP1)

### Approach
Copy-pasted from @nvarscar happy path in Get-SQLInstanceComponent (thanks). We signal that we're normalizing the version away, and in this case `Build` and `BuildLevel` wouldn't be matching, although the reported `MatchType` is `Exact`. Even here, I don't know if we want to signal another value for it, such as `Exact (Alias)`

I included regression tests to make sure this stays in, pending the aforementioned considerations.