### PR TITLE
Test-DBALsnChain - Fix missing log backup (#7515)

### DIFF
--- a/private/functions/Test-DbaLsnChain.ps1
+++ b/private/functions/Test-DbaLsnChain.ps1
@@ -83,7 +83,7 @@ function Test-DbaLsnChain {
         }
         $DiffAnchor = $TestHistory | Where-Object { $_.$TypeName -in ('Database Differential', 'Differential') }
         #Check for no more than a single Differential backup
-        if (($DiffAnchor.FirstLSN | Select-Object -unique | Measure-Object).count -gt 1) {
+        if (($DiffAnchor.FirstLSN | Select-Object -Unique | Measure-Object).count -gt 1) {
             Write-Message -Level Warning -Message "More than 1 differential backup, not supported"
             return $false
             break;
@@ -96,7 +96,8 @@ function Test-DbaLsnChain {
 
 
         #Check T-log LSNs form a chain.
-        $TranLogBackups = $TestHistory | Where-Object { $_.$TypeName -in ('Transaction Log', 'Log') -and (($_.DatabaseBackupLSN.ToString() -eq $FullDBAnchor.CheckPointLSN) -or (($_.DatabaseBackupLSN.ToString() -ne $FullDBAnchor.CheckPointLSN) -and ($TranLogBackups[$i].FirstLSN -gt $FullDBAnchor.CheckPointLSN)))
+        $TranLogBackups = $TestHistory | Where-Object {
+            $_.$TypeName -in ('Transaction Log', 'Log') -and (($_.DatabaseBackupLSN.ToString() -eq $FullDBAnchor.CheckPointLSN) -or (($_.DatabaseBackupLSN.ToString() -ne $FullDBAnchor.CheckPointLSN) -and ($TranLogBackups[$i].FirstLSN -gt $FullDBAnchor.CheckPointLSN)))
         } | Sort-Object -Property LastLSN, FirstLsn
 
         for ($i = 0; $i -lt ($TranLogBackups.count)) {

--- a/private/functions/Test-DbaLsnChain.ps1
+++ b/private/functions/Test-DbaLsnChain.ps1
@@ -96,7 +96,7 @@ function Test-DbaLsnChain {
 
 
         #Check T-log LSNs form a chain.
-        $TranLogBackups = $TestHistory | Where-Object { $_.$TypeName -in ('Transaction Log', 'Log') -and $_.DatabaseBackupLSN -eq $FullDBAnchor.CheckPointLSN } | Sort-Object -Property LastLSN, FirstLsn
+        $TranLogBackups = $TestHistory | Where-Object { $_.$TypeName -in ('Transaction Log', 'Log') -and (($_.DatabaseBackupLSN -eq $FullDBAnchor.CheckPointLSN) -or ($_.FirstLSN -gt $FullDBAnchor.CheckPointLSN))} | Sort-Object -Property LastLSN, FirstLsn
         for ($i = 0; $i -lt ($TranLogBackups.count)) {
             Write-Message -Level Debug -Message "looping t logs"
             if ($i -eq 0) {

--- a/private/functions/Test-DbaLsnChain.ps1
+++ b/private/functions/Test-DbaLsnChain.ps1
@@ -96,11 +96,13 @@ function Test-DbaLsnChain {
 
 
         #Check T-log LSNs form a chain.
-        $TranLogBackups = $TestHistory | Where-Object { $_.$TypeName -in ('Transaction Log', 'Log') -and (($_.DatabaseBackupLSN -eq $FullDBAnchor.CheckPointLSN) -or ($_.FirstLSN -gt $FullDBAnchor.CheckPointLSN))} | Sort-Object -Property LastLSN, FirstLsn
+        $TranLogBackups = $TestHistory | Where-Object { $_.$TypeName -in ('Transaction Log', 'Log') -and (($_.DatabaseBackupLSN.ToString() -eq $FullDBAnchor.CheckPointLSN) -or (($_.DatabaseBackupLSN.ToString() -ne $FullDBAnchor.CheckPointLSN) -and ($TranLogBackups[$i].FirstLSN -gt $FullDBAnchor.CheckPointLSN)))
+        } | Sort-Object -Property LastLSN, FirstLsn
+
         for ($i = 0; $i -lt ($TranLogBackups.count)) {
             Write-Message -Level Debug -Message "looping t logs"
             if ($i -eq 0) {
-                if ($TranLogBackups[$i].FirstLSN -gt $TlogAnchor.LastLSN) {
+                if ($TranLogBackups[$i].FirstLSN.ToString() -gt $TlogAnchor.LastLSN) {
                     Write-Message -Level Warning -Message "Break in LSN Chain between $($TlogAnchor.FullName) and $($TranLogBackups[($i)].FullName) "
                     Write-Message -Level Verbose -Message "Anchor $($TlogAnchor.LastLSN) - FirstLSN $($TranLogBackups[$i].FirstLSN)"
                     return $false

--- a/private/functions/Test-DbaLsnChain.ps1
+++ b/private/functions/Test-DbaLsnChain.ps1
@@ -100,26 +100,26 @@ function Test-DbaLsnChain {
             $_.$TypeName -in ('Transaction Log', 'Log') -and (($_.DatabaseBackupLSN.ToString() -eq $FullDBAnchor.CheckPointLSN) -or (($_.DatabaseBackupLSN.ToString() -ne $FullDBAnchor.CheckPointLSN) -and ($TranLogBackups[$i].FirstLSN -gt $FullDBAnchor.CheckPointLSN)))
         } | Sort-Object -Property LastLSN, FirstLsn
 
-        for ($i = 0; $i -lt ($TranLogBackups.count)) {
-            Write-Message -Level Debug -Message "looping t logs"
-            if ($i -eq 0) {
-                if ($TranLogBackups[$i].FirstLSN.ToString() -gt $TlogAnchor.LastLSN) {
-                    Write-Message -Level Warning -Message "Break in LSN Chain between $($TlogAnchor.FullName) and $($TranLogBackups[($i)].FullName) "
-                    Write-Message -Level Verbose -Message "Anchor $($TlogAnchor.LastLSN) - FirstLSN $($TranLogBackups[$i].FirstLSN)"
-                    return $false
-                    break
-                }
-            } else {
-                if ($TranLogBackups[($i - 1)].LastLsn -ne $TranLogBackups[($i)].FirstLSN -and ($TranLogBackups[($i)] -ne $TranLogBackups[($i - 1)])) {
-                    Write-Message -Level Warning -Message "Break in transaction log between $($TranLogBackups[($i-1)].FullName) and $($TranLogBackups[($i)].FullName) "
-                    return $false
-                    break
-                }
+    for ($i = 0; $i -lt ($TranLogBackups.count)) {
+        Write-Message -Level Debug -Message "looping t logs"
+        if ($i -eq 0) {
+            if ($TranLogBackups[$i].FirstLSN.ToString() -gt $TlogAnchor.LastLSN) {
+                Write-Message -Level Warning -Message "Break in LSN Chain between $($TlogAnchor.FullName) and $($TranLogBackups[($i)].FullName) "
+                Write-Message -Level Verbose -Message "Anchor $($TlogAnchor.LastLSN) - FirstLSN $($TranLogBackups[$i].FirstLSN)"
+                return $false
+                break
             }
-            $i++
-
+        } else {
+            if ($TranLogBackups[($i - 1)].LastLsn -ne $TranLogBackups[($i)].FirstLSN -and ($TranLogBackups[($i)] -ne $TranLogBackups[($i - 1)])) {
+                Write-Message -Level Warning -Message "Break in transaction log between $($TranLogBackups[($i-1)].FullName) and $($TranLogBackups[($i)].FullName) "
+                return $false
+                break
+            }
         }
-        Write-Message -Level VeryVerbose -Message "Passed LSN Chain checks"
-        return $true
+        $i++
+
     }
+    Write-Message -Level VeryVerbose -Message "Passed LSN Chain checks"
+    return $true
+}
 }

--- a/tests/Test-DbaBackupInformation.Tests.ps1
+++ b/tests/Test-DbaBackupInformation.Tests.ps1
@@ -58,10 +58,6 @@ Describe "$commandname Integration Tests" -Tag 'IntegrationTests' {
             It "Should pass as all systems Green" {
                 $output = $BackupHistory | Test-DbaBackupInformation -SqlInstance NotExist -WarningVariable warnvar -WarningAction SilentlyContinue
                 ($output.Count) -gt 0 | Should be $true
-                    foreach ($o in $output)
-                    {
-                        Write-Host $o.FullName, $o.IsVerified
-                    }
                 "False" -in ($Output.IsVerified) | Should be $False
                 ($null -ne $WarnVar) | Should be $True
             }

--- a/tests/Test-DbaBackupInformation.Tests.ps1
+++ b/tests/Test-DbaBackupInformation.Tests.ps1
@@ -58,7 +58,11 @@ Describe "$commandname Integration Tests" -Tag 'IntegrationTests' {
             It "Should pass as all systems Green" {
                 $output = $BackupHistory | Test-DbaBackupInformation -SqlInstance NotExist -WarningVariable warnvar -WarningAction SilentlyContinue
                 ($output.Count) -gt 0 | Should be $true
-                $false -in ($Output.IsVerified) | Should be $False
+                    foreach ($o in $output)
+                    {
+                        Write-Host $o.FullName, $o.IsVerified
+                    }
+                "False" -in ($Output.IsVerified) | Should be $False
                 ($null -ne $WarnVar) | Should be $True
             }
         }

--- a/tests/Test-DbaLsnChain.Tests.ps1
+++ b/tests/Test-DbaLsnChain.Tests.ps1
@@ -5,11 +5,11 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$commandname Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'FilteredRestoreFiles', 'Continue', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -22,7 +22,7 @@ Describe "$commandname Integration Tests" -Tag 'IntegrationTests' {
 
             $filteredFiles = $header | Select-DbaBackupInformation
             It "Should Return 7" {
-                $FilteredFiles.count | should be 7
+                $FilteredFiles.count | Should be 7
             }
             It "Should return True" {
                 $Output = Test-DbaLsnChain -FilteredRestoreFiles $FilteredFiles -WarningAction SilentlyContinue


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ x] Bug fix (non-breaking change, fixes #<!--7515--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixing issue with Test-DBALsnChain that skips over a log backup that is written during a full backup that is being processed, but has not written a CheckpointLSN that can be used for the DatabaseBackupLSN record on the log backup.  

### Approach
Adding an additional check to see if the FirstLSN of the transaction log backup is greater than the CheckpointLSN of the full backup (instead of the log backup DatabaseBackupLSN being equal to the FULL backup's CheckpointLSN).  This allows for the first log backup after the FULL backup to not be skipped for evaluation in the backup chain for restore purposes.
Manual Pester Results:
![test-dbalsnchain_test_results](https://github.com/user-attachments/assets/ba99c014-bc4a-4259-bc12-083f415bd391)

LSN data from backup files affected, and the error message received:
![Backup_lsn_data](https://github.com/user-attachments/assets/e96049f4-2576-4a1a-bfae-f81845ce742f)

