### PR TITLE
Bug Fix #9068. New-DbaDbUser

### DIFF
--- a/public/New-DbaDbUser.ps1
+++ b/public/New-DbaDbUser.ps1
@@ -172,7 +172,7 @@ function New-DbaDbUser {
 
             #This block is required so that correct error message can be returned to the user when incorrect database name is given or the database doesn't exists in the server.
             if (-not $Database) {
-                $Database = $databases
+                $Database = $databases.Name
             }
 
             foreach ($db in $Database) {

--- a/public/New-DbaDbUser.ps1
+++ b/public/New-DbaDbUser.ps1
@@ -186,6 +186,7 @@ function New-DbaDbUser {
                 $userParam = $connParam.Clone()
                 $userParam.Database = $dbSmo.name
                 $userParam.User = $Username
+                $userParam.EnableException = $True
 
                 #check if the schema exists
                 if ($dbSmo.Name -in ($getValidSchema).Parent.Name) {
@@ -207,7 +208,7 @@ function New-DbaDbUser {
                         } elseif ($userExists -and $Force) {
                             try {
                                 Write-Message -Level Verbose -Message "FORCE is used, user [$Username] will be dropped in the database $dbSmo on [$instance]"
-                                Remove-DbaDbUser @userParam -Force
+                                $null = Remove-DbaDbUser @userParam -Force
                             } catch {
                                 Stop-Function -Message "Could not remove existing user [$Username] in the database $dbSmo on [$instance], skipping." -Target $User -ErrorRecord $_ -Continue
                             }

--- a/public/New-DbaDbUser.ps1
+++ b/public/New-DbaDbUser.ps1
@@ -154,7 +154,8 @@ function New-DbaDbUser {
             $getDbParam.OnlyAccessible = $True
             if ($Database) {
                 $getDbParam.Database = $Database
-            } elseif (-not $IncludeSystem) {
+            }
+            if (-not $IncludeSystem) {
                 $getDbParam.ExcludeSystem = $True
             }
             if ($ExcludeDatabase) {
@@ -168,6 +169,11 @@ function New-DbaDbUser {
 
             $databases = Get-DbaDatabase @getDbParam
             $getValidSchema = Get-DbaDbSchema -InputObject $databases -Schema $DefaultSchema -IncludeSystemSchemas
+
+            #This block is required so that correct error message can be returned to the user when incorrect database name is given or the database doesn't exists in the server.
+            if (-not $Database) {
+                $Database = $databases
+            }
 
             foreach ($db in $Database) {
                 $dbSmo = $databases | Where-Object Name -eq $db

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -44,7 +44,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         It "Creates the user and get it" {
             New-DbaDbUser -SqlInstance $script:instance2 -Database $dbname -Login $userName -DefaultSchema guest
             $newDbUser = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname | Where-Object Name -eq $userName
-            $newDbUser.Name | Should Be $userName
+            $newDbUser.Name | Should -Be $userName
             $newDbUser.DefaultSchema | Should -Be 'guest'
         }
     }
@@ -60,7 +60,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         It "Creates the user and get it. Login property is empty" {
             New-DbaDbUser -SqlInstance $script:instance2 -Database $dbname -User $userNameWithoutLogin -DefaultSchema guest
             $results = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname | Where-Object Name -eq $userNameWithoutLogin
-            $results.Name | Should Be $userNameWithoutLogin
+            $results.Name | Should -Be $userNameWithoutLogin
             $results.DefaultSchema | Should -Be 'guest'
             $results.Login | Should -BeNullOrEmpty
         }

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -74,6 +74,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
             $null = New-DbaLogin -SqlInstance $script:instance2 -Login $loginName -Password $securePassword -Force
             $null = New-DbaDatabase -SqlInstance $script:instance2 -Name $dbs
+            $accessibleDbCount = (Get-DbaDatabase -SqlInstance $script:instance2 -ExcludeSystem -OnlyAccessible).count
         }
         AfterAll {
             $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbs -Confirm:$false
@@ -88,7 +89,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
         It "Should add user to all user databases" {
             $results = New-DbaDbUser -SqlInstance $script:instance2 -Login $loginName -Force -EnableException
-            $results.Count | Should -Be 3
+            $results.Count | Should -Be $accessibleDbCount
             $results.Name | Get-Unique | Should -Be $loginName
         }
     }

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -85,5 +85,11 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $results.Name | Should -Be $loginName, $loginName, $loginName
             $results.DefaultSchema | Should -Be dbo, dbo, dbo
         }
+
+        It "Should add user to all user databases" {
+            $results = New-DbaDbUser -SqlInstance $script:instance2 -Login $loginName -Force -EnableException
+            $results.Count | Should -Be 3
+            $results.Name | Get-Unique | Should -Be $loginName
+        }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x ] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->

### Approach
<!-- How does this change solve that purpose -->
Bug fix #9068 

`New-DbaDbUser` function failed to create the user in all the user databases when `Database` parameter is not provided. Changes are made to fix this, when the `Database` parameter is not provided then the user will be created in all the user databases.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`New-DbaDbUser -SqlInstance Server1 -Login User1`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
