### PR TITLE
Skip PR builds if push build exists in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@
 image: Previous Visual Studio 2015
 configuration: "Debug"
 
+# skip PR builds when there's already a push build
+skip_branch_with_pr: true
+
 build_script:
  - ps: Set-Service wuauserv -StartupType Manual #otherwise, choco command exits with code 1058
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ cache:
   - C:\Program Files\WindowsPowerShell\Modules\dbatools.library -> .github/dbatools-library-version.json
 
 #shallow_clone: true
-clone_depth: 100
+clone_depth: 20
 
 # Set build info
 environment:


### PR DESCRIPTION
Added 'skip_branch_with_pr: true' to appveyor.yml to prevent duplicate builds for pull requests when a push build is already running. Might fix #9733 

## **How `skip_branch_with_pr: true` Works**

- **Team member workflow**:
  1. Push to branch → AppVeyor runs (10 scenarios)
  2. Create PR from that branch → AppVeyor skips ✅ (because there's already a push build for the same commit)

- **External contributor workflow**:
  1. Fork repo → Create PR → AppVeyor runs (10 scenarios) ✅ (because there's NO push build - they can't push to your repo)

## **Why External PRs Still Run**

External contributors can't push to your `dataplat/dbatools` repository, so there's never a "push build" for AppVeyor to detect. The `skip_branch_with_pr` logic only skips when:

1. There's a PR **AND**  
2. There's already a push build for the same commit **AND**
3. Both are in the same repository

Since external PRs come from forks, condition #3 is never met, so AppVeyor runs their tests normally.