### PR TITLE
Get-DbaBackupInformation is not reading values for "IsCopyOnly" attribute.

### DIFF
--- a/public/Get-DbaBackupInformation.ps1
+++ b/public/Get-DbaBackupInformation.ps1
@@ -352,6 +352,7 @@ function Get-DbaBackupInformation {
                 $historyObject.LastLsn = $group.Group[0].LastLsn
                 $historyObject.SoftwareVersionMajor = $group.Group[0].SoftwareVersionMajor
                 $historyObject.RecoveryModel = $group.Group.RecoveryModel
+                $historyObject.IsCopyOnly = $group.Group[0].IsCopyOnly
                 $groupResults += $historyObject
             }
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->

<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9295 )

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Get-DbaBackupInformation is not properly reading the CopyOnly attribute from the backup headers.

### Commands to test

Get-DbaBackupInformation and Read-DbaBackupHeader on a CopyOnly backup, there will be differences in the output.

### Screenshots

Before the fix:

![image](https://github.com/dataplat/dbatools/assets/9599352/6041fcbb-694a-4d6c-8167-b885e252cbb2)

After the fix:

![image](https://github.com/dataplat/dbatools/assets/9599352/0dd2a4ec-efd6-424a-bdef-3a78fcfc1ab1)



