### PR TITLE
bump date for build reference

### DIFF
--- a/bin/dbatools-buildref-index.json
+++ b/bin/dbatools-buildref-index.json
@@ -1,5 +1,5 @@
 {
-    "LastUpdated": "2025-07-10T00:00:00",
+    "LastUpdated": "2025-07-11T00:00:00",
     "Data": [
         {
             "Version": "8.0.47",


### PR DESCRIPTION
this #9705 didn't bump the date at the top.

@potatoqualitee : is this still blowing the repo size ?