### PR TITLE
Convert-DbaIndexToTable - Fix for [n]varchar(max)

### DIFF
--- a/private/functions/Convert-DbaIndexToTable.ps1
+++ b/private/functions/Convert-DbaIndexToTable.ps1
@@ -76,6 +76,10 @@ function Convert-DbaIndexToTable {
                     { $_ -in "bigint", "date", "datetime", "datetime2", "smallint", "time", "tinyint" } {
                         $columnStatements += "[$($columnObject.Name)] [$dataType]"
                     }
+                    { $_ -like "*varcharmax" } {
+                        $columnStatements += "[$($columnObject.Name)] [$($dataType.Replace('max',''))](max)"
+                        break
+                    }
                     { $_ -like "*char*" } {
                         $columnStatements += "[$($columnObject.Name)] [$dataType]($length)"
                     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [ ] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8509 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

`$columnObject.DataType.SqlDataType.ToString().ToLower()` is used and returns "varcharmax" for "varchar(max)"-columns. So this needs special care.

Also have a look at the before and after screenshot:
![image](https://github.com/dataplat/dbatools/assets/66946165/65f3cd77-d278-4cec-b34b-12458b7dd52b)

