### PR TITLE
Update dbatools command count

### DIFF
--- a/private/functions/New-DbaLogShippingPrimarySecondary.ps1
+++ b/private/functions/New-DbaLogShippingPrimarySecondary.ps1
@@ -85,12 +85,12 @@ function New-DbaLogShippingPrimarySecondary {
 
     # Check if the database is present on the source sql server
     if ($serverPrimary.Databases.Name -notcontains $PrimaryDatabase) {
-        Stop-Function -Message "Database $PrimaryDatabase is not available on instance $SqlInstance" -ErrorRecord $_ -Target $SqlInstance -Continue
+        Stop-Function -Message "Database $PrimaryDatabase is not available on instance $SqlInstance" -Target $SqlInstance -Continue
     }
 
     # Check if the database is present on the destination sql server
     if ($serverSecondary.Databases.Name -notcontains $SecondaryDatabase) {
-        Stop-Function -Message "Database $SecondaryDatabase is not available on instance $SecondaryServer" -ErrorRecord $_ -Target $SecondaryServer -Continue
+        Stop-Function -Message "Database $SecondaryDatabase is not available on instance $SecondaryServer" -Target $SecondaryServer -Continue
     }
 
     $Query = "SELECT primary_database FROM msdb.dbo.log_shipping_primary_databases WHERE primary_database = '$PrimaryDatabase'"

--- a/public/Add-DbaAgReplica.ps1
+++ b/public/Add-DbaAgReplica.ps1
@@ -209,7 +209,7 @@ function Add-DbaAgReplica {
             if ($Certificate) {
                 $cert = Get-DbaDbCertificate -SqlInstance $server -Certificate $Certificate
                 if (-not $cert) {
-                    Stop-Function -Message "Certificate $Certificate does not exist on $instance" -ErrorRecord $_ -Target $Certificate -Continue
+                    Stop-Function -Message "Certificate $Certificate does not exist on $instance" -Target $Certificate -Continue
                 }
             }
 

--- a/public/Add-DbaReplArticle.ps1
+++ b/public/Add-DbaReplArticle.ps1
@@ -112,11 +112,11 @@ function Add-DbaReplArticle {
 
         # Check that $CreationScriptOptions is a valid object
         if ($CreationScriptOptions -and ($CreationScriptOptions -isnot [Microsoft.SqlServer.Replication.CreationScriptOptions])) {
-            Stop-Function -Message "CreationScriptOptions should be the right type. Use New-DbaReplCreationScriptOptions to create the object" -ErrorRecord $_ -Target $instance -Continue
+            Stop-Function -Message "CreationScriptOptions should be the right type. Use New-DbaReplCreationScriptOptions to create the object" -Target $instance -Continue
         }
 
         if ($Filter -like 'WHERE*') {
-            Stop-Function -Message "Filter should not include the word 'WHERE'" -ErrorRecord $_ -Target $instance -Continue
+            Stop-Function -Message "Filter should not include the word 'WHERE'" -Target $instance -Continue
         }
 
         foreach ($instance in $SqlInstance) {
@@ -132,7 +132,7 @@ function Add-DbaReplArticle {
 
                     $pub = Get-DbaReplPublication -SqlInstance $instance -SqlCredential $SqlCredential -Name $Publication -EnableException:$EnableException
                     if (-not $pub) {
-                        Stop-Function -Message "Publication $Publication does not exist on $instance" -ErrorRecord $_ -Target $instance -Continue
+                        Stop-Function -Message "Publication $Publication does not exist on $instance" -Target $instance -Continue
                     }
                 }
             } catch {
@@ -180,7 +180,7 @@ function Add-DbaReplArticle {
                     if (-not ($article.IsExistingObject)) {
                         $article.Create()
                     } else {
-                        Stop-Function -Message "Article already exists in $Publication on $instance" -ErrorRecord $_ -Target $instance -Continue
+                        Stop-Function -Message "Article already exists in $Publication on $instance" -Target $instance -Continue
                     }
 
                     if ($pub.Type -in ('Transactional', 'Snapshot')) {

--- a/public/Backup-DbaDbMasterKey.ps1
+++ b/public/Backup-DbaDbMasterKey.ps1
@@ -111,7 +111,7 @@ function Backup-DbaDbMasterKey {
             }
 
             if (-not (Test-DbaPath -SqlInstance $server -Path $Path)) {
-                Stop-Function -Message "$instance cannot access $Path" -Target $server -ErrorRecord $_ -Continue
+                Stop-Function -Message "$instance cannot access $Path" -Target $server -Continue
             }
 
             $actualPath = "$Path".TrimEnd('\').TrimEnd('/')

--- a/public/Backup-DbaServiceMasterKey.ps1
+++ b/public/Backup-DbaServiceMasterKey.ps1
@@ -97,7 +97,7 @@ function Backup-DbaServiceMasterKey {
             }
 
             if (!(Test-DbaPath -SqlInstance $server -Path $Path)) {
-                Stop-Function -Message "$instance cannot access $Path" -Target $server -ErrorRecord $_ -Continue
+                Stop-Function -Message "$instance cannot access $Path" -Target $server -Continue
             }
 
 

--- a/public/Enable-DbaReplPublishing.ps1
+++ b/public/Enable-DbaReplPublishing.ps1
@@ -112,7 +112,7 @@ function Enable-DbaReplPublishing {
                     Stop-Function -Message "Unable to enable replication publishing" -ErrorRecord $_ -Target $instance -Continue
                 }
             } else {
-                Stop-Function -Message "$instance isn't currently enabled for distributing. Please enable that first." -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "$instance isn't currently enabled for distributing. Please enable that first." -Target $instance -Continue
             }
         }
     }

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -741,7 +741,7 @@ function Import-DbaCsv {
                             Path          = $file
                         }
                     } else {
-                        Stop-Function -Message "Transaction rolled back. Was the proper delimiter specified? Is the first row the column name?" -ErrorRecord $_
+                        Stop-Function -Message "Transaction rolled back. Was the proper delimiter specified? Is the first row the column name?"
                         return
                     }
                 }

--- a/public/Import-DbaSpConfigure.ps1
+++ b/public/Import-DbaSpConfigure.ps1
@@ -123,7 +123,7 @@ function Import-DbaSpConfigure {
             }
 
             if (-not (Test-SqlSa -SqlInstance $sourceserver -SqlCredential $SourceSqlCredential)) {
-                Stop-Function -Message "Not a sysadmin on $sourceserver. Quitting." -Category PermissionDenied -ErrorRecord $_ -Target $server -Continue
+                Stop-Function -Message "Not a sysadmin on $sourceserver. Quitting." -Category PermissionDenied -Target $server -Continue
             }
 
             try {
@@ -134,7 +134,7 @@ function Import-DbaSpConfigure {
             }
 
             if (-not (Test-SqlSa -SqlInstance $destserver -SqlCredential $DestinationSqlCredential)) {
-                Stop-Function -Message "Not a sysadmin on $destserver. Quitting." -Category PermissionDenied -ErrorRecord $_ -Target $server -Continue
+                Stop-Function -Message "Not a sysadmin on $destserver. Quitting." -Category PermissionDenied -Target $server -Continue
             }
 
             $source = $sourceserver.DomainInstanceName
@@ -148,7 +148,7 @@ function Import-DbaSpConfigure {
             }
 
             if (!(Test-SqlSa -SqlInstance $server -SqlCredential $SqlCredential)) {
-                Stop-Function -Message "Not a sysadmin on $server. Quitting." -Category PermissionDenied -ErrorRecord $_ -Target $server -Continue
+                Stop-Function -Message "Not a sysadmin on $server. Quitting." -Category PermissionDenied -Target $server -Continue
             }
 
             if (-not (Test-Path $Path)) {

--- a/public/Install-DbaWhoIsActive.ps1
+++ b/public/Install-DbaWhoIsActive.ps1
@@ -190,7 +190,7 @@ function Install-DbaWhoIsActive {
                             Status       = $status
                         }
                     } else {
-                        Stop-Function -Message "Failed to find database $Database on $instance or $Database is not writeable." -ErrorRecord $_ -Continue -Target $instance
+                        Stop-Function -Message "Failed to find database $Database on $instance or $Database is not writeable." -Continue -Target $instance
                     }
 
                 } catch {

--- a/public/Invoke-DbaDbDataMasking.ps1
+++ b/public/Invoke-DbaDbDataMasking.ps1
@@ -279,7 +279,7 @@ function Invoke-DbaDbDataMasking {
                             Stop-Function -Message "Could not import csv data from file '$file'" -ErrorRecord $_ -Target $file
                         }
                     } else {
-                        Stop-Function -Message "Could not import dictionary file '$file'" -ErrorRecord $_ -Target $file
+                        Stop-Function -Message "Could not import dictionary file '$file'" -Target $file
                     }
                 }
             }

