### PR TITLE
Fix tests for Availability Groups

### DIFF
--- a/tests/Add-DbaAgListener.Tests.ps1
+++ b/tests/Add-DbaAgListener.Tests.ps1
@@ -27,8 +27,8 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     }
     Context "creates a listener" {
         It "returns results with proper data" {
-            $results = $ag | Add-DbaAgListener -Name $listenerName -IPAddress 127.0.20.1 -Confirm:$false
-            $results.PortNumber | Should -Be 1433
+            $results = $ag | Add-DbaAgListener -Name $listenerName -IPAddress 127.0.20.1 -Port 14330 -Confirm:$false
+            $results.PortNumber | Should -Be 14330
         }
     }
 } #$script:instance2 for appveyor

--- a/tests/Add-DbaAgReplica.Tests.ps1
+++ b/tests/Add-DbaAgReplica.Tests.ps1
@@ -15,16 +15,16 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $agname = "dbatoolsci_agroup"
-        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
+        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert -Confirm:$false
         $replicaName = $ag.PrimaryReplica
     }
     AfterAll {
-        $null = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname
+        $null = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname -Confirm:$false
     }
     Context "gets ag replicas" {
         # the only way to test, really, is to call New-DbaAvailabilityGroup which calls Add-DbaAgReplica
         $agname = "dbatoolsci_add_replicagroup"
-        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
+        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert -Confirm:$false
         $replicaName = $ag.PrimaryReplica
 
         It "returns results with proper data" {

--- a/tests/Add-DbaAgReplica.Tests.ps1
+++ b/tests/Add-DbaAgReplica.Tests.ps1
@@ -13,14 +13,19 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
     }
 }
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
+    BeforeAll {
+        $agname = "dbatoolsci_agroup"
+        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
+        $replicaName = $ag.PrimaryReplica
+    }
     AfterAll {
-        Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname -Confirm:$false
+        $null = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname
     }
     Context "gets ag replicas" {
         # the only way to test, really, is to call New-DbaAvailabilityGroup which calls Add-DbaAgReplica
         $agname = "dbatoolsci_add_replicagroup"
-        $null = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Confirm:$false -Certificate dbatoolsci_AGCert
-
+        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
+        $replicaName = $ag.PrimaryReplica
 
         It "returns results with proper data" {
             $results = Get-DbaAgReplica -SqlInstance $script:instance3
@@ -30,8 +35,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $results.FailoverMode | Should -Contain 'Manual'
         }
         It "returns just one result" {
-            $server = Connect-DbaInstance -SqlInstance $script:instance3
-            $results = Get-DbaAgReplica -SqlInstance $script:instance3 -Replica $server.DomainInstanceName -AvailabilityGroup $agname
+            $results = Get-DbaAgReplica -SqlInstance $script:instance3 -Replica $replicaName -AvailabilityGroup $agname
             $results.AvailabilityGroup | Should -Be $agname
             $results.Role | Should -Be 'Primary'
             $results.AvailabilityMode | Should -Be 'SynchronousCommit'

--- a/tests/Get-DbaAgListener.Tests.ps1
+++ b/tests/Get-DbaAgListener.Tests.ps1
@@ -16,16 +16,16 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $agname = "dbatoolsci_ag_listener"
-        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Confirm:$false -Certificate dbatoolsci_AGCert |
-            Add-DbaAgListener -IPAddress 127.0.20.1 -Confirm:$false
+        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
+        $ag | Add-DbaAgListener -IPAddress 127.0.20.1 -Port 14330
     }
     AfterAll {
-        $null = Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname -Confirm:$false
+        $null = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname
     }
     Context "gets ags" {
         It "returns results with proper data" {
             $results = Get-DbaAgListener -SqlInstance $script:instance3
-            $results.PortNumber | Should -Contain 1433
+            $results.PortNumber | Should -Contain 14330
         }
     }
 } #$script:instance2 for appveyor

