### PR TITLE
Added AppendServerInstance to Invoke-DbaWhoIsActive.

### DIFF
--- a/public/Invoke-DbaWhoIsActive.ps1
+++ b/public/Invoke-DbaWhoIsActive.ps1
@@ -141,6 +141,9 @@ function Invoke-DbaWhoIsActive {
 
         PSObject output introduces overhead but adds flexibility for working with results: https://forums.powershell.org/t/dealing-with-dbnull/2328/2
 
+    .PARAMETER AppendServerInstance
+        If this switch is enabled, the SQL Server instance will be appended to PSObject and DataRow output.
+
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
 
@@ -230,6 +233,7 @@ function Invoke-DbaWhoIsActive {
         [switch]$Help,
         [ValidateSet("DataSet", "DataTable", "DataRow", "PSObject")]
         [string]$As = "DataRow",
+        [switch]$AppendServerInstance,
         [switch]$EnableException
     )
     begin {
@@ -292,7 +296,7 @@ function Invoke-DbaWhoIsActive {
                         $sqlParameter[$sqlParam] = $value
                     }
                 }
-                Invoke-DbaQuery -SqlInstance $server -Query "dbo.sp_WhoIsActive" -CommandType "StoredProcedure" -SqlParameter $sqlParameter -As $As -EnableException
+                Invoke-DbaQuery -SqlInstance $server -Query "dbo.sp_WhoIsActive" -CommandType "StoredProcedure" -SqlParameter $sqlParameter -As $As -AppendServerInstance:$AppendServerInstance -EnableException
             } catch {
                 if ($_.Exception.InnerException -Like "*Could not find*") {
                     Stop-Function -Message "sp_whoisactive not found, please install using Install-DbaWhoIsActive." -Continue


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #9540  )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [X] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
When you call `Invoke-DbaWhoIsActive` on a bunch of servers at once, it pays to know which server you're seeing.

### Approach
<!-- How does this change solve that purpose -->
The key was to realise that the bulk of the code in `Invoke-DbaWhoIsActive` is for SQL parameters, not PowerShell ones.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
I used `Invoke-DbaWhoIsActive -SqlInstance $ins -ShowSystemSpids -AppendServerInstance`. The glaring omission in my testing is that I only have one instance running locally. I'm already pushing my ancient laptop too hard to risk spinning up another.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://github.com/user-attachments/assets/78b07aca-e8af-4378-912d-75d4715a133c)


### Learning
<!-- Optional -->
`-AppendServerInstance:$AppendServerInstance` is a good trick that I didn't know previously. In fact, it concerns me. **Is the `EnableException` parameter in `Invoke-DbaWhoIsActive` dead code?**