### PR TITLE
Enable test for Invoke-DbaDbMirroring

### DIFF
--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -36,9 +36,6 @@ $TestsRunGroups = @{
         'Invoke-DbaBalanceDataFiles',
         'Invoke-DbaWhoisActive',  # Works locally aganint a SQL Server 2022 instance without problems.
         'Install-DbaDarlingData',
-        # impossible to do within one server
-        # "the partner server name must be distinct"
-        #'Invoke-DbaDbMirroring',
         # previous tests that were failing on older versions too
         'Remove-DbaAvailabilityGroup',
         'Set-DbaAgReplica',

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -38,7 +38,7 @@ $TestsRunGroups = @{
         'Install-DbaDarlingData',
         # impossible to do within one server
         # "the partner server name must be distinct"
-        'Invoke-DbaDbMirroring',
+        #'Invoke-DbaDbMirroring',
         # previous tests that were failing on older versions too
         'Remove-DbaAvailabilityGroup',
         'Set-DbaAgReplica',


### PR DESCRIPTION
This PR only changes tests and no code of the module itself.

By using different ports for the mirroring endpoint, this test can run on AppVeyor.