### PR TITLE
Connect-DbaInstance: Fix for issue when changing database context

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -643,6 +643,9 @@ function Connect-DbaInstance {
                         $connContext.StatementTimeout = $savedStatementTimeout
                     }
                     $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $connContext
+                    if ($Database -and $server.ConnectionContext.CurrentDatabase -ne $Database) {
+                        Write-Message -Level Warning -Message "Changing connection context to database $Database was not successful. Current database is $($server.ConnectionContext.CurrentDatabase). Please open an issue on https://github.com/dataplat/dbatools/issues."
+                    }
                 } else {
                     $server = $inputObject
                 }

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -639,7 +639,7 @@ function Connect-DbaInstance {
                     if ($Database) {
                         # Save StatementTimeout because it might be reset on GetDatabaseConnection
                         $savedStatementTimeout = $connContext.StatementTimeout
-                        $connContext = $connContext.GetDatabaseConnection($Database)
+                        $connContext = $connContext.GetDatabaseConnection($Database, $false)
                         $connContext.StatementTimeout = $savedStatementTimeout
                     }
                     $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $connContext

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -206,6 +206,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $serverClone.ConnectionContext.ServerInstance | Should -Match '^ADMIN:'
             $serverClone | Disconnect-DbaInstance
         }
+
+        It "clones when using Backup-DabInstace" {
+            $server = Connect-DbaInstance -SqlInstance $script:instance1 -Database tempdb
+            $null = Backup-DbaDatabase -SqlInstance $server -Database msdb
+            $null = Backup-DbaDatabase -SqlInstance $server -Database msdb -WarningVariable warn
+            $warn | Should -BeNullOrEmpty
+        }
     }
 
     Context "multiple connections are properly made using strings" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

The problem was discovered while working on the test for Remove-DbaDbTableData. Inside of Backup-DabaDatabase changing the database context to master was not possible and resulted in using a cached connection to an already dropped database.

In the first commit, I added a test inside of Connect-DbaInstance to write a warning:

```
if ($Database -and $server.ConnectionContext.CurrentDatabase -ne $Database) {
    Write-Message -Level Warning -Message "Changing connection context to database $Database was not successful. Current database is $($server.ConnectionContext.CurrentDatabase). Please open an issue on https://github.com/dataplat/dbatools/issues."
}
```

In the second commit I added a test to show the warning:

![image](https://github.com/user-attachments/assets/896775bd-eb3b-47b1-b398-ee42404956f7)


In the third commit, I implement the fix, changing `$connContext = $connContext.GetDatabaseConnection($Database)` to `$connContext = $connContext.GetDatabaseConnection($Database, $false)`.