### PR TITLE
New-DbaEndpoint - New parameter AuthenticationOrder

### DIFF
--- a/public/New-DbaEndpoint.ps1
+++ b/public/New-DbaEndpoint.ps1
@@ -58,6 +58,21 @@ function New-DbaEndpoint {
         RC4
         RC4Aes
 
+    .PARAMETER AuthenticationOrder
+        The type of connection authentication required for connections to this endpoint. Defaults to Negotiate.
+
+        Options are:
+        Certificate
+        CertificateKerberos
+        CertificateNegotiate
+        CertificateNtlm
+        Kerberos
+        KerberosCertificate
+        Negotiate
+        NegotiateCertificate
+        Ntlm
+        NtlmCertificate
+
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
 
@@ -115,6 +130,8 @@ function New-DbaEndpoint {
         [string]$EndpointEncryption = 'Required',
         [ValidateSet('Aes', 'AesRC4', 'None', 'RC4', 'RC4Aes')]
         [string]$EncryptionAlgorithm = 'Aes',
+        [ValidateSet('Certificate', 'CertificateKerberos', 'CertificateNegotiate', 'CertificateNtlm', 'Kerberos', 'KerberosCertificate', 'Negotiate', 'NegotiateCertificate', 'Ntlm', 'NtlmCertificate')]
+        [string]$AuthenticationOrder = 'Negotiate',
         [string]$Certificate,
         [System.Net.IPAddress]$IPAddress = '0.0.0.0',
         [int]$Port,
@@ -185,6 +202,7 @@ function New-DbaEndpoint {
                         }
                         $endpoint.Payload.DatabaseMirroring.EndpointEncryption = [Microsoft.SqlServer.Management.Smo.EndpointEncryption]::$EndpointEncryption
                         $endpoint.Payload.DatabaseMirroring.EndpointEncryptionAlgorithm = [Microsoft.SqlServer.Management.Smo.EndpointEncryptionAlgorithm]::$EncryptionAlgorithm
+                        $endpoint.Payload.DatabaseMirroring.EndpointAuthenticationOrder = [Microsoft.SqlServer.Management.Smo.EndpointAuthenticationOrder]::$AuthenticationOrder
                     }
                     if ($Certificate) {
                         $outscript = $endpoint.Script()

--- a/tests/New-DbaEndpoint.Tests.ps1
+++ b/tests/New-DbaEndpoint.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tags "UnitTests" {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Type', 'Protocol', 'Role', 'EndpointEncryption', 'IPAddress', 'EncryptionAlgorithm', 'Certificate', 'Port', 'SslPort', 'Owner', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Type', 'Protocol', 'Role', 'EndpointEncryption', 'IPAddress', 'EncryptionAlgorithm', 'AuthenticationOrder', 'Certificate', 'Port', 'SslPort', 'Owner', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [ ] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8759 )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

See issue for details.

Setting an SPN to be able to use Kerberos is out of the scope of the command, as it needs permissions in the active directory. We have `Set-DbaSpn` for that purpose.

@mattcargile Can you please test this branch?