### PR TITLE
Copy-DbaDatabase - Fix enabling broker on prefixed databases

### DIFF
--- a/public/Copy-DbaDatabase.ps1
+++ b/public/Copy-DbaDatabase.ps1
@@ -1402,7 +1402,7 @@ function Copy-DbaDatabase {
                                         $quotedDatabaseName = $destserver.Query("SELECT QUOTENAME('$($destinationDbName.Replace("'", "''"))') AS quotename").quotename
                                         $null = $destserver.Query("ALTER DATABASE $quotedDatabaseName SET NEW_BROKER WITH ROLLBACK IMMEDIATE")
                                         $NewDatabase.BrokerEnabled = $sourceDbBrokerEnabled
-                                        $NewDatabase.Alter()
+                                        $null = $NewDatabase.Alter()
                                         Write-Message -Level Verbose -Message "Successfully updated BrokerEnabled to $sourceDbBrokerEnabled for $destinationDbName on $destinstance."
                                     } catch {
                                         Write-Message -Level Warning -Message "Failed to update BrokerEnabled to $sourceDbBrokerEnabled for $destinationDbName on $destinstance."

--- a/public/Copy-DbaDatabase.ps1
+++ b/public/Copy-DbaDatabase.ps1
@@ -1397,9 +1397,17 @@ function Copy-DbaDatabase {
                                     $NewDatabase.Alter()
                                     Write-Message -Level Verbose -Message "Successfully updated BrokerEnabled to $sourceDbBrokerEnabled for $destinationDbName on $destinstance."
                                 } catch {
-                                    Write-Message -Level Warning -Message "Failed to update BrokerEnabled to $sourceDbBrokerEnabled for $destinationDbName on $destinstance."
-
-                                    $propfailures += "Message broker"
+                                    try {
+                                        Write-Message -Level Verbose -Message "Updating BrokerEnabled to $sourceDbBrokerEnabled for $destinationDbName on $destinstance failed so we try to regenerate the broker identifier."
+                                        $quotedDatabaseName = $destserver.Query("SELECT QUOTENAME('$($destinationDbName.Replace("'", "''"))') AS quotename").quotename
+                                        $null = $destserver.Query("ALTER DATABASE $quotedDatabaseName SET NEW_BROKER WITH ROLLBACK IMMEDIATE")
+                                        $NewDatabase.BrokerEnabled = $sourceDbBrokerEnabled
+                                        $NewDatabase.Alter()
+                                        Write-Message -Level Verbose -Message "Successfully updated BrokerEnabled to $sourceDbBrokerEnabled for $destinationDbName on $destinstance."
+                                    } catch {
+                                        Write-Message -Level Warning -Message "Failed to update BrokerEnabled to $sourceDbBrokerEnabled for $destinationDbName on $destinstance."
+                                        $propfailures += "Message broker"
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

When using `-Prefix`, broker could not be enabled in the copied database.
Solution was to use NEW_BROKER to regenerate the broker identifier.