### PR TITLE
Set-DbaLogin, report correct name for -WhatIf

### DIFF
--- a/public/Set-DbaLogin.ps1
+++ b/public/Set-DbaLogin.ps1
@@ -251,7 +251,7 @@ function Set-DbaLogin {
 
         # Loop through all the logins
         foreach ($l in $InputObject) {
-            if ($Pscmdlet.ShouldProcess($l, "Setting Changes to Login on $($server.name)")) {
+            if ($Pscmdlet.ShouldProcess($l, "Setting Changes to Login on $($l.Parent.Name)")) {
                 $server = $l.Parent
 
                 # Create the notes


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9580 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Approach
Printing was fixed on first server, indeed. Every login has a "Parent" object that is the server the login is from, so a quick property swap and the print is now okay for all.

Thanks @Sirwill1968 for reporting