--- a/tests/Get-DbaAgListener.Tests.ps1
+++ b/tests/Get-DbaAgListener.Tests.ps1
@@ -16,11 +16,11 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $agname = "dbatoolsci_ag_listener"
-        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
-        $ag | Add-DbaAgListener -IPAddress 127.0.20.1 -Port 14330
+        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert -Confirm:$false
+        $ag | Add-DbaAgListener -IPAddress 127.0.20.1 -Port 14330 -Confirm:$false
     }
     AfterAll {
-        $null = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname
+        $null = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname -Confirm:$false
     }
     Context "gets ags" {
         It "returns results with proper data" {

--- a/tests/Get-DbaAgReplica.Tests.ps1
+++ b/tests/Get-DbaAgReplica.Tests.ps1
@@ -16,11 +16,11 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $agname = "dbatoolsci_agroup"
-        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
+        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert -Confirm:$false
         $replicaName = $ag.PrimaryReplica
     }
     AfterAll {
-        $null = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname
+        $null = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname -Confirm:$false
     }
     Context "gets ag replicas" {
         It "returns results with proper data" {
@@ -30,7 +30,6 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $results.AvailabilityMode | Should -Contain 'SynchronousCommit'
         }
         It "returns just one result" {
-            $server = Connect-DbaInstance -SqlInstance $script:instance3
             $results = Get-DbaAgReplica -SqlInstance $script:instance3 -Replica $replicaName -AvailabilityGroup $agname
             $results.AvailabilityGroup | Should -Be $agname
             $results.Role | Should -Be 'Primary'

--- a/tests/Get-DbaAgReplica.Tests.ps1
+++ b/tests/Get-DbaAgReplica.Tests.ps1
@@ -16,10 +16,11 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $agname = "dbatoolsci_agroup"
-        $null = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Confirm:$false -Certificate dbatoolsci_AGCert
+        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
+        $replicaName = $ag.PrimaryReplica
     }
     AfterAll {
-        Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname -Confirm:$false
+        $null = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname
     }
     Context "gets ag replicas" {
         It "returns results with proper data" {
@@ -30,7 +31,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         }
         It "returns just one result" {
             $server = Connect-DbaInstance -SqlInstance $script:instance3
-            $results = Get-DbaAgReplica -SqlInstance $script:instance3 -Replica $server.DomainInstanceName -AvailabilityGroup $agname
+            $results = Get-DbaAgReplica -SqlInstance $script:instance3 -Replica $replicaName -AvailabilityGroup $agname
             $results.AvailabilityGroup | Should -Be $agname
             $results.Role | Should -Be 'Primary'
             $results.AvailabilityMode | Should -Be 'SynchronousCommit'

--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -24,14 +24,12 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $password = 'MyV3ry$ecur3P@ssw0rd'
         $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
         $null = New-DbaDbMasterKey -SqlInstance $script:instance3 -Database master -WarningAction SilentlyContinue -ErrorAction Ignore -EnableException:$false -SecurePassword $securePassword -Confirm:$false
-        $null = New-DbaDbCertificate -SqlInstance $script:instance3 -Database master -Name dbatoolsci_AGCert -Subject 'AG Certificate' -ErrorAction Ignore
         $null = New-DbaEndpoint -SqlInstance $script:instance3 -Type DatabaseMirroring -Name dbatoolsci_AGEndpoint -Certificate dbatoolsci_AGCert | Start-DbaEndpoint
         $backup = Get-DbaDatabase -SqlInstance $script:instance3 -Database $dbname | Backup-DbaDatabase
     }
     AfterAll {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname -Confirm:$false
         $null = Remove-DbaEndpoint -SqlInstance $server -Endpoint dbatoolsci_AGEndpoint -Confirm:$false
-        $null = Get-DbaDbCertificate -SqlInstance $server -Certificate dbatoolsci_AGCert | Remove-DbaDbCertificate -Confirm:$false
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname -Confirm:$false
     }
     Context "adds an ag" {

--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -24,7 +24,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $result = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname
     }
     AfterAll {
-        $null = Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbname
+        $null = Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbname -Confirm:$false
     }
     Context "adds an ag" {
         It "returns an ag with a db named" {

--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -21,7 +21,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $null = New-DbaDatabase -SqlInstance $script:instance3 -Database $dbname | Backup-DbaDatabase
     }
     AfterEach {
-        $result = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname
+        $result = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname -Confirm:$false
     }
     AfterAll {
         $null = Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbname -Confirm:$false

--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -28,13 +28,13 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     }
     Context "adds an ag" {
         It "returns an ag with a db named" {
-            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Database $dbname -Certificate dbatoolsci_AGCert -Confirm:$false
+            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Database $dbname -Confirm:$false -Certificate dbatoolsci_AGCert
             $results.AvailabilityDatabases.Name | Should -Be $dbname
             $results.AvailabilityDatabases.Count | Should -Be 1 -Because "There should be only the named database in the group"
         }
         It "returns an ag with no database if one was not named" {
-            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert -Confirm:$false
+            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Confirm:$false -Certificate dbatoolsci_AGCert
             $results.AvailabilityDatabases.Count | Should -Be 0 -Because "No database was named"
         }
     }
-}
+} #$script:instance2 for appveyor

--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -28,12 +28,12 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     }
     Context "adds an ag" {
         It "returns an ag with a db named" {
-            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Database $dbname -Certificate dbatoolsci_AGCert
+            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Database $dbname -Certificate dbatoolsci_AGCert -Confirm:$false
             $results.AvailabilityDatabases.Name | Should -Be $dbname
             $results.AvailabilityDatabases.Count | Should -Be 1 -Because "There should be only the named database in the group"
         }
         It "returns an ag with no database if one was not named" {
-            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
+            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert -Confirm:$false
             $results.AvailabilityDatabases.Count | Should -Be 0 -Because "No database was named"
         }
     }

--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -15,32 +15,26 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
-        $computername = ($script:instance3).Split("\")[0]
         $null = Get-DbaProcess -SqlInstance $script:instance3 -Program 'dbatools PowerShell module - dbatools.io' | Stop-DbaProcess -WarningAction SilentlyContinue
-        $server = Connect-DbaInstance -SqlInstance $script:instance3
         $dbname = "dbatoolsci_addag_agroupdb"
-        $server.Query("create database $dbname")
         $agname = "dbatoolsci_addag_agroup"
-        $password = 'MyV3ry$ecur3P@ssw0rd'
-        $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
-        $null = New-DbaDbMasterKey -SqlInstance $script:instance3 -Database master -WarningAction SilentlyContinue -ErrorAction Ignore -EnableException:$false -SecurePassword $securePassword -Confirm:$false
-        $null = New-DbaEndpoint -SqlInstance $script:instance3 -Type DatabaseMirroring -Name dbatoolsci_AGEndpoint -Certificate dbatoolsci_AGCert | Start-DbaEndpoint
-        $backup = Get-DbaDatabase -SqlInstance $script:instance3 -Database $dbname | Backup-DbaDatabase
+        $null = New-DbaDatabase -SqlInstance $script:instance3 -Database $dbname | Backup-DbaDatabase
+    }
+    AfterEach {
+        $result = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname
     }
     AfterAll {
-        $null = Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname -Confirm:$false
-        $null = Remove-DbaEndpoint -SqlInstance $server -Endpoint dbatoolsci_AGEndpoint -Confirm:$false
-        $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname -Confirm:$false
+        $null = Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbname
     }
     Context "adds an ag" {
         It "returns an ag with a db named" {
-            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Database $dbname -Confirm:$false -Certificate dbatoolsci_AGCert
+            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Database $dbname -Certificate dbatoolsci_AGCert
             $results.AvailabilityDatabases.Name | Should -Be $dbname
             $results.AvailabilityDatabases.Count | Should -Be 1 -Because "There should be only the named database in the group"
         }
         It "returns an ag with no database if one was not named" {
-            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Confirm:$false -Certificate dbatoolsci_AGCert
+            $results = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
             $results.AvailabilityDatabases.Count | Should -Be 0 -Because "No database was named"
         }
     }
-} #$script:instance2 for appveyor
+}

