### PR TITLE
Update-ServiceStatus - fix cross-domain issue by changing ComputerName to PSComputerName

### DIFF
--- a/private/functions/Update-ServiceStatus.ps1
+++ b/private/functions/Update-ServiceStatus.ps1
@@ -185,7 +185,7 @@ $errorCodes = Get-DbaServiceErrorMessage
 
 process {
     #Group services for each computer
-    $serviceComputerGroup = $InputObject | Group-Object -Property ComputerName
+    $serviceComputerGroup = $InputObject | Group-Object -Property PSComputerName
     foreach ($group in $serviceComputerGroup) {
         Write-Message -Message "Getting CIM objects from computer $($group.Name)"
         $serviceNames = $group.Group.ServiceName -join "' OR name = '"


### PR DESCRIPTION
When running commands from a server connected to domainA to a computer running on domainB, the short name is used as documented on https://github.com/dataplat/dbatools/issues/9184.  This is my attempt to get this change moving forward as the issue conversation has been quiet.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- Mixed domains causing issues with setting a new service account, a MSA for what what is worth -->
 - [X] Bug fix (non-breaking change, fixes #<!--Issue #9184--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
