### PR TITLE
support lower-than-2012 instances (using RAISERROR instead of THROW)

### DIFF
--- a/private/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/private/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -237,14 +237,28 @@ function New-DbaLogShippingSecondaryDatabase {
         $Query += ";"
     }
 
-    $Query += "
+    if ($ServerSecondary.Version.Major -ge 11) {
+        $Query += "
+            IF (@SP_Add_RetCode <> 0)
+            BEGIN
+                DECLARE @msg VARCHAR(1000);
+                SELECT @msg = 'Unexpected result executing sp_add_log_shipping_secondary_database ('
+                    + CAST (@SP_Add_RetCode AS VARCHAR(5)) + ').';
+                THROW 51000, @msg, 1;
+            END
+            "
+    } else {
+        $Query += "
         IF (@SP_Add_RetCode <> 0)
         BEGIN
             DECLARE @msg VARCHAR(1000);
-            SELECT @msg = 'Unexpected result executing sp_add_log_shipping_seondary_database ('
+            SELECT @msg = 'Unexpected result executing sp_add_log_shipping_secondary_database ('
                 + CAST (@SP_Add_RetCode AS VARCHAR(5)) + ').';
-            THROW 51000, @msg, 1;
-        END"
+            RAISERROR (@msg, 16, 1) WITH NOWAIT;
+            RETURN;
+        END
+        "
+    }
 
     # Execute the query to add the log shipping primary
     if ($PSCmdlet.ShouldProcess($SqlServer, ("Configuring logshipping for secondary database $SecondaryDatabase on $SqlInstance"))) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9657  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Support sproc syntax also on < 2012 instances, using RAISERROR instead of THROW

@sanderstad as the original author you may be want to chime in on these