--- a/tests/Remove-DbaAgListener.Tests.ps1
+++ b/tests/Remove-DbaAgListener.Tests.ps1
@@ -17,7 +17,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $agname = "dbatoolsci_ag_removelistener"
         $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Confirm:$false -Certificate dbatoolsci_AGCert
-        $aglistener = $ag | Add-DbaAgListener -IPAddress 127.0.20.1 -Confirm:$false
+        $aglistener = $ag | Add-DbaAgListener -IPAddress 127.0.20.1 -Port 14330 -Confirm:$false
     }
     AfterAll {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname -Confirm:$false

--- a/tests/Set-DbaAgReplica.Tests.ps1
+++ b/tests/Set-DbaAgReplica.Tests.ps1
@@ -16,25 +16,25 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $agname = "dbatoolsci_arepgroup"
-        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
+        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert -Confirm:$false
         $replicaName = $ag.PrimaryReplica
     }
     AfterAll {
-        Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname
+        Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname -Confirm:$false
     }
     Context "sets ag properties" {
         It "returns modified results" {
-            $results = Set-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname -Replica $replicaName -BackupPriority 100
+            $results = Set-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname -Replica $replicaName -BackupPriority 100 -Confirm:$false
             $results.AvailabilityGroup | Should -Be $agname
             $results.BackupPriority | Should -Be 100
         }
         It "returns modified results" {
-            $results = Set-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname -Replica $replicaName -SeedingMode Automatic
+            $results = Set-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname -Replica $replicaName -SeedingMode Automatic -Confirm:$false
             $results.AvailabilityGroup | Should -Be $agname
             $results.SeedingMode | Should -Be Automatic
         }
         It "attempts to add a ReadOnlyRoutingList" {
-            $null = Get-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname | Select-Object -First 1 | Set-DbaAgReplica -ReadOnlyRoutingList nondockersql -WarningAction SilentlyContinue -WarningVariable warn
+            $null = Get-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname | Select-Object -First 1 | Set-DbaAgReplica -ReadOnlyRoutingList nondockersql -WarningAction SilentlyContinue -WarningVariable warn -Confirm:$false
             $warn | Should -match "does not exist. Only availability"
         }
     }

