### PR TITLE
Refactor the Credential related tests

### DIFF
--- a/tests/Copy-DbaCredential.Tests.ps1
+++ b/tests/Copy-DbaCredential.Tests.ps1
@@ -16,7 +16,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
-        $logins = "dbatoolsci_thor", "dbatoolsci_thorsmomma", "dbatoolsci_thor_crypto"
+        $logins = "thor", "thorsmomma", "thor_crypto"
         $plaintext = "BigOlPassword!"
         $password = ConvertTo-SecureString $plaintext -AsPlainText -Force
 
@@ -26,7 +26,6 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         # Add user
         foreach ($login in $logins) {
             $null = Invoke-Command2 -ScriptBlock { net user $args[0] $args[1] /add *>&1 } -ArgumentList $login, $plaintext -ComputerName $TestConfig.instance2
-            $null = Invoke-Command2 -ScriptBlock { net user $args[0] $args[1] /add *>&1 } -ArgumentList $login, $plaintext -ComputerName $TestConfig.instance3
         }
 
         <#
@@ -64,29 +63,27 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $cryptoProvider = ($instance2CryptoProviders | Where-Object { $_.name -eq $instance3CryptoProviders.name } | Select-Object -First 1).name
     }
     AfterAll {
-        (Get-DbaCredential -SqlInstance $server2 -Identity dbatoolsci_thor, dbatoolsci_thorsmomma, dbatoolsci_thor_crypto -ErrorAction Stop -WarningAction SilentlyContinue).Drop()
-        (Get-DbaCredential -SqlInstance $server3 -Identity dbatoolsci_thor, dbatoolsci_thorsmomma, dbatoolsci_thor_crypto -ErrorAction Stop -WarningAction SilentlyContinue).Drop()
+        Remove-DbaCredential -SqlInstance $server2, $server3 -Identity thor, thorsmomma, thor_crypto -Confirm:$false
 
         foreach ($login in $logins) {
             $null = Invoke-Command2 -ScriptBlock { net user $args /delete *>&1 } -ArgumentList $login -ComputerName $TestConfig.instance2
-            $null = Invoke-Command2 -ScriptBlock { net user $args /delete *>&1 } -ArgumentList $login -ComputerName $TestConfig.instance3
         }
     }
 
     Context "Create new credential" {
         It "Should create new credentials with the proper properties" {
-            $results = New-DbaCredential -SqlInstance $server2 -Name dbatoolsci_thorcred -Identity dbatoolsci_thor -Password $password
-            $results.Name | Should Be "dbatoolsci_thorcred"
-            $results.Identity | Should Be "dbatoolsci_thor"
+            $results = New-DbaCredential -SqlInstance $server2 -Name thorcred -Identity thor -Password $password
+            $results.Name | Should Be "thorcred"
+            $results.Identity | Should Be "thor"
 
-            $results = New-DbaCredential -SqlInstance $server2 -Identity dbatoolsci_thorsmomma -Password $password
-            $results.Name | Should Be "dbatoolsci_thorsmomma"
-            $results.Identity | Should Be "dbatoolsci_thorsmomma"
+            $results = New-DbaCredential -SqlInstance $server2 -Identity thorsmomma -Password $password
+            $results.Name | Should Be "thorsmomma"
+            $results.Identity | Should Be "thorsmomma"
 
             if ($cryptoProvider) {
-                $results = New-DbaCredential -SqlInstance $server2 -Identity dbatoolsci_thor_crypto -Password $password -MappedClassType CryptographicProvider -ProviderName $cryptoProvider
-                $results.Name | Should Be "dbatoolsci_thor_crypto"
-                $results.Identity | Should Be "dbatoolsci_thor_crypto"
+                $results = New-DbaCredential -SqlInstance $server2 -Identity thor_crypto -Password $password -MappedClassType CryptographicProvider -ProviderName $cryptoProvider
+                $results.Name | Should Be "thor_crypto"
+                $results.Identity | Should Be "thor_crypto"
                 $results.ProviderName | Should -Be $cryptoProvider
             }
         }
@@ -94,13 +91,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     Context "Copy Credential with the same properties." {
         It "Should copy successfully" {
-            $results = Copy-DbaCredential -Source $server2 -Destination $server3 -Name dbatoolsci_thorcred
+            $results = Copy-DbaCredential -Source $server2 -Destination $server3 -Name thorcred
             $results.Status | Should Be "Successful"
         }
 
         It "Should retain its same properties" {
-            $Credential1 = Get-DbaCredential -SqlInstance $server2 -Name dbatoolsci_thor -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
-            $Credential2 = Get-DbaCredential -SqlInstance $server3 -Name dbatoolsci_thor -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+            $Credential1 = Get-DbaCredential -SqlInstance $server2 -Name thor -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+            $Credential2 = Get-DbaCredential -SqlInstance $server3 -Name thor -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
 
             # Compare its value
             $Credential1.Name | Should Be $Credential2.Name
@@ -110,7 +107,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     Context "No overwrite" {
         It "does not overwrite without force" {
-            $results = Copy-DbaCredential -Source $server2 -Destination $server3 -Name dbatoolsci_thorcred
+            $results = Copy-DbaCredential -Source $server2 -Destination $server3 -Name thorcred
             $results.Status | Should Be "Skipping"
         }
     }
@@ -118,17 +115,17 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     # See https://github.com/dataplat/dbatools/issues/7896 and comments above in BeforeAll
     Context "Crypto provider cred" {
         It -Skip:(-not $cryptoProvider) "ensure copied credential is using the same crypto provider" {
-            $results = Copy-DbaCredential -Source $server2 -Destination $server3 -Name dbatoolsci_thor_crypto
+            $results = Copy-DbaCredential -Source $server2 -Destination $server3 -Name thor_crypto
             $results.Status | Should Be Successful
-            $results = Get-DbaCredential -SqlInstance $server3 -Name dbatoolsci_thor_crypto
-            $results.Name | Should -Be dbatoolsci_thor_crypto
+            $results = Get-DbaCredential -SqlInstance $server3 -Name thor_crypto
+            $results.Name | Should -Be thor_crypto
             $results.ProviderName | Should -Be $cryptoProvider
         }
 
         It -Skip:(-not $cryptoProvider) "check warning message if crypto provider is not configured/enabled on destination" {
-            Remove-DbaCredential -SqlInstance $server3 -Credential dbatoolsci_thor_crypto -Confirm:$false
+            Remove-DbaCredential -SqlInstance $server3 -Credential thor_crypto -Confirm:$false
             $server3.Query("ALTER CRYPTOGRAPHIC PROVIDER $cryptoProvider DISABLE")
-            $results = Copy-DbaCredential -Source $server2 -Destination $server3 -Name dbatoolsci_thor_crypto
+            $results = Copy-DbaCredential -Source $server2 -Destination $server3 -Name thor_crypto
             $server3.Query("ALTER CRYPTOGRAPHIC PROVIDER $cryptoProvider ENABLE")
             $results.Status | Should Be Failed
             $results.Notes | Should -Match "The cryptographic provider $cryptoProvider needs to be configured and enabled on"

--- a/tests/Get-DbaCredential.Tests.ps1
+++ b/tests/Get-DbaCredential.Tests.ps1
@@ -17,7 +17,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
-        $logins = "dbatoolsci_thor", "dbatoolsci_thorsmomma"
+        $logins = "thor", "thorsmomma"
         $plaintext = "BigOlPassword!"
         $password = ConvertTo-SecureString $plaintext -AsPlainText -Force
 
@@ -26,33 +26,32 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $null = Invoke-Command2 -ScriptBlock { net user $args[0] $args[1] /add *>&1 } -ArgumentList $login, $plaintext -ComputerName $TestConfig.instance2
         }
 
-        $results = New-DbaCredential -SqlInstance $TestConfig.instance2 -Name dbatoolsci_thorcred -Identity dbatoolsci_thor -Password $password
-        $results = New-DbaCredential -SqlInstance $TestConfig.instance2 -Identity dbatoolsci_thorsmomma -Password $password
+        $null = New-DbaCredential -SqlInstance $TestConfig.instance2 -Name thorcred -Identity thor -Password $password
+        $null = New-DbaCredential -SqlInstance $TestConfig.instance2 -Identity thorsmomma -Password $password
     }
     AfterAll {
         try {
-            (Get-DbaCredential -SqlInstance $TestConfig.instance2 -Identity dbatoolsci_thor, dbatoolsci_thorsmomma -ErrorAction Stop -WarningAction SilentlyContinue).Drop()
+            (Get-DbaCredential -SqlInstance $TestConfig.instance2 -Identity thor, thorsmomma -ErrorAction Stop -WarningAction SilentlyContinue).Drop()
         } catch { }
 
         foreach ($login in $logins) {
-            $null = Invoke-Command2 -ScriptBlock { net user $args /delete *>&1 } -ArgumentList $login -ComputerName $TestConfig.instance2
             $null = Invoke-Command2 -ScriptBlock { net user $args /delete *>&1 } -ArgumentList $login -ComputerName $TestConfig.instance2
         }
     }
 
     Context "Get credentials" {
         It "Should get just one credential with the proper properties when using Identity" {
-            $results = Get-DbaCredential -SqlInstance $TestConfig.instance2 -Identity dbatoolsci_thorsmomma
-            $results.Name | Should Be "dbatoolsci_thorsmomma"
-            $results.Identity | Should Be "dbatoolsci_thorsmomma"
+            $results = Get-DbaCredential -SqlInstance $TestConfig.instance2 -Identity thorsmomma
+            $results.Name | Should Be "thorsmomma"
+            $results.Identity | Should Be "thorsmomma"
         }
         It "Should get just one credential with the proper properties when using Name" {
-            $results = Get-DbaCredential -SqlInstance $TestConfig.instance2 -Name dbatoolsci_thorsmomma
-            $results.Name | Should Be "dbatoolsci_thorsmomma"
-            $results.Identity | Should Be "dbatoolsci_thorsmomma"
+            $results = Get-DbaCredential -SqlInstance $TestConfig.instance2 -Name thorsmomma
+            $results.Name | Should Be "thorsmomma"
+            $results.Identity | Should Be "thorsmomma"
         }
         It "gets more than one credential" {
-            $results = Get-DbaCredential -SqlInstance $TestConfig.instance2 -Identity dbatoolsci_thor, dbatoolsci_thorsmomma
+            $results = Get-DbaCredential -SqlInstance $TestConfig.instance2 -Identity thor, thorsmomma
             $results.count -gt 1
         }
     }

--- a/tests/New-DbaCredential.Tests.ps1
+++ b/tests/New-DbaCredential.Tests.ps1
@@ -16,7 +16,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
-        $logins = "dbatoolsci_thor", "dbatoolsci_thorsmomma"
+        $logins = "thor", "thorsmomma"
         $plaintext = "BigOlPassword!"
         $password = ConvertTo-SecureString $plaintext -AsPlainText -Force
 
@@ -27,29 +27,28 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     }
     AfterAll {
         try {
-            (Get-DbaCredential -SqlInstance $TestConfig.instance2 -Identity dbatoolsci_thor, dbatoolsci_thorsmomma -ErrorAction Stop -WarningAction SilentlyContinue).Drop()
+            (Get-DbaCredential -SqlInstance $TestConfig.instance2 -Identity thor, thorsmomma -ErrorAction Stop -WarningAction SilentlyContinue).Drop()
             (Get-DbaCredential -SqlInstance $TestConfig.instance2 -Name "https://mystorageaccount.blob.core.windows.net/mycontainer" -ErrorAction Stop -WarningAction SilentlyContinue).Drop()
         } catch { }
 
         foreach ($login in $logins) {
-            $null = Invoke-Command2 -ScriptBlock { net user $args /delete *>&1 } -ArgumentList $login -ComputerName $TestConfig.instance2
             $null = Invoke-Command2 -ScriptBlock { net user $args /delete *>&1 } -ArgumentList $login -ComputerName $TestConfig.instance2
         }
     }
 
     Context "Create a new credential" {
         It "Should create new credentials with the proper properties" {
-            $results = New-DbaCredential -SqlInstance $TestConfig.instance2 -Name dbatoolsci_thorcred -Identity dbatoolsci_thor -Password $password
-            $results.Name | Should Be "dbatoolsci_thorcred"
-            $results.Identity | Should Be "dbatoolsci_thor"
+            $results = New-DbaCredential -SqlInstance $TestConfig.instance2 -Name thorcred -Identity thor -Password $password
+            $results.Name | Should Be "thorcred"
+            $results.Identity | Should Be "thor"
 
-            $results = New-DbaCredential -SqlInstance $TestConfig.instance2 -Identity dbatoolsci_thorsmomma -Password $password
+            $results = New-DbaCredential -SqlInstance $TestConfig.instance2 -Identity thorsmomma -Password $password
             $results | Should Not Be $null
         }
         It "Gets the newly created credential" {
-            $results = Get-DbaCredential -SqlInstance $TestConfig.instance2 -Identity dbatoolsci_thorsmomma
-            $results.Name | Should Be "dbatoolsci_thorsmomma"
-            $results.Identity | Should Be "dbatoolsci_thorsmomma"
+            $results = Get-DbaCredential -SqlInstance $TestConfig.instance2 -Identity thorsmomma
+            $results.Name | Should Be "thorsmomma"
+            $results.Identity | Should Be "thorsmomma"
         }
     }
 


### PR DESCRIPTION
At least in my environment, "new user" does not like usernames with underscores - so I removed the "dbatoolsci_" prefix.

And because instance2 and instance3 live on the same host only one user is created and removed.

Also some more minor changes...