### PR TITLE
Set-DbatoolsInsecureConnection - Use 'Optional' instead of false, and fix casing on PassThru parameter

### DIFF
--- a/public/Set-DbatoolsInsecureConnection.ps1
+++ b/public/Set-DbatoolsInsecureConnection.ps1
@@ -51,8 +51,8 @@ function Set-DbatoolsInsecureConnection {
             Write-Message -Level Warning -Message "The Register parameter is deprecated and will be removed in a future release."
         }
         # Set these defaults for all future sessions on this machine
-        Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Passthru
-        Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -Passthru
+        Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -PassThru
+        Set-DbatoolsConfig -FullName sql.connection.encrypt -Value 'Optional' -PassThru
 
         if (-not $SessionOnly) {
             Register-DbatoolsConfig -FullName sql.connection.trustcert -Scope $Scope

--- a/tests/Set-DbatoolsInsecureConnection.Tests.ps1
+++ b/tests/Set-DbatoolsInsecureConnection.Tests.ps1
@@ -18,19 +18,19 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     BeforeEach {
         # Set defaults just for this session
         Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $false -Register
-        Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $true -Register
+        Set-DbatoolsConfig -FullName sql.connection.encrypt -Value 'Mandatory' -Register
     }
     Context "command actually works" {
         It "Should set the default connection settings to trust all server certificates and not require encrypted connections" {
             $trustcert = Get-DbatoolsConfigValue -FullName sql.connection.trustcert
             $encrypt = Get-DbatoolsConfigValue -FullName sql.connection.encrypt
             $trustcert | Should -BeFalse
-            $encrypt | Should -BeTrue
+            $encrypt | Should -Be 'Mandatory'
 
             $null = Set-DbatoolsInsecureConnection
             Get-DbatoolsConfigValue -FullName sql.connection.trustcert | Should -BeTrue
             # sql.connection.encrypt is a string because it needs to be mandatory, optional, true or false
-            Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Should -Be 'False'
+            Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Should -Be 'Optional'
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [x] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
`Set-DbatoolsInsecureConnection` uses false instead of optional for the encrypt setting. This PR updates that to use optional.

### Approach
<!-- How does this change solve that purpose -->
Updated cmdlet to pass `'Optional'` for the value instead of `$false`.

I also updated the casing on the PassThru parameter to be consistent with the `Set-DbatoolsConfig` cmdlet.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Set-DbatoolsInsecureConnection`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->


### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
