### PR TITLE
Copy-DbaDbTableData - Enable failback to default group

### DIFF
--- a/public/Copy-DbaDbTableData.ps1
+++ b/public/Copy-DbaDbTableData.ps1
@@ -111,6 +111,11 @@ function Copy-DbaDbTableData {
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
+    .PARAMETER UseDefaultFileGroup
+        By default, this command will use a filegroup of the same name between
+        source and target. Use this flag if you'd instead like to use the
+        default filegroup in the target database.
+
     .NOTES
         Tags: Table, Data
         Author: Simone Bizzotto (@niphlod)
@@ -212,6 +217,7 @@ function Copy-DbaDbTableData {
         [switch]$Truncate,
         [int]$BulkCopyTimeout = 5000,
         [int]$CommandTimeout = 0,
+        [switch]$UseDefaultFileGroup,
         [Parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.TableViewBase[]]$InputObject,
         [switch]$EnableException
@@ -230,6 +236,14 @@ function Copy-DbaDbTableData {
             if ($optionValue -eq $true) {
                 $bulkCopyOptions += $([Microsoft.Data.SqlClient.SqlBulkCopyOptions]::$option).value__
             }
+        }
+
+        $defaultFGScriptingOption = @{
+            ScriptingOptionsObject = $(
+                $so = New-DbaScriptingOption
+                $so.NoFileGroup = $UseDefaultFileGroup
+                $so
+            )
         }
     }
 
@@ -334,13 +348,13 @@ function Copy-DbaDbTableData {
                             $schemaNameToReplace = $tempTable.Schema
                             $tableNameToReplace = $tempTable.Name
                             $tablescript = $tempTable |
-                                Export-DbaScript -Passthru |
+                                Export-DbaScript @defaultFGScriptingOption -Passthru |
                                 Out-String
                             # cleanup
                             Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "DROP TABLE tempdb..$tempTableName" -EnableException
                         } else {
                             $tablescript = $sqlObject |
-                                Export-DbaScript -Passthru |
+                                Export-DbaScript @defaultFGScriptingOption -Passthru |
                                 Out-String
                             $schemaNameToReplace = $sqlObject.Schema
                             $tableNameToReplace = $sqlObject.Name

--- a/public/Copy-DbaDbTableData.ps1
+++ b/public/Copy-DbaDbTableData.ps1
@@ -333,11 +333,15 @@ function Copy-DbaDbTableData {
                             # need these for generating the script of the table and then replacing the schema and name
                             $schemaNameToReplace = $tempTable.Schema
                             $tableNameToReplace = $tempTable.Name
-                            $tablescript = $tempTable | Export-DbaScript -Passthru | Out-String
+                            $tablescript = $tempTable |
+                                Export-DbaScript -Passthru |
+                                Out-String
                             # cleanup
                             Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "DROP TABLE tempdb..$tempTableName" -EnableException
                         } else {
-                            $tablescript = $sqlObject | Export-DbaScript -Passthru | Out-String
+                            $tablescript = $sqlObject |
+                                Export-DbaScript -Passthru |
+                                Out-String
                             $schemaNameToReplace = $sqlObject.Schema
                             $tableNameToReplace = $sqlObject.Name
                         }

--- a/tests/Copy-DbaDbTableData.Tests.ps1
+++ b/tests/Copy-DbaDbTableData.Tests.ps1
@@ -6,7 +6,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         It "Should only contain our specific parameters" {
             [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-            [object[]]$knownParameters = 'AutoCreateTable', 'BatchSize', 'BulkCopyTimeout', 'CheckConstraints', 'CommandTimeout', 'Database', 'Destination', 'DestinationDatabase', 'DestinationSqlCredential', 'DestinationTable', 'EnableException', 'FireTriggers', 'InputObject', 'KeepIdentity', 'KeepNulls', 'NoTableLock', 'NotifyAfter', 'Query', 'SqlCredential', 'SqlInstance', 'Table', 'Truncate', 'View'
+            [object[]]$knownParameters = 'AutoCreateTable', 'BatchSize', 'BulkCopyTimeout', 'CheckConstraints', 'CommandTimeout', 'Database', 'Destination', 'DestinationDatabase', 'DestinationSqlCredential', 'DestinationTable', 'EnableException', 'FireTriggers', 'InputObject', 'KeepIdentity', 'KeepNulls', 'NoTableLock', 'NotifyAfter', 'Query', 'SqlCredential', 'SqlInstance', 'Table', 'Truncate', 'View', 'UseDefaultFileGroup'
             $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
 
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number-->)
 - [x] New feature (non-breaking change, adds functionality, fixes #9121 )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Allow copying table with `Copy-DbaDbTable` where target database does not have a filegroup of the same name as the source table.

### Approach
Adds a new switch param that says to use the default filegroup in the target database.

### Commands to test
Copy-DbaDbTable

### Screenshots
![image](https://github.com/dataplat/dbatools/assets/13566569/92b3fcbf-e6d3-45bb-9b79-c2850a6d8414)
