### PR TITLE
Invoke-DbaQuery, pass along appendconnectionstring only if needed

### DIFF
--- a/public/Invoke-DbaQuery.ps1
+++ b/public/Invoke-DbaQuery.ps1
@@ -460,6 +460,9 @@ function Invoke-DbaQuery {
                             Verbose                = $false
                             AppendConnectionString = $AppendConnectionString
                         }
+                        if (Test-Bound -Not -ParameterName AppendConnectionString) {
+                            $connDbaInstanceParams.Remove('AppendConnectionString')
+                        }
                         if ($ReadOnly) {
                             $connDbaInstanceParams.ApplicationIntent = "ReadOnly"
                         }
@@ -479,6 +482,9 @@ function Invoke-DbaQuery {
                         NonPooledConnection    = $true           # see #8491 for details, also #7725 is still relevant
                         Verbose                = $false
                         AppendConnectionString = $AppendConnectionString
+                    }
+                    if (Test-Bound -Not -ParameterName AppendConnectionString) {
+                        $connDbaInstanceParams.Remove('AppendConnectionString')
                     }
                     if ($ReadOnly) {
                         $connDbaInstanceParams.ApplicationIntent = "ReadOnly"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9665  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Avoid passing down unuseful argument if not needed

### Approach
Detect via Test-Bound and if not needed, prune the splat before passing it down the line
