### PR TITLE
Get-DbaDbBackupHistory - Change warning to verbose for recovery fork message

### DIFF
--- a/public/Get-DbaDbBackupHistory.ps1
+++ b/public/Get-DbaDbBackupHistory.ps1
@@ -323,7 +323,7 @@ function Get-DbaDbBackupHistory {
                         $results = $server.ConnectionContext.ExecuteWithResults($forkCheckSql).Tables.Rows
                         if ($results.count -gt 1) {
                             if (-not $LastFull) {
-                                Write-Message -Message "Found backups from multiple recovery forks for $($db.name) on $($server.name), this may affect your results" -Level Warning
+                                Write-Message -Message "Found backups from multiple recovery forks for $($db.name) on $($server.name), this may affect your results" -Level Verbose
                                 foreach ($result in $results) {
                                     Write-Message -Message "Between $($result.MinDate)/$($result.FirstLsn) and $($result.MaxDate)/$($result.FinalLsn) $($result.database_name) was on Recovery Fork GUID $($result.RecFork) ($($result.backupcount) backups)" -Level Warning
                                 }
@@ -409,7 +409,7 @@ function Get-DbaDbBackupHistory {
                         $results = $server.ConnectionContext.ExecuteWithResults($forkCheckSql).Tables.Rows
                         if ($results.count -gt 1) {
                             if (-not $LastFull) {
-                                Write-Message -Message "Found backups from multiple recovery forks for $($db.name) on $($server.name), this may affect your results" -Level Warning
+                                Write-Message -Message "Found backups from multiple recovery forks for $($db.name) on $($server.name), this may affect your results" -Level Verbose
                                 foreach ($result in $results) {
                                     Write-Message -Message "Between $($result.MinDate)/$($result.FirstLsn) and $($result.MaxDate)/$($result.FinalLsn) $($result.database_name) was on Recovery Fork GUID $($result.RecFork) ($($result.backupcount) backups)" -Level Warning
                                 }


### PR DESCRIPTION
This happens all the time in my env with AGs and nearly everywhere else. It's ugly and if someone needs, they can slap a verbose and see what's up if they are having issues.

Updated the log level from Warning to Verbose for messages about multiple recovery forks in Get-DbaDbBackupHistory. This reduces unnecessary warning output when multiple recovery forks are detected but no last full backup is found.