### PR TITLE
Get-DbaHelpIndex - Bad joins based on Index Name instead of Index ID when Indexes in same DB named the same #9447

### DIFF
--- a/public/Get-DbaHelpIndex.ps1
+++ b/public/Get-DbaHelpIndex.ps1
@@ -404,7 +404,7 @@ function Get-DbaHelpIndex {
                                 name AS IndexName ,
                                 STUFF((SELECT   N', ' + ColumnName
                                     FROM     cteIndex ci2
-                                    WHERE    ci2.name = ci.name
+                                    WHERE    ci2.name = ci.name AND ci2.object_id=ci.object_id
                                                 AND ci2.is_included_column = 0
                                     GROUP BY ci2.index_column_id ,
                                                 ci2.ColumnName
@@ -414,7 +414,7 @@ function Get-DbaHelpIndex {
                                     2, N'') AS KeyColumns ,
                                 ISNULL(STUFF((SELECT    N',  ' + ColumnName
                                             FROM      cteIndex ci3
-                                            WHERE     ci3.name = ci.name
+                                            WHERE     ci3.name = ci.name AND ci3.object_id=ci.object_id
                                                         AND ci3.is_included_column = 1
                                             GROUP BY  ci3.index_column_id ,
                                                         ci3.ColumnName
@@ -801,7 +801,7 @@ function Get-DbaHelpIndex {
                                 name AS IndexName ,
                                 STUFF((SELECT   N', ' + ColumnName
                                     FROM     cteIndex ci2
-                                    WHERE    ci2.name = ci.name
+                                    WHERE    ci2.name = ci.name and ci2.object_id=ci.object_id
                                                 AND ci2.is_included_column = 0
                                     GROUP BY ci2.index_column_id ,
                                                 ci2.ColumnName
@@ -811,7 +811,7 @@ function Get-DbaHelpIndex {
                                     2, N'') AS KeyColumns ,
                                 ISNULL(STUFF((SELECT    N',  ' + ColumnName
                                             FROM      cteIndex ci3
-                                            WHERE     ci3.name = ci.name
+                                            WHERE     ci3.name = ci.name and ci3.object_id=ci.object_id
                                                         AND ci3.is_included_column = 1
                                             GROUP BY  ci3.index_column_id ,
                                                         ci3.ColumnName

--- a/public/Get-DbaHelpIndex.ps1
+++ b/public/Get-DbaHelpIndex.ps1
@@ -1,6 +1,5 @@
 function Get-DbaHelpIndex {
     <#
-    test
     .SYNOPSIS
         Returns size, row and configuration information for indexes in databases.
 

--- a/public/Get-DbaHelpIndex.ps1
+++ b/public/Get-DbaHelpIndex.ps1
@@ -1,5 +1,6 @@
 function Get-DbaHelpIndex {
     <#
+    test
     .SYNOPSIS
         Returns size, row and configuration information for indexes in databases.
 

--- a/public/Get-DbaHelpIndex.ps1
+++ b/public/Get-DbaHelpIndex.ps1
@@ -412,7 +412,7 @@ function Get-DbaHelpIndex {
                                 FOR   XML PATH(N'') ,
                                         TYPE).value(N'.[1]', N'nvarchar(1000)'), 1,
                                     2, N'') AS KeyColumns ,
-                                ISNULL(STUFF((SELECT    N',  ' + ColumnName
+                                ISNULL(STUFF((SELECT    N', ' + ColumnName
                                             FROM      cteIndex ci3
                                             WHERE     ci3.name = ci.name AND ci3.object_id=ci.object_id
                                                         AND ci3.is_included_column = 1
@@ -809,7 +809,7 @@ function Get-DbaHelpIndex {
                                 FOR   XML PATH(N'') ,
                                         TYPE).value(N'.[1]', N'nvarchar(1000)'), 1,
                                     2, N'') AS KeyColumns ,
-                                ISNULL(STUFF((SELECT    N',  ' + ColumnName
+                                ISNULL(STUFF((SELECT    N', ' + ColumnName
                                             FROM      cteIndex ci3
                                             WHERE     ci3.name = ci.name and ci3.object_id=ci.object_id
                                                         AND ci3.is_included_column = 1


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9447  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [x] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Fix #9447 

### Approach
<!-- How does this change solve that purpose -->
Changed the sql code by adding a new where condition
Added a new unit test

### Commands to test
<!-- if these are the examples in the help just note it as such -->
 .\tests\manual.pester.ps1 -Path .\tests\Get-DbaHelpIndex.Tests.ps1   -TestIntegration
 
 The original function will fail the following new unit test.
     Context Result is correct for tables having the indexes with the same names
      [+] Table t1 has correct index key columns and included columns 7ms
      [+] Table t2 has correct index key columns and included columns 12ms

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Here is a simple reproducible test.
create a test database with tables having an index each with the same name.

create database test1;
go
use test1;
go
create table t1(c1 int,c2 int,c3 int,c4 int);
create nonclustered index idx_1 on t1(c1) include(c3);
create table t2(c1 int,c2 int,c3 int,c4 int);
create nonclustered index idx_1 on t2(c1,c2) include(c3,c4); 
go

Run get-dbahelpindex to check. 
For example:
get-dbahelpindex -sqlinstance 'localhost,14330' -database test1|out-gridview

The existing version returns the following result, which is wrong for both tables.
![image](https://github.com/user-attachments/assets/61e434a9-4d7e-4ccd-bf3d-30465330afe2)

The proposed version returns the following result, which is correct.
![image](https://github.com/user-attachments/assets/b07faff2-8f48-4d6c-b2ed-6b5322d952d3)

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
