### PR TITLE
Invoke-DbaDbShrink, accept pipelined databases

### DIFF
--- a/public/Invoke-DbaDbShrink.ps1
+++ b/public/Invoke-DbaDbShrink.ps1
@@ -296,8 +296,7 @@ function Invoke-DbaDbShrink {
                             $success = $false
                             Stop-Function -Message 'Failure' -EnableException $EnableException -ErrorRecord $_ -Continue
                             continue
-                        }
-                        finally {
+                        } finally {
                             $instance.ConnectionContext.StatementTimeout = $previousStatementTimeout
                         }
                         $end = Get-Date

--- a/public/Invoke-DbaDbShrink.ps1
+++ b/public/Invoke-DbaDbShrink.ps1
@@ -133,9 +133,10 @@ function Invoke-DbaDbShrink {
         Shrinks all databases coming from a pre-filtered list via Get-DbaDatabase
 
     #>
-    [CmdletBinding(DefaultParameterSetName = 'Default', SupportsShouldProcess, ConfirmImpact = 'Low')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
     param (
-        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'Instance')]
+        [Parameter(ValueFromPipeline)]
+        [Parameter(ParameterSetName = 'SqlInstance', Position = 0)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [object[]]$Database,
@@ -152,7 +153,7 @@ function Invoke-DbaDbShrink {
         [switch]$ExcludeIndexStats,
         [switch]$ExcludeUpdateUsage,
         [switch]$EnableException,
-        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'Pipeline')]
+        [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject
     )
 
@@ -229,6 +230,7 @@ function Invoke-DbaDbShrink {
                 $files += $db.FileGroups.Files
             }
 
+
             foreach ($file in $files) {
                 # $file.Size and $file.UsedSpace are in KB and translated here to bytes as the dbasize type requires
                 [dbasize]$startingSizeKB = $file.Size * 1024
@@ -292,7 +294,7 @@ function Invoke-DbaDbShrink {
                             $success = $true
                         } catch {
                             $success = $false
-                            Stop-Function -message 'Failure' -EnableException $EnableException -ErrorRecord $_ -Continue
+                            Stop-Function -Message 'Failure' -EnableException $EnableException -ErrorRecord $_ -Continue
                             continue
                         }
                         finally {
@@ -315,7 +317,7 @@ function Invoke-DbaDbShrink {
 
                         $timSpan = New-TimeSpan -Start $start -End $end
                         $ts = [TimeSpan]::FromSeconds($timSpan.TotalSeconds)
-                        $elapsed = '{0:HH:mm:ss}' -f ([DateTime]$ts.Ticks)
+                        $elapsed = "{0:HH:mm:ss}" -f ([datetime]$ts.Ticks)
 
                         $object = [PSCustomObject]@{
                             ComputerName                = $server.ComputerName

--- a/tests/Invoke-DbaDbShrink.Tests.ps1
+++ b/tests/Invoke-DbaDbShrink.Tests.ps1
@@ -5,7 +5,7 @@ $global:TestConfig = Get-TestConfig
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'AllUserDatabases', 'PercentFreeSpace', 'ShrinkMethod', 'FileType', 'StepSize', 'StatementTimeout', 'ExcludeIndexStats', 'ExcludeUpdateUsage', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'AllUserDatabases', 'PercentFreeSpace', 'ShrinkMethod', 'FileType', 'StepSize', 'StatementTimeout', 'ExcludeIndexStats', 'ExcludeUpdateUsage', 'EnableException', 'InputObject'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
@@ -100,6 +100,19 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
         It "Shrinks just the data file(s) when FileType is Data and uses the StepSize" {
             $result = Invoke-DbaDbShrink $server -Database $db.Name -FileType Data -StepSize 2MB
+            $result.Database | Should -Be $db.Name
+            $result.File | Should -Be $db.Name
+            $result.Success | Should -Be $true
+            $db.Refresh()
+            $db.RecalculateSpaceUsage()
+            $db.FileGroups[0].Files[0].Refresh()
+            $db.LogFiles[0].Refresh()
+            $db.FileGroups[0].Files[0].Size | Should BeLessThan $oldDataSize
+            $db.LogFiles[0].Size | Should Be $oldLogSize
+        }
+
+        It "Accepts pipelined databases (see #9495)" {
+            $result = $db | Invoke-DbaDbShrink
             $result.Database | Should -Be $db.Name
             $result.File | Should -Be $db.Name
             $result.Success | Should -Be $true

--- a/tests/Invoke-DbaDbShrink.Tests.ps1
+++ b/tests/Invoke-DbaDbShrink.Tests.ps1
@@ -112,7 +112,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "Accepts pipelined databases (see #9495)" {
-            $result = $db | Invoke-DbaDbShrink
+            $result = $db | Invoke-DbaDbShrink -FileType Data
             $result.Database | Should -Be $db.Name
             $result.File | Should -Be $db.Name
             $result.Success | Should -Be $true


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #9495 )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Given it's a `-DbaDb*` I tend to agree with the original reporter, which assumed pipelined databases "just work"

### Approach
The usual dance around parametersets and pipelines

### Commands to test
Added a regr test to make sure the feature stays in

