### PR TITLE
Get-TestConfig - Cleanup code

### DIFF
--- a/private/testing/Get-TestConfig.ps1
+++ b/private/testing/Get-TestConfig.ps1
@@ -5,9 +5,7 @@ function Get-TestConfig {
     $config = [ordered]@{}
 
     if (Test-Path $LocalConfigPath) {
-        Write-Host "Tests will use local constants file: tests\constants.local.ps1." -ForegroundColor Cyan
         . $LocalConfigPath
-        # Note: Local constants are sourced but not explicitly added to $config
     } elseif ($env:CODESPACES -or ($env:TERM_PROGRAM -eq 'vscode' -and $env:REMOTE_CONTAINERS)) {
         $null = Set-DbatoolsInsecureConnection
         $config['Instance1'] = "dbatools1"
@@ -59,13 +57,6 @@ function Get-TestConfig {
         $config['Defaults'] = [System.Management.Automation.DefaultParameterDictionary]@{
             '*:WarningAction' = 'SilentlyContinue'
         }
-    }
-
-    # derive the command name from the CALLING script's filename
-    $config['CommandName'] = ($MyInvocation.MyCommand.Name | Split-Path -Leaf).Replace(".Tests.ps1", "")
-
-    if (-not $config['CommandName']) {
-        $config['CommandName'] = "Unknown"
     }
 
     $config['CommonParameters'] = [System.Management.Automation.PSCmdlet]::CommonParameters


### PR DESCRIPTION
Just cleaning the code a bit.

* Removing a Write-Host that produces output that is not relevant and only takes up space
* Removing a comment that I don't understand and think is useless.
* Removing code that does not work as intended, as Get-TestConfig is invoked by pester and not the test itself.
