### PR TITLE
Invoke-DbaQuery, support reuse of parameters

### DIFF
--- a/private/functions/Invoke-DbaAsync.ps1
+++ b/private/functions/Invoke-DbaAsync.ps1
@@ -304,7 +304,7 @@ function Invoke-DbaAsync {
                     }
                 }
             }
-
+            $cmd.Parameters.Clear()
             switch ($As) {
                 'DataSet' {
                     $ds


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [x] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9217  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Allow to reuse parameters among multiple calls of invoke-dbaquery

### Approach
Cleaning params just after query execution. BTW, this is the default behaviour of .NET, not something that dbatools did "wrong" . It's nice though to be able to reuse params if needed, so thanks for the original report
