### PR TITLE
Add support for SAS URL in Read-DbaBackupHeader and Get-DbaBackupInformation

### DIFF
--- a/public/Get-DbaBackupInformation.ps1
+++ b/public/Get-DbaBackupInformation.ps1
@@ -257,7 +257,6 @@ function Get-DbaBackupInformation {
             } else {
                 ForEach ($f in $path) {
                     Write-Message -Level VeryVerbose -Message "Not using sql for $f"
-
                     if ($f -is [System.IO.FileSystemInfo]) {
                         if ($f.PsIsContainer -eq $true -and $true -ne $MaintenanceSolution) {
                             Write-Message -Level VeryVerbose -Message "folder $($f.FullName)"

--- a/public/Get-DbaBackupInformation.ps1
+++ b/public/Get-DbaBackupInformation.ps1
@@ -273,7 +273,7 @@ function Get-DbaBackupInformation {
                             Write-Message -Level VeryVerbose -Message "File"
                             $Files += $f.FullName
                         }
-                    } elseif ($f -match "^http") {
+                    } elseif ($f -match "^http.*\?.+$") {
                         $uri = [System.Uri]$f;
                         $storageAccountName = $uri.Host.Split('.')[0];
                         $pathSegments = $uri.AbsolutePath.Trim('/').Split('/');

--- a/public/Get-DbaBackupInformation.ps1
+++ b/public/Get-DbaBackupInformation.ps1
@@ -278,7 +278,7 @@ function Get-DbaBackupInformation {
                         $storageAccountName = $uri.Host.Split('.')[0];
                         $pathSegments = $uri.AbsolutePath.Trim('/').Split('/');
                         $containerName = $pathSegments[0];
-                        $prefix = if ($pathSegments.Length -gt 1) { $pathSegments[1] } else { "" }
+                        $prefix = if ($pathSegments.Length -gt 1) { ($pathSegments | Select-Object -Skip 1) -join "/" } else { "" }
                         $sasToken = $uri.Query.TrimStart('?')
                         $ctx = New-AzStorageContext -StorageAccountName $storageAccountName -SasToken "$sasToken";
                         # Get blobs avoiding Archive tier (which needs rehydration before download)

--- a/public/Get-DbaBackupInformation.ps1
+++ b/public/Get-DbaBackupInformation.ps1
@@ -287,9 +287,9 @@ function Get-DbaBackupInformation {
                         # the full path
                         $baseUrl = "$($uri.Scheme)://$($uri.Host)/$containerName/"
                         $blobs = Get-AzStorageBlob -Container $containerName -Context $ctx -Prefix $prefix |
-                            Where-Object { ($_.AccessTier -ne 'Archive') -and ($_.Length > 0) };
+                            Where-Object { ($_.AccessTier -ne 'Archive') -and ($_.Length -gt 0) };
                         foreach ($blob in $blobs) {
-                            $blobUrl = $baseUrl + $_.Name + "?" + $sasToken
+                            $blobUrl = $baseUrl + $blob.Name + "?" + $sasToken
                             $Files += $blobUrl;
                         }
                     } else {

--- a/public/Get-DbaBackupInformation.ps1
+++ b/public/Get-DbaBackupInformation.ps1
@@ -297,6 +297,9 @@ function Get-DbaBackupInformation {
                             $Files += Get-XpDirTreeRestoreFile -Path $f\FULL -SqlInstance $server -NoRecurse
                             $Files += Get-XpDirTreeRestoreFile -Path $f\DIFF -SqlInstance $server -NoRecurse
                             $Files += Get-XpDirTreeRestoreFile -Path $f\LOG -SqlInstance $server -NoRecurse
+                        } else {
+                            Write-Message -Level VeryVerbose -Message "File"
+                            $Files += $f
                         }
                     }
                 }

--- a/public/Restore-DbaDatabase.ps1
+++ b/public/Restore-DbaDatabase.ps1
@@ -577,12 +577,6 @@ function Restore-DbaDatabase {
                     if ("BackupSetGUID" -notin $f.PSObject.Properties.Name) {
                         $f = $f | Select-Object *, @{ Name = "BackupSetGUID"; Expression = { $_.BackupSetID } }
                     }
-                    if ("BackupStartDate" -notin $f.PSObject.Properties.Name) {
-                        $f = $f | Select-Object *, @{ Name = "BackupStartDate"; Expression = { $_.Start -as [DateTime] } }
-                    }
-                    if ("ServerName" -notin $f.PSObject.Properties.Name) {
-                        $f = $f | Select-Object *, @{ Name = "ServerName"; Expression = { $_.SqlInstance} }
-                    }
                     if ($f.BackupPath -like 'http*') {
                         if ('' -ne $AzureCredential) {
                             Write-Message -Message "At least one Azure backup passed in with a credential, assume correct" -Level Verbose
@@ -603,7 +597,7 @@ function Restore-DbaDatabase {
                     }
                     # Fix #5036 by implementing a deep copy of the FileList
                     $f.FileList = $f.FileList | Select-Object *
-                    $BackupHistory += $f
+                    $BackupHistory += $f | Select-Object *, @{ Name = "ServerName"; Expression = { $_.SqlInstance } }, @{ Name = "BackupStartDate"; Expression = { $_.Start -as [DateTime] } }
                 }
             } else {
                 $files = @()

--- a/public/Restore-DbaDatabase.ps1
+++ b/public/Restore-DbaDatabase.ps1
@@ -577,6 +577,12 @@ function Restore-DbaDatabase {
                     if ("BackupSetGUID" -notin $f.PSObject.Properties.Name) {
                         $f = $f | Select-Object *, @{ Name = "BackupSetGUID"; Expression = { $_.BackupSetID } }
                     }
+                    if ("BackupStartDate" -notin $f.PSObject.Properties.Name) {
+                        $f = $f | Select-Object *, @{ Name = "BackupStartDate"; Expression = { $_.Start -as [DateTime] } }
+                    }
+                    if ("ServerName" -notin $f.PSObject.Properties.Name) {
+                        $f = $f | Select-Object *, @{ Name = "ServerName"; Expression = { $_.SqlInstance} }
+                    }
                     if ($f.BackupPath -like 'http*') {
                         if ('' -ne $AzureCredential) {
                             Write-Message -Message "At least one Azure backup passed in with a credential, assume correct" -Level Verbose
@@ -597,7 +603,7 @@ function Restore-DbaDatabase {
                     }
                     # Fix #5036 by implementing a deep copy of the FileList
                     $f.FileList = $f.FileList | Select-Object *
-                    $BackupHistory += $f | Select-Object *, @{ Name = "ServerName"; Expression = { $_.SqlInstance } }, @{ Name = "BackupStartDate"; Expression = { $_.Start -as [DateTime] } }
+                    $BackupHistory += $f
                 }
             } else {
                 $files = @()


### PR DESCRIPTION
## Type of Change

 New feature

Unless I am missing something, it is currently not possible to do database restores from a collection of backups stored in Azure Blobs (automatically). With the fixes in this PR I hope to be able to have restore automation to support the backups that can be made using Hallengren backup solution to Azure Blobs.

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Add support for Shared Access Singature URL's in Get-DbaBackupInformation and Read-DbaBackupHeader

### Approach
Small tweaks to support URLS with SAS. See comments in code.

### Commands to test
Read-DbaBackupHeader and Get-DbaBackupInformation
