### PR TITLE
Get-TestConfig - Added configuration for temp folder

### DIFF
--- a/private/testing/Get-TestConfig.ps1
+++ b/private/testing/Get-TestConfig.ps1
@@ -70,5 +70,9 @@ function Get-TestConfig {
 
     $config['CommonParameters'] = [System.Management.Automation.PSCmdlet]::CommonParameters
 
+    if (-not $config['Temp']) {
+        $config['Temp'] = 'C:\Temp'
+    }
+
     [pscustomobject]$config
 }

--- a/tests/Backup-DbaComputerCertificate.Tests.ps1
+++ b/tests/Backup-DbaComputerCertificate.Tests.ps1
@@ -35,7 +35,7 @@ Describe "Backup-DbaComputerCertificate" -Tag "IntegrationTests" {
         BeforeAll {
             $null = Add-DbaComputerCertificate -Path "$($TestConfig.appveyorlabrepo)\certificates\localhost.crt" -Confirm:$false
             $certThumbprint = "29C469578D6C6211076A09CEE5C5797EEA0C2713"
-            $backupPath = "C:\temp"
+            $backupPath = $TestConfig.Temp
         }
 
         It "Returns the proper results" {

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -16,7 +16,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
     Context "Properly restores a database on the local drive using Path" {
-        $results = Backup-DbaDatabase -SqlInstance $TestConfig.instance1 -BackupDirectory C:\temp\backups
+        $results = Backup-DbaDatabase -SqlInstance $TestConfig.instance1 -BackupDirectory "$($TestConfig.Temp)\backups"
         It "Should return a database name, specifically master" {
             ($results.DatabaseName -contains 'master') | Should -Be $true
         }
@@ -26,7 +26,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     }
 
     BeforeAll {
-        $DestBackupDir = 'C:\Temp\backups'
+        $DestBackupDir = "$($TestConfig.Temp)\backups"
         $random = Get-Random
         $DestDbRandom = "dbatools_ci_backupdbadatabase$random"
         if (-Not(Test-Path $DestBackupDir)) {
@@ -142,10 +142,10 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
 
     Context "A fully qualified path should override a backupfolder" {
-        $results = Backup-DbaDatabase -SqlInstance $TestConfig.instance1 -Database master -BackupDirectory c:\temp -BackupFileName "$DestBackupDir\PesterTest2.bak"
+        $results = Backup-DbaDatabase -SqlInstance $TestConfig.instance1 -Database master -BackupDirectory $TestConfig.Temp -BackupFileName "$DestBackupDir\PesterTest2.bak"
         It "Should report backed up to $DestBackupDir" {
             $results.FullName | Should -BeLike "$DestBackupDir\PesterTest2.bak"
-            $results.BackupFolder | Should Not Be 'c:\temp'
+            $results.BackupFolder | Should Not Be $TestConfig.Temp
         }
         It "Should have backuped up to $DestBackupDir\PesterTest2.bak" {
             Test-Path "$DestBackupDir\PesterTest2.bak" | Should -Be $true

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -15,7 +15,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
-        $NetworkPath = "C:\temp"
+        $NetworkPath = $TestConfig.Temp
         $random = Get-Random
         $backuprestoredb = "dbatoolsci_backuprestore$random"
         $backuprestoredb2 = "dbatoolsci_backuprestoreother$random"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The temp folder that is used by the tests should be configurable to support both local storage (currently C:\Temp) and also a network share (like \\fs\Temp) to support running the tests from a different server than the SQL Server instances that are tested.

### Approach
Adding the property "Temp" to the $config object returned by Get-TestConfig.

### Commands to test
I changed some of the tests that had C:\Temp hardcoded - I will change the other tests once this PR is merged.
