### PR TITLE
Invoke-DbaDbDataMasking - fix up decimal & bit support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ allcommands.ps1
 .aider/aider.chat.history.md
 .aider/aider.input.history
 .aider/aider.llm.history
+**/.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,3 @@ allcommands.ps1
 .aider/aider.chat.history.md
 .aider/aider.input.history
 .aider/aider.llm.history
-**/.claude/settings.local.json

--- a/private/functions/Convert-DbaMaskingValue.ps1
+++ b/private/functions/Convert-DbaMaskingValue.ps1
@@ -111,9 +111,12 @@ function Convert-DbaMaskingValue {
             } else {
                 switch ($DataType.ToLower()) {
                     { $_ -in 'bit', 'bool' } {
-                        if ($item -match "([0-1])") {
-
+                        if ($item -match "^[0-1]$") {
                             $newValue = "$item"
+                        } elseif ($item -in "True", "true", "TRUE") {
+                            $newValue = "1"
+                        } elseif ($item -in "False", "false", "FALSE") {
+                            $newValue = "0"
                         } else {
                             $errorMessage = "Value '$($item)' is not valid BIT or BOOL"
                         }

--- a/private/functions/Convert-DbaMaskingValue.ps1
+++ b/private/functions/Convert-DbaMaskingValue.ps1
@@ -111,11 +111,11 @@ function Convert-DbaMaskingValue {
             } else {
                 switch ($DataType.ToLower()) {
                     { $_ -in 'bit', 'bool' } {
-                        if ($item -match "^[0-1]$") {
+                        if ($item -match "^[01]$") {
                             $newValue = "$item"
-                        } elseif ($item -in "True", "true", "TRUE") {
+                        } elseif ($item -eq "true") {
                             $newValue = "1"
-                        } elseif ($item -in "False", "false", "FALSE") {
+                        } elseif ($item -eq "false") {
                             $newValue = "0"
                         } else {
                             $errorMessage = "Value '$($item)' is not valid BIT or BOOL"

--- a/public/Invoke-DbaDbDataMasking.ps1
+++ b/public/Invoke-DbaDbDataMasking.ps1
@@ -917,7 +917,8 @@ function Invoke-DbaDbDataMasking {
                                                     Format          = $columnobject.Format
                                                     Locale          = $Locale
                                                 }
-                                            } elseif ($columnobject.SubType.ToLowerInvariant() -eq 'shuffle') {
+                                            } elseif ($columnobject.SubType.ToLowerInvariant() -in 'shuffle','string2','string')
+                                            {
                                                 if ($columnobject.ColumnType -in 'bigint', 'char', 'int', 'nchar', 'nvarchar', 'smallint', 'tinyint', 'varchar') {
                                                     $newValueParams = @{
                                                         RandomizerType    = "Random"
@@ -958,7 +959,11 @@ function Invoke-DbaDbDataMasking {
                                         # Convert the values so they can used in T-SQL
                                         try {
                                             if ($row.($columnobject.Name) -eq '') {
-                                                $convertedValue = Convert-DbaMaskingValue -Value ' ' -DataType $columnobject.ColumnType -Nullable:$columnobject.Nullable -EnableException
+                                                if ($columnobject.ColumnType -in 'decimal')
+                                                {
+                                                    $newvalue = "0.00"
+                                                }
+                                               $convertedValue = Convert-DbaMaskingValue -Value $newvalue -DataType $columnobject.ColumnType -Nullable:$columnobject.Nullable -EnableException
                                             } else {
                                                 $convertedValue = Convert-DbaMaskingValue -Value $newValue -DataType $columnobject.ColumnType -Nullable:$columnobject.Nullable -EnableException
                                             }

--- a/public/Invoke-DbaDbDataMasking.ps1
+++ b/public/Invoke-DbaDbDataMasking.ps1
@@ -957,14 +957,10 @@ function Invoke-DbaDbDataMasking {
 
                                         # Convert the values so they can used in T-SQL
                                         try {
-                                            if ($row.($columnobject.Name) -eq '') {
-                                                if ($columnobject.ColumnType -in 'decimal') {
-                                                    $newvalue = "0.00"
-                                                }
-                                                $convertedValue = Convert-DbaMaskingValue -Value $newvalue -DataType $columnobject.ColumnType -Nullable:$columnobject.Nullable -EnableException
-                                            } else {
-                                                $convertedValue = Convert-DbaMaskingValue -Value $newValue -DataType $columnobject.ColumnType -Nullable:$columnobject.Nullable -EnableException
+                                            if ($row.($columnobject.Name) -eq '' -and $columnobject.ColumnType -in 'decimal') {
+                                                $newvalue = "0.00"
                                             }
+                                            $convertedValue = Convert-DbaMaskingValue -Value $newValue -DataType $columnobject.ColumnType -Nullable:$columnobject.Nullable -EnableException
 
                                             if ($convertedValue.ErrorMessage) {
                                                 $maskingErrorFlag = $true

--- a/public/Invoke-DbaDbDataMasking.ps1
+++ b/public/Invoke-DbaDbDataMasking.ps1
@@ -917,8 +917,7 @@ function Invoke-DbaDbDataMasking {
                                                     Format          = $columnobject.Format
                                                     Locale          = $Locale
                                                 }
-                                            } elseif ($columnobject.SubType.ToLowerInvariant() -in 'shuffle','string2','string')
-                                            {
+                                            } elseif ($columnobject.SubType.ToLowerInvariant() -in 'shuffle', 'string2', 'string') {
                                                 if ($columnobject.ColumnType -in 'bigint', 'char', 'int', 'nchar', 'nvarchar', 'smallint', 'tinyint', 'varchar') {
                                                     $newValueParams = @{
                                                         RandomizerType    = "Random"
@@ -959,11 +958,10 @@ function Invoke-DbaDbDataMasking {
                                         # Convert the values so they can used in T-SQL
                                         try {
                                             if ($row.($columnobject.Name) -eq '') {
-                                                if ($columnobject.ColumnType -in 'decimal')
-                                                {
+                                                if ($columnobject.ColumnType -in 'decimal') {
                                                     $newvalue = "0.00"
                                                 }
-                                               $convertedValue = Convert-DbaMaskingValue -Value $newvalue -DataType $columnobject.ColumnType -Nullable:$columnobject.Nullable -EnableException
+                                                $convertedValue = Convert-DbaMaskingValue -Value $newvalue -DataType $columnobject.ColumnType -Nullable:$columnobject.Nullable -EnableException
                                             } else {
                                                 $convertedValue = Convert-DbaMaskingValue -Value $newValue -DataType $columnobject.ColumnType -Nullable:$columnobject.Nullable -EnableException
                                             }

--- a/tests/Invoke-DbaDbDataMasking.Tests.ps1
+++ b/tests/Invoke-DbaDbDataMasking.Tests.ps1
@@ -39,20 +39,24 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $sql = "CREATE TABLE [dbo].[people](
                     [fname] [varchar](50) NULL,
                     [lname] [varchar](50) NULL,
-                    [dob] [datetime] NULL
+                    [dob] [datetime] NULL,
+                    [percenttest] [decimal](15,3) NULL,
+                    [bittest] bit NULL
                 ) ON [PRIMARY]
                 GO
-                INSERT INTO people (fname, lname, dob) VALUES ('Joe','Schmoe','2/2/2000')
-                INSERT INTO people (fname, lname, dob) VALUES ('Jane','Schmee','2/2/1950')
+                INSERT INTO people (fname, lname, dob, percenttest,bittest) VALUES ('Joe','Schmoe','2/2/2000',29.53,1)
+                INSERT INTO people (fname, lname, dob, percenttest,bittest) VALUES ('Jane','Schmee','2/2/1950',65.38,0)
                 GO
                 CREATE TABLE [dbo].[people2](
                                     [fname] [varchar](50) NULL,
                                     [lname] [varchar](50) NULL,
-                                    [dob] [datetime] NULL
+                                    [dob] [datetime] NULL,
+                                    [percenttest] [decimal](15,3) NULL,
+                                    [bittest] bit NULL
                                 ) ON [PRIMARY]
                 GO
-                INSERT INTO people2 (fname, lname, dob) VALUES ('Layla','Schmoe','2/2/2000')
-                INSERT INTO people2 (fname, lname, dob) VALUES ('Eric','Schmee','2/2/1950')"
+                INSERT INTO people2 (fname, lname, dob, percenttest,bittest) VALUES ('Layla','Schmoe','2/2/2000',29.53,1)
+                INSERT INTO people2 (fname, lname, dob, percenttest,bittest) VALUES ('Eric','Schmee','2/2/1950',65.38,0)"
         New-DbaDatabase -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Name $db
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query $sql
     }
@@ -66,6 +70,10 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         It "starts with the right data" {
             Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where fname = 'Joe'" | Should -Not -Be $null
             Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where lname = 'Schmee'" | Should -Not -Be $null
+            Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where percenttest = 29.53" | Should -Not -Be $null
+            Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where percenttest = 65.38" | Should -Not -Be $null
+            Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where bittest = 1 AND lname = 'Schmoe'" | Should -Not -Be $null
+            Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where bittest = 0 AND lname = 'Schmee'" | Should -Not -Be $null
         }
         It "returns the proper output" {
             $file = New-DbaDbMaskingConfig -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Path C:\temp
@@ -83,6 +91,10 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people" | Should -Not -Be $null
             Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where fname = 'Joe'" | Should -Be $null
             Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where lname = 'Schmee'" | Should -Be $null
+            Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where percenttest = 29.53" | Should -Be $null
+            Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where percenttest = 65.38" | Should -Be $null
+            Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where bittest = 1 AND lname = 'Schmoe'" | Should -Be $null
+            Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -SqlCredential $TestConfig.SqlCredential -Database $db -Query "select * from people where bittest = 0 AND lname = 'Schmee'" | Should -Be $null
         }
     }
 }


### PR DESCRIPTION
Bug #9180

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #9180 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [X] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->

**Purpose**
Fix up Invoke-DbaDbDatamasking to improve bit & decimal value support

**Approach**
There was a missing check if a data type was a decimal and the value came back blank instead of with an actual value.  I changed this to make sure that if blank is returned, it is set to 0.00 instead.  I also encountered errors with bit values as in the open item, and was able to track down the error to Convert-DbaMaskingValue using Claude Code & my error message.  It made the recommendations to improve the RegEx search string and to add the additional checks for boolean values to convert to 1 & 0 for a bit column in the database.  I also updated the tests to test for decimal and bit values & masking them as well.
