### PR TITLE
Connect-DbaInstance - Connect DAC to test connection as soon as possible

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -948,14 +948,12 @@ function Connect-DbaInstance {
             # But ConnectionContext.IsOpen does not tell the truth if the instance was just shut down
             # And we don't use $server.ConnectionContext.Connect() as this would create a non pooled connection
             # Instead we run a real T-SQL command and just SELECT something to be sure we have a valid connection and let the SMO handle the connection
-            if (-not $DedicatedAdminConnection) {
-                try {
-                    Write-Message -Level Debug -Message "We connect to the instance by running SELECT 'dbatools is opening a new connection'"
-                    $null = $server.ConnectionContext.ExecuteWithResults("SELECT 'dbatools is opening a new connection'")
-                    Write-Message -Level Debug -Message "We have a connected server object"
-                } catch {
-                    Stop-Function -Target $instance -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Continue
-                }
+            try {
+                Write-Message -Level Debug -Message "We connect to the instance by running SELECT 'dbatools is opening a new connection'"
+                $null = $server.ConnectionContext.ExecuteWithResults("SELECT 'dbatools is opening a new connection'")
+                Write-Message -Level Debug -Message "We have a connected server object"
+            } catch {
+                Stop-Function -Target $instance -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Continue
             }
 
             if ($AzureUnsupported -and $server.DatabaseEngineType -eq "SqlAzureDatabase") {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Hopefully helps fixing #9253 together with other changes

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
All other commands rely on Connect-DbaInstance returning an open connection. So this has to be true for DAC as well. So we have to open the DAC inside of Connect-DbaInstance.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```
# This should fail on the second line:
$dac1 = Connect-DbaInstance -SqlInstance SQL01 -DedicatedAdminConnection
$dac2 = Connect-DbaInstance -SqlInstance SQL01 -DedicatedAdminConnection
```

See #9253 for more details.