### PR TITLE
Test-DbaLoginPassword, use parametrized query

### DIFF
--- a/public/Test-DbaLoginPassword.ps1
+++ b/public/Test-DbaLoginPassword.ps1
@@ -89,8 +89,7 @@ function Test-DbaLoginPassword {
                 [int] $size = 1
             )
             $chunkCount = [Math]::Ceiling($source.Count / $size)
-            0 .. ($chunkCount - 1) `
-            | ForEach-Object {
+            0 .. ($chunkCount - 1) | ForEach-Object {
                 $startIndex = $_ * $size
                 $endIndex = [Math]::Min(($_ + 1) * $size, $source.Count)
                 , $source[$startIndex .. ($endIndex - 1)]

--- a/public/Test-DbaLoginPassword.ps1
+++ b/public/Test-DbaLoginPassword.ps1
@@ -93,11 +93,11 @@ function Test-DbaLoginPassword {
             | ForEach-Object {
                 $startIndex = $_ * $size
                 $endIndex = [Math]::Min(($_ + 1) * $size, $source.Count)
-                ,$source[$startIndex .. ($endIndex - 1)]
+                , $source[$startIndex .. ($endIndex - 1)]
             }
         }
-		
-		$maxBatch = 200
+
+        $maxBatch = 200
 
         $CheckPasses = "", "@@Name"
         if ($Dictionary) {
@@ -105,26 +105,26 @@ function Test-DbaLoginPassword {
         }
 
         $sqlStart = "DECLARE @WeakPwdList TABLE(WeakPwd NVARCHAR(255))
-            --Define weak password list
-            --Use @@Name if users password contain their name
-            INSERT INTO @WeakPwdList(WeakPwd)
-            VALUES (NULL)"
+                --Define weak password list
+                --Use @@Name if users password contain their name
+                INSERT INTO @WeakPwdList(WeakPwd)
+                VALUES (NULL)"
 
         $sqlEnd = "
-            SELECT SERVERPROPERTY('MachineName') AS [ComputerName],
-                ISNULL(SERVERPROPERTY('InstanceName'), 'MSSQLSERVER') AS InstanceName,
-                SERVERPROPERTY('ServerName') AS [SqlInstance],
-                SysLogins.name as SqlLogin,
-                WeakPassword = 'True',
-                REPLACE(WeakPassword.WeakPwd,'@@Name',SysLogins.name) As [Password],
-                SysLogins.is_disabled as Disabled,
-                SysLogins.create_date as CreatedDate,
-                SysLogins.modify_date as ModifiedDate,
-                SysLogins.default_database_name as DefaultDatabase
-            FROM sys.sql_logins SysLogins
-            INNER JOIN @WeakPwdList WeakPassword 
-            ON PWDCOMPARE(REPLACE(WeakPassword.WeakPwd,'@@Name',SysLogins.name),password_hash) = 1
-            "
+                SELECT SERVERPROPERTY('MachineName') AS [ComputerName],
+                    ISNULL(SERVERPROPERTY('InstanceName'), 'MSSQLSERVER') AS InstanceName,
+                    SERVERPROPERTY('ServerName') AS [SqlInstance],
+                    SysLogins.name as SqlLogin,
+                    WeakPassword = 'True',
+                    REPLACE(WeakPassword.WeakPwd,'@@Name',SysLogins.name) As [Password],
+                    SysLogins.is_disabled as Disabled,
+                    SysLogins.create_date as CreatedDate,
+                    SysLogins.modify_date as ModifiedDate,
+                    SysLogins.default_database_name as DefaultDatabase
+                FROM sys.sql_logins SysLogins
+                INNER JOIN @WeakPwdList WeakPassword
+                ON PWDCOMPARE(REPLACE(WeakPassword.WeakPwd,'@@Name',SysLogins.name),password_hash) = 1
+                "
     }
     process {
         foreach ($instance in $SqlInstance) {
@@ -145,13 +145,13 @@ function Test-DbaLoginPassword {
             Write-Message -Level Verbose -Message "Testing: same username as Password"
             Write-Message -Level Verbose -Message "Testing: the following Passwords $CheckPasses"
             try {
-                $checkParts = ,(Split-ArrayInChunks -source $CheckPasses -size $maxBatch)
-                
+                $checkParts = , (Split-ArrayInChunks -source $CheckPasses -size $maxBatch)
+
                 $loopIndex = 0
 
                 foreach ($batch in $checkParts) {
                     $thisBatch = $sqlStart
-                    $sqlParams = @{}
+                    $sqlParams = @{ }
                     foreach ($piece in $batch) {
                         $loopIndex += 1
                         $paramKey = "@p_$loopIndex"

--- a/tests/Test-DbaLoginPassword.Tests.ps1
+++ b/tests/Test-DbaLoginPassword.Tests.ps1
@@ -38,5 +38,9 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $results = Test-DbaLoginPassword -SqlInstance $script:instance1 -Login $weaksauce
             $results.SqlLogin | Should -Be $weaksauce
         }
+        It "handles passwords with quotes, see #9095" {
+            $results = Test-DbaLoginPassword -SqlInstance $script:instance1 -Login $weaksauce -Dictionary "&é`"'(-", "hello"
+            $results.SqlLogin | Should -Be $weaksauce
+        }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9095 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [x] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Use parametrized queries since escaping inputs is .... so 1990.+

### Approach
Use Invoke-DbaQuery to run the query, which just has a problem of not being able to support zillions of params in one go.
So we split in "regular batches".

I *think* the query is now fine, although a password set as "@@Name" won't get detected... But I didn't want to completely change every piece of it.
