### PR TITLE
change backupDate fixes #9024

### DIFF
--- a/public/Test-DbaLastBackup.ps1
+++ b/public/Test-DbaLastBackup.ps1
@@ -84,7 +84,7 @@ function Test-DbaLastBackup {
         If this switch is enabled, transaction log backups will be ignored. The restore will stop at the latest full or differential backup point.
 
     .PARAMETER IgnoreDiffBackup
-        If this switch is enabled, differential backuys will be ignored. The restore will only use Full and Log backups, so will take longer to complete
+        If this switch is enabled, differential backups will be ignored. The restore will only use Full and Log backups, so will take longer to complete
 
     .PARAMETER Prefix
         The database is restored as "dbatools-testrestore-$databaseName" by default. You can change dbatools-testrestore to whatever you would like using this parameter.
@@ -100,12 +100,12 @@ function Test-DbaLastBackup {
 
     .PARAMETER MaxTransferSize
         Parameter to set the unit of transfer. Values must be a multiple of 64kb and a max of 4GB
-        Parameter is used as passtrough for Restore-DbaDatabase.
+        Parameter is used as passthrough for Restore-DbaDatabase.
 
     .PARAMETER BufferCount
         Number of I/O buffers to use to perform the operation.
-        Refererence: https://msdn.microsoft.com/en-us/library/ms178615.aspx#data-transfer-options
-        Parameter is used as passtrough for Restore-DbaDatabase.
+        Reference: https://msdn.microsoft.com/en-us/library/ms178615.aspx#data-transfer-options
+        Parameter is used as passthrough for Restore-DbaDatabase.
 
     .PARAMETER ReuseSourceFolderStructure
         By default, databases will be migrated to the destination Sql Server's default data and log directories. You can override this by specifying -ReuseSourceFolderStructure.
@@ -178,7 +178,7 @@ function Test-DbaLastBackup {
 
         Determines the last full backup for ALL databases, attempts to restore all databases (with a different name and file structure).
         The Restore will use more memory for reading the backup files. Do not set these values to high or you can get an Out of Memory error!!!
-        When running the restore with these additional parameters and there is other server activity it could affect server OLTP performance. Please use with causion.
+        When running the restore with these additional parameters and there is other server activity it could affect server OLTP performance. Please use with caution.
         Prior to running, you should check memory and server resources before configure it to run automatically.
         More information:
         https://www.mssqltips.com/sqlservertip/4935/optimize-sql-server-database-restore-performance/
@@ -243,7 +243,7 @@ function Test-DbaLastBackup {
             }
 
             if ($db.LastFullBackup.Year -eq 1) {
-                [pscustomobject]@{
+                [PSCustomObject]@{
                     SourceServer   = $source
                     TestServer     = $destination
                     Database       = $db.name
@@ -346,7 +346,7 @@ function Test-DbaLastBackup {
 
             $totalSizeMB = ($lastbackup.TotalSize.Megabyte | Measure-Object -Sum).Sum
             if ($MaxSize -and $MaxSize -lt $totalSizeMB) {
-                [pscustomobject]@{
+                [PSCustomObject]@{
                     SourceServer   = $source
                     TestServer     = $destination
                     Database       = $db.name
@@ -361,7 +361,7 @@ function Test-DbaLastBackup {
                     DbccStart      = $null
                     DbccEnd        = $null
                     DbccElapsed    = $null
-                    BackupDates    = [String[]]($lastbackup.Start)
+                    BackupDates    = [dbadatetime[]]($lastbackup.Start)
                     BackupFiles    = $lastbackup.FullName
                 }
                 continue
@@ -540,7 +540,7 @@ function Test-DbaLastBackup {
                 }
 
                 if (-not $NoDrop -and $null -ne $destserver.databases[$dbName]) {
-                    if ($Pscmdlet.ShouldProcess($dbName, "Dropping Database $dbName on $destination")) {
+                    if ($PSCmdlet.ShouldProcess($dbName, "Dropping Database $dbName on $destination")) {
                         Write-Message -Level Verbose -Message "Dropping database."
 
                         ## Drop the database
@@ -575,7 +575,7 @@ function Test-DbaLastBackup {
             }
 
             if ($Pscmdlet.ShouldProcess("console", "Showing results")) {
-                [pscustomobject]@{
+                [PSCustomObject]@{
                     SourceServer   = $source
                     TestServer     = $destination
                     Database       = $db.name
@@ -590,7 +590,7 @@ function Test-DbaLastBackup {
                     DbccStart      = [dbadatetime]$startDbcc
                     DbccEnd        = [dbadatetime]$endDbcc
                     DbccElapsed    = $dbccElapsed
-                    BackupDates    = [String[]]($lastbackup.Start)
+                    BackupDates    = [dbadatetime[]]($lastbackup.Start)
                     BackupFiles    = $lastbackup.FullName
                 }
             }

--- a/tests/Test-DbaLastBackup.Tests.ps1
+++ b/tests/Test-DbaLastBackup.Tests.ps1
@@ -57,6 +57,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         It "Should return success" {
             $results.RestoreResult | Should Be "Success"
             $results.DbccResult | Should Be "Success"
+            $results.BackupDates | ForEach-Object { $_ | Should BeOfType DbaDateTime }
         }
     }
 
@@ -84,7 +85,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.RestoreResult | Should Be "Success"
         }
 
-        It "Should tno contain a diff backup" {
+        It "Should not contain a diff backup" {
             ($results.BackupFiles | Where-Object { $_ -like '*diff*' }).count | Should -Be 0
         }
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [X] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #9024 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Resolve issues with dates described in #9024 

`BackupDates` is currently returned as array of strings, which means dates are being calculated incorrectly.
![image](https://github.com/dataplat/dbatools/assets/981370/aa7217f5-16d1-4c60-bc3f-91a4c39b6681)


### Approach
change this line to use dbadatetime instead of string
`BackupDates    = [dbadatetime[]]($lastbackup.Start)`

### Commands to test

```PowerShell

# import out version of the module
cd C:\GitHub\dbatools
Import-Module .\dbatools.psd1 -force

# lets save the password for connecting to containers because I'm lazy
$securePassword = ('dbatools.IO' | ConvertTo-SecureString -AsPlainText -Force)
$credential = New-Object System.Management.Automation.PSCredential('sqladmin', $securePassword)

$PSDefaultParameterValues = @{
    "*:SqlCredential"            = $credential
    "*:DestinationCredential"    = $credential
    "*:DestinationSqlCredential" = $credential
    "*:SourceSqlCredential"      = $credential
    "*:PublisherSqlCredential"   = $credential
}


# create a couple of new databases for testing
New-DbaDatabase -SqlInstance mssql1 -Name TestRestoreMe -RecoveryModel Full
New-DbaDatabase -SqlInstance mssql1 -Name TestRestoreMe2 -RecoveryModel Full

# full backups
Backup-DbaDatabase -SqlInstance mssql1 -Database TestRestoreMe, TestRestoreMe2 -Type Full

# log backups for one 
Backup-DbaDatabase -SqlInstance mssql1 -Database TestRestoreMe -Type Log

# test restore them
$results = Test-DbaLastBackup -SqlInstance mssql1 -Database TestRestoreMe, TestRestoreMe2

# results look good
$results 

<#
SourceServer   : mssql1
TestServer     : mssql1
Database       : TestRestoreMe
FileExists     : True
Size           : 2.73 MB
RestoreResult  : Success
DbccResult     : Success
RestoreStart   : 2023-07-04 10:39:21.567
RestoreEnd     : 2023-07-04 10:39:23.782
RestoreElapsed : 00:00:02
DbccMaxDop     : 0
DbccStart      : 2023-07-04 10:39:23.838
DbccEnd        : 2023-07-04 10:39:24.427
DbccElapsed    : 00:00:00
BackupDates    : {07/04/2023 09:39:04, 07/04/2023 09:39:13} ## this is backwards!
BackupFiles    : {/shared/TestRestoreMe_202307041039.bak, /shared/TestRestoreMe_202307041039.trn}

SourceServer   : mssql1
TestServer     : mssql1
Database       : TestRestoreMe2
FileExists     : True
Size           : 2.65 MB
RestoreResult  : Success
DbccResult     : Success
RestoreStart   : 2023-07-04 10:39:25.094
RestoreEnd     : 2023-07-04 10:39:26.127
RestoreElapsed : 00:00:01
DbccMaxDop     : 0
DbccStart      : 2023-07-04 10:39:26.177
DbccEnd        : 2023-07-04 10:39:26.396
DbccElapsed    : 00:00:00
BackupDates    : {07/04/2023 09:39:05} ## this is backwards!
BackupFiles    : {/shared/TestRestoreMe2_202307041039.bak}
#>

# except these dates are strings :o
$results.BackupDates[0].GetType()

<#
IsPublic IsSerial Name                                     BaseType
-------- -------- ----                                     --------
True     True     String                                   System.Object
#>

## apply fix and reimport module
Import-Module .\dbatools.psd1 -force

$resultsNew = Test-DbaLastBackup -SqlInstance mssql1 -Database TestRestoreMe, TestRestoreMe2

# results still look good
$resultsNew 
<#
SourceServer   : mssql1
TestServer     : mssql1
Database       : TestRestoreMe
FileExists     : True
Size           : 2.73 MB
RestoreResult  : Success
DbccResult     : Success
RestoreStart   : 2023-07-04 10:52:05.618
RestoreEnd     : 2023-07-04 10:52:07.056
RestoreElapsed : 00:00:01
DbccMaxDop     : 0
DbccStart      : 2023-07-04 10:52:07.119
DbccEnd        : 2023-07-04 10:52:07.410
DbccElapsed    : 00:00:00
BackupDates    : {2023-07-04 09:39:04.000, 2023-07-04 09:39:13.000} ## this looks better!
BackupFiles    : {/shared/TestRestoreMe_202307041039.bak, /shared/TestRestoreMe_202307041039.trn}

SourceServer   : mssql1
TestServer     : mssql1
Database       : TestRestoreMe2
FileExists     : True
Size           : 2.65 MB
RestoreResult  : Success
DbccResult     : Success
RestoreStart   : 2023-07-04 10:52:08.014
RestoreEnd     : 2023-07-04 10:52:09.031
RestoreElapsed : 00:00:01
DbccMaxDop     : 0
DbccStart      : 2023-07-04 10:52:09.096
DbccEnd        : 2023-07-04 10:52:09.363
DbccElapsed    : 00:00:00
BackupDates    : {2023-07-04 09:39:05.000} ## this looks better!
BackupFiles    : {/shared/TestRestoreMe2_202307041039.bak}

#>

# and now these dates are dates!
$resultsNew.BackupDates[0].GetType()

<#

IsPublic IsSerial Name                                     BaseType
-------- -------- ----                                     --------
True     False    DbaDateTime                              Dataplat.Dbatools.Utility.DbaDateTimeBase

#>
```