### PR TITLE
Set-DbaAgentJobOutputFile: Made it more clear that the Job and Step parameters expect names.

### DIFF
--- a/public/Set-DbaAgentJobOutputFile.ps1
+++ b/public/Set-DbaAgentJobOutputFile.ps1
@@ -17,13 +17,19 @@ function Set-DbaAgentJobOutputFile {
         For MFA support, please use Connect-DbaInstance. be it Windows or SQL Server. Windows users are determined by the existence of a backslash, so if you are intending to use an alternative Windows connection instead of a SQL login, ensure it contains a backslash.
 
     .PARAMETER Job
-        The job to process - this list is auto-populated from the server.
+        The name of the job to process.
+        
+        This parameter is not officially mandatory, but you will always be asked to provide a job if you have not.
 
     .PARAMETER Step
-        The Agent Job Step to provide Output File Path for. Also available dynamically
+        The name of the Agent Job Step to provide Output File Path for.
+        
+        Within a job, step names are unique so this is a safe way to select steps.
+        
+        Also available dynamically. If you do not specify this parameter and the target job has only one step, then we use that step. If it has more than one, then a GUI will be used to make you pick steps. If that GUI does not work, then we use all steps.
 
     .PARAMETER OutputFile
-        The Full Path to the New Output file
+        The Full Path to the New Output file.
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.


### PR DESCRIPTION
Made it more clear that the `Job` and `Step` parameters expect names. Also mentioned how `Step` handles special cases. Closes #9674.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [X] Documentation
 - [ ] Build system

### Commands to test
`Out-GridView` doesn't work on my machine, so it may be prudent to verify that these special cases function as I've said that they do. My tests say that they do.

### Screenshots
Shamefully, I couldn't get one! `Get-Help` doesn't seem to show the details of parameters on my machine.

### Learning
Confirming the step names within an Agent Job are unique was reassuring. 
