### PR TITLE
Connect-DbaInstance - Fix for using a connection string

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -657,39 +657,44 @@ function Connect-DbaInstance {
                         'Data Source' {
                             Write-Message -Level Debug -Message "ServerName will be set to '$($csb.DataSource)'"
                             $sqlConnectionInfo.ServerName = $csb.DataSource
+                            $null = $csb.Remove('Data Source')
                         }
                         'Application Name' {
                             Write-Message -Level Debug -Message "ApplicationName will be set to '$($csb.ApplicationName)'"
                             $sqlConnectionInfo.ApplicationName = $csb.ApplicationName
+                            $null = $csb.Remove('Data Source')
                         }
                         'Initial Catalog' {
                             Write-Message -Level Debug -Message "Database will be set to '$($csb.InitialCatalog)'"
                             $sqlConnectionInfo.DatabaseName = $csb.InitialCatalog
+                            $null = $csb.Remove('Initial Catalog')
                         }
                         'Pooling' {
                             Write-Message -Level Debug -Message "Pooled will be set to '$($csb.Pooling)'"
                             $sqlConnectionInfo.Pooled = $csb.Pooling
+                            $null = $csb.Remove('Pooling')
                         }
                         'Trust Server Certificate' {
                             Write-Message -Level Debug -Message "TrustServerCertificate will be set to '$($csb.TrustServerCertificate)'"
                             $sqlConnectionInfo.TrustServerCertificate = $csb.TrustServerCertificate
+                            $null = $csb.Remove('Trust Server Certificate')
                         }
                         'User ID' {
                             Write-Message -Level Debug -Message "UserName will be set to '$($csb.UserID)'"
                             $sqlConnectionInfo.UserName = $csb.UserID
+                            $null = $csb.Remove('User ID')
                         }
                         'Password' {
                             Write-Message -Level Debug -Message "Password will be set"
                             $sqlConnectionInfo.Password = $csb.Password
-                        }
-                        default {
-                            Write-Message -Level warning -Message "The connection string key '$key' is currently unsupported and ignored. Please open an issue on GitHub to add support for that key."
+                            $null = $csb.Remove('Password')
                         }
                     }
                 }
+                # Add all remaining parts of the connection string as additional parameters
+                $sqlConnectionInfo.AdditionalParameters = $csb.ConnectionString
 
-                <# Liste of other possible keys (from $csb.Keys):
-                Data Source
+                <# List of other possible keys (from $csb.Keys):
                 Failover Partner
                 AttachDbFilename
                 Integrated Security

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -659,26 +659,6 @@ function Connect-DbaInstance {
                             $sqlConnectionInfo.ServerName = $csb.DataSource
                             $null = $csb.Remove('Data Source')
                         }
-                        'Application Name' {
-                            Write-Message -Level Debug -Message "ApplicationName will be set to '$($csb.ApplicationName)'"
-                            $sqlConnectionInfo.ApplicationName = $csb.ApplicationName
-                            $null = $csb.Remove('Data Source')
-                        }
-                        'Initial Catalog' {
-                            Write-Message -Level Debug -Message "Database will be set to '$($csb.InitialCatalog)'"
-                            $sqlConnectionInfo.DatabaseName = $csb.InitialCatalog
-                            $null = $csb.Remove('Initial Catalog')
-                        }
-                        'Pooling' {
-                            Write-Message -Level Debug -Message "Pooled will be set to '$($csb.Pooling)'"
-                            $sqlConnectionInfo.Pooled = $csb.Pooling
-                            $null = $csb.Remove('Pooling')
-                        }
-                        'Trust Server Certificate' {
-                            Write-Message -Level Debug -Message "TrustServerCertificate will be set to '$($csb.TrustServerCertificate)'"
-                            $sqlConnectionInfo.TrustServerCertificate = $csb.TrustServerCertificate
-                            $null = $csb.Remove('Trust Server Certificate')
-                        }
                         'User ID' {
                             Write-Message -Level Debug -Message "UserName will be set to '$($csb.UserID)'"
                             $sqlConnectionInfo.UserName = $csb.UserID
@@ -691,46 +671,8 @@ function Connect-DbaInstance {
                         }
                     }
                 }
-                # Add all remaining parts of the connection string as additional parameters
+                # Add all remaining parts of the connection string as additional parameters.
                 $sqlConnectionInfo.AdditionalParameters = $csb.ConnectionString
