### PR TITLE
Write-DbaDbTableData: Fix for connections to Azure SQL Database with AccessToken

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -592,7 +592,6 @@ function Connect-DbaInstance {
                 # Currently only if we have a different Database or have to switch to a NonPooledConnection or using a specific StatementTimeout or using ApplicationIntent
                 # We do not test for SqlCredential as this would change the behavior compared to the legacy code path
                 $copyContext = $false
-                $dbChanged = $false
                 if ($Database) {
                     Write-Message -Level Debug -Message "Database [$Database] provided."
                     if (-not $inputObject.ConnectionContext.CurrentDatabase) {
@@ -603,7 +602,6 @@ function Connect-DbaInstance {
                     if ($inputObject.ConnectionContext.CurrentDatabase -ne $Database) {
                         Write-Message -Level Verbose -Message "Database [$Database] provided. Does not match ConnectionContext.CurrentDatabase [$($inputObject.ConnectionContext.CurrentDatabase)], copying ConnectionContext and setting the CurrentDatabase"
                         $copyContext = $true
-                        $dbChanged = $true
                     }
                 }
                 if ($ApplicationIntent -and $inputObject.ConnectionContext.ApplicationIntent -ne $ApplicationIntent) {
@@ -638,7 +636,7 @@ function Connect-DbaInstance {
                         $connContext.ServerInstance = 'ADMIN:' + $connContext.ServerInstance
                         $connContext.NonPooledConnection = $true
                     }
-                    if ($dbChanged) {
+                    if ($Database) {
                         # Save StatementTimeout because it might be reset on GetDatabaseConnection
                         $savedStatementTimeout = $connContext.StatementTimeout
                         $connContext = $connContext.GetDatabaseConnection($Database)

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -592,6 +592,7 @@ function Connect-DbaInstance {
                 # Currently only if we have a different Database or have to switch to a NonPooledConnection or using a specific StatementTimeout or using ApplicationIntent
                 # We do not test for SqlCredential as this would change the behavior compared to the legacy code path
                 $copyContext = $false
+                $dbChanged = $false
                 if ($Database) {
                     Write-Message -Level Debug -Message "Database [$Database] provided."
                     if (-not $inputObject.ConnectionContext.CurrentDatabase) {
@@ -602,6 +603,7 @@ function Connect-DbaInstance {
                     if ($inputObject.ConnectionContext.CurrentDatabase -ne $Database) {
                         Write-Message -Level Verbose -Message "Database [$Database] provided. Does not match ConnectionContext.CurrentDatabase [$($inputObject.ConnectionContext.CurrentDatabase)], copying ConnectionContext and setting the CurrentDatabase"
                         $copyContext = $true
+                        $dbChanged = $true
                     }
                 }
                 if ($ApplicationIntent -and $inputObject.ConnectionContext.ApplicationIntent -ne $ApplicationIntent) {
@@ -636,7 +638,7 @@ function Connect-DbaInstance {
                         $connContext.ServerInstance = 'ADMIN:' + $connContext.ServerInstance
                         $connContext.NonPooledConnection = $true
                     }
-                    if ($Database) {
+                    if ($dbChanged) {
                         # Save StatementTimeout because it might be reset on GetDatabaseConnection
                         $savedStatementTimeout = $connContext.StatementTimeout
                         $connContext = $connContext.GetDatabaseConnection($Database)

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -142,6 +142,8 @@ function Connect-DbaInstance {
 
         Note that the token is valid for only one hour and cannot be renewed automatically.
 
+        Note that the returned SMO is not a fully functional SMO. It can only be used in a limited list of commands like Invoke-DbaQuery or Write-DbaDbTableData.
+
     .PARAMETER DedicatedAdminConnection
         Connects using "ADMIN:" to create a dedicated admin connection (DAC) as a non-pooled connection.
         If the instance is on a remote server, the remote access has to be enabled via "Set-DbaSpConfigure -Name RemoteDacConnectionsEnabled -Value $true" or "sp_configure 'remote admin connections', 1".

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -142,7 +142,7 @@ function Connect-DbaInstance {
 
         Note that the token is valid for only one hour and cannot be renewed automatically.
 
-        Note that the returned SMO is not a fully functional SMO. It can only be used in a limited list of commands like Invoke-DbaQuery or Write-DbaDbTableData.
+        Note that the returned SMO is not a fully functional SMO. It can only be used in a limited list of commands like Invoke-DbaQuery, Import-DbaCsv or Write-DbaDbTableData.
 
     .PARAMETER DedicatedAdminConnection
         Connects using "ADMIN:" to create a dedicated admin connection (DAC) as a non-pooled connection.

--- a/public/Get-DbaTopResourceUsage.ps1
+++ b/public/Get-DbaTopResourceUsage.ps1
@@ -254,7 +254,7 @@ function Get-DbaTopResourceUsage {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10 -StatementTimeout 0
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             } catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -456,7 +456,7 @@ function Import-DbaCsv {
                 $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
                 # Open Connection to SQL Server
                 try {
-                    $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database -StatementTimeout 0 -MinimumVersion 9
+                    $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database -MinimumVersion 9
                     $sqlconn = $server.ConnectionContext.SqlConnectionObject
                     if ($sqlconn.State -ne 'Open') {
                         $sqlconn.Open()

--- a/public/Invoke-DbaDbUpgrade.ps1
+++ b/public/Invoke-DbaDbUpgrade.ps1
@@ -132,7 +132,7 @@ function Invoke-DbaDbUpgrade {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -StatementTimeout 0
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }

--- a/public/Set-DbaDbCompression.ps1
+++ b/public/Set-DbaDbCompression.ps1
@@ -128,7 +128,7 @@ function Set-DbaDbCompression {
         $starttime = Get-Date
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10 -StatementTimeout 0
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             } catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -195,9 +195,9 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "clones when using parameter StatementTimeout" {
-            $serverClone = Connect-DbaInstance -SqlInstance $server -StatementTimeout 0
+            $serverClone = Connect-DbaInstance -SqlInstance $server -StatementTimeout 123
             $server.ConnectionContext.StatementTimeout | Should -Be (Get-DbatoolsConfigValue -FullName 'sql.execution.timeout')
-            $serverClone.ConnectionContext.StatementTimeout | Should -Be 0
+            $serverClone.ConnectionContext.StatementTimeout | Should -Be 123
         }
 
         It "clones when using parameter DedicatedAdminConnection" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9394 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

See issue for details.

Also included in this pull request:
* Import-DbaCsv is now also supported, as I removed the all the `StatementTimeout 0` as they are the default anyway.
* Added a note in the documentation of AccessToken in Connect-DbaInstance on which commands are supported.
