### PR TITLE
Refactor the Endpoint related tests

### DIFF
--- a/tests/Copy-DbaEndpoint.Tests.ps1
+++ b/tests/Copy-DbaEndpoint.Tests.ps1
@@ -36,16 +36,12 @@ Describe "Copy-DbaEndpoint" -Tag "UnitTests" {
 
 Describe "Copy-DbaEndpoint" -Tag "IntegrationTests" {
     BeforeAll {
-        Get-DbaEndpoint -SqlInstance $TestConfig.instance2 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
-        New-DbaEndpoint -SqlInstance $TestConfig.instance2 -Name dbatoolsci_MirroringEndpoint -Type DatabaseMirroring -Port 5022 -Owner sa
-        Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
+        New-DbaEndpoint -SqlInstance $TestConfig.instance2 -Name dbatoolsci_MirroringEndpoint -Type DatabaseMirroring -Port 5022 -Owner sa -EnableException
     }
 
     AfterAll {
         Get-DbaEndpoint -SqlInstance $TestConfig.instance2 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
-        New-DbaEndpoint -SqlInstance $TestConfig.instance2 -Name dbatoolsci_MirroringEndpoint -Type DatabaseMirroring -Port 5022 -Owner sa
         Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
-        New-DbaEndpoint -SqlInstance $TestConfig.instance3 -Name dbatoolsci_MirroringEndpoint -Type DatabaseMirroring -Port 5023 -Owner sa
     }
 
     Context "When copying endpoints between instances" {

--- a/tests/New-DbaEndpoint.Tests.ps1
+++ b/tests/New-DbaEndpoint.Tests.ps1
@@ -14,18 +14,11 @@ Describe "$CommandName Unit Tests" -Tags "UnitTests" {
 }
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
-    BeforeAll {
-        $endpoint = Get-DbaEndpoint -SqlInstance $TestConfig.instance2 | Where-Object EndpointType -eq DatabaseMirroring
-        $create = $endpoint | Export-DbaScript -Passthru
-        Get-DbaEndpoint -SqlInstance $TestConfig.instance2 | Where-Object EndpointType -eq DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
-    }
     AfterAll {
-        Get-DbaEndpoint -SqlInstance $TestConfig.instance2 | Where-Object EndpointType -eq DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
-        if ($create) {
-            Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query "$create"
-        }
+        $null = Remove-DbaEndpoint -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -EndPoint dbatoolsci_MirroringEndpoint -Confirm:$false
     }
-    $results = New-DbaEndpoint -SqlInstance $TestConfig.instance2 -Type DatabaseMirroring -Role Partner -Name Mirroring -Confirm:$false | Start-DbaEndpoint -Confirm:$false
+
+    $results = New-DbaEndpoint -SqlInstance $TestConfig.instance2 -Type DatabaseMirroring -Role Partner -Name dbatoolsci_MirroringEndpoint -Confirm:$false | Start-DbaEndpoint -Confirm:$false
 
     It "creates an endpoint of the db mirroring type" {
         $results.EndpointType | Should -Be 'DatabaseMirroring'

--- a/tests/Remove-DbaEndpoint.Tests.ps1
+++ b/tests/Remove-DbaEndpoint.Tests.ps1
@@ -15,15 +15,7 @@ Describe "$CommandName Unit Tests" -Tags "UnitTests" {
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
-        $endpoint = Get-DbaEndpoint -SqlInstance $TestConfig.instance2 | Where-Object EndpointType -eq DatabaseMirroring
-        $create = $endpoint | Export-DbaScript -Passthru
-        $null = $endpoint | Remove-DbaEndpoint -Confirm:$false
-        $results = New-DbaEndpoint -SqlInstance $TestConfig.instance2 -Type DatabaseMirroring -Role Partner -Name Mirroring -Confirm:$false | Start-DbaEndpoint -Confirm:$false
-    }
-    AfterAll {
-        if ($create) {
-            Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query "$create"
-        }
+        $null = New-DbaEndpoint -SqlInstance $TestConfig.instance2 -Type DatabaseMirroring -Role Partner -Name Mirroring -EnableException -Confirm:$false | Start-DbaEndpoint -EnableException -Confirm:$false
     }
 
     It "removes an endpoint" {

--- a/tests/Test-DbaEndpoint.Tests.ps1
+++ b/tests/Test-DbaEndpoint.Tests.ps1
@@ -14,8 +14,15 @@ Describe "$CommandName Unit Tests" -Tags "UnitTests" {
 }
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
-    It -Skip "returns success" {
-        $results = Test-DbaEndpoint -SqlInstance $TestConfig.instance3
+    BeforeAll {
+        $null = New-DbaEndpoint -SqlInstance $TestConfig.instance2 -Type DatabaseMirroring -Name dbatoolsci_MirroringEndpoint -EnableException -Confirm:$false | Start-DbaEndpoint -EnableException
+    }
+    AfterAll {
+        $null = Remove-DbaEndpoint -SqlInstance $TestConfig.instance2 -EndPoint dbatoolsci_MirroringEndpoint -Confirm:$false
+    }
+
+    It "returns success" {
+        $results = Test-DbaEndpoint -SqlInstance $TestConfig.instance2
         $results | Select-Object -First 1 -ExpandProperty Connection | Should -Be 'Success'
     }
 } #$TestConfig.instance2 for appveyor


### PR DESCRIPTION
In the beginning and in between of the tests there should not be any endpoint.

This way we don't have to test for existance and have cleaner tests that are more readable.

Added a test for Test-DbaEndpoint as it was missing.