### PR TITLE
Make Get-DbaPrivilege more efficient

### DIFF
--- a/public/Get-DbaPrivilege.ps1
+++ b/public/Get-DbaPrivilege.ps1
@@ -156,7 +156,7 @@ function Get-DbaPrivilege {
                 }
 
                 Write-Message -Level Verbose -Message "Getting Logon as a service Privileges on $computer"
-                $losEntries = $secPol | Where-Object {$_ -like "SeServiceLogonRight*"}
+                $losEntries = $secPol | Where-Object { $_ -like "SeServiceLogonRight*" }
 
                 $los = if ($null -ne $losEntries) {
                     $losEntries.Substring(22).split(",") | ForEach-Object {


### PR DESCRIPTION
Perform both the data extract and clean-up of the security policy file in just one trip to the remote computer(s). The extract is saved into the object `$secPol`, and further processing is made from only this object, which saves having to reach out to the remote computer(s) multiple times.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [x] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
Make code more efficient

### Approach
The cmdlet was making multiple trips to the computer(s) to get data for each of the security policies. The code has been updated so that only one trip is made to the remote computer(s) and the data is saved into the `$secPol` object. Then further processing is made from only this object, which saves multiple trips to the remote computer(s)
