### PR TITLE
Get-DbatoolsError: Use FullyQualifiedErrorId to filter $global:error

### DIFF
--- a/public/Get-DbatoolsError.ps1
+++ b/public/Get-DbatoolsError.ps1
@@ -62,6 +62,6 @@ function Get-DbatoolsError {
             $First = $global:error.Count
         }
 
-        $global:error | Where-Object ScriptStackTrace -match dbatools | Select-Object -First $First -Last $Last -Skip $Skip -Property CategoryInfo, ErrorDetails, Exception, FullyQualifiedErrorId, InvocationInfo, PipelineIterationInfo, PSMessageDetails, ScriptStackTrace, TargetObject
+        $global:error | Where-Object FullyQualifiedErrorId -match dbatools | Select-Object -First $First -Last $Last -Skip $Skip -Property CategoryInfo, ErrorDetails, Exception, FullyQualifiedErrorId, InvocationInfo, PipelineIterationInfo, PSMessageDetails, ScriptStackTrace, TargetObject
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Maybe it's only my system, but the ScriptStackTrace does not contain "dbatools". I think it's because the commands are not imported from a file but a compressed file.

![image](https://github.com/dataplat/dbatools/assets/66946165/92a8e068-83e7-451a-b3d2-61ee46ac43ee)

But "dbatools" is present in the FullyQualifiedErrorId. So we should use this.
![image](https://github.com/dataplat/dbatools/assets/66946165/e61e9d30-90b4-48e1-bb65-0765e7624024)

Or is there a better way to filter?