### PR TITLE
Backup-DbaDbCertificate, new FileBaseName parameter

### DIFF
--- a/tests/Backup-DbaDbCertificate.Tests.ps1
+++ b/tests/Backup-DbaDbCertificate.Tests.ps1
@@ -19,6 +19,7 @@ Describe "Backup-DbaDbCertificate" -Tag "UnitTests" {
                 "DecryptionPassword",
                 "Path",
                 "Suffix",
+                "FileBaseName",
                 "InputObject",
                 "EnableException",
                 "Confirm",
@@ -63,6 +64,15 @@ Describe "Backup-DbaDbCertificate" -Tag "IntegrationTests" {
             $results.DatabaseID | Should -Be (Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $db1Name).ID
         }
 
+        It "backs up the db cert with a filename (see #9485)" {
+            $results = Backup-DbaDbCertificate -SqlInstance $TestConfig.instance1 -Certificate $cert.Name -Database $db1Name -EncryptionPassword $pw -DecryptionPassword $pw -FileBaseName "dbatoolscli_cert1_$random"
+            $results.Certificate | Should -Be $cert.Name
+            $results.Status | Should -Match "Success"
+            $results.DatabaseID | Should -Be (Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $db1Name).ID
+            [IO.Path]::GetFileNameWithoutExtension($results.Path) | Should -Be "dbatoolscli_cert1_$random"
+            $null = Get-ChildItem -Path $results.Path -ErrorAction Ignore | Remove-Item -Confirm:$false -ErrorAction Ignore
+        }
+
         It "warns the caller if the cert cannot be found" {
             $invalidDBCertName = "dbatoolscli_invalidCertName"
             $invalidDBCertName2 = "dbatoolscli_invalidCertName2"
@@ -82,5 +92,6 @@ Describe "Backup-DbaDbCertificate" -Tag "IntegrationTests" {
             $results = Backup-DbaDbCertificate -SqlInstance $TestConfig.instance1 -EncryptionPassword $pw
             $null = Get-ChildItem -Path $results.Path -ErrorAction Ignore | Remove-Item -Confirm:$false -ErrorAction Ignore
         }
+
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #9485 )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Was not convinced myself but the latest point from @serenefiresiren hit the spot, i.e. "I need my own structure because when restoring it's easier if I maintain my own conventions". Thinking of a disaster event, quick spotting of what cert has what name and ends up named by whatever convention is established is not a big deal and, frankly, it's not a mega-modification that needs certain care.

### Approach
Just trust the passed parameter that overrides the default naming, and slap a regression test to make sure the feature stays in.
