### PR TITLE
constants.local.ps1.example - Fix example for defaults for $PSDefaultParameterValues

### DIFF
--- a/tests/constants.local.ps1.example
+++ b/tests/constants.local.ps1.example
@@ -17,7 +17,7 @@ $securePassword = ConvertTo-SecureString "YourPassword" -AsPlainText -Force
 $config['SqlCred'] = New-Object System.Management.Automation.PSCredential ("sa", $securePassword)
 
 # Default parameter values for the tests
-$config['PSDefaultParameterValues'] = @{
+$config['Defaults'] = [System.Management.Automation.DefaultParameterDictionary]@{
     "*:SqlCredential" = $config['SqlCred']
 }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

In the test files we use `$PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults` so the name of the property needs to be changed. And also the type should be changed to the correct type, like it is used in Get-TestConfig.