### PR TITLE
Install-DbaMaintenanceSolution - don't drop tables if not readding

### DIFF
--- a/public/Install-DbaMaintenanceSolution.ps1
+++ b/public/Install-DbaMaintenanceSolution.ps1
@@ -31,6 +31,8 @@ function Install-DbaMaintenanceSolution {
     .PARAMETER ReplaceExisting
         If this switch is enabled, objects already present in the target database will be dropped and recreated.
 
+        Note - The tables for `LogToTable` and `InstallParallel` will only be dropped if those options are also specified.
+
     .PARAMETER LogToTable
         If this switch is enabled, the Maintenance Solution will be configured to log commands to a table.
 
@@ -119,16 +121,32 @@ function Install-DbaMaintenanceSolution {
 
         Installs Maintenance Solution to myserver in database. Adds Agent Jobs, and if any currently exist, they'll be replaced.
 
+        Since the `LogToTable` switch is enabled, the CommandLog table will be dropped and recreated also.
+
+        If the tables relating to `InstallParallel` are present, they will not be dropped.
+
     .EXAMPLE
-        PS C:\> Install-DbaMaintenanceSolution -SqlInstance RES14224 -Database DBA -InstallJobs -BackupLocation "Z:\SQLBackup" -CleanupTime 72 -ReplaceExisting
+        PS C:\> $params = @{
+        >> SqlInstance = 'RES14224'
+        >> Database = 'DBA'
+        >> InstallJobs = $true
+        >> BackupLocation = 'Z:\SQLBackup'
+        >> CleanupTime = 72
+        >> ReplaceExisting = $true
+        >> }
+        PS C:\> Install-DbaMaintenanceSolution @params
 
         This will drop and then recreate the Ola Hallengren's Solution objects
         The cleanup script will drop and recreate:
-        - TABLE [dbo].[CommandLog]
         - STORED PROCEDURE [dbo].[CommandExecute]
         - STORED PROCEDURE [dbo].[DatabaseBackup]
         - STORED PROCEDURE [dbo].[DatabaseIntegrityCheck]
         - STORED PROCEDURE [dbo].[IndexOptimize]
+
+        The tables will not be dropped as the `LogToTable` and `InstallParallel` switches are not enabled.
+        - [dbo].[CommandLog]
+        - [dbo].[Queue]
+        - [dbo].[QueueDatabase]
 
         The following SQL Agent jobs will be deleted:
         - 'Output File Cleanup'

--- a/public/Install-DbaMaintenanceSolution.ps1
+++ b/public/Install-DbaMaintenanceSolution.ps1
@@ -90,7 +90,7 @@ function Install-DbaMaintenanceSolution {
         https://ola.hallengren.com
 
     .LINK
-         https://dbatools.io/Install-DbaMaintenanceSolution
+        https://dbatools.io/Install-DbaMaintenanceSolution
 
     .EXAMPLE
         PS C:\> Install-DbaMaintenanceSolution -SqlInstance RES14224 -Database DBA -InstallJobs -CleanupTime 72
@@ -402,12 +402,6 @@ function Install-DbaMaintenanceSolution {
             $cleanupQuery = $null
             if ($ReplaceExisting) {
                 [string]$cleanupQuery = $("
-                            IF OBJECT_ID('[dbo].[CommandLog]', 'U') IS NOT NULL
-                                DROP TABLE [dbo].[CommandLog];
-                            IF OBJECT_ID('[dbo].[QueueDatabase]', 'U') IS NOT NULL
-                                DROP TABLE [dbo].[QueueDatabase];
-                            IF OBJECT_ID('[dbo].[Queue]', 'U') IS NOT NULL
-                                DROP TABLE [dbo].[Queue];
                             IF OBJECT_ID('[dbo].[CommandExecute]', 'P') IS NOT NULL
                                 DROP PROCEDURE [dbo].[CommandExecute];
                             IF OBJECT_ID('[dbo].[DatabaseBackup]', 'P') IS NOT NULL
@@ -417,6 +411,22 @@ function Install-DbaMaintenanceSolution {
                             IF OBJECT_ID('[dbo].[IndexOptimize]', 'P') IS NOT NULL
                                 DROP PROCEDURE [dbo].[IndexOptimize];
                             ")
+
+                if ($LogToTable) {
+                    $cleanupQuery += $("
+                            IF OBJECT_ID('[dbo].[CommandLog]', 'U') IS NOT NULL
+                                DROP TABLE [dbo].[CommandLog];
+                            ")
+                }
+
+                if ($InstallParallel) {
+                    $cleanupQuery += $("
+                            IF OBJECT_ID('[dbo].[QueueDatabase]', 'U') IS NOT NULL
+                                DROP TABLE [dbo].[QueueDatabase];
+                            IF OBJECT_ID('[dbo].[Queue]', 'U') IS NOT NULL
+                                DROP TABLE [dbo].[Queue];
+                            ")
+                }
 
                 if ($Pscmdlet.ShouldProcess($instance, "Dropping all objects created by Ola's Maintenance Solution")) {
                     Write-ProgressHelper -ExcludePercent -Message "Dropping objects created by Ola's Maintenance Solution"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #9553 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [X] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Reported in #9553 the `CommandLog` table is always dropped when `ReplaceExisting` is specified - this is causing issues if the SPs are calling the `LogToTable` parameter.

### Approach
This change provides more control - the tables will only be dropped if the switches that use them are specified. This way if you want to keep the history in the `CommandLog` table but update the SPs you can.

I implemented the same logic for the `InstallParallel` parameter - and the `Queue*` tables - if the parameter is specified they will be dropped, if not they will remain on the server.

### Commands to test
This will drop and replace all the SPs but none of the tables.
```
$paramHash = @{
  SqlInstance      = $svr
   Database        = 'Maint'
   SqlCredential   = $someCred
   Verbose         = $True
   ReplaceExisting = $True
}
Install-DbaMaintenanceSolution @paramHash
```
This will drop and replace the SPs and the `CommandLog` table
```
$paramHash = @{
  SqlInstance      = $svr
   Database        = 'Maint'
   SqlCredential   = $someCred
   Verbose         = $True
   ReplaceExisting = $True
   LogToTable = $True
}
Install-DbaMaintenanceSolution @paramHash
```
This will drop and create SPs and all tables.
```
$paramHash = @{
  SqlInstance      = $svr
   Database        = 'Maint'
   SqlCredential   = $someCred
   Verbose         = $True
   ReplaceExisting = $True
   LogToTable = $True
   InstallParallel = $True
}
Install-DbaMaintenanceSolution @paramHash
```