### PR TITLE
change splatting to remove <br> from docs

### DIFF
--- a/public/Add-DbaReplArticle.ps1
+++ b/public/Add-DbaReplArticle.ps1
@@ -68,12 +68,12 @@ function Add-DbaReplArticle {
 
     .EXAMPLE
         PS C:\> $article = @{
-                    SqlInstance           = "mssql1"
-                    Database              = "pubs"
-                    Publication           = "testPub"
-                    Name                  = "publishers"
-                    Filter                = "city = 'seattle'"
-                }
+        >> SqlInstance           = "mssql1"
+        >> Database              = "pubs"
+        >> Publication           = "testPub"
+        >> Name                  = "publishers"
+        >> Filter                = "city = 'seattle'"
+        >> }
         PS C:\> Add-DbaReplArticle @article -EnableException
 
         Adds the publishers table to the TestPub publication from mssql1.Pubs with a horizontal filter of only rows where city = 'seattle.
@@ -81,12 +81,12 @@ function Add-DbaReplArticle {
     .EXAMPLE
         PS C:\> $cso = New-DbaReplCreationScriptOptions -Options NonClusteredIndexes, Statistics
         PS C:\> $article = @{
-                    SqlInstance           = 'mssql1'
-                    Database              = 'pubs'
-                    Publication           = 'testPub'
-                    Name                  = 'stores'
-                    CreationScriptOptions = $cso
-                }
+        >> SqlInstance           = 'mssql1'
+        >> Database              = 'pubs'
+        >> Publication           = 'testPub'
+        >> Name                  = 'stores'
+        >> CreationScriptOptions = $cso
+        >> }
         PS C:\> Add-DbaReplArticle @article -EnableException
 
         Adds the stores table to the testPub publication from mssql1.pubs with the NonClusteredIndexes and Statistics options set

--- a/public/New-DbaReplCreationScriptOptions.ps1
+++ b/public/New-DbaReplCreationScriptOptions.ps1
@@ -35,13 +35,13 @@ function New-DbaReplCreationScriptOptions {
     .EXAMPLE
         PS C:\> $cso = New-DbaReplCreationScriptOptions -Options NonClusteredIndexes, Statistics
         PS C:\> $article = @{
-                    SqlInstance           = 'mssql1'
-                    Database              = 'pubs'
-                    PublicationName       = 'testPub'
-                    Name                  = 'stores'
-                    CreationScriptOptions = $cso
-                }
-                Add-DbaReplArticle @article -EnableException
+        >> SqlInstance           = 'mssql1'
+        >> Database              = 'pubs'
+        >> PublicationName       = 'testPub'
+        >> Name                  = 'stores'
+        >> CreationScriptOptions = $cso
+        >> }
+        PS C:\> Add-DbaReplArticle @article -EnableException
 
         Adds the stores table to the testPub publication from mssql1.pubs with the NonClusteredIndexes and Statistics options set
         includes default options.
@@ -50,13 +50,13 @@ function New-DbaReplCreationScriptOptions {
     .EXAMPLE
         PS C:\> $cso = New-DbaReplCreationScriptOptions -Options ClusteredIndexes, Identity -NoDefaults
         PS C:\> $article = @{
-                    SqlInstance           = 'mssql1'
-                    Database              = 'pubs'
-                    PublicationName       = 'testPub'
-                    Name                  = 'stores'
-                    CreationScriptOptions = $cso
-                }
-                Add-DbaReplArticle @article -EnableException
+        >> SqlInstance           = 'mssql1'
+        >> Database              = 'pubs'
+        >> PublicationName       = 'testPub'
+        >> Name                  = 'stores'
+        >> CreationScriptOptions = $cso
+        >> }
+        PS C:\> Add-DbaReplArticle @article -EnableException
 
         Adds the stores table to the testPub publication from mssql1.pubs with the ClusteredIndexes and Identity options set, excludes default options.
     #>

--- a/public/Remove-DbaReplSubscription.ps1
+++ b/public/Remove-DbaReplSubscription.ps1
@@ -62,12 +62,12 @@ function Remove-DbaReplSubscription {
 
     .EXAMPLE
         PS C:\> $sub = @{
-                    SqlInstance           = 'mssql1'
-                    Database              = 'pubs'
-                    PublicationName       = 'testPub'
-                    SubscriberSqlInstance = 'mssql2'
-                    SubscriptionDatabase  = 'pubs'
-                    }
+        >> SqlInstance           = 'mssql1'
+        >> Database              = 'pubs'
+        >> PublicationName       = 'testPub'
+        >> SubscriberSqlInstance = 'mssql2'
+        >> SubscriptionDatabase  = 'pubs'
+        >> }
         PS C:\> Remove-DbaReplSubscription @sub
 
         Removes a subscription for the testPub publication on mssql2.pubs.


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [X] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The docs on the website have `<br>` at the end of each row currently from splatting 
![image](https://github.com/dataplat/dbatools/assets/981370/95d37b01-4b35-48d3-8398-c6e835725dc9)

@niphlod - is there any other options? or is this the fix? Got this from looking at other commands where it works
![image](https://github.com/dataplat/dbatools/assets/981370/1d69a637-a8fb-4a71-bce6-0f930ed4b4a1)

If this is the fix - I have some more to fix before this PR gets merged... so marking as draft for now