### PR TITLE
New-DbaAvailabilityGroup - Remove parameter ReadonlyRoutingConnectionUrl 

### DIFF
--- a/public/New-DbaAvailabilityGroup.ps1
+++ b/public/New-DbaAvailabilityGroup.ps1
@@ -154,9 +154,6 @@ function New-DbaAvailabilityGroup {
         The default can be changed with:
         Set-DbatoolsConfig -FullName 'AvailabilityGroups.Default.ConnectionModeInSecondaryRole' -Value '...' -Passthru | Register-DbatoolsConfig
 
-    .PARAMETER ReadonlyRoutingConnectionUrl
-        Sets the read only routing connection url for the availability replica.
-
     .PARAMETER SeedingMode
         Specifies how the secondary replica will be initially seeded.
 
@@ -303,7 +300,6 @@ function New-DbaAvailabilityGroup {
         [string]$SeedingMode = 'Manual',
         [string]$Endpoint,
         [string[]]$EndpointUrl,
-        [string]$ReadonlyRoutingConnectionUrl,
         [string]$Certificate,
         [switch]$ConfigureXESession,
         # network
@@ -517,7 +513,6 @@ function New-DbaAvailabilityGroup {
                     ConnectionModeInPrimaryRole   = $ConnectionModeInPrimaryRole
                     ConnectionModeInSecondaryRole = $ConnectionModeInSecondaryRole
                     Endpoint                      = $Endpoint
-                    ReadonlyRoutingConnectionUrl  = $ReadonlyRoutingConnectionUrl
                     Certificate                   = $Certificate
                     ConfigureXESession            = $ConfigureXESession
                 }

--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$commandname Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'Primary', 'PrimarySqlCredential', 'Secondary', 'SecondarySqlCredential', 'Name', 'DtcSupport', 'ClusterType', 'AutomatedBackupPreference', 'FailureConditionLevel', 'HealthCheckTimeout', 'Basic', 'DatabaseHealthTrigger', 'Passthru', 'Database', 'SharedPath', 'UseLastBackup', 'Force', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'ConfigureXESession', 'IPAddress', 'SubnetMask', 'Port', 'Dhcp', 'EnableException'
+        [object[]]$knownParameters = 'Primary', 'PrimarySqlCredential', 'Secondary', 'SecondarySqlCredential', 'Name', 'DtcSupport', 'ClusterType', 'AutomatedBackupPreference', 'FailureConditionLevel', 'HealthCheckTimeout', 'Basic', 'DatabaseHealthTrigger', 'Passthru', 'Database', 'SharedPath', 'UseLastBackup', 'Force', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'Certificate', 'ConfigureXESession', 'IPAddress', 'SubnetMask', 'Port', 'Dhcp', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [ ] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [x] Breaking change (affects multiple commands or functionality, fixes #8589 )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

See issue for details. The parameter has to be set individualy for every replica and works only together with ReadOnlyRoutingList, so this is not a suitable parameter for this command.