### PR TITLE
Fix test for Get-DbaDump

### DIFF
--- a/tests/Get-DbaDump.Tests.ps1
+++ b/tests/Get-DbaDump.Tests.ps1
@@ -20,7 +20,7 @@ if (-not $env:appveyor) {
             BeforeAll {
                 $server = Connect-DbaInstance -SqlInstance $script:instance1
                 $server.Query("DBCC STACKDUMP")
-                Start-Sleep -Seconds 5
+                $server.Query("DBCC STACKDUMP")
             }
 
             $results = Get-DbaDump -SqlInstance $script:instance1


### PR DESCRIPTION
This PR only changes tests and no code of the module itself.

I don't know why, but creating a second stackdump immediatly triggers the visibility of the stackdumps to Get-DbaDump.

That is much more saver and faster than waiting.