### PR TITLE
Fix test for Measure-DbaBackupThroughput

### DIFF
--- a/tests/Measure-DbaBackupThroughput.Tests.ps1
+++ b/tests/Measure-DbaBackupThroughput.Tests.ps1
@@ -16,6 +16,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Returns output for single database" {
         BeforeAll {
+            $null = Get-DbaProcess -SqlInstance $script:instance2 | Where-Object Program -Match dbatools | Stop-DbaProcess -Confirm:$false -WarningAction SilentlyContinue
             $random = Get-Random
             $db = "dbatoolsci_measurethruput$random"
             $null = New-DbaDatabase -SqlInstance $script:instance2 -Database $db | Backup-DbaDatabase


### PR DESCRIPTION
This PR only changes tests and no code of the module itself.

Sometimes model database was still locked from another test and New-DbaDatabase failed.