### PR TITLE
Mount-DbaDatabase: Deduplicate filepaths if more that one backup is in the last backup file

### DIFF
--- a/public/Mount-DbaDatabase.ps1
+++ b/public/Mount-DbaDatabase.ps1
@@ -115,7 +115,7 @@ function Mount-DbaDatabase {
                     }
 
                     $backupfile = $backuphistory.Path[0]
-                    $filepaths = (Read-DbaBackupHeader -SqlInstance $server -FileList -Path $backupfile).PhysicalName
+                    $filepaths = (Read-DbaBackupHeader -SqlInstance $server -FileList -Path $backupfile).PhysicalName | Select-Object -Unique
 
                     $FileStructure = New-Object System.Collections.Specialized.StringCollection
                     foreach ($file in $filepaths) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

In case there is more than one backup in the last backup file (that was the case when I started the test two times within the same minute), `Read-DbaBackupHeader` returns all the different paths more than once, resulting in a bad $FileStructure.