### PR TITLE
New-DbaEndPoint - Fix Auth Order Param issue

### DIFF
--- a/public/New-DbaEndpoint.ps1
+++ b/public/New-DbaEndpoint.ps1
@@ -131,7 +131,7 @@ function New-DbaEndpoint {
         [ValidateSet('Aes', 'AesRC4', 'None', 'RC4', 'RC4Aes')]
         [string]$EncryptionAlgorithm = 'Aes',
         [ValidateSet('Certificate', 'CertificateKerberos', 'CertificateNegotiate', 'CertificateNtlm', 'Kerberos', 'KerberosCertificate', 'Negotiate', 'NegotiateCertificate', 'Ntlm', 'NtlmCertificate')]
-        [string]$AuthenticationOrder = 'Negotiate',
+        [string]$AuthenticationOrder, # defaults to Negotiate anyway
         [string]$Certificate,
         [System.Net.IPAddress]$IPAddress = '0.0.0.0',
         [int]$Port,
@@ -202,7 +202,9 @@ function New-DbaEndpoint {
                         }
                         $endpoint.Payload.DatabaseMirroring.EndpointEncryption = [Microsoft.SqlServer.Management.Smo.EndpointEncryption]::$EndpointEncryption
                         $endpoint.Payload.DatabaseMirroring.EndpointEncryptionAlgorithm = [Microsoft.SqlServer.Management.Smo.EndpointEncryptionAlgorithm]::$EncryptionAlgorithm
-                        #$endpoint.Payload.DatabaseMirroring.EndpointAuthenticationOrder = [Microsoft.SqlServer.Management.Smo.EndpointAuthenticationOrder]::$AuthenticationOrder
+                        if (Test-Bound -ParameterName AuthenticationOrder) {
+                            $endpoint.Payload.DatabaseMirroring.EndpointAuthenticationOrder = [Microsoft.SqlServer.Management.Smo.EndpointAuthenticationOrder]::$AuthenticationOrder
+                        }
                     }
                     if ($Certificate) {
                         $outscript = $endpoint.Script()

--- a/public/New-DbaEndpoint.ps1
+++ b/public/New-DbaEndpoint.ps1
@@ -202,7 +202,7 @@ function New-DbaEndpoint {
                         }
                         $endpoint.Payload.DatabaseMirroring.EndpointEncryption = [Microsoft.SqlServer.Management.Smo.EndpointEncryption]::$EndpointEncryption
                         $endpoint.Payload.DatabaseMirroring.EndpointEncryptionAlgorithm = [Microsoft.SqlServer.Management.Smo.EndpointEncryptionAlgorithm]::$EncryptionAlgorithm
-                        $endpoint.Payload.DatabaseMirroring.EndpointAuthenticationOrder = [Microsoft.SqlServer.Management.Smo.EndpointAuthenticationOrder]::$AuthenticationOrder
+                        #$endpoint.Payload.DatabaseMirroring.EndpointAuthenticationOrder = [Microsoft.SqlServer.Management.Smo.EndpointAuthenticationOrder]::$AuthenticationOrder
                     }
                     if ($Certificate) {
                         $outscript = $endpoint.Script()


### PR DESCRIPTION
It fails ..but only sometimes... when AuthenticationOrder is explicit