### PR TITLE
Connect-DbaInstance - Change EncryptConnection to a switch with a default of $true

### DIFF
--- a/.github/workflows/integration-tests-repl.yml
+++ b/.github/workflows/integration-tests-repl.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           Import-Module ./dbatools.psd1 -Force
           Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Register
-          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value Optional -Register
+          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -Register
           Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Write-Warning
 
       - name:  Setup docker images
@@ -70,7 +70,7 @@ jobs:
         run: |
           Import-Module ./dbatools.psd1 -Force
           Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Register
-          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value Optional -Register
+          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -Register
           Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Write-Warning
 
       - name:  Setup docker images
@@ -119,7 +119,7 @@ jobs:
         run: |
           Import-Module ./dbatools.psd1 -Force
           Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Register
-          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value Optional -Register
+          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -Register
           Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Write-Warning
 
       - name:  Setup docker images

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           Import-Module ./dbatools.psd1 -Force
           Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Register
-          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value Optional -Register
+          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -Register
           Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Write-Warning
 
       - name:  Setup docker images
@@ -83,7 +83,7 @@ jobs:
         run: |
           Import-Module ./dbatools -Force
           Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -PassThru | Register-DbatoolsConfig -Scope FileUserShared
-          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value Optional -PassThru | Register-DbatoolsConfig -Scope FileUserShared
+          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -PassThru | Register-DbatoolsConfig -Scope FileUserShared
           Connect-DbaInstance -SqlInstance "(localdb)\MSSQLLocalDB"
 
       - name: Connect to localdb instance pwsh
@@ -91,7 +91,7 @@ jobs:
         run: |
           Import-Module ./dbatools -Force
           Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -PassThru | Register-DbatoolsConfig -Scope FileUserShared
-          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value Optional -PassThru | Register-DbatoolsConfig -Scope FileUserShared
+          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -PassThru | Register-DbatoolsConfig -Scope FileUserShared
           Connect-DbaInstance -SqlInstance "(localdb)\MSSQLLocalDB"
 
       - name: Run pwsh tests

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set encryption values
         run: |
           Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Register
-          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value Optional -Register
+          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -Register
           Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Write-Warning
 
       - name:  Setup docker images
@@ -99,14 +99,14 @@ jobs:
         shell: powershell
         run: |
           Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -PassThru | Register-DbatoolsConfig -Scope FileUserShared
-          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value Optional -PassThru | Register-DbatoolsConfig -Scope FileUserShared
+          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -PassThru | Register-DbatoolsConfig -Scope FileUserShared
           Connect-DbaInstance -SqlInstance "(localdb)\MSSQLLocalDB"
 
       - name: Connect to localdb instance pwsh
         shell: pwsh
         run: |
           Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -PassThru | Register-DbatoolsConfig -Scope FileUserShared
