### PR TITLE
Backup-DbaDatabase : add a new switch parameter "NoAppendDbNameInPath" to prevent dbname systematically appended at the end of backup path

### DIFF
--- a/public/Backup-DbaDatabase.ps1
+++ b/public/Backup-DbaDatabase.ps1
@@ -668,7 +668,7 @@ function Backup-DbaDatabase {
                     if ($NoAppendDbNameInPath) {
                         $FinalBackupPath[$i] = [IO.Path]::Combine($parent, $leaf)
                     } else {
-                    $FinalBackupPath[$i] = [IO.Path]::Combine($parent, $dbName, $leaf)
+                        $FinalBackupPath[$i] = [IO.Path]::Combine($parent, $dbName, $leaf)
                     }
                 }
             }

--- a/public/Backup-DbaDatabase.ps1
+++ b/public/Backup-DbaDatabase.ps1
@@ -54,6 +54,9 @@ function Backup-DbaDatabase {
             timestamp - will be replaced with the timestamp (either the default, or the format provided)
             backuptype - will be replaced with Full, Log or Differential as appropriate
 
+    .PARAMETER NoAppendDbNameInPath
+        A switch that will prevent to systematically appended dbname to the path when creating the backup file path
+
     .PARAMETER CopyOnly
         If this switch is enabled, CopyOnly backups will be taken. By default function performs a normal backup, these backups interfere with the restore chain of the database. CopyOnly backups will not interfere with the restore chain of the database.
 
@@ -217,6 +220,7 @@ function Backup-DbaDatabase {
         [string]$FilePath,
         [switch]$IncrementPrefix,
         [switch]$ReplaceInName,
+        [switch]$NoAppendDbNameInPath,
         [switch]$CopyOnly,
         [ValidateSet('Full', 'Log', 'Differential', 'Diff', 'Database')]
         [string]$Type = 'Database',
@@ -661,7 +665,11 @@ function Backup-DbaDatabase {
                 for ($i = 0; $i -lt $FinalBackupPath.Count; $i++) {
                     $parent = [IO.Path]::GetDirectoryName($FinalBackupPath[$i])
                     $leaf = [IO.Path]::GetFileName($FinalBackupPath[$i])
+                    if ($NoAppendDbNameInPath) {
+                        $FinalBackupPath[$i] = [IO.Path]::Combine($parent, $leaf)
+                    } else {
                     $FinalBackupPath[$i] = [IO.Path]::Combine($parent, $dbName, $leaf)
+                    }
                 }
             }
 

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Path', 'FilePath', 'ReplaceInName', 'CopyOnly', 'Type', 'InputObject', 'CreateFolder', 'FileCount', 'CompressBackup', 'Checksum', 'Verify', 'MaxTransferSize', 'BlockSize', 'BufferCount', 'AzureBaseUrl', 'AzureCredential', 'NoRecovery', 'BuildPath', 'WithFormat', 'Initialize', 'SkipTapeHeader', 'TimeStampFormat', 'IgnoreFileChecks', 'OutputScriptOnly', 'EnableException', 'EncryptionAlgorithm', 'EncryptionCertificate', 'IncrementPrefix', 'Description'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Path', 'FilePath', 'ReplaceInName', 'NoAppendDbNameInPath', 'CopyOnly', 'Type', 'InputObject', 'CreateFolder', 'FileCount', 'CompressBackup', 'Checksum', 'Verify', 'MaxTransferSize', 'BlockSize', 'BufferCount', 'AzureBaseUrl', 'AzureCredential', 'NoRecovery', 'BuildPath', 'WithFormat', 'Initialize', 'SkipTapeHeader', 'TimeStampFormat', 'IgnoreFileChecks', 'OutputScriptOnly', 'EnableException', 'EncryptionAlgorithm', 'EncryptionCertificate', 'IncrementPrefix', 'Description'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose


1. Avoid to force the directory path to finish with the dbname whereas the path can be variabilized with -ReplaceInName and dbname token
2. When the dbname is long the directory path length limit (259 characters) imposed by MSSQL Engine can be reach very easily when dbname is used twice in the path
3. To allow to stick with Ola Hallengren default backup path
4. Solve feature request [#9346](https://github.com/dataplat/dbatools/issues/9346)

### Approach
Add a new switch variable that will avoid breaking changes to existing backup scripts using Backup-DbaDatabase but will allow to prevent the dbname to be systematicaly added at the end of the path

### Commands to test
```powershell
Backup-DbaDatabase -SqlInstance localhost -Database TESTDATABASE_ABC_1eed02d4-f58b-4110-9cee-78c2fa65123a_123456789012345678901234567890 -Type Full -CompressBackup -Checksum -Verify -FileCount 1 -Path "D:\MSSQL\BACKUPS\servername\instancename\dbname\backuptype" -FilePath "servername_dbname_backuptype_timestamp.bak" -TimeStampFormat "yyyyMMdd_HHmm" -ReplaceInName -CreateFolder -WarningVariable WarningVariable -OutVariable BackupResults -EnableException -NoAppendDbNameInPath
```

### Screenshots
![2024-05-13_15h04_34](https://github.com/dataplat/dbatools/assets/16419423/173b6c37-75a8-4aa8-bdb7-43926cfe30ed)



