### PR TITLE
Fix test for Enable-DbaHideInstance

### DIFF
--- a/tests/Enable-DbaHideInstance.Tests.ps1
+++ b/tests/Enable-DbaHideInstance.Tests.ps1
@@ -14,6 +14,10 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    AfterAll {
+        $null = Disable-DbaHideInstance $script:instance1
+    }
+
     $results = Enable-DbaHideInstance $script:instance1 -EnableException
 
     It "returns true" {


### PR DESCRIPTION
This PR only changes tests and no code of the module itself.

Hiding the instance causes problems in other tests, so revertimng the change at the end of the test.