### PR TITLE
Get-DbaDbStoredProcedure: Moved Test-Bound -ParameterName ExcludeSystemSp outside of nested loop

### DIFF
--- a/public/Get-DbaDbStoredProcedure.ps1
+++ b/public/Get-DbaDbStoredProcedure.ps1
@@ -144,6 +144,8 @@ function Get-DbaDbStoredProcedure {
             $InputObject = Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
         }
 
+        $ExcludeSystemSpIsBound = Test-Bound -ParameterName ExcludeSystemSp
+
         foreach ($db in $InputObject) {
             if (!$db.IsAccessible) {
                 Write-Message -Level Warning -Message "Database $db is not accessible. Skipping."
@@ -182,7 +184,7 @@ function Get-DbaDbStoredProcedure {
             }
 
             foreach ($proc in $procs) {
-                if ( (Test-Bound -ParameterName ExcludeSystemSp) -and $proc.IsSystemObject ) {
+                if ($ExcludeSystemSpIsBound -and $proc.IsSystemObject ) {
                     continue
                 }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #9418 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
As I have complained about in #9418 , I have some concerns about the performance of `Get-DbaDbStoredProcedure`. This is my best guess at what will fix it. Running `Test-Bound` (which is itself a loop) inside of a nested loop despite its value being set from the moment you call the function seems like something that will negatively impact performance, so this fixes that. Running it inside the loops means running it a great deal of times. Over 1,000 per database by my count.

### Approach
Aside from what I've said above, all that I can mention is to stress that this is a guess. It is an edit made in GitHub's GUI after a late-night eureka moment. I don't have any skill in measuring PowerShell performance.

### Commands to test
`Get-DbaDbStoredProcedure`