--- a/public/Invoke-DbaDbDecryptObject.ps1
+++ b/public/Invoke-DbaDbDecryptObject.ps1
@@ -282,7 +282,7 @@ function Invoke-DbaDbDecryptObject {
                                 Stop-Function -Message "Couldn't convert the known plain to binary" -ErrorRecord $_ -Target $instance -Continue
                             }
                         } else {
-                            Stop-Function -Message "Something went wrong setting up the known plain" -ErrorRecord $_ -Target $instance -Continue
+                            Stop-Function -Message "Something went wrong setting up the known plain" -Target $instance -Continue
                         }
 
                         # Setup the query to change the object in SQL Server and roll it back getting the encrypted version

--- a/public/Invoke-DbaDbLogShipRecovery.ps1
+++ b/public/Invoke-DbaDbLogShipRecovery.ps1
@@ -133,7 +133,7 @@ function Invoke-DbaDbLogShipRecovery {
                 $agentStatus = $server.Query("SELECT COUNT(*) as AgentCount FROM master.dbo.sysprocesses WITH (nolock) WHERE Program_Name LIKE 'SQLAgent%'")
 
                 if ($agentStatus.AgentCount -lt 1) {
-                    Stop-Function -Message "The agent service is not in a running state. Please start the service." -ErrorRecord $_ -Target $server.name
+                    Stop-Function -Message "The agent service is not in a running state. Please start the service." -Target $server.name
                     return
                 }
             } catch {

--- a/public/Invoke-DbaDbLogShipping.ps1
+++ b/public/Invoke-DbaDbLogShipping.ps1
@@ -1122,7 +1122,7 @@ function Invoke-DbaDbLogShipping {
                     $setupResult = "Failed"
                     $comment = "Secondary database already exists on instance"
 
-                    Stop-Function -Message "Secondary database already exists on instance $destInstance." -ErrorRecord $_ -Target $destInstance -Continue
+                    Stop-Function -Message "Secondary database already exists on instance $destInstance." -Target $destInstance -Continue
                 }
 
                 # Check if the secondary database needs to be initialized
@@ -1231,7 +1231,7 @@ function Invoke-DbaDbLogShipping {
                             if ((Test-DbaPath -Path $FullBackupPath -SqlInstance $destInstance -SqlCredential $DestinationCredential) -ne $true) {
                                 $setupResult = "Failed"
                                 $comment = "The path to the full backup could not be reached"
-                                Stop-Function -Message ("The path to the full backup could not be reached. Check the path and/or the crdential") -ErrorRecord $_ -Target $destInstance -Continue
+                                Stop-Function -Message ("The path to the full backup could not be reached. Check the path and/or the crdential") -Target $destInstance -Continue
                             }
 
                             $BackupPath = $FullBackupPath
@@ -1240,7 +1240,7 @@ function Invoke-DbaDbLogShipping {
                             if ((Test-DbaPath -Path $UseBackupFolder -SqlInstance $destInstance -SqlCredential $DestinationCredential) -ne $true) {
                                 $setupResult = "Failed"
                                 $comment = "The path to the backup folder could not be reached"
-                                Stop-Function -Message ("The path to the backup folder could not be reached. Check the path and/or the crdential") -ErrorRecord $_ -Target $destInstance -Continue
+                                Stop-Function -Message ("The path to the backup folder could not be reached. Check the path and/or the crdential") -Target $destInstance -Continue
                             }
 
                             $BackupPath = $UseBackupFolder
@@ -1257,13 +1257,13 @@ function Invoke-DbaDbLogShipping {
                                 if ((Test-DbaPath -Path ($LastBackup[-1]).Path[-1] -SqlInstance $SourceSqlInstance -SqlCredential $SourceCredential) -ne $true) {
                                     $setupResult = "Failed"
                                     $comment = "The full backup could not be found"
-                                    Stop-Function -Message "The full backup could not be found on $($LastBackup.Path). Check path and/or credentials" -ErrorRecord $_ -Target $destInstance -Continue
+                                    Stop-Function -Message "The full backup could not be found on $($LastBackup.Path). Check path and/or credentials" -Target $destInstance -Continue
                                 }
                                 # Check if the source for the last full backup is remote and the backup is on a shared location
                                 elseif (($LastBackup.Computername -ne $SourceServerName) -and (($LastBackup[-1]).Path[-1].StartsWith('\\') -eq $false)) {
                                     $setupResult = "Failed"
                                     $comment = "The last full backup is not located on shared location"
-                                    Stop-Function -Message "The last full backup is not located on shared location. `n$($_.Exception.Message)" -ErrorRecord $_ -Target $destInstance -Continue
+                                    Stop-Function -Message "The last full backup is not located on shared location. `n$($_.Exception.Message)" -Target $destInstance -Continue
                                 } else {
                                     #$FullBackupPath = $LastBackup.Path
                                     $BackupPath = $LastBackup.Path

--- a/public/Invoke-DbaDiagnosticQuery.ps1
+++ b/public/Invoke-DbaDiagnosticQuery.ps1
@@ -184,7 +184,7 @@ function Invoke-DbaDiagnosticQuery {
 
             $scriptfiles = Get-ChildItem "$base\bin\diagnosticquery\SQLServerDiagnosticQueries_*.sql"
             if (!$scriptfiles) {
-                Stop-Function -Message "Unable to download scripts, do you have an internet connection? $_" -ErrorRecord $_
+                Stop-Function -Message "Unable to download scripts, do you have an internet connection? $_"
                 return
             }
         }

--- a/public/Measure-DbaDiskSpaceRequirement.ps1
+++ b/public/Measure-DbaDiskSpaceRequirement.ps1
@@ -209,7 +209,7 @@ function Measure-DbaDiskSpaceRequirement {
 
         $sourceDb = Get-DbaDatabase -SqlInstance $sourceServer -Database $Database -SqlCredential $SourceSqlCredential
         if (Test-Bound 'Database' -not) {
-            Stop-Function -Message "Database [$Database] MUST exist on Source Instance $Source." -ErrorRecord $_
+            Stop-Function -Message "Database [$Database] MUST exist on Source Instance $Source."
         }
         $sourceFiles = @($sourceDb.FileGroups.Files | Select-Object Name, FileName, Size, @{n = 'Type'; e = { 'Data' } })
         $sourceFiles += @($sourceDb.LogFiles | Select-Object Name, FileName, Size, @{n = 'Type'; e = { 'Log' } })

--- a/public/New-DbaAvailabilityGroup.ps1
+++ b/public/New-DbaAvailabilityGroup.ps1
@@ -418,7 +418,7 @@ function New-DbaAvailabilityGroup {
         if ($Certificate) {
             $cert = Get-DbaDbCertificate -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -Certificate $Certificate
             if (-not $cert) {
-                Stop-Function -Message "Certificate $Certificate does not exist on $Primary" -ErrorRecord $_ -Target $Primary
+                Stop-Function -Message "Certificate $Certificate does not exist on $Primary" -Target $Primary
                 return
             }
         }

--- a/public/New-DbaComputerCertificate.ps1
+++ b/public/New-DbaComputerCertificate.ps1
@@ -373,7 +373,7 @@ function New-DbaComputerCertificate {
                         Write-Message -Level Warning -Message "Something went wrong"
                         Write-Message -Level Warning -Message "$create"
                         Write-Message -Level Warning -Message "$submit"
-                        Stop-Function -Message "Failure when attempting to create the cert on $computer. Exception: $_" -ErrorRecord $_ -Target $computer -Continue
+                        Stop-Function -Message "Failure when attempting to create the cert on $computer. Exception: $_" -Target $computer -Continue
                     }
 
                     if ($Computer.IsLocalHost) {

--- a/public/New-DbaDbMailAccount.ps1
+++ b/public/New-DbaDbMailAccount.ps1
@@ -92,7 +92,7 @@ function New-DbaDbMailAccount {
 
             if (Test-Bound -ParameterName MailServer) {
                 if (-not (Get-DbaDbMailServer -SqlInstance $server -Server $MailServer) -and -not (Test-Bound -ParameterName Force)) {
-                    Stop-Function -Message "The mail server '$MailServer' does not exist on $instance. Use -Force if you need to create it anyway." -ErrorRecord $_ -Target $instance -Continue
+                    Stop-Function -Message "The mail server '$MailServer' does not exist on $instance. Use -Force if you need to create it anyway." -Target $instance -Continue
                 }
             }
 

--- a/public/New-DbaDbSnapshot.ps1
+++ b/public/New-DbaDbSnapshot.ps1
@@ -164,7 +164,7 @@ function New-DbaDbSnapshot {
             #Checks for path existence, left the length test because test-bound wasn't working for some reason
             if ($Path.Length -gt 0) {
                 if (!(Test-DbaPath -SqlInstance $server -Path $Path)) {
-                    Stop-Function -Message "$instance cannot access the directory $Path" -ErrorRecord $_ -Target $instance -Continue -EnableException $EnableException
+                    Stop-Function -Message "$instance cannot access the directory $Path" -Target $instance -Continue -EnableException $EnableException
                 }
             }
 

--- a/public/New-DbaEndpoint.ps1
+++ b/public/New-DbaEndpoint.ps1
@@ -163,7 +163,7 @@ function New-DbaEndpoint {
             if ($Certificate) {
                 $cert = Get-DbaDbCertificate -SqlInstance $server -Certificate $Certificate
                 if (-not $cert) {
-                    Stop-Function -Message "Certificate $Certificate does not exist on $instance" -ErrorRecord $_ -Target $Certificate -Continue
+                    Stop-Function -Message "Certificate $Certificate does not exist on $instance" -Target $Certificate -Continue
                 }
             }
 

--- a/public/New-DbaReplSubscription.ps1
+++ b/public/New-DbaReplSubscription.ps1
@@ -217,7 +217,7 @@ function New-DbaReplSubscription {
 
                             $transSub.Create()
                         } else {
-                            Stop-Function -Message ("Publication {0} not found on {1}" -f $PublicationName, $instance) -ErrorRecord $_ -Target $instance -Continue
+                            Stop-Function -Message ("Publication {0} not found on {1}" -f $PublicationName, $instance) -Target $instance -Continue
                         }
 
                     } elseif ($pub.Type -eq 'Merge') {
@@ -288,7 +288,7 @@ function New-DbaReplSubscription {
                         }
 
                     } else {
-                        Stop-Function -Message ("Publication {0} not found on {1}" -f $PublicationName, $instance) -ErrorRecord $_ -Target $instance -Continue
+                        Stop-Function -Message ("Publication {0} not found on {1}" -f $PublicationName, $instance) -Target $instance -Continue
                     }
                 }
             } catch {

--- a/public/New-DbaRgResourcePool.ps1
+++ b/public/New-DbaRgResourcePool.ps1
@@ -140,7 +140,7 @@ function New-DbaRgResourcePool {
                             }
                         }
                     } else {
-                        Stop-Function -Message "Resource Pool '$resPool' already exists." -Category ResourceExists -ErrorRecord $_ -Target $existingResourcePool -Continue
+                        Stop-Function -Message "Resource Pool '$resPool' already exists." -Category ResourceExists -Target $existingResourcePool -Continue
                         return
                     }
                 }

--- a/public/Publish-DbaDacPackage.ps1
+++ b/public/Publish-DbaDacPackage.ps1
@@ -141,7 +141,7 @@ function Publish-DbaDacPackage {
             }
         } elseif ($Type -eq 'Bacpac') {
             if ($ScriptOnly -or $GenerateDeploymentReport) {
-                Stop-Function -Message "ScriptOnly and GenerateDeploymentReport cannot be used in a Bacpac scenario." -ErrorRecord $_
+                Stop-Function -Message "ScriptOnly and GenerateDeploymentReport cannot be used in a Bacpac scenario."
                 return
             }
             $defaultColumns = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Bacpac', 'Result', 'DeployOptions'

--- a/public/Remove-DbaReplArticle.ps1
+++ b/public/Remove-DbaReplArticle.ps1
@@ -136,7 +136,7 @@ function Remove-DbaReplArticle {
                     if (($art.IsExistingObject)) {
                         $art.Remove()
                     } else {
-                        Stop-Function -Message "Article doesn't exist in $PublicationName on $instance" -ErrorRecord $_ -Target $instance -Continue
+                        Stop-Function -Message "Article doesn't exist in $PublicationName on $instance" -Target $instance -Continue
                     }
                     $output.Status = "Removed"
                     $output.IsRemoved = $true

--- a/public/Rename-DbaLogin.ps1
+++ b/public/Rename-DbaLogin.ps1
@@ -95,7 +95,7 @@ function Rename-DbaLogin {
             $currentLogin = $server.Logins[$Login]
 
             if ( -not $currentLogin) {
-                Stop-Function -Message "Login '$login' not found on $instance" -ErrorRecord $_ -Target login -Continue
+                Stop-Function -Message "Login '$login' not found on $instance" -Target login -Continue
             }
 
             if ($Pscmdlet.ShouldProcess($SqlInstance, "Changing Login name from  [$Login] to [$NewLogin]")) {

--- a/public/Repair-DbaInstanceName.ps1
+++ b/public/Repair-DbaInstanceName.ps1
@@ -123,7 +123,7 @@ function Repair-DbaInstanceName {
                                 $result = $host.ui.PromptForChoice($title, $message, $options, 1)
 
                                 if ($result -eq 1) {
-                                    Stop-Function -Message "Failure" -Target $server -ErrorRecord $_ -Continue
+                                    Stop-Function -Message "Failure" -Target $server -Continue
                                 } else {
                                     Write-Message -Level Output -Message "`nPerforming sp_dropdistributor @no_checks = 1."
                                     $sql = "sp_dropdistributor @no_checks = 1"

--- a/public/Save-DbaCommunitySoftware.ps1
+++ b/public/Save-DbaCommunitySoftware.ps1
@@ -141,7 +141,7 @@ function Save-DbaCommunitySoftware {
                 }
                 $latestRelease = ($releasesJson | ConvertFrom-Json) | Where-Object prerelease -eq $preRelease | Select-Object -First 1
                 if ($null -eq $latestRelease) {
-                    Stop-Function -Message "No release found." -ErrorRecord $_
+                    Stop-Function -Message "No release found."
                     return
                 }
                 $Url = $latestRelease.assets[0].browser_download_url
@@ -171,7 +171,7 @@ function Save-DbaCommunitySoftware {
                 }
                 $latestRelease = ($releasesJson | ConvertFrom-Json) | Select-Object -First 1
                 if ($null -eq $latestRelease) {
-                    Stop-Function -Message "No release found." -ErrorRecord $_
+                    Stop-Function -Message "No release found."
                     return
                 }
                 $Url = $latestRelease.zipball_url
@@ -207,7 +207,7 @@ function Save-DbaCommunitySoftware {
                 }
                 $latestRelease = ($releasesJson | ConvertFrom-Json) | Select-Object -First 1
                 if ($null -eq $latestRelease) {
-                    Stop-Function -Message "No release found." -ErrorRecord $_
+                    Stop-Function -Message "No release found."
                     return
                 }
                 $Url = $latestRelease.zipball_url

--- a/public/Set-DbaMaxDop.ps1
+++ b/public/Set-DbaMaxDop.ps1
@@ -136,7 +136,7 @@ function Set-DbaMaxDop {
             }
 
             if (!(Test-SqlSa -SqlInstance $server -SqlCredential $SqlCredential)) {
-                Stop-Function -Message "Not a sysadmin on $instance. Skipping." -Category PermissionDenied -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Not a sysadmin on $instance. Skipping." -Category PermissionDenied -Target $instance -Continue
             }
 
             if ($server.versionMajor -ge 13) {

--- a/public/Set-DbaResourceGovernor.ps1
+++ b/public/Set-DbaResourceGovernor.ps1
@@ -118,7 +118,7 @@ function Set-DbaResourceGovernor {
                         if ($objClassifierFunction) {
                             $server.ResourceGovernor.ClassifierFunction = $objClassifierFunction
                         } else {
-                            Stop-Function -Message "Classifier function '$ClassifierFunction' does not exist." -Category ObjectNotFound -ErrorRecord $_ -Continue
+                            Stop-Function -Message "Classifier function '$ClassifierFunction' does not exist." -Category ObjectNotFound -Continue
                         }
                     }
                 }

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ## Getting Started
 
-<img align="left" src=bin/dbatools.png alt="dbatools logo">  dbatools is PowerShell module that you may think of like a command-line SQL Server Management Studio. The project initially started out as just `Start-SqlMigration.ps1`, but has now grown into a collection of [over 500 commands](https://dbatools.io/commands) that help automate SQL Server tasks and encourage best practices.
+<img align="left" src=bin/dbatools.png alt="dbatools logo">  dbatools is PowerShell module that you may think of like a command-line SQL Server Management Studio. The project initially started out as just `Start-SqlMigration.ps1`, but has now grown into a collection of [over 700 commands](https://dbatools.io/commands) that help automate SQL Server tasks and encourage best practices.
 
 Want to contribute to the project? We'd love to have you! Visit our [contributing.md](contributing.md) for a jump start.
 
@@ -39,7 +39,7 @@ In addition to the simple things you can do in SSMS (e.g. starting a job, backin
 
 ## Usage examples
 
-As previously mentioned, dbatools now offers [over 500 commands](https://dbatools.io/commands)! [Here are some of the ones we highlight at conferences](https://gist.github.com/potatoqualitee/e8932b64aeb6ef404e252d656b6318a2).
+As previously mentioned, dbatools now offers [over 700 commands](https://dbatools.io/commands)! [Here are some of the ones we highlight at conferences](https://gist.github.com/potatoqualitee/e8932b64aeb6ef404e252d656b6318a2).
 
 PowerShell v3 and above required. (See below for important information about alternative logins and specifying SQL Server ports).
 


### PR DESCRIPTION
As of dbatools v2.1.7, there are more than 700 commands now.
```
PS C:\> (gcm -module dbatools | Measure-Object).Count
707
PS C:\>
```

<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [v] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [v] Documentation
 - [ ] Build system

