### PR TITLE
Set-DbaDbCompatbility - Fix for using piped input and don't trust master compatibility level

### DIFF
--- a/tests/Set-DbaDbCompatibility.Tests.ps1
+++ b/tests/Set-DbaDbCompatibility.Tests.ps1
@@ -33,7 +33,7 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
         $sqlCn.Refresh()
         $sqlCn.Databases.Refresh()
         $resultMatches = Set-DbaDbCompatibility -SqlInstance $sqlCn -Database 'master' -Verbose 4>&1
-        $verboseMsg = '*current Compatibility Level matches instance level*'
+        $verboseMsg = '*current Compatibility Level matches target level*'
 
         $sqlCn.Refresh()
         $sqlCn.Databases.Refresh()


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Experienced this bug today at a client wihle doing `Get-DbaDatabase -SqlInstance sql01 | Where-Object Name -like Test* | Set-DbaDbCompatibility`.

If we support pipeline input, we must not use $SqlInstance. And every database can be on a different server with a different server level. So we can only get the server level inside of the loop for every individual database. And I used the same method to get the server level like in Test-DbaDbCompatibility (see #8992 for details).