### PR TITLE
Get-DbaProcess: Fix for empty most_recent_sql_handle

### DIFF
--- a/public/Get-DbaProcess.ps1
+++ b/public/Get-DbaProcess.ps1
@@ -121,7 +121,7 @@ function Get-DbaProcess {
                 on c.session_id = s.session_id
             JOIN sys.endpoints e
                 ON c.endpoint_id = e.endpoint_id
-            CROSS APPLY sys.dm_exec_sql_text(c.most_recent_sql_handle) t"
+            OUTER APPLY sys.dm_exec_sql_text(c.most_recent_sql_handle) t"
 
             if ($server.VersionMajor -gt 8) {
                 $results = $server.Query($sql)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Sometimes, when there is no last sql handle, most_recent_sql_handle is 0x0. Then the CROSS APPLY filters out that process.

### Approach
We now use OUTER APPLY to get the row.
