### PR TITLE
Restore-DbaDatabase - improve warning output for standby mode databases

### DIFF
--- a/public/Restore-DbaDatabase.ps1
+++ b/public/Restore-DbaDatabase.ps1
@@ -650,7 +650,8 @@ function Restore-DbaDatabase {
                     Write-Message -Message "$Database does not exist on $RestoreInstance" -level Warning
                     continue
                 }
-                if ($RestoreInstance.Databases[$Database].Status -ne "Restoring") {
+
+                if (@("Restoring", "Normal, Standby") -notcontains $RestoreInstance.Databases[$Database].Status) {
                     Write-Message -Message "$Database on $RestoreInstance is not in a Restoring State" -Level Warning
                     continue
                 }
@@ -807,7 +808,6 @@ function Restore-DbaDatabase {
             } catch {
                 Stop-Function -Message "Failure" -ErrorRecord $_ -Continue -Target $RestoreInstance
             }
-
             if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
                 if ($RestoreInstance.Edition -like '*Enterprise*') {
                     Write-Message -Message "Taking Tail log backup for page restore for Enterprise" -Level Verbose

--- a/public/Restore-DbaDatabase.ps1
+++ b/public/Restore-DbaDatabase.ps1
@@ -652,7 +652,7 @@ function Restore-DbaDatabase {
                 }
 
                 if (@("Restoring", "Normal, Standby") -notcontains $RestoreInstance.Databases[$Database].Status) {
-                    Write-Message -Message "$Database on $RestoreInstance is not in Restoring or Standby State" -Level Warning
+                    Write-Message -Message "$Database on $RestoreInstance state [$($RestoreInstance.Databases[$Database].Status)] is not a valid state. Valid state is Restoring or Standby" -Level Warning
                     continue
                 }
                 $RestoreComplete = $true

--- a/public/Restore-DbaDatabase.ps1
+++ b/public/Restore-DbaDatabase.ps1
@@ -652,7 +652,7 @@ function Restore-DbaDatabase {
                 }
 
                 if (@("Restoring", "Normal, Standby") -notcontains $RestoreInstance.Databases[$Database].Status) {
-                    Write-Message -Message "$Database on $RestoreInstance is not in a Restoring State" -Level Warning
+                    Write-Message -Message "$Database on $RestoreInstance is not in Restoring or Standby State" -Level Warning
                     continue
                 }
                 $RestoreComplete = $true


### PR DESCRIPTION
Updated the recovery logic to include databases in standby mode. Previously, the code only addressed databases in the restoring state, which did not account for standby scenarios. This change ensures a more comprehensive recovery process.

<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [v] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system
