### PR TITLE
Start-DbccCheck, better extraction of errors

### DIFF
--- a/private/functions/Start-DbccCheck.ps1
+++ b/private/functions/Start-DbccCheck.ps1
@@ -31,37 +31,32 @@ function Start-DbccCheck {
         } catch {
             $originalException = $_.Exception
             $loopNo = 0
-            while ($loopNo -ne 5)
-            {
+            while ($loopNo -ne 5) {
                 $loopNo ++
-                if ($null -ne $originalException.InnerException) { 
-                    $originalException = $originalException.InnerException 
+                if ($null -ne $originalException.InnerException) {
+                    $originalException = $originalException.InnerException
                 } else {
                     break
                 }
             }
             $message = $originalException.ToString()
-            
+
             # english cleanup only sorry
             try {
                 $newmessage = $message
-                if ($newmessage -like '*at Microsoft.SqlServer.Management.Common.ConnectionManager.ExecuteTSql*')
-                {
+                if ($newmessage -like '*at Microsoft.SqlServer.Management.Common.ConnectionManager.ExecuteTSql*') {
                     $newmessage = ($newmessage -split "at Microsoft.SqlServer.Management.Common.ConnectionManager.ExecuteTSql")[0]
                 }
-                if ($newmessage -like '*Microsoft.SqlServer.Management.Common.ExecutionFailureException:*')
-                {
+                if ($newmessage -like '*Microsoft.SqlServer.Management.Common.ExecutionFailureException:*') {
                     $newmessage = ($newmessage -split "Microsoft.SqlServer.Management.Common.ExecutionFailureException:")[1]
                 }
-                if ($newmessage -like '*An exception occurred while executing a Transact-SQL statement or batch. ---> Microsoft.Data.SqlClient.SqlException:*')
-                {
+                if ($newmessage -like '*An exception occurred while executing a Transact-SQL statement or batch. ---> Microsoft.Data.SqlClient.SqlException:*') {
                     $newmessage = ($newmessage -replace "An exception occurred while executing a Transact-SQL statement or batch. ---> Microsoft.Data.SqlClient.SqlException:").Trim()
                 }
-                if ($newmessage -like '*An exception occurred while executing a Transact-SQL statement or batch*')
-                {
+                if ($newmessage -like '*An exception occurred while executing a Transact-SQL statement or batch*') {
                     $newmessage = ($newmessage -split "An exception occurred while executing a Transact-SQL statement or batch")[1]
                 }
-                
+
                 $message = $newmessage
             } catch {
                 $null


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9428  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Test-DbaLastBackup reported "" instead of the errormessage of checkdb. Checking Start-DbccCheck I noticed that the error wasn't parsed correctly in all cases... this strategy aims to preserve the most of the error message without splitting "blindfully" as before. Notice that probably different PS versions and MS libraries can change the result, so this probably slipped in some time ago and went unnoticed.

### Approach
Extract in a loop the innerexception. Split only if text is actually found on the string


@johnsterrett thanks for the report