### PR TITLE
Test-DbaDbRecoveryModel: Fix for instances with case sensitive collation

### DIFF
--- a/public/Test-DbaDbRecoveryModel.ps1
+++ b/public/Test-DbaDbRecoveryModel.ps1
@@ -98,9 +98,9 @@ function Test-DbaDbRecoveryModel {
                             WHEN d.recovery_model = 1 AND drs.last_log_backup_lsn IS NOT NULL THEN 1
                             ELSE 0
                            END AS IsReallyInFullRecoveryModel
-                  FROM sys.databases AS D
+                  FROM sys.databases AS d
                     INNER JOIN sys.database_recovery_status AS drs
-                       ON D.database_id = drs.database_id
+                       ON d.database_id = drs.database_id
                   WHERE d.recovery_model = $recoveryCode"
 
         if ($Database) {


### PR DESCRIPTION
I was getting the following results on a system with a case sensitive collation (Latin1_General_100_CS_AS)

WARNING: [19:42:15][Test-DbaDbRecoveryModel] Error occurred while establishing connection to xxxxxxxxxx | The multi-part identifier "d.recovery_model" could not be bound. The multi-part identifier "d.name" could not be bound. The multi-part identifier "d.recovery_model" could not be bound. The multi-part identifier "d.recovery_model_desc" could not be bound. The multi-part identifier "d.recovery_model" could not be bound.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Be able to use dbacheck "PseudoSimple" that uses this dbatool function

### Approach
<!-- How does this change solve that purpose -->
Using the same casing for the table alias will resolve any casing issues with case sensitive collations.L