-
-                <# List of other possible keys (from $csb.Keys):
-                Failover Partner
-                AttachDbFilename
-                Integrated Security
-                Persist Security Info
-                Password
-                Enlist
-                Pooling
-                Min Pool Size
-                Max Pool Size
-                Pool Blocking Period
-                Multiple Active Result Sets
-                Replication
-                Connect Timeout
-                Encrypt
-                Host Name In Certificate
-                Server Certificate
-                Load Balance Timeout
-                Packet Size
-                Type System Version
-                Authentication
-                Current Language
-                Workstation ID
-                User Instance
-                Transaction Binding
-                Application Intent
-                Multi Subnet Failover
-                Connect Retry Count
-                Connect Retry Interval
-                Column Encryption Setting
-                Enclave Attestation Url
-                Attestation Protocol
-                Command Timeout
-                IP Address Preference
-                Server SPN
-                Failover Partner SPN
-                #>
 
                 # Set properties based on used parameters.
                 if ($TrustServerCertificate) {
@@ -741,18 +683,6 @@ function Connect-DbaInstance {
                 # Create the server SMO in the same way as when passing a string.
                 $serverConnection = New-Object -TypeName Microsoft.SqlServer.Management.Common.ServerConnection -ArgumentList $sqlConnectionInfo
                 $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $serverConnection
-
-                <# Old code:
-                $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $serverName
-                # Parameter TrustServerCertificate changes the connection string be allow connections to instances with the default self-signed certificate
-                if ($TrustServerCertificate) {
-                    Write-Message -Level Verbose -Message "TrustServerCertificate will be set to 'True'"
-                    $csb = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnectionStringBuilder -ArgumentList $connectionString
-                    $csb.TrustServerCertificate = $true
-                    $connectionString = $csb.ConnectionString
-                }
-                $server.ConnectionContext.ConnectionString = $connectionString
-                #>
             } elseif ($inputObjectType -eq 'String') {
                 # Identify authentication method
                 if (Test-Azure -SqlInstance $instance) {

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -67,6 +67,11 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $server.ConnectionContext.ConnectionString -match "Intent=ReadOnly" | Should Be $true
         }
 
+        It "keeps the same database context" {
+            $null = $server.Databases['msdb'].Tables.Count
+            $server.Query("select db_name() as dbname").dbname | Should -Be 'master'
+        }
+
         It "sets StatementTimeout to 0" {
             $server = Connect-DbaInstance -SqlInstance $script:instance1 -StatementTimeout 0
 
@@ -76,6 +81,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It "connects using a connection string" {
             $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True"
             $server.Databases.Name.Count -gt 0 | Should Be $true
+        }
+
+        It "keeps the same database context when connected using a connection string" {
+            $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True"
+            # Before #8962 this changed the context to msdb
+            $null = $server.Databases['msdb'].Tables.Count
+            $server.Query("select db_name() as dbname").dbname | Should -Be 'tempdb'
         }
 
         It "connects using a dot" {

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -69,7 +69,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
         It "keeps the same database context" {
             $null = $server.Databases['msdb'].Tables.Count
-            $server.Query("select db_name() as dbname").dbname | Should -Be 'master'
+            $server.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be 'master'
         }
 
         It "sets StatementTimeout to 0" {
@@ -87,7 +87,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True"
             # Before #8962 this changed the context to msdb
             $null = $server.Databases['msdb'].Tables.Count
-            $server.Query("select db_name() as dbname").dbname | Should -Be 'tempdb'
+            $server.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be 'tempdb'
         }
 
         It "connects using a dot" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [ ] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8940, fixes #8927 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Connecting to an instance using a connection string should create a server SMO that does not change the current database when passed to other commands that work with all databases.

### Approach
Using the same intermediate objects as when passing in a string:
* Microsoft.SqlServer.Management.Common.SqlConnectionInfo
* Microsoft.SqlServer.Management.Common.ServerConnection
* Microsoft.SqlServer.Management.Smo.Server

To set the properties for SqlConnectionInfo, we use Microsoft.Data.SqlClient.SqlConnectionStringBuilder to parse the given connection string and then to access the properties "Data Source", "User ID" and "Password" and set the corresponding properties of SqlConnectionInfo.
All other parts of the connection string (including "Initial catalog") are set as SqlConnectionInfo.AdditionalParameters. So this solution should work with all valid connection strings.

### Commands to test
```
$cs = 'Data Source=DockerDatabases; User ID=sa; Password=Passw0rd!; Database=tempdb'
$server = Connect-DbaInstance -ConnectionString $cs -TrustServerCertificate -Verbose
Invoke-DbaQuery -SqlInstance $server -Query 'SELECT DB_NAME()' -As SingleValue
$null = Get-DbaDbForeignKey -SqlInstance $server
Invoke-DbaQuery -SqlInstance $server -Query 'SELECT DB_NAME()' -As SingleValue      
```

### Screenshots
![image](https://github.com/dataplat/dbatools/assets/66946165/389f13a6-6f30-4b11-81c8-a009d088f519)
