### PR TITLE
New-DbaDbMaskingConfig, account for lots of tables

### DIFF
--- a/public/New-DbaDbMaskingConfig.ps1
+++ b/public/New-DbaDbMaskingConfig.ps1
@@ -609,7 +609,11 @@ function New-DbaDbMaskingConfig {
                     $filenamepart = $server.Name.Replace('\', '$').Replace('TCP:', '').Replace(',', '.')
 
                     if ($Table) {
-                        $temppath = Join-Path -Path $Path -ChildPath "$($filenamepart).$($db.Name).$($Table -join '-').DataMaskingConfig.json"
+                        if ($Table.Count -ge 5) {
+                            $temppath = Join-Path -Path $Path -ChildPath "$($filenamepart).$($db.Name).Tables_$(Get-Date -f 'yyyyMMddHHmmss').DataMaskingConfig.json"
+                        } else {
+                            $temppath = Join-Path -Path $Path -ChildPath "$($filenamepart).$($db.Name).$($Table -join '-').DataMaskingConfig.json"
+                        }
                     } else {
                         $temppath = Join-Path -Path $Path -ChildPath "$($filenamepart).$($db.Name).DataMaskingConfig.json"
                     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #9639 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Don't generate an insanely long path for the config file.

### Approach
If tables reach a certain number, switch path generation to `Tables_<timestamp>` instead.
