### PR TITLE
Update Set-DbaNetworkCertificate to work with PowerShell Core when using RSA certificates

### DIFF
--- a/public/Set-DbaNetworkCertificate.ps1
+++ b/public/Set-DbaNetworkCertificate.ps1
@@ -171,7 +171,7 @@ function Set-DbaNetworkCertificate {
                     $keyName = switch ($PSEdition) {
                         Core { $cert.PrivateKey.Key.UniqueName }
                         Desktop { $cert.PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName }
-                        default { $cert.PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName }
+                        default { $cert.PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName }  # for PowerShell v3 and earlier which does not return $PSEdition
                     }
                     $keyFullPath = $keyPath + $keyName
                 } else {

--- a/public/Set-DbaNetworkCertificate.ps1
+++ b/public/Set-DbaNetworkCertificate.ps1
@@ -168,7 +168,11 @@ function Set-DbaNetworkCertificate {
 
                 if ($null -ne $cert.PrivateKey) {
                     $keyPath = $env:ProgramData + "\Microsoft\Crypto\RSA\MachineKeys\"
-                    $keyName = $cert.PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName
+                    $keyName = switch ($PSEdition) {
+                        Core { $cert.PrivateKey.Key.UniqueName }
+                        Desktop { $cert.PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName }
+                        default { $cert.PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName }
+                    }
                     $keyFullPath = $keyPath + $keyName
                 } else {
                     $keyPath = $env:ProgramData + '\Microsoft\Crypto\Keys\'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Set-DbaNetworkCertificate errors on PowerShell Core when using RSA certificates due to a difference in certificate object properties between Desktop and Core editions.
### Approach
<!-- How does this change solve that purpose -->
Add an Edition check at the appropriate place to get the proper value to calculate the certificate path.
### Commands to test
<!-- if these are the examples in the help just note it as such -->
Using an RSA certificate, run the same command on Windows PowerShell and PowerShell Core (7) and observe the results.  The PowerShell Core will fail.

`Set-DbaNetworkCertificate -SqlInstance server\instance -Thumbprint 'thumbprintofcertificate' `
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![WindowsPowerShell-vs-PowerShell](https://github.com/dataplat/dbatools/assets/99306324/394d04b1-ea18-43c5-85ef-d1d8d8ae555c)

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
