### PR TITLE
Import-DbaCsv, map correct types for BulkCopy

### DIFF
--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -683,7 +683,6 @@ function Import-DbaCsv {
                             # we can get default columns, all strings. This "fills" the $reader.Columns list, that we use later
                             $null = $reader.GetFieldHeaders()
                             # we get the table definition
-                            Write-Host -fore magenta "ddd $Database $table $schema"
                             # we do not use $server because the connection is active here
                             $tableDef = Get-DbaDbTable $instance -SqlCredential $SqlCredential -Database $Database -Table $table -Schema $schema
 

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -746,7 +746,7 @@ function Import-DbaCsv {
                                             # now we know the column, we need to get the type, let's be extra-obvious here
                                             $colTypeFromSql = $sqlCol.DataType
                                             # and now we translate to C# type
-                                            $colTypeCSharp = ConvertTo-CSharpType -DataType $colTypeFromSql
+                                            $colTypeCSharp = ConvertTo-DotnetType -DataType $colTypeFromSql
                                             # and now we assign the type to the LumenCsv column
                                             foreach ($csvCol in $reader.Columns) {
                                                 if ($csvCol.Name -eq $colNameFromCsv) {
@@ -796,7 +796,7 @@ function Import-DbaCsv {
                                         if ($sqlColComparison -eq $colNameFromSql) {
                                             $colTypeFromSql = $sqlCol.DataType
                                             # and now we translate to C# type
-                                            $colTypeCSharp = ConvertTo-CSharpType -DataType $colTypeFromSql
+                                            $colTypeCSharp = ConvertTo-DotnetType -DataType $colTypeFromSql
                                             # assign it to the column
                                             $newcol.Type = $colTypeCSharp
                                             # and adding to the column collection

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -436,15 +436,20 @@ function Import-DbaCsv {
             $null = $sqlcmd.Parameters.AddWithValue('table', $table)
 
             $result = @()
-            $reader = $sqlcmd.ExecuteReader()
-            foreach ($dataRow in $reader) {
-                $result += [PSCustomObject]@{
-                    Name     = $dataRow[0]
-                    DataType = $dataRow[1]
-                    Index    = $dataRow[2]
+            try {
+                $reader = $sqlcmd.ExecuteReader()
+                foreach ($dataRow in $reader) {
+                    $result += [PSCustomObject]@{
+                        Name     = $dataRow[0]
+                        DataType = $dataRow[1]
+                        Index    = $dataRow[2]
+                    }
                 }
+                $reader.Close()
+            } catch {
+                # callers report back the error if $result is empty
             }
-            $reader.Close()
+
             return $result
         }
 

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -390,7 +390,7 @@ function Import-DbaCsv {
 
 
 
-        function ConvertTo-CSharpType {
+        function ConvertTo-DotnetType {
             param (
                 [string]$DataType
             )

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -730,7 +730,7 @@ function Import-DbaCsv {
                                 # we do not use $server because the connection is active here
                                 $tableDef = Get-TableDefinitionFromInfoSchema -table $table -schema $schema -sqlconn $sqlconn
                                 if ($tableDef.Length -eq 0) {
-                                    Stop-Function -Message "Could not fetch table definition for table $table in schema $schema" -ErrorRecord $_
+                                    Stop-Function -Message "Could not fetch table definition for table $table in schema $schema"
                                 }
                                 foreach ($bcMapping in $bulkcopy.ColumnMappings) {
                                     # loop over mappings, we need to be careful and assign the correct type
@@ -759,7 +759,7 @@ function Import-DbaCsv {
                                 # start by getting the table definition
                                 $tableDef = Get-TableDefinitionFromInfoSchema -table $table -schema $schema -sqlconn $sqlconn
                                 if ($tableDef.Length -eq 0) {
-                                    Stop-Function -Message "Could not fetch table definition for table $table in schema $schema" -ErrorRecord $_
+                                    Stop-Function -Message "Could not fetch table definition for table $table in schema $schema"
                                 }
                                 if ($bulkcopy.ColumnMappings.Count -eq 0) {
                                     # if we land here, we aren't (probably ? ) forcing any mappings, but we kinda need them for later
@@ -830,7 +830,6 @@ function Import-DbaCsv {
                         $bulkCopy.Add_SqlRowsCopied( {
                                 $script:totalRowsCopied += (Get-AdjustedTotalRowsCopied -ReportedRowsCopied $args[1].RowsCopied -PreviousRowsCopied $script:prevRowsCopied).NewRowCountAdded
 
-                                #Write-Message -Level Verbose -FunctionName "Import-DbaCsv" -Message " The bulk copy library reported RowsCopied = $($args[1].RowsCopied). The previous RowsCopied = $($script:prevRowsCopied). The adjusted total rows copied = $($script:totalRowsCopied)"
                                 Write-Message -Level Verbose -FunctionName "Import-DbaCsv" -Message " Total rows copied = $($script:totalRowsCopied)"
                                 # progress is written by the ProgressStream callback
                                 # save the previous count of rows copied to be used on the next event notification

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -687,7 +687,7 @@ function Import-DbaCsv {
                             $tableDef = Get-DbaDbTable $instance -SqlCredential $SqlCredential -Database $Database -Table $table -Schema $schema
 
                             if ($tableDef.Count -ne 1) {
-                                Stop-Function -Message "Could not create $schema" -ErrorRecord $_
+                                Stop-Function -Message "Could not fetch table definition for table $table in schema $schema" -ErrorRecord $_
                             }
                             $tableDef = $tableDef[0]
                             foreach ($bcMapping in $bulkcopy.ColumnMappings) {

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -125,18 +125,19 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
         It "works with tables which have non-varchar types (guid, bit)" {
             # See #9433
+            $filePath = '.\foo.csv'
             $server = Connect-DbaInstance $script:instance1 -Database tempdb
             Invoke-DbaQuery -SqlInstance $server -Query 'CREATE TABLE WithGuidsAndBits (one_guid UNIQUEIDENTIFIER, one_bit BIT)'
             $row = [pscustomobject]@{
                 one_guid = (New-Guid).Guid
                 one_bit  = 1
             }
-            $row | Export-Csv ./foo.csv
-            $result = Import-DbaCsv -Path ./foo.csv -SqlInstance $server -Database tempdb -Table 'WithGuidsAndBits'
+            $row | Export-Csv $filePath
+            $result = Import-DbaCsv -Path $filePath -SqlInstance $server -Database tempdb -Table 'WithGuidsAndBits'
             Invoke-DbaQuery -SqlInstance $server -Query 'DROP TABLE WithGuidsAndBits'
 
             $result.RowsCopied | Should -Be 1
-            Remove-Item ./foo.csv
+            Remove-Item $filePath
         }
     }
 }

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -131,11 +131,10 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
                 one_guid = (New-Guid).Guid
                 one_bit  = 1
             }
-            $row | Export-Csv ./foo.csv 
+            $row | Export-Csv ./foo.csv
             $result = Import-DbaCsv -Path ./foo.csv -SqlInstance $server -Database tempdb -Table 'WithGuidsAndBits'
             Invoke-DbaQuery -SqlInstance $server -Query 'DROP TABLE WithGuidsAndBits'
 
-            $result | Should -Not -BeNullOrEmpty
             $result.RowsCopied | Should -Be 1
             Remove-Item ./foo.csv
         }

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -132,7 +132,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
                 one_guid = (New-Guid).Guid
                 one_bit  = 1
             }
-            $row | Export-Csv $filePath
+            $row | Export-Csv -Path $filePath -NoTypeInformation
             $result = Import-DbaCsv -Path $filePath -SqlInstance $server -Database tempdb -Table 'WithGuidsAndBits'
             Invoke-DbaQuery -SqlInstance $server -Query 'DROP TABLE WithGuidsAndBits'
 

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -15,7 +15,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     AfterAll {
-        Invoke-DbaQuery -SqlInstance $script:instance1, $script:instance2 -Database tempdb -Query "drop table SuperSmall"
+        Invoke-DbaQuery -SqlInstance $script:instance1, $script:instance2 -Database tempdb -Query "drop table SuperSmall; drop table CommaSeparatedWithHeader"
     }
 
     $path = "$script:appveyorlabrepo\csv\SuperSmall.csv"
@@ -95,6 +95,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $result.RowsCopied | Should -Be 1
             $result.Database | Should -Be tempdb
             $result.Table | Should -Be CommaSeparatedWithHeader
+            Invoke-DbaQuery -SqlInstance $server -Query 'DROP TABLE NoHeaderRow'
         }
 
         It "works with NoHeaderRow" {
@@ -109,6 +110,34 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $result | Should -Not -BeNullOrEmpty
             $result.RowsCopied | Should -Be 3
             $data[0].c1 | Should -Be 'firstcol'
+        }
+
+        It "works with tables which have non-varchar types (date)" {
+            # See #9433
+            $server = Connect-DbaInstance $script:instance1 -Database tempdb
+            Invoke-DbaQuery -SqlInstance $server -Query 'CREATE TABLE WithTypes ([date] DATE, col1 VARCHAR(50), col2 VARCHAR(50))'
+            $result = Import-DbaCsv -Path $CommaSeparatedWithHeader -SqlInstance $server -Database tempdb -Table 'WithTypes'
+            Invoke-DbaQuery -SqlInstance $server -Query 'DROP TABLE WithTypes'
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.RowsCopied | Should -Be 1
+        }
+
+        It "works with tables which have non-varchar types (guid, bit)" {
+            # See #9433
+            $server = Connect-DbaInstance $script:instance1 -Database tempdb
+            Invoke-DbaQuery -SqlInstance $server -Query 'CREATE TABLE WithGuidsAndBits (one_guid UNIQUEIDENTIFIER, one_bit BIT)'
+            $row = [pscustomobject]@{
+                one_guid = (New-Guid).Guid
+                one_bit  = 1
+            }
+            $row | Export-Csv ./foo.csv 
+            $result = Import-DbaCsv -Path ./foo.csv -SqlInstance $server -Database tempdb -Table 'WithGuidsAndBits'
+            Invoke-DbaQuery -SqlInstance $server -Query 'DROP TABLE WithGuidsAndBits'
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.RowsCopied | Should -Be 1
+            Remove-Item ./foo.csv
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #9433 and others )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Enlarge the usecase of Import-DbaCsv. 
Right now it's either going to never fail (creating a table of all nvarchar(max)) or it will as soon as the table has some not-that-weird types (bit or guid, for example).
This should also greatly speed-up loads to existing tables without users needing to "stage" to a nvarchar(max) table and then copying over to the destination table.
I'm guessing it also helps without even counting the "stage-then-move" bit: loading a pre-existing table with the correct types should be faster than loading to a nvarchar(max) table.

### Approach
It's long, and windy, but I made the code redundant and verbose (hoperfully readable and obvious as well) rather than short and speedy. My 2c here is that it's a bit of code that is rather convoluted and it's better to be explicit more than anything. Cost (as in milliseconds spent) on adding the proper machinery is minimal if you take into account loading even just 1k rows.

I'm unsure about approaching the "get the types from the table" using SMO (like this version) or if it'd be better to just use a quicker query going directly to system tables to get "name, datatype" resultset and use that for the mapping. Pro of that is that we don't open another connection, because at that point of the function one has already been established and a transaction is pending, so re-using $server for Get-DbaDbTable ends up in errors.

There's another bit that's missing which is enabling this on a csv that has no headers... not sure if it's needed by users but if so the code gets longer because we can't let lumen do "quite a bit of work" (the `$reader.GetFieldHeaders()` call)

That being said, @potatoqualitee is the original creator and MAY have an opinionated view on how to tackle that. 
@petervandivier : I got it working for most of my tables, but you may want to give it a whirl and maybe test extensively with any type you can throw at it.

### Commands to test

The one on the report is good, short and simple

```
Invoke-DbaQuery `
    -SqlInstance localhost `
    -Database tempdb `
    -Query "create table foo ([Guid] uniqueidentifier);"

New-Guid | Export-Csv ./foo.csv 

Import-DbaCsv `
    -SqlInstance localhost `
    -Database tempdb `
    -Table foo `
    -Path ./foo.csv `
    -SingleColumn
```


NB: this is a first PROPOSAL. If this approach is "accepted" I'm going to add a few tests for it in new commits.
