### PR TITLE
pester runner, detection based on standard Requires directive

### DIFF
--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -1,4 +1,4 @@
-#HaveParameter - yeah, I know.
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
 
 BeforeAll {
     $CommandName = (Get-Item $PSCommandPath).Name.Replace(".Tests.ps1", "")

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -162,7 +162,7 @@ function Get-CodecovReport($Results, $ModuleBase) {
 
 function Get-PesterTestVersion($testFilePath) {
     $testFileContent = Get-Content -Path $testFilePath -Raw
-    if ($testFileContent -match 'HaveParameter')
+    if ($testFileContent -match '#Requires\s+-Module\s+@\{\s+ModuleName="Pester";\s+ModuleVersion="5\.')
     {
         return '5'
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [x] Build system


### Purpose
change the way to detect pester5 tests based on standard requires directive : https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-7.4
