### PR TITLE
Get-DbaLogin - clean up old code causing issues

### DIFF
--- a/public/Get-DbaLogin.ps1
+++ b/public/Get-DbaLogin.ps1
@@ -44,12 +44,6 @@ function Get-DbaLogin {
     .PARAMETER MustChangePassword
         A Switch to return Logins that need to change password.
 
-    .PARAMETER SqlLogins
-        Deprecated. Please use -Type SQL
-
-    .PARAMETER WindowsLogins
-        Deprecated. Please use -Type Windows.
-
     .PARAMETER HasAccess
         A Switch to return Logins that have access to the instance of SQL Server.
 
@@ -173,12 +167,6 @@ function Get-DbaLogin {
         [switch]$EnableException
     )
     begin {
-        if ($SQLLogins) {
-            $Type = "SQL"
-        }
-        if ($WindowsLogins) {
-            $Type = "Windows"
-        }
 
         $loginTimeSql = "SELECT login_name, MAX(login_time) AS login_time FROM sys.dm_exec_sessions GROUP BY login_name"
         $loginProperty = "SELECT


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9290 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix an issue where the command didn't work properly if you had a variable in your session called `$SqlLogins`

### Approach
Remove deprecated code - this used to be needed, but after the parameters were renamed it no longer is.

### Commands to test
```PowerShell
# this should work
Get-DbaLogin -SqlInstance $source |ft

# then set a variable and rerun - it'll only show sql logins - after this PR this works
$sqllogins = @(
"myDomain\UserA",
"myDomain\UserA")
Get-DbaLogin -SqlInstance $source |ft
```

### Screenshots
Before - shows issue - second screenshot there are now Windows* logins
![image](https://github.com/dataplat/dbatools/assets/981370/dbc47110-04cf-4085-bff0-81abe8590d4f)

After - variable doesn't change results
![image](https://github.com/dataplat/dbatools/assets/981370/fb368c5d-c9b5-48a2-9858-531a1a8cae4a)

tests passing
![image](https://github.com/dataplat/dbatools/assets/981370/98f690fa-9d2c-459f-8f75-2ec209710465)
