### PR TITLE
New-DbaSqlParameter, check bound parameters correctly

### DIFF
--- a/public/New-DbaSqlParameter.ps1
+++ b/public/New-DbaSqlParameter.ps1
@@ -119,88 +119,90 @@ function New-DbaSqlParameter {
         [string]$SourceVersion,
         [ValidateSet("BigInt", "Binary", "Bit", "Char", "DateTime", "Decimal", "Float", "Image", "Int", "Money", "NChar", "NText", "NVarChar", "Real", "UniqueIdentifier", "SmallDateTime", "SmallInt", "SmallMoney", "Text", "Timestamp", "TinyInt", "VarBinary", "VarChar", "Variant", "Xml", "Udt", "Structured", "Date", "Time", "DateTime2", "DateTimeOffset")]
         [string]$SqlDbType,
-        [string]$SqlValue,
+        [object]$SqlValue,
         [string]$TypeName,
         [string]$UdtTypeName,
         [object]$Value,
         [switch]$EnableException
     )
+
     $param = New-Object Microsoft.Data.SqlClient.SqlParameter
 
     try {
-        if ($PSBoundParameters.CompareInfo) {
+        
+        if (Test-Bound -ParameterName CompareInfo) {
             $param.CompareInfo = $CompareInfo
         }
 
-        if ($PSBoundParameters.DbType) {
+        if (Test-Bound -ParameterName DbType) {
             $param.DbType = $DbType
         }
 
-        if ($PSBoundParameters.Direction) {
+        if (Test-Bound -ParameterName Direction) {
             $param.Direction = $Direction
         }
 
-        if ($PSBoundParameters.ForceColumnEncryption) {
+        if (Test-Bound -ParameterName ForceColumnEncryption) {
             $param.ForceColumnEncryption = $ForceColumnEncryption
         }
 
-        if ($PSBoundParameters.IsNullable) {
+        if (Test-Bound -ParameterName IsNullable) {
             $param.IsNullable = $IsNullable
         }
 
-        if ($PSBoundParameters.LocaleId) {
+        if (Test-Bound -ParameterName LocaleId) {
             $param.LocaleId = $LocaleId
         }
 
-        if ($PSBoundParameters.Offset) {
+        if (Test-Bound -ParameterName Offset) {
             $param.Offset = $Offset
         }
 
-        if ($PSBoundParameters.ParameterName) {
+        if (Test-Bound -ParameterName ParameterName) {
             $param.ParameterName = $ParameterName
         }
 
-        if ($PSBoundParameters.Precision) {
+        if (Test-Bound -ParameterName Precision) {
             $param.Precision = $Precision
         }
 
-        if ($PSBoundParameters.Scale) {
+        if (Test-Bound -ParameterName Scale) {
             $param.Scale = $Scale
         }
 
-        if ($PSBoundParameters.Size) {
+        if (Test-Bound -ParameterName Size) {
             $param.Size = $Size
         }
 
-        if ($PSBoundParameters.SourceColumn) {
+        if (Test-Bound -ParameterName SourceColumn) {
             $param.SourceColumn = $SourceColumn
         }
 
-        if ($PSBoundParameters.SourceColumnNullMapping) {
+        if (Test-Bound -ParameterName SourceColumnNullMapping) {
             $param.SourceColumnNullMapping = $SourceColumnNullMapping
         }
 
-        if ($PSBoundParameters.SourceVersion) {
+        if (Test-Bound -ParameterName SourceVersion) {
             $param.SourceVersion = $SourceVersion
         }
 
-        if ($PSBoundParameters.SqlDbType) {
+        if (Test-Bound -ParameterName SqlDbType) {
             $param.SqlDbType = $SqlDbType
         }
 
-        if ($PSBoundParameters.SqlValue) {
+        if (Test-Bound -ParameterName SqlValue) {
             $param.SqlValue = $SqlValue
         }
 
-        if ($PSBoundParameters.TypeName) {
+        if (Test-Bound -ParameterName TypeName) {
             $param.TypeName = $TypeName
         }
 
-        if ($PSBoundParameters.UdtTypeName) {
+        if (Test-Bound -ParameterName UdtTypeName) {
             $param.UdtTypeName = $UdtTypeName
         }
 
-        if ($PSBoundParameters.Value) {
+        if (Test-Bound -ParameterName Value) {
             $param.Value = $Value
         }
         $param

--- a/tests/New-DbaSqlParameter.Tests.ps1
+++ b/tests/New-DbaSqlParameter.Tests.ps1
@@ -37,4 +37,9 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Database tempdb -CommandType StoredProcedure -Query my_proc -SqlParameters $output
         $output.Value | Should -Be '{"example":"sample"}'
     }
+    It "binds a 'falsy' value properly (see #9542)" {
+        [int]$ZeroInt = 0
+        $ZeroSqlParam = New-DbaSqlParameter -ParameterName ZeroInt -Value $ZeroInt -SqlDbType int
+        $ZeroSqlParam.Value | Should -Be 0
+    }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9542 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Allow "falsy" values .
BTW, changed param "SqlType" from [string] to [object] to avoid automatic conversions.
The underlying API accepts an [object] as well.

### Approach
Check bound parameters via dedicated (and more precise) Test-Bound function.

### Commands to test
Added a regression test to make sure this doesn't happen again.
