### PR TITLE
fix typo in Get-DecryptedObject.ps1

### DIFF
--- a/private/functions/Get-DecryptedObject.ps1
+++ b/private/functions/Get-DecryptedObject.ps1
@@ -49,7 +49,7 @@ function Get-DecryptedObject {
             return $serviceKey
         }
     } catch {
-        Stop-Function -Message "Can't unprotect registry data on $sourceName. Do you have administrative access to the Windows registry on $sourceName? Otherwise, we're out of ideas." -Target $sourceName
+        Stop-Function -Message "Can't unprotect registry data on $sourceName. Do you have administrative access to the Windows registry on $sourceName ? Otherwise, we're out of ideas." -Target $sourceName
         return
     }
 
@@ -59,7 +59,7 @@ function Get-DecryptedObject {
 
     if (($serviceKey.Length -ne 16) -and ($serviceKey.Length -ne 32)) {
         Write-Message -Level Verbose -Message "ServiceKey found: $serviceKey.Length"
-        Stop-Function -Message "Unknown key size. Do you have administrative access to the Windows registry on $sourceName? Otherwise, we're out of ideas." -Target $sourceName
+        Stop-Function -Message "Unknown key size. Do you have administrative access to the Windows registry on $sourceName ? Otherwise, we're out of ideas." -Target $sourceName
         return
     }
 

--- a/private/functions/Get-DecryptedObject.ps1
+++ b/private/functions/Get-DecryptedObject.ps1
@@ -59,7 +59,7 @@ function Get-DecryptedObject {
 
     if (($serviceKey.Length -ne 16) -and ($serviceKey.Length -ne 32)) {
         Write-Message -Level Verbose -Message "ServiceKey found: $serviceKey.Length"
-        Stop-Function -Message "Unknown key size. Do you have administrative access to the Windows registry on $sourceName ? Otherwise, we're out of ideas." -Target $sourceName
+        Stop-Function -Message "Unknown key size. Do you have administrative access to the Windows registry on $($sourceName)? Otherwise, we're out of ideas." -Target $sourceName
         return
     }
 

--- a/private/functions/Get-DecryptedObject.ps1
+++ b/private/functions/Get-DecryptedObject.ps1
@@ -49,7 +49,7 @@ function Get-DecryptedObject {
             return $serviceKey
         }
     } catch {
-        Stop-Function -Message "Can't unprotect registry data on $sourceName. Do you have administrative access to the Windows registry on $sourceName ? Otherwise, we're out of ideas." -Target $sourceName
+        Stop-Function -Message "Can't unprotect registry data on $sourceName. Do you have administrative access to the Windows registry on $($sourceName)? Otherwise, we're out of ideas." -Target $sourceName
         return
     }
 


### PR DESCRIPTION
line 52 and 62 added space between $sourceName and "?"

<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x ] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)
just synched the dev repo just before my fix

## Type of Change
<!-- What type of change does your code introduce -->
 - [x ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose

just fixed a type. Figured out in a client environment that the stop message skipped the Servername when outputting
"Do you have administrative access to the Windows registry on  Otherwise, we're out of ideas."

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
