### PR TITLE
Set-DbaDbCompression, prefer online rebuilds where possible

### DIFF
--- a/public/Set-DbaDbCompression.ps1
+++ b/public/Set-DbaDbCompression.ps1
@@ -41,7 +41,7 @@ function Set-DbaDbCompression {
         Will only work on the tables/indexes that have the calculated savings at and higher for the given number provided.
 
     .PARAMETER ForceOfflineRebuilds
-        By default, this function prefers online rebuilds over offline ones. 
+        By default, this function prefers online rebuilds over offline ones.
         If you are on a supported version of SQL Server but still prefer to do offline rebuilds, enable this flag
 
     .PARAMETER InputObject
@@ -163,8 +163,7 @@ function Set-DbaDbCompression {
                         break
                     }
                     foreach ($index in $($obj.Indexes | Where-Object { !$_.IsMemoryOptimized -and $_.IndexType -notmatch 'Columnstore' })) {
-                        if ($index.IsOnlineRebuildSupported -or $isAzure)
-                        {
+                        if ($index.IsOnlineRebuildSupported -or $isAzure) {
                             $isOnlineRebuildSupported = $true
                             $onlineRebuildScanCompleted = $true
                             break
@@ -173,8 +172,7 @@ function Set-DbaDbCompression {
                 }
                 Write-Message -Level Verbose -Message "Are Online Rebuilds supported ? $isOnlineRebuildSupported"
                 $CanDoOnlineOperation = $false
-                if ($IsOnlineRebuildSupported -and !$ForceOfflineRebuilds)
-                {
+                if ($IsOnlineRebuildSupported -and !$ForceOfflineRebuilds) {
                     $CanDoOnlineOperation = $true
                     Write-Message -Level Verbose -Message "Using Online Rebuilds where possible"
                 }
@@ -283,8 +281,7 @@ function Set-DbaDbCompression {
                                         ## https://feedback.azure.com/forums/908035-sql-server/suggestions/34080112-data-compression-smo-bug
                                         if ($CompressionType -eq "None") {
                                             $query = "ALTER INDEX [$($index.Name)] ON $($index.Parent) REBUILD PARTITION = ALL WITH"
-                                            if ($CanDoOnlineOperation)
-                                            {
+                                            if ($CanDoOnlineOperation) {
                                                 $query += "(DATA_COMPRESSION = $CompressionType, ONLINE = ON)"
                                             } else {
                                                 $query += "(DATA_COMPRESSION = $CompressionType)"
@@ -330,8 +327,7 @@ function Set-DbaDbCompression {
                                     ## Once this UserVoice item is fixed the workaround can be removed
                                     ## https://feedback.azure.com/forums/908035-sql-server/suggestions/34080112-data-compression-smo-bug
                                     if ($CompressionType -eq "None") {
-                                        if ($CanDoOnlineOperation)
-                                        {
+                                        if ($CanDoOnlineOperation) {
                                             $query += "(DATA_COMPRESSION = $CompressionType, ONLINE = ON)"
                                         } else {
                                             $query += "(DATA_COMPRESSION = $CompressionType)"

--- a/public/Set-DbaDbCompression.ps1
+++ b/public/Set-DbaDbCompression.ps1
@@ -137,7 +137,6 @@ function Set-DbaDbCompression {
             if ($server.EngineEdition -notmatch 'Enterprise' -and $server.VersionMajor -lt '13') {
                 Stop-Function -Message "Only SQL Server Enterprise Edition supports compression on $server" -Target $server -Continue
             }
-            $isAzure = $server.DatabaseEngineType -match "Azure"
             $dbs = $server.Databases | Where-Object { $_.IsAccessible -and $_.IsSystemObject -eq 0 }
             if ($Database) {
                 $dbs = $dbs | Where-Object { $_.Name -in $Database }
@@ -163,7 +162,7 @@ function Set-DbaDbCompression {
                         break
                     }
                     foreach ($index in $($obj.Indexes | Where-Object { !$_.IsMemoryOptimized -and $_.IndexType -notmatch 'Columnstore' })) {
-                        if ($index.IsOnlineRebuildSupported -or $isAzure) {
+                        if ($index.IsOnlineRebuildSupported -or $server.isAzure) {
                             $isOnlineRebuildSupported = $true
                             $onlineRebuildScanCompleted = $true
                             break

--- a/public/Set-DbaDbCompression.ps1
+++ b/public/Set-DbaDbCompression.ps1
@@ -217,7 +217,7 @@ function Set-DbaDbCompression {
                                     $underlyingObj = $server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].Indexes[$obj.IndexName]
                                     ($underlyingObj.PhysicalPartitions | Where-Object { $_.PartitionNumber -eq $obj.Partition }).DataCompression = $obj.CompressionTypeRecommendation
                                     $underlyingObj.OnlineIndexOperation = $CanDoOnlineOperation
-                                    $server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].Indexes[$obj.IndexName].Rebuild()
+                                    $underlyingObj.Rebuild()
                                 } catch {
                                     Stop-Function -Message "Compression failed for $instance - $db - table $($obj.Schema).$($obj.TableName) - index $($obj.IndexName) - partition $($obj.Partition)" -Target $db -ErrorRecord $_ -Continue
                                 }
@@ -279,7 +279,7 @@ function Set-DbaDbCompression {
                                     Write-Message -Level Verbose -Message "Compressing $($Index.IndexType) $($Index.Name) Partition $($p.PartitionNumber)"
                                     try {
                                         $($index.PhysicalPartitions | Where-Object { $_.PartitionNumber -eq $P.PartitionNumber }).DataCompression = $CompressionType
-                                        $obj.OnlineIndexOperation = $CanDoOnlineOperation
+                                        $index.OnlineIndexOperation = $CanDoOnlineOperation
                                         $index.Rebuild()
                                     } catch {
                                         Stop-Function -Message "Compression failed for $instance - $db - table $($obj.Schema).$($obj.Name) - index $($index.Name) - partition $($p.PartitionNumber)" -Target $db -ErrorRecord $_ -Continue
@@ -313,7 +313,7 @@ function Set-DbaDbCompression {
                                 Write-Message -Level Verbose -Message "Compressing $($index.IndexType) $($index.Name) Partition $($p.PartitionNumber)"
                                 try {
                                     $($index.PhysicalPartitions | Where-Object { $_.PartitionNumber -eq $P.PartitionNumber }).DataCompression = $CompressionType
-                                    $obj.OnlineIndexOperation = $CanDoOnlineOperation
+                                    $index.OnlineIndexOperation = $CanDoOnlineOperation
                                     $index.Rebuild()
                                 } catch {
                                     Stop-Function -Message "Compression failed for $instance - $db - table $($obj.Schema).$($obj.Name) - index $($index.Name) - partition $($p.PartitionNumber)" -Target $db -ErrorRecord $_ -Continue

--- a/tests/Set-DbaDbCompression.Tests.ps1
+++ b/tests/Set-DbaDbCompression.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Table', 'CompressionType', 'MaxRunTime', 'PercentCompression', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Table', 'CompressionType', 'MaxRunTime', 'PercentCompression', 'ForceOfflineRebuilds', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #9102 )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
Try to do online operations where possible. 

### Approach
There's a swanky "IsOnlineRebuildSupported" on the index property to signal if the version supports online operations. Unfortunately, it's not on the database level.
So, we loop over existing indexes, and if one is found and IsOnlineRebuildSupported is true, we set the relevant flags on the rebuild operation.
Fixes:
- ~~there was a manual FIX due to a SMO bug for resetting tables to "None", but it seems to be fixed, so I removed the workaround from the code~~ reintroduced, as it seems to be working on AZ but not onprem.

Problems:
- Azure gets back false on any index, even if AFAIK every Azure instance supports online rebuilds.... so we patch SMO at the top

Possible problems:
- if you just have heaps, there's no way to detect if online operations are supported if not manually detecting versions and editions 
- technically every index can have that flag .... is there some kind of situation in which one index is rebuildable online and another isn't ? if so, even if AN index is "online rebuildable", this code fails to set it on every operation, and the check must be done on each object and reverted to a clunky "globally I should be able to do it, but I can't for this specific one"... which, in Azure-related cases, is going to be impossible as the property on each index is set to false 
 
