### PR TITLE
Get- and Copy-DbaDbQueryStoreOption: Fix DBNull issue and add missing Notes property

### DIFF
--- a/public/Copy-DbaDbQueryStoreOption.ps1
+++ b/public/Copy-DbaDbQueryStoreOption.ps1
@@ -104,12 +104,6 @@ function Copy-DbaDbQueryStoreOption {
 
         $sourceDB = Get-DbaDatabase -SqlInstance $sourceServer -Database $SourceDatabase
 
-        if ($sourceServer.VersionMajor -eq 14) {
-            $QueryStoreOptions = $sourceDB.Query("SELECT max_plans_per_query AS MaxPlansPerQuery, wait_stats_capture_mode_desc AS WaitStatsCaptureMode FROM sys.database_query_store_options;", $sourceDB.Name)
-        } elseif ($sourceServer.VersionMajor -ge 15) {
-            $QueryStoreOptions = $sourceDB.Query("SELECT max_plans_per_query AS MaxPlansPerQuery, wait_stats_capture_mode_desc AS WaitStatsCaptureMode, capture_policy_execution_count AS CustomCapturePolicyExecutionCount, capture_policy_stale_threshold_hours AS CustomCapturePolicyStaleThresholdHours, capture_policy_total_compile_cpu_time_ms AS CustomCapturePolicyTotalCompileCPUTimeMS, capture_policy_total_execution_cpu_time_ms AS CustomCapturePolicyTotalExecutionCPUTimeMS FROM sys.database_query_store_options;", $sourceDB.Name)
-        }
-
         foreach ($destinstance in $Destination) {
 
             if (!$DestinationDatabase -and !$Exclude -and !$AllDatabases) {
@@ -152,6 +146,7 @@ function Copy-DbaDbQueryStoreOption {
                     DestinationDatabaseID = $destDB.ID
                     Type                  = "QueryStore Configuration"
                     Status                = $null
+                    Notes                 = $null
                     DateTime              = [Dataplat.Dbatools.Utility.DbaDateTime](Get-Date)
                 }
 
@@ -191,8 +186,8 @@ function Copy-DbaDbQueryStoreOption {
                                 CaptureMode          = $SourceQSConfig.QueryCaptureMode
                                 CleanupMode          = $SourceQSConfig.SizeBasedCleanupMode
                                 StaleQueryThreshold  = $SourceQSConfig.StaleQueryThresholdInDays
-                                MaxPlansPerQuery     = $QueryStoreOptions.MaxPlansPerQuery
-                                WaitStatsCaptureMode = $QueryStoreOptions.WaitStatsCaptureMode
+                                MaxPlansPerQuery     = $SourceQSConfig.MaxPlansPerQuery
+                                WaitStatsCaptureMode = $SourceQSConfig.WaitStatsCaptureMode
                             }
                         } elseif ($sourceServer.VersionMajor -ge 15) {
                             $setDbaDbQueryStoreOptionParameters = @{
@@ -206,12 +201,12 @@ function Copy-DbaDbQueryStoreOption {
                                 CaptureMode                                = $SourceQSConfig.QueryCaptureMode
                                 CleanupMode                                = $SourceQSConfig.SizeBasedCleanupMode
                                 StaleQueryThreshold                        = $SourceQSConfig.StaleQueryThresholdInDays
-                                MaxPlansPerQuery                           = $QueryStoreOptions.MaxPlansPerQuery
-                                WaitStatsCaptureMode                       = $QueryStoreOptions.WaitStatsCaptureMode
-                                CustomCapturePolicyExecutionCount          = $QueryStoreOptions.CustomCapturePolicyExecutionCount
-                                CustomCapturePolicyTotalCompileCPUTimeMS   = $QueryStoreOptions.CustomCapturePolicyTotalCompileCPUTimeMS
-                                CustomCapturePolicyTotalExecutionCPUTimeMS = $QueryStoreOptions.CustomCapturePolicyTotalExecutionCPUTimeMS
-                                CustomCapturePolicyStaleThresholdHours     = $QueryStoreOptions.CustomCapturePolicyStaleThresholdHours
+                                MaxPlansPerQuery                           = $SourceQSConfig.MaxPlansPerQuery
+                                WaitStatsCaptureMode                       = $SourceQSConfig.WaitStatsCaptureMode
+                                CustomCapturePolicyExecutionCount          = $SourceQSConfig.CustomCapturePolicyExecutionCount
+                                CustomCapturePolicyTotalCompileCPUTimeMS   = $SourceQSConfig.CustomCapturePolicyTotalCompileCPUTimeMS
+                                CustomCapturePolicyTotalExecutionCPUTimeMS = $SourceQSConfig.CustomCapturePolicyTotalExecutionCPUTimeMS
+                                CustomCapturePolicyStaleThresholdHours     = $SourceQSConfig.CustomCapturePolicyStaleThresholdHours
                             }
                         }
 

--- a/public/Get-DbaDbQueryStoreOption.ps1
+++ b/public/Get-DbaDbQueryStoreOption.ps1
@@ -89,9 +89,9 @@ function Get-DbaDbQueryStoreOption {
                 $qso = $db.QueryStoreOptions
 
                 if ($server.VersionMajor -eq 14) {
-                    $QueryStoreOptions = $db.Query("SELECT max_plans_per_query AS MaxPlansPerQuery, wait_stats_capture_mode_desc AS WaitStatsCaptureMode FROM sys.database_query_store_options;", $db.Name)
+                    $QueryStoreOptions = Invoke-DbaQuery -SqlInstance $server -Database $db.Name -Query "SELECT max_plans_per_query AS MaxPlansPerQuery, wait_stats_capture_mode_desc AS WaitStatsCaptureMode FROM sys.database_query_store_options;" -As PSObject
                 } elseif ($server.VersionMajor -ge 15) {
-                    $QueryStoreOptions = $db.Query("SELECT max_plans_per_query AS MaxPlansPerQuery, wait_stats_capture_mode_desc AS WaitStatsCaptureMode, capture_policy_execution_count AS CustomCapturePolicyExecutionCount, capture_policy_stale_threshold_hours AS CustomCapturePolicyStaleThresholdHours, capture_policy_total_compile_cpu_time_ms AS CustomCapturePolicyTotalCompileCPUTimeMS, capture_policy_total_execution_cpu_time_ms AS CustomCapturePolicyTotalExecutionCPUTimeMS FROM sys.database_query_store_options;", $db.Name)
+                    $QueryStoreOptions = Invoke-DbaQuery -SqlInstance $server -Database $db.Name -Query "SELECT max_plans_per_query AS MaxPlansPerQuery, wait_stats_capture_mode_desc AS WaitStatsCaptureMode, capture_policy_execution_count AS CustomCapturePolicyExecutionCount, capture_policy_stale_threshold_hours AS CustomCapturePolicyStaleThresholdHours, capture_policy_total_compile_cpu_time_ms AS CustomCapturePolicyTotalCompileCPUTimeMS, capture_policy_total_execution_cpu_time_ms AS CustomCapturePolicyTotalExecutionCPUTimeMS FROM sys.database_query_store_options;" -As PSObject
                 }
 
                 Add-Member -Force -InputObject $qso -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Notes was part of the default view, but not part of the object.

`.Query("...")` has returned NULL values as DBNull objects that could not be casted to int.

This needs to be tested with current version, not the old 2017 we have on AppVevor...