-          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value Optional -PassThru | Register-DbatoolsConfig -Scope FileUserShared
+          Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -PassThru | Register-DbatoolsConfig -Scope FileUserShared
           Connect-DbaInstance -SqlInstance "(localdb)\MSSQLLocalDB"
 
       - name: Run pwsh tests

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -1099,7 +1099,7 @@ $script:connectionhash = @{ }
 if (Get-DbatoolsConfigValue -FullName Import.EncryptionMessageCheck) {
     $trustcert = Get-DbatoolsConfigValue -FullName sql.connection.trustcert
     $encrypt = Get-DbatoolsConfigValue -FullName sql.connection.encrypt
-    if (-not $trustcert -or $encrypt -in "Mandatory", "$true") {
+    if (-not $trustcert -or $encrypt) {
         # keep it write-host for psv3
         Write-Message -Level Output -Message '
 /   /                                                                     /   /

--- a/private/configurations/settings/sql.ps1
+++ b/private/configurations/settings/sql.ps1
@@ -18,7 +18,7 @@ Set-DbatoolsConfig -FullName 'sql.execution.timeout' -Value 0 -Initialize -Valid
 
 # Force encryption on the client
 # Mandatory per Microsoft's defaults https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlconnectionstringbuilder.encrypt
-Set-DbatoolsConfig -FullName 'sql.connection.encrypt' -Value 'Mandatory' -Initialize -Validation string -Handler { } -Description "Encrypt connection to server"
+Set-DbatoolsConfig -FullName 'sql.connection.encrypt' -Value $true -Initialize -Validation bool -Handler { } -Description "Encrypt connection to server"
 
 # Trust server certificate
 Set-DbatoolsConfig -FullName 'sql.connection.trustcert' -Value $false -Initialize -Validation bool -Handler { } -Description "Trust SQL Server certificate"

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -49,11 +49,9 @@ function Connect-DbaInstance {
         When opening a connection to a Azure SQL Database, set the connection timeout to 30 seconds.
 
     .PARAMETER EncryptConnection
-        If this switch is enabled, SQL Server uses SSL encryption for all data sent between the client and server if the server has a certificate installed.
+        If this switch is enabled, SQL Server uses SSL encryption for all data sent between the client and server.
 
-        For more information, see Connection String Syntax. https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/connection-string-syntax
-
-        Beginning in .NET Framework 4.5, when TrustServerCertificate is false and Encrypt is true, the server name (or IP address) in a SQL Server SSL certificate must exactly match the server name (or IP address) specified in the connection string. Otherwise, the connection attempt will fail. For information about support for certificates whose subject starts with a wildcard character (*), see Accepted wildcards used by server certificates for server authentication. https://support.microsoft.com/en-us/help/258858/accepted-wildcards-used-by-server-certificates-for-server-authenticati
+        Beginning in .NET Framework 4.5, when TrustServerCertificate is false and EncryptConnection is true, the server name (or IP address) in a SQL Server SSL certificate must exactly match the server name (or IP address) specified in the connection string. Otherwise, the connection attempt will fail. For information about support for certificates whose subject starts with a wildcard character (*), see Accepted wildcards used by server certificates for server authentication. https://support.microsoft.com/en-us/help/258858/accepted-wildcards-used-by-server-certificates-for-server-authenticati
 
     .PARAMETER FailoverPartner
         The name of the failover partner server where database mirroring is configured.
@@ -301,7 +299,7 @@ function Connect-DbaInstance {
         [string]$BatchSeparator,
         [string]$ClientName = (Get-DbatoolsConfigValue -FullName 'sql.connection.clientname'),
         [int]$ConnectTimeout = ([Dataplat.Dbatools.Connection.ConnectionHost]::SqlConnectionTimeout),
-        [string]$EncryptConnection = (Get-DbatoolsConfigValue -FullName 'sql.connection.encrypt'),
+        [switch]$EncryptConnection = (Get-DbatoolsConfigValue -FullName 'sql.connection.encrypt'),
         [string]$FailoverPartner,
         [int]$LockTimeout,
         [int]$MaxPoolSize,
@@ -785,10 +783,8 @@ function Connect-DbaInstance {
 
                 if ($instance -notmatch "localdb") {
                     #EncryptConnection      Property   bool EncryptConnection {get;set;}
-                    if ($EncryptConnection) {
-                        Write-Message -Level Debug -Message "EncryptConnection will be set to '$EncryptConnection'"
-                        $sqlConnectionInfo.EncryptConnection = $EncryptConnection
-                    }
+                    Write-Message -Level Debug -Message "EncryptConnection will be set to '$EncryptConnection'"
+                    $sqlConnectionInfo.EncryptConnection = $EncryptConnection
                 } else {
                     Write-Message -Level Verbose -Message "localdb detected, skipping unsupported keyword 'Encryption'"
                 }
@@ -851,10 +847,8 @@ function Connect-DbaInstance {
                 # We can set that? No, we don't want to...
 
                 #TrustServerCertificate Property   bool TrustServerCertificate {get;set;}
-                if ($TrustServerCertificate) {
-                    Write-Message -Level Debug -Message "TrustServerCertificate will be set to '$TrustServerCertificate'"
-                    $sqlConnectionInfo.TrustServerCertificate = $TrustServerCertificate
-                }
+                Write-Message -Level Debug -Message "TrustServerCertificate will be set to '$TrustServerCertificate'"
+                $sqlConnectionInfo.TrustServerCertificate = $TrustServerCertificate
 
                 #UseIntegratedSecurity  Property   bool UseIntegratedSecurity {get;set;}
                 # $true is the default and it is automatically set to $false if we set a UserName, so we don't touch

--- a/public/New-DbaConnectionString.ps1
+++ b/public/New-DbaConnectionString.ps1
@@ -197,7 +197,7 @@ function New-DbaConnectionString {
         [int]$ConnectTimeout,
         [string]$Database,
         [ValidateSet('Mandatory', 'Optional', 'Strict', 'True', 'False')]
-        [string]$EncryptConnection = (Get-DbatoolsConfigValue -FullName 'sql.connection.encrypt'),
+        [switch]$EncryptConnection = (Get-DbatoolsConfigValue -FullName 'sql.connection.encrypt'),
         [string]$FailoverPartner,
         [switch]$IsActiveDirectoryUniversalAuth,
         [int]$LockTimeout,

--- a/tests/Set-DbatoolsInsecureConnection.Tests.ps1
+++ b/tests/Set-DbatoolsInsecureConnection.Tests.ps1
@@ -29,8 +29,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
             $null = Set-DbatoolsInsecureConnection
             Get-DbatoolsConfigValue -FullName sql.connection.trustcert | Should -BeTrue
-            # sql.connection.encrypt is a string because it needs to be mandatory, optional, true or false
-            Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Should -Be 'False'
+            Get-DbatoolsConfigValue -FullName sql.connection.encrypt | Should -BeFalse
         }
     }
 }

--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -53,6 +53,6 @@ Write-Host -Object "appveyor.prep: Trust SQL Server Cert (now required)" -Foregr
 Import-Module dbatools.library
 Import-Module C:\github\dbatools\dbatools.psd1
 Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Register
-Set-DbatoolsConfig -FullName sql.connection.encrypt -Value Optional -Register
+Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -Register
 $sw.Stop()
 Update-AppveyorTest -Name "appveyor.prep" -Framework NUnit -FileName "appveyor.prep.ps1" -Outcome Passed -Duration $sw.ElapsedMilliseconds


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9113 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

See issue for details.

Up for discussion: Should we always use EncryptConnection = $true and only change TrustServerCertificate to $true within `Set-DbatoolsInsecureConnection`? I think it would be best practice to change the least number of default as possible. And switching off encryption is not needed if we only trust the (self-signed) server certificate.