### PR TITLE
Documentation - correct typo of TThe to The

### DIFF
--- a/public/Get-DbaAvailableCollation.ps1
+++ b/public/Get-DbaAvailableCollation.ps1
@@ -8,7 +8,7 @@ function Get-DbaAvailableCollation {
         Only the connect permission is required to get this information.
 
     .PARAMETER SqlInstance
-        TThe target SQL Server instance or instances. Only connect permission is required.
+        The target SQL Server instance or instances. Only connect permission is required.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).

--- a/public/Get-DbaDbMail.ps1
+++ b/public/Get-DbaDbMail.ps1
@@ -7,7 +7,7 @@ function Get-DbaDbMail {
         Gets the database mail from SQL Server
 
     .PARAMETER SqlInstance
-        TThe target SQL Server instance or instances.
+        The target SQL Server instance or instances.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).

--- a/public/Get-DbaDbMailConfig.ps1
+++ b/public/Get-DbaDbMailConfig.ps1
@@ -7,7 +7,7 @@ function Get-DbaDbMailConfig {
         Gets database mail configs from SQL Server
 
     .PARAMETER SqlInstance
-        TThe target SQL Server instance or instances.
+        The target SQL Server instance or instances.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).

--- a/public/Get-DbaDbMailHistory.ps1
+++ b/public/Get-DbaDbMailHistory.ps1
@@ -7,7 +7,7 @@ function Get-DbaDbMailHistory {
         Gets the history of mail sent from a SQL instance
 
     .PARAMETER SqlInstance
-        TThe target SQL Server instance or instances.
+        The target SQL Server instance or instances.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).

--- a/public/Get-DbaDbMailLog.ps1
+++ b/public/Get-DbaDbMailLog.ps1
@@ -7,7 +7,7 @@ function Get-DbaDbMailLog {
         Gets the DBMail log from a SQL instance
 
     .PARAMETER SqlInstance
-        TThe target SQL Server instance or instances.
+        The target SQL Server instance or instances.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).

--- a/public/Get-DbaDbMailServer.ps1
+++ b/public/Get-DbaDbMailServer.ps1
@@ -7,7 +7,7 @@ function Get-DbaDbMailServer {
         Gets database mail servers from SQL Server
 
     .PARAMETER SqlInstance
-        TThe target SQL Server instance or instances.
+        The target SQL Server instance or instances.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).

--- a/public/Get-DbaDefaultPath.ps1
+++ b/public/Get-DbaDefaultPath.ps1
@@ -7,7 +7,7 @@ function Get-DbaDefaultPath {
         Gets the default SQL Server paths for data, logs and backups
 
     .PARAMETER SqlInstance
-        TThe target SQL Server instance or instances.
+        The target SQL Server instance or instances.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).

--- a/public/Get-DbaErrorLog.ps1
+++ b/public/Get-DbaErrorLog.ps1
@@ -7,7 +7,7 @@ function Get-DbaErrorLog {
         Gets the "SQL Error Log" of an instance. Returns all 10 error logs by default.
 
     .PARAMETER SqlInstance
-        TThe target SQL Server instance or instances.
+        The target SQL Server instance or instances.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).


### PR DESCRIPTION
this addresses issue 
https://github.com/dataplat/dbatools/issues/8999

<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8999 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose

address copy-pasted typos in eight different documentation pages

### Approach

Fixed the typos
