### PR TITLE
Invoke-DbaQuery, re-wire connection with integrated as another user

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -694,12 +694,11 @@ function Connect-DbaInstance {
                 }
                 if ($SqlCredential) {
                     # support both ad\username and username@ad
+                    # username@ad works only for domain joined
+                    # so we stick to what we get and allow ad\username
+                    # as well, that works on local and workgroup
                     $username = ($SqlCredential.UserName).TrimStart("\")
-                    if ($username -like "*\*") {
-                        $domain, $login = $username.Split("\")
-                        $username = "$login@$domain"
-                    }
-                    if ($username -like '*@*') {
+                    if ($username -like '*@*' -or $username -like '*\*') {
                         $authType += 'ad'
                     } else {
                         $authType += 'sql'

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -27,7 +27,8 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
                 'ReadOnly',
                 'EnableException',
                 'CommandType',
-                'NoExec'
+                'NoExec',
+                'AppendConnectionString'
             )
         }
         It "Should only contain our specific parameters" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9579 and #9459 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Tried to put it all in the new comments. Feel free to ping me on Slack for further details.
I'd like someone to try it in their own environment and see if it breaks things.

Small test 
```
$cred = Get-Credential 'domain\anotheruser'
$server = Connect-DbaInstance -SqlInstance 'yourinstance' -Database dbatools -SqlCredential $cred
Invoke-DbaQuery -SqlInstance $server -Query 'select suser_sname()' -SqlCredential $cred
$server.Query('select suser_sname()')
```

### Approach
Path of least resistance, should kick in and recreate the connection only if needed, if not, back to pooling that helps with performances.
