### PR TITLE
New-DbaComputerCertifficate - Only use MonthsValid for self-signed certificates

### DIFF
--- a/public/New-DbaComputerCertificate.ps1
+++ b/public/New-DbaComputerCertificate.ps1
@@ -349,11 +349,11 @@ function New-DbaComputerCertificate {
                 Add-Content $certCfg "ProviderType = 12"
                 if ($SelfSigned) {
                     Add-Content $certCfg "RequestType = Cert"
+                    Add-Content $certCfg "NotBefore = $((get-date).ToShortDateString())"
+                    Add-Content $certCfg "NotAfter = $((get-date).AddMonths($MonthsValid).ToShortDateString())"
                 } else {
                     Add-Content $certCfg "RequestType = PKCS10"
                 }
-                Add-Content $certCfg "NotBefore = $((get-date).ToShortDateString())"
-                Add-Content $certCfg "NotAfter = $((get-date).AddMonths($MonthsValid).ToShortDateString())"
                 Add-Content $certCfg "HashAlgorithm = $HashAlgorithm"
                 Add-Content $certCfg "KeyUsage = 0xa0"
                 Add-Content $certCfg "[EnhancedKeyUsageExtension]"


### PR DESCRIPTION
…cate)

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes an issue with pr #9264  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

See comments on #9264 for details.

Summary: NotBefore and NotAfter are only valid for RequestType = Cert, which are the self-signed certificates. They are not valid for the others as they use RequestType = PKCS10. See documentation: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certreq_1