--- a/tests/Set-DbaAgReplica.Tests.ps1
+++ b/tests/Set-DbaAgReplica.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'AvailabilityGroup', 'Replica', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'EndpointUrl', 'ReadonlyRoutingConnectionUrl', 'InputObject', 'EnableException', 'ReadOnlyRoutingList'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'AvailabilityGroup', 'Replica', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'SessionTimeout', 'EndpointUrl', 'ReadonlyRoutingConnectionUrl', 'ReadOnlyRoutingList', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -16,24 +16,25 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $agname = "dbatoolsci_arepgroup"
-        $null = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Confirm:$false -Certificate dbatoolsci_AGCert
+        $ag = New-DbaAvailabilityGroup -Primary $script:instance3 -Name $agname -ClusterType None -FailoverMode Manual -Certificate dbatoolsci_AGCert
+        $replicaName = $ag.PrimaryReplica
     }
     AfterAll {
-        Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname -Confirm:$false
+        Remove-DbaAvailabilityGroup -SqlInstance $script:instance3 -AvailabilityGroup $agname
     }
     Context "sets ag properties" {
         It "returns modified results" {
-            $results = Set-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname -Confirm:$false -BackupPriority 5000
+            $results = Set-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname -Replica $replicaName -BackupPriority 100
             $results.AvailabilityGroup | Should -Be $agname
-            $results.BackupPriority | Should -Be 5000
+            $results.BackupPriority | Should -Be 100
         }
         It "returns modified results" {
-            $results = Set-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname -Confirm:$false -BackupPriority 1000
+            $results = Set-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname -Replica $replicaName -SeedingMode Automatic
             $results.AvailabilityGroup | Should -Be $agname
-            $results.BackupPriority | Should -Be 1000
+            $results.SeedingMode | Should -Be Automatic
         }
         It "attempts to add a ReadOnlyRoutingList" {
-            $null = Get-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname | Select-Object -First 1 | Set-DbaAgReplica -ReadOnlyRoutingList nondockersql -WarningVariable warn
+            $null = Get-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname | Select-Object -First 1 | Set-DbaAgReplica -ReadOnlyRoutingList nondockersql -WarningAction SilentlyContinue -WarningVariable warn
             $warn | Should -match "does not exist. Only availability"
         }
     }

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -41,7 +41,7 @@ $TestsRunGroups = @{
         'Invoke-DbaDbMirroring',
         # previous tests that were failing on older versions too
         'Remove-DbaAvailabilityGroup',
-        'Set-DbaAgReplica',
+        #'Set-DbaAgReplica',
         'Read-DbaAuditFile',
         'Sync-DbaLoginPermission',
         'Read-DbaXEFile',
@@ -60,7 +60,7 @@ $TestsRunGroups = @{
         'Test-DbaManagementObject',
         'Export-DbaDacPackage',
         'New-DbaDbTransfer',
-        'Remove-DbaAgDatabase',
+        #'Remove-DbaAgDatabase',
         'Get-DbaDbSynonym',
         'Get-DbaDbVirtualLogFile',
         'Get-DbaFile',

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -41,7 +41,6 @@ $TestsRunGroups = @{
         'Invoke-DbaDbMirroring',
         # previous tests that were failing on older versions too
         'Remove-DbaAvailabilityGroup',
-        #'Set-DbaAgReplica',
         'Read-DbaAuditFile',
         'Sync-DbaLoginPermission',
         'Read-DbaXEFile',
@@ -60,7 +59,6 @@ $TestsRunGroups = @{
         'Test-DbaManagementObject',
         'Export-DbaDacPackage',
         'New-DbaDbTransfer',
-        #'Remove-DbaAgDatabase',
         'Get-DbaDbSynonym',
         'Get-DbaDbVirtualLogFile',
         'Get-DbaFile',


### PR DESCRIPTION
This PR only changes tests and no code of the module itself.

The certificate "dbatoolsci_AGCert" is part of the test environment and must not be created. This is done for AppVeyor in appveyor.SQL2027.ps1 with `$server.Query("CREATE CERTIFICATE dbatoolsci_AGCert WITH SUBJECT = 'AG Certificate'")`.

The certificate "dbatoolsci_AGCert" is needed in other tests and must not be deleted.

I changed the portnumber of the listener, so I'm able to run the test locally when instance1 is listening on 1433.