### PR TITLE
New-DbaAgentJob: Fix wrong output when using -Force to remove existing job

### DIFF
--- a/public/New-DbaAgentJob.ps1
+++ b/public/New-DbaAgentJob.ps1
@@ -250,7 +250,7 @@ function New-DbaAgentJob {
 
                 if ($PSCmdlet.ShouldProcess($instance, "Removing the job $Job on $instance")) {
                     try {
-                        Remove-DbaAgentJob -SqlInstance $server -Job $Job -EnableException -Confirm:$false
+                        $null = Remove-DbaAgentJob -SqlInstance $server -Job $Job -EnableException -Confirm:$false
                         $server.JobServer.Refresh()
                     } catch {
                         Stop-Function -Message "Couldn't remove job $Job from $instance" -Target $instance -Continue -ErrorRecord $_


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

If -Force was used and the existing job was removed, the output of `Remove-DbaAgentJob` was sent back to the output of the command.