### PR TITLE
Update-SqlPermission (used by Copy-DbaLogin) - Fix for using LoginRenameHashtable together with user different to login

### DIFF
--- a/private/functions/Update-SqlPermission.ps1
+++ b/private/functions/Update-SqlPermission.ps1
@@ -295,7 +295,7 @@ function Update-SqlPermission {
                 if ($Pscmdlet.ShouldProcess($destination, "Adding $newDbUsername to $dbName.")) {
                     $sql = $SourceServer.Databases[$dbName].Users[$dbUsername].Script() | Out-String
                     try {
-                        $destDb.ExecuteNonQuery($sql.Replace("[$dbUsername]", "[$newDbUsername]"))
+                        $destDb.ExecuteNonQuery($sql.Replace("[$dbUsername]", "[$newDbUsername]").Replace("[$loginName]", "[$newLoginName]"))
                         Write-Message -Level Verbose -Message "Adding user $newDbUsername (login: $newLoginName) to $dbName successfully performed."
                     } catch {
                         Stop-Function -Message "Failed to add $newDbUsername (login: $newLoginName) to $dbName on $destination." -Target $db -ErrorRecord $_


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #9283 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

See issue for details.

This solves the issue, but do we want to leave the user with the old name in the database? Or should the old user be deleted?