### PR TITLE
Get-DbaDbMailServer: Fix e-mail account names if more than one account exists

### DIFF
--- a/public/Get-DbaDbMailServer.ps1
+++ b/public/Get-DbaDbMailServer.ps1
@@ -97,7 +97,7 @@ function Get-DbaDbMailServer {
                     $servers | Add-Member -Force -MemberType NoteProperty -Name ComputerName -value $mailserver.ComputerName
                     $servers | Add-Member -Force -MemberType NoteProperty -Name InstanceName -value $mailserver.InstanceName
                     $servers | Add-Member -Force -MemberType NoteProperty -Name SqlInstance -value $mailserver.SqlInstance
-                    $servers | Add-Member -Force -MemberType NoteProperty -Name Account -value $servers[0].Parent.Name
+                    $servers | Add-Member -Force -MemberType NoteProperty -Name Account -value $servers.Parent.Name
                     $servers | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, Account, Name, Port, EnableSsl, ServerType, UserName, UseDefaultCredentials, NoCredentialChange
                 }
             } catch {


### PR DESCRIPTION
Redo of this PR with smaller git repo: https://github.com/dataplat/dbatools/pull/9497

Fix an error that results in all account names matching the first account instead of corresponding to real account names.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9496 )

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix an error that results in all account names matching the first account instead of corresponding to real account names.

### Approach
Each corresponding account name is used instead of the only using first account name for all results.



Note: I changed the coding slightly, as it seemed that -Force would keep overwriting the account names. So now it's an array. Please let me know if I need to take a different approach.