### PR TITLE
buildref, "touch" LastUpdated even if no new CU have been shipped

### DIFF
--- a/bin/dbatools-buildref-index.json
+++ b/bin/dbatools-buildref-index.json
@@ -1,5 +1,5 @@
 {
-    "LastUpdated": "2025-03-14T00:00:00",
+    "LastUpdated": "2025-05-05T00:00:00",
     "Data": [
         {
             "Version": "8.0.47",


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
MS didn't ship anything in the last month, and our function expects a "fresh" index, nonetheless.

