### PR TITLE
Get-DbaDbRoleMember - EnableException support on child function call

### DIFF
--- a/public/Get-DbaDbRole.ps1
+++ b/public/Get-DbaDbRole.ps1
@@ -84,7 +84,7 @@ function Get-DbaDbRole {
     #>
     [CmdletBinding()]
     param (
-        [parameter(ValueFromPipeline)]
+        [Parameter(ValueFromPipeline)]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$Database,
@@ -92,11 +92,10 @@ function Get-DbaDbRole {
         [string[]]$Role,
         [string[]]$ExcludeRole,
         [switch]$ExcludeFixedRole,
-        [parameter(ValueFromPipeline)]
+        [Parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
         [switch]$EnableException
     )
-
     process {
         if (-not $InputObject -and -not $SqlInstance) {
             Stop-Function -Message "You must pipe in a database or specify a SqlInstance"
@@ -104,7 +103,7 @@ function Get-DbaDbRole {
         }
 
         if ($SqlInstance) {
-            $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
+            $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -EnableException:$EnableException
         }
 
         foreach ($db in $InputObject) {
@@ -115,15 +114,12 @@ function Get-DbaDbRole {
             Write-Message -Level 'Verbose' -Message "Getting Database Roles for $db on $server"
 
             $dbRoles = $db.Roles
-
             if ($Role) {
                 $dbRoles = $dbRoles | Where-Object { $_.Name -in $Role }
             }
-
             if ($ExcludeRole) {
                 $dbRoles = $dbRoles | Where-Object { $_.Name -notin $ExcludeRole }
             }
-
             if ($ExcludeFixedRole) {
                 $dbRoles = $dbRoles | Where-Object { $_.IsFixedRole -eq $false -and $_.Name -ne 'public' }
             }
@@ -133,7 +129,6 @@ function Get-DbaDbRole {
                 Add-Member -Force -InputObject $dbRole -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                 Add-Member -Force -InputObject $dbRole -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
                 Add-Member -Force -InputObject $dbRole -MemberType NoteProperty -Name Database -Value $db.Name
-
                 Select-DefaultView -InputObject $dbRole -Property "ComputerName", "InstanceName", "Database", "Name", "IsFixedRole"
             }
         }

--- a/public/Get-DbaDbRoleMember.ps1
+++ b/public/Get-DbaDbRoleMember.ps1
@@ -92,7 +92,7 @@ function Get-DbaDbRoleMember {
     #>
     [CmdletBinding()]
     param (
-        [parameter(ValueFromPipeline)]
+        [Parameter(ValueFromPipeline)]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$Database,
@@ -101,7 +101,7 @@ function Get-DbaDbRoleMember {
         [string[]]$ExcludeRole,
         [switch]$ExcludeFixedRole,
         [switch]$IncludeSystemUser,
-        [parameter(ValueFromPipeline)]
+        [Parameter(ValueFromPipeline)]
         [object[]]$InputObject,
         [switch]$EnableException
     )
@@ -118,18 +118,31 @@ function Get-DbaDbRoleMember {
 
         foreach ($input in $InputObject) {
             $inputType = $input.GetType().FullName
+            $dbRoleParams = @{
+                SqlInstance      = $input
+                SqlCredential    = $SqlCredential
+                Database         = $Database
+                ExcludeDatabase  = $ExcludeDatabase
+                Role             = $Role
+                ExcludeRole      = $ExcludeRole
+                ExcludeFixedRole = $ExcludeFixedRole
+                EnableException  = $EnableException
+            }
             switch ($inputType) {
                 'Dataplat.Dbatools.Parameter.DbaInstanceParameter' {
                     Write-Message -Level Verbose -Message "Processing DbaInstanceParameter through InputObject"
-                    $dbRoles = Get-DbaDBRole -SqlInstance $input -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -Role $Role -ExcludeRole $ExcludeRole -ExcludeFixedRole:$ExcludeFixedRole
+                    $dbRoles = Get-DbaDbRole @dbRoleParams
                 }
                 'Microsoft.SqlServer.Management.Smo.Server' {
                     Write-Message -Level Verbose -Message "Processing Server through InputObject"
-                    $dbRoles = Get-DbaDBRole -SqlInstance $input -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -Role $Role -ExcludeRole $ExcludeRole -ExcludeFixedRole:$ExcludeFixedRole
+                    $dbRoles = Get-DbaDbRole @dbRoleParams
                 }
                 'Microsoft.SqlServer.Management.Smo.Database' {
+                    $dbRoleParams.Remove('SqlInstance')
+                    $dbRoleParams.Remove('SqlCredential')
+                    $dbRoleParams.Remove('Database')
                     Write-Message -Level Verbose -Message "Processing Database through InputObject"
-                    $dbRoles = $input | Get-DbaDBRole -Role $Role -ExcludeRole $ExcludeRole -ExcludeFixedRole:$ExcludeFixedRole
+                    $dbRoles = $input | Get-DbaDbRole @dbRoleParams
                 }
                 'Microsoft.SqlServer.Management.Smo.DatabaseRole' {
                     Write-Message -Level Verbose -Message "Processing DatabaseRole through InputObject"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8986 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Allow `EnableException` to function as documented.

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
It is difficult to add this to the Pester test because `ErrorActionPreference` is not inherited by the child function call that I could tell.
