### PR TITLE
Always use same description for EnableException

### DIFF
--- a/public/Add-DbaRegServer.ps1
+++ b/public/Add-DbaRegServer.ps1
@@ -56,9 +56,7 @@ function Add-DbaRegServer {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Add-DbaRegServerGroup.ps1
+++ b/public/Add-DbaRegServerGroup.ps1
@@ -37,9 +37,7 @@ function Add-DbaRegServerGroup {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Disable-DbaDbEncryption.ps1
+++ b/public/Disable-DbaDbEncryption.ps1
@@ -34,7 +34,7 @@ function Disable-DbaDbEncryption {
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-        Using this switch turns this "nice by default" feature off and disables you to catch exceptions with your own try/catch.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.

--- a/public/Export-DbaRegServer.ps1
+++ b/public/Export-DbaRegServer.ps1
@@ -41,9 +41,7 @@ function Export-DbaRegServer {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Export-DbatoolsConfig.ps1
+++ b/public/Export-DbatoolsConfig.ps1
@@ -40,8 +40,9 @@ function Export-DbatoolsConfig {
         (Note: Settings that were updated with the same value as the original default will still be considered changed)
 
     .PARAMETER EnableException
-        This parameters disables user-friendly warnings and enables the throwing of exceptions.
-        This is less user friendly, but allows catching exceptions in calling scripts.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Module

--- a/public/Get-DbaBackupInformation.ps1
+++ b/public/Get-DbaBackupInformation.ps1
@@ -78,8 +78,9 @@ function Get-DbaBackupInformation {
         When specified along with a path the command will import a previously exported BackupHistory object from an xml file.
 
     .PARAMETER EnableException
-        Replaces user friendly yellow warnings with bloody red exceptions of doom!
-        Use this if you want the function to throw terminating errors you want to catch.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: DisasterRecovery, Backup, Restore

--- a/public/Get-DbaDbAssembly.ps1
+++ b/public/Get-DbaDbAssembly.ps1
@@ -24,7 +24,7 @@ function Get-DbaDbAssembly {
         Specify an Assembly to be fetched. If not specified all Assemblies will be returned
 
     .PARAMETER EnableException
-        By default, when something goes wrong, we try to catch it, interpret it and give you a friendly warning message.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 

--- a/public/Get-DbaDbObjectTrigger.ps1
+++ b/public/Get-DbaDbObjectTrigger.ps1
@@ -31,7 +31,7 @@ function Get-DbaDbObjectTrigger {
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/ca
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Database, Trigger

--- a/public/Get-DbaDbTrigger.ps1
+++ b/public/Get-DbaDbTrigger.ps1
@@ -28,7 +28,7 @@ function Get-DbaDbTrigger {
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/ca
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Database, Trigger

--- a/public/Get-DbaKbUpdate.ps1
+++ b/public/Get-DbaKbUpdate.ps1
@@ -25,9 +25,7 @@ function Get-DbaKbUpdate {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Get-DbaLastBackup.ps1
+++ b/public/Get-DbaLastBackup.ps1
@@ -25,7 +25,9 @@ function Get-DbaLastBackup {
         Specifies one or more database(s) to exclude from processing.
 
     .PARAMETER EnableException
-        If this switch is enabled exceptions will be thrown to the caller, which will need to perform its own exception processing. Otherwise, the function will try to catch the exception, interpret it and provide a friendly error message.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: DisasterRecovery, Backup

--- a/public/Get-DbaMsdtc.ps1
+++ b/public/Get-DbaMsdtc.ps1
@@ -15,11 +15,10 @@ function Get-DbaMsdtc {
         Alternative credential
 
     .PARAMETER EnableException
-        By default in most of our commands, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-        This command, however, gifts you  with "sea of red" exceptions, by default, because it is useful for advanced scripting.
-
-        Using this switch turns our "nice by default" feature on which makes errors into pretty warnings.
     .NOTES
         Tags: Msdtc, dtc, General
         Author: Klaas Vandenberghe (@powerdbaklaas)

--- a/public/Get-DbaPermission.ps1
+++ b/public/Get-DbaPermission.ps1
@@ -39,7 +39,9 @@ function Get-DbaPermission {
         If this switch is enabled, permissions on system securables will be excluded.
 
     .PARAMETER EnableException
-        If this switch is enabled exceptions will be thrown to the caller, which will need to perform its own exception processing. Otherwise, the function will try to catch the exception, interpret it and provide a friendly error message.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Permissions, Instance, Database, Security

--- a/public/Get-DbaRegServer.ps1
+++ b/public/Get-DbaRegServer.ps1
@@ -44,9 +44,7 @@ function Get-DbaRegServer {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Get-DbaRegServerGroup.ps1
+++ b/public/Get-DbaRegServerGroup.ps1
@@ -27,9 +27,7 @@ function Get-DbaRegServerGroup {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Get-DbaServerRole.ps1
+++ b/public/Get-DbaServerRole.ps1
@@ -26,7 +26,9 @@ function Get-DbaServerRole {
         Filter the fixed server-level roles. Only applies to SQL Server 2017 that supports creation of server-level roles.
 
     .PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message. This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting. Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Role

--- a/public/Get-DbaStartupParameter.ps1
+++ b/public/Get-DbaStartupParameter.ps1
@@ -22,7 +22,9 @@ function Get-DbaStartupParameter {
         If this switch is enabled, simplified output will be produced including only Server, Master Data path, Master Log path, ErrorLog, TraceFlags and ParameterString.
 
     .PARAMETER EnableException
-        If this switch is enabled, exceptions will be thrown to the caller, which will need to perform its own exception processing. Otherwise, the function will try to catch the exception, interpret it and provide a friendly error message.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: WSMan, SQLWMI, Memory, Startup

--- a/public/Get-DbaWaitResource.ps1
+++ b/public/Get-DbaWaitResource.ps1
@@ -25,8 +25,9 @@ function Get-DbaWaitResource {
         If this switch provided also returns the value of the row being waited on with KEY wait resources
 
     .PARAMETER EnableException
-        Replaces user friendly yellow warnings with bloody red exceptions of doom!
-        Use this if you want the function to throw terminating errors you want to catch.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Diagnostic, Pages, DBCC

--- a/public/Get-DbaXEObject.ps1
+++ b/public/Get-DbaXEObject.ps1
@@ -29,7 +29,9 @@ function Get-DbaXEObject {
         Type
 
     .PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message. This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting. Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: ExtendedEvent, XE, XEvent

--- a/public/Import-DbaRegServer.ps1
+++ b/public/Import-DbaRegServer.ps1
@@ -29,9 +29,7 @@ function Import-DbaRegServer {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Import-DbatoolsConfig.ps1
+++ b/public/Import-DbatoolsConfig.ps1
@@ -30,8 +30,9 @@ function Import-DbatoolsConfig {
         Rather than applying the setting, return the configuration items that would have been applied.
 
     .PARAMETER EnableException
-        This parameters disables user-friendly warnings and enables the throwing of exceptions.
-        This is less user friendly, but allows catching exceptions in calling scripts.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Module

--- a/public/Invoke-DbaAdvancedRestore.ps1
+++ b/public/Invoke-DbaAdvancedRestore.ps1
@@ -95,8 +95,9 @@ function Invoke-DbaAdvancedRestore {
         By default the restore will stop at the first occurence of StopMark found in the chain, passing a datetime where will cause it to stop the first StopMark atfer that datetime
 
     .PARAMETER EnableException
-        Replaces user friendly yellow warnings with bloody red exceptions of doom!
-        Use this if you want the function to throw terminating errors you want to catch.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Restore, Backup

--- a/public/Invoke-DbaDbLogShipping.ps1
+++ b/public/Invoke-DbaDbLogShipping.ps1
@@ -342,7 +342,9 @@ function Invoke-DbaDbLogShipping {
         Prompts you for confirmation before executing any changing operations within the command.
 
     .PARAMETER EnableException
-        Use this switch to disable any kind of verbose messages
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .PARAMETER Force
         The force parameter will ignore some errors in the parameters and assume defaults.

--- a/public/Move-DbaDbFile.ps1
+++ b/public/Move-DbaDbFile.ps1
@@ -50,9 +50,7 @@ function Move-DbaDbFile {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Move-DbaRegServer.ps1
+++ b/public/Move-DbaRegServer.ps1
@@ -36,9 +36,7 @@ function Move-DbaRegServer {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Move-DbaRegServerGroup.ps1
+++ b/public/Move-DbaRegServerGroup.ps1
@@ -33,9 +33,7 @@ function Move-DbaRegServerGroup {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/New-DbaAzAccessToken.ps1
+++ b/public/New-DbaAzAccessToken.ps1
@@ -45,11 +45,9 @@ function New-DbaAzAccessToken {
         Store where the Azure MSI certificate is stored
 
     .PARAMETER EnableException
-        By default in most of our commands, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
-        This command, however, gifts you  with "sea of red" exceptions, by default, because it is useful for advanced scripting.
-
-        Using this switch turns our "nice by default" feature on which makes errors into pretty warnings.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Connect, Connection, Azure

--- a/public/Read-DbaBackupHeader.ps1
+++ b/public/Read-DbaBackupHeader.ps1
@@ -29,7 +29,8 @@ function Read-DbaBackupHeader {
         Name of the SQL Server credential that should be used for Azure storage access.
 
     .PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message. This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Register-DbatoolsConfig.ps1
+++ b/public/Register-DbatoolsConfig.ps1
@@ -28,8 +28,9 @@ function Register-DbatoolsConfig {
         Legal values: UserDefault, UserMandatory, SystemDefault, SystemMandatory
 
     .PARAMETER EnableException
-        This parameters disables user-friendly warnings and enables the throwing of exceptions.
-        This is less user friendly, but allows catching exceptions in calling scripts.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Module

--- a/public/Remove-DbaDbLogShipping.ps1
+++ b/public/Remove-DbaDbLogShipping.ps1
@@ -48,7 +48,9 @@
         Prompts you for confirmation before executing any changing operations within the command.
 
     .PARAMETER EnableException
-        Use this switch to disable any kind of verbose messages
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: LogShipping

--- a/public/Remove-DbaRegServer.ps1
+++ b/public/Remove-DbaRegServer.ps1
@@ -36,9 +36,7 @@ function Remove-DbaRegServer {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Remove-DbaRegServerGroup.ps1
+++ b/public/Remove-DbaRegServerGroup.ps1
@@ -30,9 +30,7 @@ function Remove-DbaRegServerGroup {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Reset-DbatoolsConfig.ps1
+++ b/public/Reset-DbatoolsConfig.ps1
@@ -25,8 +25,9 @@ function Reset-DbatoolsConfig {
         Used in conjunction with the -Module parameter to select which settings to reset using wildcard comparison.
 
     .PARAMETER EnableException
-        This parameters disables user-friendly warnings and enables the throwing of exceptions.
-        This is less user friendly, but allows catching exceptions in calling scripts.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .PARAMETER Confirm
         If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.

--- a/public/Save-DbaKbUpdate.ps1
+++ b/public/Save-DbaKbUpdate.ps1
@@ -28,9 +28,7 @@ function Save-DbaKbUpdate {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES

--- a/public/Show-DbaDbList.ps1
+++ b/public/Show-DbaDbList.ps1
@@ -26,11 +26,9 @@ function Show-DbaDbList {
         Specify a database to have selected when the window appears.
 
     .PARAMETER EnableException
-        By default in most of our commands, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
-        This command, however, gifts you  with "sea of red" exceptions, by default, because it is useful for advanced scripting.
-
-        Using this switch turns our "nice by default" feature on which makes errors into pretty warnings.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Database, FileSystem

--- a/public/Test-DbaLinkedServerConnection.ps1
+++ b/public/Test-DbaLinkedServerConnection.ps1
@@ -18,7 +18,6 @@ function Test-DbaLinkedServerConnection {
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 

--- a/public/Test-DbaOptimizeForAdHoc.ps1
+++ b/public/Test-DbaOptimizeForAdHoc.ps1
@@ -22,7 +22,9 @@ function Test-DbaOptimizeForAdHoc {
         For MFA support, please use Connect-DbaInstance.
 
     .PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message. This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting. Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: Configure, SPConfigure


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

Sometimes I stumble across different descriptions for the same parameter. I would like to harmonize the descriptions for the very frequently used parameters and then set them consistently.

As most commands already used the same description for EnableException, I changed the other commands accordingly.