### PR TITLE
Get-DbaStartupParameter - Return debug flags instead of writing warning

### DIFF
--- a/public/Get-DbaStartupParameter.ps1
+++ b/public/Get-DbaStartupParameter.ps1
@@ -83,18 +83,18 @@ function Get-DbaStartupParameter {
                     $masterLog = $params | Where-Object { $_.StartsWith('-l') }
                     $errorLog = $params | Where-Object { $_.StartsWith('-e') }
                     $traceFlags = $params | Where-Object { $_.StartsWith('-T') }
-
-                    $debugflag = $params | Where-Object { $_.StartsWith('-t') }
-
-                    if ($debugflag.length -ne 0) {
-                        Write-Message -Level Warning "$instance is using the lowercase -t trace flag. This is for internal debugging only. Please ensure this was intentional."
-                    }
-                    #>
+                    $debugFlags = $params | Where-Object { $_.StartsWith('-t') }
 
                     if ($traceFlags.length -eq 0) {
                         $traceFlags = "None"
                     } else {
                         [int[]]$traceFlags = $traceFlags.substring(2)
+                    }
+
+                    if ($debugFlags.length -eq 0) {
+                        $debugFlags = "None"
+                    } else {
+                        [int[]]$debugFlags = $debugFlags.substring(2)
                     }
 
                     if ($Simple -eq $true) {
@@ -106,6 +106,7 @@ function Get-DbaStartupParameter {
                             MasterLog       = $masterLog.TrimStart('-l')
                             ErrorLog        = $errorLog.TrimStart('-e')
                             TraceFlags      = $traceFlags
+                            DebugFlags      = $debugFlags
                             ParameterString = $wmisvc.StartupParameters
                         }
                     } else {
@@ -159,6 +160,7 @@ function Get-DbaStartupParameter {
                             MasterLog            = $masterLog -replace '^-[lL]', ''
                             ErrorLog             = $errorLog -replace '^-[eE]', ''
                             TraceFlags           = $traceFlags
+                            DebugFlags           = $debugFlags
                             CommandPromptStart   = $commandPrompt
                             MinimalStart         = $minimalStart
                             MemoryToReserve      = $memoryToReserve


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [ ] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8756 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

See issues for details.