### PR TITLE
Refactor AgHadr tests

### DIFF
--- a/tests/Disable-DbaAgHadr.Tests.ps1
+++ b/tests/Disable-DbaAgHadr.Tests.ps1
@@ -13,8 +13,10 @@ Describe "$CommandName Unit Tests" -Tag "UnitTests" {
     }
 }
 
+# $script:instance3 is used for Availability Group tests and needs Hadr service setting enabled
+
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
-    BeforeAll {
+    AfterAll {
         Enable-DbaAgHadr -SqlInstance $script:instance3 -Confirm:$false -Force
     }
 

--- a/tests/Enable-DbaAgHadr.Tests.ps1
+++ b/tests/Enable-DbaAgHadr.Tests.ps1
@@ -15,15 +15,7 @@ Describe "$CommandName Unit Tests" -Tag "UnitTests" {
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
-        $current = Get-DbaAgHadr -SqlInstance $script:instance3 # for appveyor $script:instance2
-        if ($current.IsHadrEnabled) {
-            Disable-DbaAgHadr -SqlInstance $script:instance3 -Confirm:$false -WarningAction SilentlyContinue -Force
-        }
-    }
-    AfterAll {
-        if (-not $current.IsHadrEnabled) {
-            Disable-DbaAgHadr -SqlInstance $script:instance3 -Confirm:$false -WarningAction SilentlyContinue -Force
-        }
+        Disable-DbaAgHadr -SqlInstance $script:instance3 -Confirm:$false -Force
     }
 
     $results = Enable-DbaAgHadr -SqlInstance $script:instance3 -Confirm:$false -Force

--- a/tests/Get-DbaAgHadr.Tests.ps1
+++ b/tests/Get-DbaAgHadr.Tests.ps1
@@ -22,4 +22,4 @@ Describe "$CommandName Integration Test" -Tag "IntegrationTests" {
             $results.IsHadrEnabled | Should -Be $true
         }
     }
-}
+} #$script:instance2 for appveyor

--- a/tests/Get-DbaAgHadr.Tests.ps1
+++ b/tests/Get-DbaAgHadr.Tests.ps1
@@ -13,11 +13,13 @@ Describe "$CommandName Unit Tests" -Tag "UnitTests" {
     }
 }
 
+# $script:instance3 is used for Availability Group tests and needs Hadr service setting enabled
+
 Describe "$CommandName Integration Test" -Tag "IntegrationTests" {
-    $results = Get-DbaAgHadr -SqlInstance $script:instance2
+    $results = Get-DbaAgHadr -SqlInstance $script:instance3
     Context "Validate output" {
         It "returns the correct properties" {
-            $results.IsHadrEnabled | Should -Not -Be $null
+            $results.IsHadrEnabled | Should -Be $true
         }
     }
 }


### PR DESCRIPTION
This PR only changes tests and no code of the module itself.

Currently `$script:instance3` is used for Availability Group tests and needs Hadr service setting enabled. This is done for AppVeyor in appveyor.SQL2027.ps1 with `$null = Enable-DbaAgHadr -SqlInstance $sqlinstance -Confirm:$false -Force`.

So every test can assume that the instance is configured correctly and has to end the test with a correctly configured instance.

Currently we don't see problems in AppVeyor because Disable-DbaAgHadr.Tests.ps1 is run as last test. But to be able to test locally we need to fix this.