### PR TITLE
Fix for #9456: duplicated results from Export-DbaUser when using -Passthru

### DIFF
--- a/public/Export-DbaUser.ps1
+++ b/public/Export-DbaUser.ps1
@@ -267,7 +267,7 @@ function Export-DbaUser {
                     }
                 }
 
-                if ($Passthru){
+                if ($Passthru) {
                     $progressMessage = "Generating script for user $dbuser"
                 } else {
                     $progressMessage = "Generating script ($FilePath) for user $dbuser"

--- a/public/Export-DbaUser.ps1
+++ b/public/Export-DbaUser.ps1
@@ -252,6 +252,9 @@ function Export-DbaUser {
 
             $stepCounter = 0
             foreach ($dbuser in $users) {
+                # Clear output for each user
+                $outsql = @()
+                $sql = ""
 
                 if ($GenerateFilePerUser) {
                     if ($null -eq $usersProcessed[$dbuser.Name]) {
@@ -264,7 +267,12 @@ function Export-DbaUser {
                     }
                 }
 
-                Write-ProgressHelper -TotalSteps $users.Count -Activity "Exporting from $($db.Name)" -StepNumber ($stepCounter++) -Message "Generating script ($FilePath) for user $dbuser"
+                if ($Passthru){
+                    $progressMessage = "Generating script for user $dbuser"
+                } else {
+                    $progressMessage = "Generating script ($FilePath) for user $dbuser"
+                }
+                Write-ProgressHelper -TotalSteps $users.Count -Activity "Exporting from $($db.Name)" -StepNumber ($stepCounter++) -Message $progressMessage
 
                 #setting database
                 if (((Test-Bound ScriptingOptionsObject) -and $ScriptingOptionsObject.IncludeDatabaseContext) -or - (Test-Bound ScriptingOptionsObject -Not)) {
@@ -366,7 +374,7 @@ function Export-DbaUser {
                             $withGrant = " WITH GRANT OPTION"
                             $grantDatabasePermission = 'GRANT'
                         } else {
-                            $withGrant = " "
+                            $withGrant = ""
                             $grantDatabasePermission = $databasePermission.PermissionState.ToString().ToUpper()
                         }
                         if ($Template) {
@@ -526,7 +534,7 @@ function Export-DbaUser {
                             $withGrant = " WITH GRANT OPTION"
                             $grantObjectPermission = 'GRANT'
                         } else {
-                            $withGrant = " "
+                            $withGrant = ""
                             $grantObjectPermission = $objectPermission.PermissionState.ToString().ToUpper()
                         }
                         if ($Template) {
@@ -573,9 +581,6 @@ function Export-DbaUser {
                             $sql | Out-File -Encoding:$Encoding -FilePath $FilePath -Append
                         }
                     }
-                    # Clear variables for next user
-                    $outsql = @()
-                    $sql = ""
                 } else {
                     $sql
                 }


### PR DESCRIPTION
- Move clearing the output variables outside of the `if (-not $Passthru)` block. This fixes the issue of repeated results when using -Passthru.
- Move clearing the output variables to the top of the loop to be more explicit and not rely on empty assignment for the first object.
- If using -Passthru, don't output the filepath in the progress message.
- Just a formatting fix, if there is no "WITH GRANT OPTION", just use an empty string instead of a space. This removes the double spaces in the output.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9456 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
If passthru was used then the output was not cleared between users.

### Approach
Move the variable assignment lines up to the top of the loop. Always clear them.

### Commands to test
See issue for sample commands.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
