### PR TITLE
Get-DbaExternalProcess - Test failing

### DIFF
--- a/tests/Get-DbaExternalProcess.Tests.ps1
+++ b/tests/Get-DbaExternalProcess.Tests.ps1
@@ -37,7 +37,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
         It "returns a process" {
             Start-Sleep -Seconds 1
-            $results = Get-DbaExternalProcess -ComputerName localhost | Select-Object -First 1
+            $results = Get-DbaExternalProcess -ComputerName localhost | Where-Object { $_.Name -eq "cmd.exe" }
             $results.ComputerName | Should -Be "localhost"
             $results.Name | Should -Be "cmd.exe"
             $results.ProcessId | Should -Not -Be $null


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Test failed on a different PR - it's just picking the first external process, and this time it didn't pick the expected one
![image](https://github.com/user-attachments/assets/6143ef66-05c4-40d1-8477-c82a23ccbe63)

### Approach
Filter the results so if it gets the processes it returns the correct one

### Commands to test
Run the Get-DbaExternalProcess pester tests
