### PR TITLE
Remove-DbaDbOrphanUser, avoid readonly dbs

### DIFF
--- a/public/Remove-DbaDbOrphanUser.ps1
+++ b/public/Remove-DbaDbOrphanUser.ps1
@@ -118,7 +118,7 @@ function Remove-DbaDbOrphanUser {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            $DatabaseCollection = $server.Databases | Where-Object IsAccessible | Where-Object -Not ReadOnly
+            $DatabaseCollection = $server.Databases | Where-Object IsAccessible | Where-Object ReadOnly -eq $false
 
             if ($Database) {
                 $DatabaseCollection = $DatabaseCollection | Where-Object Name -In $Database

--- a/public/Remove-DbaDbOrphanUser.ps1
+++ b/public/Remove-DbaDbOrphanUser.ps1
@@ -118,7 +118,7 @@ function Remove-DbaDbOrphanUser {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            $DatabaseCollection = $server.Databases | Where-Object IsAccessible
+            $DatabaseCollection = $server.Databases | Where-Object IsAccessible | Where-Object -Not ReadOnly
 
             if ($Database) {
                 $DatabaseCollection = $DatabaseCollection | Where-Object Name -In $Database


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9690  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Bug report is on-point. We can't repair users on a readonly db, and that includes snapshots.

### Approach
Add a filter on the initial db collection
