### PR TITLE
Fix SSIS Connection Logic

### DIFF
--- a/public/Get-DbaSsisEnvironmentVariable.ps1
+++ b/public/Get-DbaSsisEnvironmentVariable.ps1
@@ -133,11 +133,7 @@ function Get-DbaSsisEnvironmentVariable {
             }
 
             try {
-                $legacyconnstring = $server | New-DbaConnectionString -Legacy
-                $sqlconnection = New-Object System.Data.SqlClient.SqlConnection $legacyconnstring
-                $null = $sqlconnection.Open()
-                $serverObj = New-Object Microsoft.SqlServer.Management.Smo.Server $sqlconnection
-                $ssis = New-Object Microsoft.SqlServer.Management.IntegrationServices.IntegrationServices $serverObj
+                $ssis = New-Object Microsoft.SqlServer.Management.IntegrationServices.IntegrationServices $server
             } catch {
                 Stop-Function -Message "Can't load server" -Target $instance -ErrorRecord $_
                 return

--- a/public/Get-DbaSsisEnvironmentVariable.ps1
+++ b/public/Get-DbaSsisEnvironmentVariable.ps1
@@ -136,7 +136,8 @@ function Get-DbaSsisEnvironmentVariable {
                 $legacyconnstring = $server | New-DbaConnectionString -Legacy
                 $sqlconnection = New-Object System.Data.SqlClient.SqlConnection $legacyconnstring
                 $null = $sqlconnection.Open()
-                $ssis = New-Object Microsoft.SqlServer.Management.IntegrationServices.IntegrationServices $sqlconnection
+                $serverObj = New-Object Microsoft.SqlServer.Management.Smo.Server $sqlconnection
+                $ssis = New-Object Microsoft.SqlServer.Management.IntegrationServices.IntegrationServices $serverObj
             } catch {
                 Stop-Function -Message "Can't load server" -Target $instance -ErrorRecord $_
                 return

--- a/public/New-DbaSsisCatalog.ps1
+++ b/public/New-DbaSsisCatalog.ps1
@@ -128,11 +128,7 @@ function New-DbaSsisCatalog {
             }
 
             try {
-                $legacyconnstring = $server | New-DbaConnectionString -Legacy
-                $sqlconnection = New-Object System.Data.SqlClient.SqlConnection $legacyconnstring
-                $null = $sqlconnection.Open()
-                $serverObj = New-Object Microsoft.SqlServer.Management.Smo.Server $sqlconnection
-                $ssis = New-Object Microsoft.SqlServer.Management.IntegrationServices.IntegrationServices $serverObj
+                $ssis = New-Object Microsoft.SqlServer.Management.IntegrationServices.IntegrationServices $server
             } catch {
                 Stop-Function -Message "Can't load server" -Target $instance -ErrorRecord $_
                 return

--- a/public/New-DbaSsisCatalog.ps1
+++ b/public/New-DbaSsisCatalog.ps1
@@ -131,7 +131,8 @@ function New-DbaSsisCatalog {
                 $legacyconnstring = $server | New-DbaConnectionString -Legacy
                 $sqlconnection = New-Object System.Data.SqlClient.SqlConnection $legacyconnstring
                 $null = $sqlconnection.Open()
-                $ssis = New-Object Microsoft.SqlServer.Management.IntegrationServices.IntegrationServices $sqlconnection
+                $serverObj = New-Object Microsoft.SqlServer.Management.Smo.Server $sqlconnection
+                $ssis = New-Object Microsoft.SqlServer.Management.IntegrationServices.IntegrationServices $serverObj
             } catch {
                 Stop-Function -Message "Can't load server" -Target $instance -ErrorRecord $_
                 return

--- a/tests/Get-DbaSsisEnvironmentVariable.Tests.ps1
+++ b/tests/Get-DbaSsisEnvironmentVariable.Tests.ps1
@@ -12,6 +12,46 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
 }
+
+<#
+
+-- Create a folder if it doesn't exist
+IF NOT EXISTS (SELECT 1 FROM [SSISDB].[catalog].[folders] WHERE name = N'TestFolder')
+BEGIN
+    EXEC [SSISDB].[catalog].[create_folder] @folder_name = N'TestFolder', @folder_id = NULL;
+END
+
+-- Create an environment in the folder if it doesn't exist
+IF NOT EXISTS (
+    SELECT 1 FROM [SSISDB].[catalog].[environments]
+    WHERE name = N'TestEnv' AND folder_id = (SELECT folder_id FROM [SSISDB].[catalog].[folders] WHERE name = N'TestFolder')
+)
+BEGIN
+    EXEC [SSISDB].[catalog].[create_environment] @folder_name = N'TestFolder', @environment_name = N'TestEnv';
+END
+
+-- Create an environment variable in the environment if it doesn't exist
+IF NOT EXISTS (
+    SELECT 1 FROM [SSISDB].[catalog].[environment_variables]
+    WHERE name = N'TestVar'
+      AND environment_id = (
+            SELECT environment_id
+            FROM [SSISDB].[catalog].[environments]
+            WHERE name = N'TestEnv'
+              AND folder_id = (SELECT folder_id FROM [SSISDB].[catalog].[folders] WHERE name = N'TestFolder')
+      )
+)
+BEGIN
+    EXEC [SSISDB].[catalog].[create_environment_variable]
+        @folder_name = N'TestFolder',
+        @environment_name = N'TestEnv',
+        @variable_name = N'TestVar',
+        @data_type = N'String',
+        @sensitive = 0,
+        @value = N'Chello';
+END
+
+#>
 <#
     Integration test should appear below and are custom to the command you are writing.
     Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests


### PR DESCRIPTION
Improves handling of of SSIS server connections in two public functions and enhances the unit tests for `Get-DbaSsisEnvironmentVariable`. The changes reduce complexity in the codebase and improve test coverage.

Basically, Microsoft used to use System.Data and it's since moved to Microsoft.Data and SSIS is catching up.

### Simplification of SSIS server connection handling:
* In `public/Get-DbaSsisEnvironmentVariable.ps1` and `public/New-DbaSsisCatalog.ps1`, the creation of a legacy connection string and SQL connection object was removed. Instead, the `Microsoft.SqlServer.Management.IntegrationServices.IntegrationServices` object is now instantiated directly using the `$server` object. This streamlines the connection process and reduces dependency on intermediate objects. [[1]](diffhunk://#diff-b580f6c24e94f97985b6767ebbdc5fec4240b00f849921daa1d9b330e7d0059bL136-R136) [[2]](diffhunk://#diff-95f7598f509085dd41fa2acf5d399fb49a7e1385298b52db43c3b95fe83c95baL131-R131)

### Enhancements to unit tests:
* In `tests/Get-DbaSsisEnvironmentVariable.Tests.ps1`, a block of SQL code was added to set up test data in the SSIS catalog. This includes creating a folder, an environment, and an environment variable if they do not already exist. This ensures the test environment is properly initialized for unit tests, improving reliability and reproducibility.