### PR TITLE
Backup-DbaDatabase - allow users to specify no compression

### DIFF
--- a/public/Backup-DbaDatabase.ps1
+++ b/public/Backup-DbaDatabase.ps1
@@ -563,13 +563,11 @@ function Backup-DbaDatabase {
                         Write-Message -Level Verbose -Message "Compression enabled"
                         $backup.CompressionOption = [Microsoft.SqlServer.Management.Smo.BackupCompressionOptions]::On
                     }
-                }
-                else {
+                } else {
                     Write-Message -Level Verbose -Message "Compression disabled"
                     $backup.CompressionOption = [Microsoft.SqlServer.Management.Smo.BackupCompressionOptions]::Off
                 }
-            }
-            else {
+            } else {
                 Write-Message -Level Verbose -Message "Using instance default backup compression setting"
                 $backup.CompressionOption = [Microsoft.SqlServer.Management.Smo.BackupCompressionOptions]::Default
             }

--- a/public/Backup-DbaDatabase.ps1
+++ b/public/Backup-DbaDatabase.ps1
@@ -549,16 +549,16 @@ function Backup-DbaDatabase {
                     $flagCorrectMaxTransferSize = ($MaxTransferSize -gt 64kb)
                     if ($flagTDESQLVersion -and $flagCorrectMaxTransferSize) {
                         Write-Message -Level Verbose -Message "$dbName is enabled for encryption but will compress"
-                        $backup.CompressionOption = 1
+                        $backup.CompressionOption = [Microsoft.SqlServer.Management.Smo.BackupCompressionOptions]::On
                     } else {
                         Write-Message -Level Warning -Message "$dbName is enabled for encryption, will not compress"
-                        $backup.CompressionOption = 2
+                        $backup.CompressionOption = [Microsoft.SqlServer.Management.Smo.BackupCompressionOptions]::Off
                     }
                 } elseif ($server.Edition -like 'Express*' -or ($server.VersionMajor -eq 10 -and $server.VersionMinor -eq 0 -and $server.Edition -notlike '*enterprise*') -or $server.VersionMajor -lt 10) {
                     Stop-Function -Message "Compression is not supported with this version/edition of Sql Server" -Continue -Target $db
                 } else {
                     Write-Message -Level Verbose -Message "Compression enabled"
-                    $backup.CompressionOption = 1
+                    $backup.CompressionOption = [Microsoft.SqlServer.Management.Smo.BackupCompressionOptions]::On
                 }
             }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9150 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Align `-CompressBackup` flag for `Backup-DbaDatabase` with analogous T-SQL options.

### Approach
Allows user to specify `-CompressBackup:$false` to disable backup compression.

### Commands to test
`Backup-DbaDatabase` with various values for `-CompressBackup`

### Screenshots

![image](https://github.com/dataplat/dbatools/assets/13566569/49043120-45cf-4fcd-b952-c971aaca9fb2)

