### PR TITLE
Install-DbaMaintenanceSolution does not work inside a container

### DIFF
--- a/public/Install-DbaMaintenanceSolution.ps1
+++ b/public/Install-DbaMaintenanceSolution.ps1
@@ -234,6 +234,27 @@ function Install-DbaMaintenanceSolution {
             Write-ProgressHelper -ExcludePercent -Message "If Ola Hallengren's scripts are found, we will drop and recreate them"
         }
 
+
+        # does this machine have internet access to download the files if required?
+        if (-not $isLinux -and -not $isMacOs) {
+            if ((Get-Command -Name Get-NetConnectionProfile -ErrorAction SilentlyContinue)) {
+                $script:internet = (Get-NetConnectionProfile -ErrorAction SilentlyContinue).IPv4Connectivity -contains "Internet"
+            } else {
+                try {
+                    $network = [Type]::GetTypeFromCLSID([Guid]"{DCB00C01-570F-4A9B-8D69-199FDBA5723B}")
+                    $script:internet = ([Activator]::CreateInstance($network)).GetNetworkConnections() | ForEach-Object { $_.GetNetwork().GetConnectivity() } | Where-Object { ($_ -band 64) -eq 64 }
+                } catch {
+                    # probably a container with internet
+                    $script:internet = $true
+                }
+            }
+
+            if (-not $internet) {
+                Write-Message -Level Verbose -Message "No internet connection found, using included copy of Maintenance Solution."
+                $localCachedCopy = [System.IO.Path]::Combine($script:PSModuleRoot, "bin", "maintenancesolution")
+            }
+        }
+
         if (-not $localCachedCopy) {
             # Do we need a fresly cached version of the software?
             $dbatoolsData = Get-DbatoolsConfigValue -FullName 'Path.DbatoolsData'

--- a/public/Install-DbaMaintenanceSolution.ps1
+++ b/public/Install-DbaMaintenanceSolution.ps1
@@ -234,25 +234,6 @@ function Install-DbaMaintenanceSolution {
             Write-ProgressHelper -ExcludePercent -Message "If Ola Hallengren's scripts are found, we will drop and recreate them"
         }
 
-        # does this machine have internet access to download the files if required?
-        if (-not $isLinux -and -not $isMacOs) {
-            if ((Get-Command -Name Get-NetConnectionProfile -ErrorAction SilentlyContinue)) {
-                $script:internet = (Get-NetConnectionProfile).IPv4Connectivity -contains "Internet"
-            } else {
-                try {
-                    $network = [Type]::GetTypeFromCLSID([Guid]"{DCB00C01-570F-4A9B-8D69-199FDBA5723B}")
-                    $script:internet = ([Activator]::CreateInstance($network)).GetNetworkConnections() | ForEach-Object { $_.GetNetwork().GetConnectivity() } | Where-Object { ($_ -band 64) -eq 64 }
-                } catch {
-                    # don't care
-                }
-            }
-
-            if (-not $internet) {
-                Write-Message -Level Verbose -Message "No internet connection found, using included copy of Maintenance Solution."
-                $localCachedCopy = [System.IO.Path]::Combine($script:PSModuleRoot, "bin", "maintenancesolution")
-            }
-        }
-
         if (-not $localCachedCopy) {
             # Do we need a fresly cached version of the software?
             $dbatoolsData = Get-DbatoolsConfigValue -FullName 'Path.DbatoolsData'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Please read -- recent changes to our repo
On November 10, 2022, [we removed some bloat from our repository (for the second and final time)](https://github.com/dataplat/dbatools/issues/8542). This change requires that all contributors reclone or refork their repo.

PRs from repos that have not been recently reforked or recloned will be closed and @potatoqualitee will cherry-pick your commits and open a new PR with your changes.

 - [X] Please confirm you have the smaller repo (85MB .git directory vs 275MB or 110MB or 185MB .git directory)

## Type of Change
 [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 
### Purpose
Fix internet connection check inside windows containers

### Approach
Remove uneeded internet connection check prior to download attempt. Current implementation already does fallback to embedded maintenance solution if download fails, so there is no need pre-check.

Inside a windows container, see output of current commands used to pre-check if an internet connection is available.

```
PS C:\> Get-NetConnectionProfile
Get-NetConnectionProfile : A general error occurred that is not covered by a 
more specific error code.
At line:1 char:1
+ Get-NetConnectionProfile
+ ~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (MSFT_NetConnectionProfile:root/St 
   andardCi...nnectionProfile) [Get-NetConnectionProfile], CimException
    + FullyQualifiedErrorId : MI RESULT 1,Get-NetConnectionProfile
 
PS C:\> $network = [Type]::GetTypeFromCLSID([Guid]"{DCB00C01-570F-4A9B-8D69-199FDBA5723B}")
PS C:\> 
      >                     $script:internet = ([Activator]::CreateInstance($network)).GetNetworkConnections() | ForEach-Object { $_.GetNetwork().GetConnectivity() } | Where-Object { ($_ -band 64) -eq 64 }
The service cannot be started, either because it is disabled or because it has 
    + CategoryInfo          : OperationStopped: (:) [], COMException~~~~~~~     
PS C:\>ullyQualifiedErrorId : System.Runtime.InteropServices.COMException       
+ ...             $script:internet = ([Activator]::CreateInstance($network) ... 
```
### Commands to test
Install-DbaMaintenanceSolution

### Screenshots

### Learning

