### PR TITLE
Connect-DbaInstance, honor -Database parameter

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -673,6 +673,18 @@ function Connect-DbaInstance {
                     $sqlConnectionInfo.Password = $csb.Password
                     $null = $csb.Remove('Password')
                 }
+                # look for 'Initial Catalog' and 'Database' in the connection string
+                $specifiedDatabase = $csb['Database']
+                if ($specifiedDatabase -eq '') {
+                    $specifiedDatabase = $csb['Initial Catalog']
+                }
+                if ($Database -and $Database -ne $specifiedDatabase) {
+                    Write-Message -Level Debug -Message "Database specified in connection string '$specifiedDatabase' does not match Database parameter '$Database'. Database parameter will be used."
+                    # clear both, in order to not be overridden later by setting all AddtionalParameters
+                    $csb.Remove('Database')
+                    $csb.Remove('Initial Catalog')
+                    $sqlConnectionInfo.DatabaseName = $Database
+                }
 
                 # Add all remaining parts of the connection string as additional parameters.
                 $sqlConnectionInfo.AdditionalParameters = $csb.ConnectionString

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -681,8 +681,12 @@ function Connect-DbaInstance {
                 if ($Database -and $Database -ne $specifiedDatabase) {
                     Write-Message -Level Debug -Message "Database specified in connection string '$specifiedDatabase' does not match Database parameter '$Database'. Database parameter will be used."
                     # clear both, in order to not be overridden later by setting all AddtionalParameters
-                    $csb.Remove('Database')
-                    $csb.Remove('Initial Catalog')
+                    if ($csb.ShouldSerialize('Database')) {
+                        $csb.Remove('Database')
+                    }
+                    if ($csb.ShouldSerialize('Initial Catalog')) {
+                        $csb.Remove('Initial Catalog')
+                    }
                     $sqlConnectionInfo.DatabaseName = $Database
                 }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9541 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Honor `-Database` parameter in some cases (passed connstring, passed registeredinstance).

### Approach
Connect-DbaInstance is quite a "hotpath" so I tried to make the edit just where needed, it shouldn't (finger crossed) break existing code, but we'll know from appveyor if so.

### Commands to test
Before, this resulted in "master" being returned
`Get-DbaRegServer -IncludeLocal | Connect-DbaInstance -Database msdb  | % { $_.Query("select db_name()") }`
now, it returns "msdb".

On my laptop (tm) it also returns "msdb" for 
`Get-DbaRegServer -IncludeLocal | Connect-DbaInstance -Database msdb  | Invoke-DbaQuery -Query 'select db_name();' ` as reported in #9541 (thanks @mattcargile and @ReeceGoding , both the original report and the findings made me waste little time in finding the culprit)

