### PR TITLE
Update Set-DbaDbQueryStoreOption.ps1

### DIFF
--- a/public/Set-DbaDbQueryStoreOption.ps1
+++ b/public/Set-DbaDbQueryStoreOption.ps1
@@ -170,7 +170,7 @@ function Set-DbaDbQueryStoreOption {
             }
 
             # We have to exclude all the system databases since they cannot have the Query Store feature enabled
-            $dbs = Get-DbaDatabase -SqlInstance $server -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object { ($_.IsAccessible) -and (!$_.IsDatabaseSnapshot) }
+            $dbs = Get-DbaDatabase -SqlInstance $server -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object { $_.IsAccessible -and !$_.IsDatabaseSnapshot }
 
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $($db.name) on $instance"

--- a/public/Set-DbaDbQueryStoreOption.ps1
+++ b/public/Set-DbaDbQueryStoreOption.ps1
@@ -170,7 +170,7 @@ function Set-DbaDbQueryStoreOption {
             }
 
             # We have to exclude all the system databases since they cannot have the Query Store feature enabled
-            $dbs = Get-DbaDatabase -SqlInstance $server -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object IsAccessible
+            $dbs = Get-DbaDatabase -SqlInstance $server -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object { ($_.IsAccessible) -and (!$_.IsDatabaseSnapshot) }
 
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $($db.name) on $instance"


### PR DESCRIPTION
Ignore snapshots when setting Query Store options

Set-DbaDbQueryStoreOptions uses ALTER DATABASE statements under the hood, and these fail when run against a read only database snapshot. Update the call to Get-DbaDatabase to exclude snapshots upfront.

<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9203 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
Stop Set-DbaDbQueryStoreOption from failing when a database snapshot exists but isn't explicitly added to an exclusion list

### Approach
Excludes database snapshots when retrieving the available databases from an instance

### Commands to test
`Set-DbaDbQueryStoreOption` is the only command affected.

Running the below, targeting a SQL instance that hosts at least one database snapshot will no longer error in the fixed version. Note, this will enable Query Store on **all** databases unless the `-Database` parameter is also provided.

```
Set-DbaDbQueryStoreOption -SqlInstance localhost `
    -State ReadWrite `
    -StaleQueryThreshold 90 `
    -FlushInterval 900 `
    -CollectionInterval 30 `
    -MaxSize 500 `
    -MaxPlansPerQuery 200 `
    -WaitStatsCaptureMode On
```