### PR TITLE
Write-DbaDbTableData - Fail AutoCreateTable if no column definition available

### DIFF
--- a/public/Write-DbaDbTableData.ps1
+++ b/public/Write-DbaDbTableData.ps1
@@ -342,6 +342,11 @@ function Write-DbaDbTableData {
                 $columns = $DataTable.Table.Columns
             }
 
+            if ($null -eq $columns) {
+                Stop-Function -Message "Unable to get column definition from input data, so AutoCreateTable is not possible"
+                return
+            }
+
             foreach ($column in $columns) {
                 $sqlColumnName = $column.ColumnName
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9357 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

See issue for details.

![image](https://github.com/dataplat/dbatools/assets/66946165/aa9932f8-7746-4353-a0a3-1808d001936a)
