### PR TITLE
Find-DbaAgentJob, work with multiple wildcards

### DIFF
--- a/private/functions/Get-JobList.ps1
+++ b/private/functions/Get-JobList.ps1
@@ -69,65 +69,50 @@ function Get-JobList {
 
         $jobs = $server.JobServer.Jobs
         if ( (Test-Bound 'JobFilter') -or (Test-Bound 'StepFilter') ) {
-            if ($JobFilter.Count -gt 1) {
-                if ($Not) {
-                    $jobs | Where-Object Name -NotIn $JobFilter
-                } else {
-                    $jobs | Where-Object Name -In $JobFilter
-                }
-            } else {
-                foreach ($job in $jobs) {
-                    if ($JobFilter -match '`*') {
+            
+            foreach ($job in $jobs) {
+                foreach($jFilter in $JobFilter) {
+                    if ($jFilter -match '`*') {
                         if ($Not) {
-                            $job | Where-Object Name -NotLike $JobFilter
+                            $job | Where-Object Name -NotLike $jFilter
                         } else {
-                            $job | Where-Object Name -Like $JobFilter
+                            $job | Where-Object Name -Like $jFilter
                         }
                     } else {
                         if ($Not) {
-                            $job | Where-Object Name -NE $JobFilter
+                            $job | Where-Object Name -NE $jFilter
                         } else {
-                            $job | Where-Object Name -EQ $JobFilter
+                            $job | Where-Object Name -EQ $jFilter
                         }
                     }
-                    if ($StepFilter -match '`*') {
+                }
+                foreach($sFilter in $StepFilter) {
+                    if ($sFilter -match '`*') {
                         if ($Not) {
-                            $stepFound = $job.JobSteps | Where-Object Name -NotLike $StepFilter
+                            $stepFound = $job.JobSteps | Where-Object Name -NotLike $sFilter
                             if ($stepFound.Count -gt 0) {
                                 $job
                             }
                         } else {
-                            $stepFound = $job.JobSteps | Where-Object Name -Like $StepFilter
-                            if ($stepFound.Count -gt 0) {
-                                $job
-                            }
-                        }
-                    } elseif ($StepName.Count -gt 1) {
-                        if ($Not) {
-                            $stepFound = $job.JobSteps | Where-Object Name -NotIn $StepName
-                            if ($stepFound.Count -gt 0) {
-                                $job
-                            }
-                        } else {
-                            $stepFound = $job.JobSteps | Where-Object Name -In $StepName
+                            $stepFound = $job.JobSteps | Where-Object Name -Like $sFilter
                             if ($stepFound.Count -gt 0) {
                                 $job
                             }
                         }
                     } else {
                         if ($Not) {
-                            $stepFound = $job.JobSteps | Where-Object Name -NE $StepName
+                            $stepFound = $job.JobSteps | Where-Object Name -NE $sFilter
                             if ($stepFound.Count -gt 0) {
                                 $job
                             }
                         } else {
-                            $stepFound = $job.JobSteps | Where-Object Name -EQ $StepName
+                            $stepFound = $job.JobSteps | Where-Object Name -EQ $sFilter
                             if ($stepFound.Count -gt 0) {
                                 $job
                             }
                         }
                     }
-                }
+                }                
             }
         } else {
             $jobs

--- a/private/functions/Get-JobList.ps1
+++ b/private/functions/Get-JobList.ps1
@@ -112,7 +112,7 @@ function Get-JobList {
                             }
                         }
                     }
-                }                
+                }
             }
         } else {
             $jobs

--- a/private/functions/Get-JobList.ps1
+++ b/private/functions/Get-JobList.ps1
@@ -69,9 +69,9 @@ function Get-JobList {
 
         $jobs = $server.JobServer.Jobs
         if ( (Test-Bound 'JobFilter') -or (Test-Bound 'StepFilter') ) {
-            
+
             foreach ($job in $jobs) {
-                foreach($jFilter in $JobFilter) {
+                foreach ($jFilter in $JobFilter) {
                     if ($jFilter -match '`*') {
                         if ($Not) {
                             $job | Where-Object Name -NotLike $jFilter
@@ -86,7 +86,7 @@ function Get-JobList {
                         }
                     }
                 }
-                foreach($sFilter in $StepFilter) {
+                foreach ($sFilter in $StepFilter) {
                     if ($sFilter -match '`*') {
                         if ($Not) {
                             $stepFound = $job.JobSteps | Where-Object Name -NotLike $sFilter

--- a/public/Find-DbaAgentJob.ps1
+++ b/public/Find-DbaAgentJob.ps1
@@ -93,7 +93,7 @@ function Find-DbaAgentJob {
         Finds all failed job then starts them. Consider using a -WhatIf at the end of Start-DbaAgentJob to see what it'll do first
 
     .EXAMPLE
-        PS C:\> Find-DbaAgentJob -SqlInstance Dev01 -LastUsed 10 -Exclude "Yearly - RollUp Workload", "SMS - Notification"
+        PS C:\> Find-DbaAgentJob -SqlInstance Dev01 -LastUsed 10 -ExcludeJobName "Yearly - RollUp Workload", "SMS - Notification"
 
         Returns all agent jobs that have not ran in the last 10 days ignoring jobs "Yearly - RollUp Workload" and "SMS - Notification"
 
@@ -222,9 +222,9 @@ function Find-DbaAgentJob {
                 }
             }
 
-            if ($Exclude) {
+            if ($ExcludeJobName) {
                 Write-Message -Level Verbose -Message "Excluding job/s based on Exclude"
-                $output = $output | Where-Object { $Exclude -notcontains $_.Name }
+                $output = $output | Where-Object { $ExcludeJobName -notcontains $_.Name }
             }
 
             if ($Since) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9572  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Having multiple wildcards working again. The code was doing different things when either jobs or steps were passed down as multiple wildcards.

### Approach
Just loop over, keep the same logic. Hopefully no tests will break.

### Commands to test
Added a test just to make sure regressions are reintroduced at a later stage.
