### PR TITLE
Copy-DbaDatabase - Add missing parameter validation

### DIFF
--- a/public/Copy-DbaDatabase.ps1
+++ b/public/Copy-DbaDatabase.ps1
@@ -164,6 +164,9 @@ function Copy-DbaDatabase {
     .LINK
         https://dbatools.io/Copy-DbaDatabase
 
+	.INPUT
+		A single database may be piped from Get-DbaDatabase.
+
     .EXAMPLE
         PS C:\> Copy-DbaDatabase -Source sql2014a -Destination sql2014b -Database TestDB -BackupRestore -SharedPath \\fileshare\sql\migration
 
@@ -707,8 +710,10 @@ function Copy-DbaDatabase {
         if ($InputObject) {
             $Source = $InputObject[0].Parent
             $Database = $InputObject.Name
-        }
-
+        } elseif (-not $Source) {
+            Stop-Function -Message "With no piped input a -Source must be specified."
+            return
+		}
 
         if ($Database -contains "master" -or $Database -contains "msdb" -or $Database -contains "tempdb") {
             Stop-Function -Message "Migrating system databases is not currently supported." -Continue

--- a/public/Copy-DbaDatabase.ps1
+++ b/public/Copy-DbaDatabase.ps1
@@ -164,8 +164,8 @@ function Copy-DbaDatabase {
     .LINK
         https://dbatools.io/Copy-DbaDatabase
 
-	.INPUT
-		A single database may be piped from Get-DbaDatabase.
+    .INPUT
+        A single database may be piped from Get-DbaDatabase.
 
     .EXAMPLE
         PS C:\> Copy-DbaDatabase -Source sql2014a -Destination sql2014b -Database TestDB -BackupRestore -SharedPath \\fileshare\sql\migration
@@ -713,7 +713,7 @@ function Copy-DbaDatabase {
         } elseif (-not $Source) {
             Stop-Function -Message "With no piped input a -Source must be specified."
             return
-		}
+        }
 
         if ($Database -contains "master" -or $Database -contains "msdb" -or $Database -contains "tempdb") {
             Stop-Function -Message "Migrating system databases is not currently supported." -Continue

--- a/public/Copy-DbaDatabase.ps1
+++ b/public/Copy-DbaDatabase.ps1
@@ -276,6 +276,10 @@ function Copy-DbaDatabase {
     begin {
         $CopyOnly = -not $NoCopyOnly
 
+        if (-not $InputObject -and -not $Source) {
+            Stop-Function -Message "With no piped input a -Source must be specified."
+            return
+        }
         if ($BackupRestore -and (-not $SharedPath -and -not $UseLastBackup)) {
             Stop-Function -Message "When using -BackupRestore, you must specify -SharedPath or -UseLastBackup"
             return
@@ -301,10 +305,6 @@ function Copy-DbaDatabase {
             $ConfirmPreference = 'none'
         }
 
-        if (-not $InputObject -and -not $Source) {
-            Stop-Function -Message "With no piped input a -Source must be specified."
-            return
-        }
 
 
         function Get-SqlFileStructure {

--- a/public/Copy-DbaDatabase.ps1
+++ b/public/Copy-DbaDatabase.ps1
@@ -164,9 +164,6 @@ function Copy-DbaDatabase {
     .LINK
         https://dbatools.io/Copy-DbaDatabase
 
-    .INPUT
-        A single database may be piped from Get-DbaDatabase.
-
     .EXAMPLE
         PS C:\> Copy-DbaDatabase -Source sql2014a -Destination sql2014b -Database TestDB -BackupRestore -SharedPath \\fileshare\sql\migration
 
@@ -304,8 +301,6 @@ function Copy-DbaDatabase {
         if ($Force) {
             $ConfirmPreference = 'none'
         }
-
-
 
         function Get-SqlFileStructure {
             $dbcollection = @{

--- a/public/Copy-DbaDatabase.ps1
+++ b/public/Copy-DbaDatabase.ps1
@@ -301,6 +301,12 @@ function Copy-DbaDatabase {
             $ConfirmPreference = 'none'
         }
 
+        if (-not $InputObject -and -not $Source) {
+            Stop-Function -Message "With no piped input a -Source must be specified."
+            return
+        }
+
+
         function Get-SqlFileStructure {
             $dbcollection = @{
             };
@@ -710,9 +716,6 @@ function Copy-DbaDatabase {
         if ($InputObject) {
             $Source = $InputObject[0].Parent
             $Database = $InputObject.Name
-        } elseif (-not $Source) {
-            Stop-Function -Message "With no piped input a -Source must be specified."
-            return
         }
 
         if ($Database -contains "master" -or $Database -contains "msdb" -or $Database -contains "tempdb") {


### PR DESCRIPTION
see issue https://github.com/dataplat/dbatools/issues/9001

<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9001 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
address weak paraemter validation in copy-dbadatabase

### Approach
add a conditional that prevents invalid (uninitialized) parameters being passed to other commands in the script.

Also, provide an `.INPUT` block in the help for this command so that its ability to accept piped input is documented.

### Commands to test
```powershell
copy-dbadatabase -destination slide -database junk -detachattach -newname junk33
```
should now generate a clear error message

