### PR TITLE
Tests: Use Force while importing module to export aliases

### DIFF
--- a/tests/manual.pester.ps1
+++ b/tests/manual.pester.ps1
@@ -158,7 +158,7 @@ Remove-Module dbatools -ErrorAction Ignore
 #imports the module making sure DLL is loaded ok
 Import-Module "$ModuleBase\dbatools.psd1" -DisableNameChecking
 #imports the psm1 to be able to use internal functions in tests
-Import-Module "$ModuleBase\dbatools.psm1" -DisableNameChecking
+Import-Module "$ModuleBase\dbatools.psm1" -DisableNameChecking -Force
 
 $ScriptAnalyzerRulesExclude = @('PSUseOutputTypeCorrectly', 'PSAvoidUsingPlainTextForPassword', 'PSUseBOMForUnicodeEncodedFile')
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Before this change, the aliases are not exported and the test for Connect-DbaInstance failed with `Get-Alias : This command cannot find a matching alias because an alias with the name 'cdi' does not exist.`.

Why is this needed? Is this change the best way?