### PR TITLE
better docs rendering, aligned with docs page

### DIFF
--- a/private/functions/Get-DbaHelp.ps1
+++ b/private/functions/Get-DbaHelp.ps1
@@ -62,6 +62,7 @@ function Get-DbaHelp {
         $availability = 'Windows, Linux, macOS'
 
         function Get-DbaDocsMD($doc_to_render) {
+
             $rtn = New-Object -TypeName "System.Collections.ArrayList"
             $null = $rtn.Add("# $($doc_to_render.CommandName)" )
             if ($doc_to_render.Author -or $doc_to_render.Availability) {
@@ -81,11 +82,17 @@ function Get-DbaHelp {
                 $null = $rtn.Add('*Aliases : ' + $doc_to_render.Alias + '*')
                 $null = $rtn.Add('')
             }
+            $null = $rtn.Add('Want to see the source code for this command? Check out [' + $doc_to_render.CommandName + '](https://github.com/dataplat/dbatools/blob/master/public/' + $doc_to_render.CommandName + '.ps1) on GitHub.')
+            $null = $rtn.Add("<br>")
+            $null = $rtn.Add('Want to see the Bill Of Health for this command? Check out [' + $doc_to_render.CommandName + '](https://dataplat.github.io/boh#' + $doc_to_render.CommandName + ').')
             $null = $rtn.Add('## Synopsis')
-            $null = $rtn.Add($doc_to_render.Synopsis)
+            $null = $rtn.Add($doc_to_render.Synopsis.Replace("`n", "  `n"))
             $null = $rtn.Add('')
             $null = $rtn.Add('## Description')
-            $null = $rtn.Add($doc_to_render.Description)
+            if ($doc_to_render.Description)
+            {
+                $null = $rtn.Add($doc_to_render.Description.Replace("`n", "  `n"))
+            }
             $null = $rtn.Add('')
             if ($doc_to_render.Syntax) {
                 $null = $rtn.Add('## Syntax')
@@ -99,16 +106,26 @@ function Get-DbaHelp {
                 foreach ($syntax in $splitted_paramsets) {
                     $x = 0
                     foreach ($val in ($syntax.Replace("`r", '').Replace("`n", '') -split ' \[')) {
-                        if ($x -eq 0) {
-                            $null = $rtn.Add($val)
-                        } else {
-                            $null = $rtn.Add('    [' + $val.replace("`n", '').replace("`n", ''))
+                    if ($x -eq 0) {
+                        $null = $rtn.Add($val)
+                    } else {
+                        $xx = 0
+                        foreach($subparam in ($val -split ' -'))
+                        {
+                            if ($xx -eq 0)
+                            {
+                                $null = $rtn.Add('    [' + $subparam.replace("`n", '').replace("`n", ''))
+                            } else {
+                                $null = $rtn.Add('    -' + $subparam.replace("`n", '').replace("`n", ''))
+                            }
+                            $xx += 1
                         }
-                        $x += 1
                     }
+                    $x += 1
+                }
                     $null = $rtn.Add('')
                 }
-
+    
                 $null = $rtn.Add('```')
                 $null = $rtn.Add("`n" + '&nbsp;' + "`n")
             }
@@ -127,13 +144,13 @@ function Get-DbaHelp {
                     $null = $rtn.Add(($row.Trim() -replace 'PS C:\\>\s*', "PS C:\> "))
                     $inside = 1
                 } elseif ($row.Trim() -eq '' -or $row.Trim() -eq 'Description') {
-
+    
                 } else {
                     if ($inside -eq 1) {
                         $inside = 0
                         $null = $rtn.Add('```')
                     }
-                    $null = $rtn.Add("$row<br>")
+                    $null = $rtn.Add("$($row.Replace("`n", "  `n"))<br>")
                 }
             }
             if ($inside -eq 1) {
@@ -155,7 +172,7 @@ function Get-DbaHelp {
                         $null = $rtn.Add('### Required Parameters')
                     }
                     $null = $rtn.Add('##### -' + $el[0])
-                    $null = $rtn.Add($el[1] + '<br>')
+                    $null = $rtn.Add($el[1].Replace("`r", "").Replace("`n", "  `n") + ' <br>')
                     $null = $rtn.Add('')
                     $null = $rtn.Add('|  |  |')
                     $null = $rtn.Add('| - | - |')
@@ -180,9 +197,9 @@ function Get-DbaHelp {
                         $dotitle = 1
                         $null = $rtn.Add('### Optional Parameters')
                     }
-
+    
                     $null = $rtn.Add('##### -' + $el[0])
-                    $null = $rtn.Add($el[1] + '<br>')
+                    $null = $rtn.Add($el[1].Replace("`r", "").Replace("`n", "  `n") + '<br>')
                     $null = $rtn.Add('')
                     $null = $rtn.Add('|  |  |')
                     $null = $rtn.Add('| - | - |')
@@ -196,13 +213,11 @@ function Get-DbaHelp {
                     $null = $rtn.Add('')
                 }
             }
+    
             $null = $rtn.Add('')
             $null = $rtn.Add("`n" + '&nbsp;' + "`n")
-            $null = $rtn.Add('Want to see the source code for this command? Check out [' + $doc_to_render.CommandName + '](https://github.com/dataplat/dbatools/blob/master/public/' + $doc_to_render.CommandName + '.ps1) on GitHub.')
-            $null = $rtn.Add("<br>")
-            $null = $rtn.Add('Want to see the Bill Of Health for this command? Check out [' + $doc_to_render.CommandName + '](https://dataplat.github.io/boh#' + $doc_to_render.CommandName + ').')
             $null = $rtn.Add('')
-
+    
             return $rtn
         }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #9367  )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

### Purpose
The change on the docs site has been pushed a little while ago (had some issues but had to do with GH Runner misbehaving).
This alignes the private function for people wanting to have a nice preview of the output with the new and "improved" rendering logic.
