### PR TITLE
Fix test for Copy-DbaDbMail

### DIFF
--- a/tests/Add-DbaAgDatabase.Tests.ps1
+++ b/tests/Add-DbaAgDatabase.Tests.ps1
@@ -1,6 +1,7 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
     $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
     # $TestConfig has to be set outside of the tests by running: $TestConfig = Get-TestConfig
     # This will set $TestConfig.Defaults with the parameter defaults, including:
     # * Confirm = $false
@@ -9,7 +10,7 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Describe "Add-DbaAgDatabase UnitTests" -Tag "UnitTests" {
+Describe $CommandName -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
             $command = Get-Command Add-DbaAgDatabase
@@ -43,7 +44,7 @@ Describe "Add-DbaAgDatabase UnitTests" -Tag "UnitTests" {
     }
 }
 
-Describe "Add-DbaAgDatabase IntegrationTests" -Tag "IntegrationTests" {
+Describe $CommandName -Tag "IntegrationTests" {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
         $PSDefaultParameterValues['*-Dba*:EnableException'] = $true

--- a/tests/Add-DbaAgListener.Tests.ps1
+++ b/tests/Add-DbaAgListener.Tests.ps1
@@ -1,10 +1,11 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
     $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Describe "Add-DbaAgListener" -Tag "UnitTests" {
+Describe $CommandName -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
             $command = Get-Command Add-DbaAgListener
@@ -38,7 +39,7 @@ Describe "Add-DbaAgListener" -Tag "UnitTests" {
     }
 }
 
-Describe "Add-DbaAgListener" -Tag "IntegrationTests" {
+Describe $CommandName -Tag "IntegrationTests" {
     BeforeAll {
         $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
 

--- a/tests/Add-DbaAgReplica.Tests.ps1
+++ b/tests/Add-DbaAgReplica.Tests.ps1
@@ -1,10 +1,11 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
-    $ModuleName = "dbatools",
-    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+    $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
+    $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Describe "Add-DbaAgReplica" -Tag "UnitTests" {
+Describe $CommandName -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
             $command = Get-Command Add-DbaAgReplica
@@ -46,7 +47,7 @@ Describe "Add-DbaAgReplica" -Tag "UnitTests" {
     }
 }
 
-Describe "Add-DbaAgReplica" -Tag "IntegrationTests" {
+Describe $CommandName -Tag "IntegrationTests" {
     BeforeAll {
         $primaryAgName = "dbatoolsci_agroup"
         $splatPrimary = @{

--- a/tests/Add-DbaComputerCertificate.Tests.ps1
+++ b/tests/Add-DbaComputerCertificate.Tests.ps1
@@ -1,10 +1,11 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
-    $ModuleName = "dbatools",
-    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+    $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
+    $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Describe "Add-DbaComputerCertificate" -Tag "UnitTests" {
+Describe $CommandName -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
             $command = Get-Command Add-DbaComputerCertificate
@@ -35,7 +36,7 @@ Describe "Add-DbaComputerCertificate" -Tag "UnitTests" {
     }
 }
 
-Describe "Add-DbaComputerCertificate" -Tag "IntegrationTests" {
+Describe $CommandName -Tag "IntegrationTests" {
     Context "Certificate is added properly" {
         BeforeAll {
             $certPath = "$($TestConfig.appveyorlabrepo)\certificates\localhost.crt"

--- a/tests/Add-DbaDbMirrorMonitor.Tests.ps1
+++ b/tests/Add-DbaDbMirrorMonitor.Tests.ps1
@@ -1,10 +1,11 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
-    $ModuleName = "dbatools",
-    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+    $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
+    $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Describe "Add-DbaDbMirrorMonitor" -Tag "UnitTests" {
+Describe $CommandName -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
             $command = Get-Command Add-DbaDbMirrorMonitor
@@ -29,7 +30,7 @@ Describe "Add-DbaDbMirrorMonitor" -Tag "UnitTests" {
     }
 }
 
-Describe "Add-DbaDbMirrorMonitor" -Tag "IntegrationTests" {
+Describe $CommandName -Tag "IntegrationTests" {
     BeforeAll {
         $null = Remove-DbaDbMirrorMonitor -SqlInstance $TestConfig.instance2 -WarningAction SilentlyContinue
     }

--- a/tests/Copy-DbaDbMail.Tests.ps1
+++ b/tests/Copy-DbaDbMail.Tests.ps1
@@ -1,15 +1,16 @@
 #Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
 param(
-    $ModuleName = "dbatools",
-    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+    $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
+    $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Describe "Copy-DbaDbMail" -Tag "UnitTests" {
+Describe $CommandName -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
-            $command = Get-Command Copy-DbaDbMail
-            $expected = $TestConfig.CommonParameters
-            $expected += @(
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "Source",
                 "Destination",
                 "Type",
@@ -20,70 +21,55 @@ Describe "Copy-DbaDbMail" -Tag "UnitTests" {
             )
         }
 
-        It "Has parameter: <_>" -ForEach $expected {
-            $command | Should -HaveParameter $PSItem
-        }
-
-        It "Should have exactly the number of expected parameters ($($expected.Count))" {
-            $hasparms = $command.Parameters.Values.Name | Where-Object { $_ -notin ('whatif', 'confirm') }
-            Compare-Object -ReferenceObject $expected -DifferenceObject $hasparms | Should -BeNullOrEmpty
+        It "Should have the expected parameters" {
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-Describe "Copy-DbaDbMail" -Tags "IntegrationTests" {
+Describe $CommandName -Tags "IntegrationTests" {
     BeforeAll {
-        $servers = Connect-DbaInstance -SqlInstance $TestConfig.instance2, $TestConfig.instance3
-        foreach ($s in $servers) {
-            if ( (Get-DbaSpConfigure -SqlInstance $s -Name 'Database Mail XPs').RunningValue -ne 1 ) {
-                Set-DbaSpConfigure -SqlInstance $s -Name 'Database Mail XPs' -Value 1
-            }
-        }
+        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+
+        # TODO: Maybe remove "-EnableException:$false -WarningAction SilentlyContinue" when we can rely on the setting beeing 0 when entering the test
+        $null = Set-DbaSpConfigure -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Name 'Database Mail XPs' -Value 1 -EnableException:$false -WarningAction SilentlyContinue
 
         $accountName = "dbatoolsci_test_$(get-random)"
-        $account_display_name = 'dbatoolsci mail alerts'
-        $account_description = 'Mail account for email alerts'
-        $profilename = "dbatoolsci_test_$(get-random)"
-        $profile_description = 'Mail profile for email alerts'
-
-        $email_address = 'dbatoolssci@dbatools.io'
-        $mailserver_name = 'smtp.dbatools.io'
-        $replyto_address = 'no-reply@dbatools.io'
-        $mailaccountpriority = 1
+        $profileName = "dbatoolsci_test_$(get-random)"
 
         $splat1 = @{
             SqlInstance    = $TestConfig.instance2
             Name           = $accountName
-            Description    = $account_description
-            EmailAddress   = $email_address
-            DisplayName    = $account_display_name
-            ReplyToAddress = $replyto_address
-            MailServer     = $mailserver_name
+            Description    = 'Mail account for email alerts'
+            EmailAddress   = 'dbatoolssci@dbatools.io'
+            DisplayName    = 'dbatoolsci mail alerts'
+            ReplyToAddress = 'no-reply@dbatools.io'
+            MailServer     = 'smtp.dbatools.io'
         }
         $null = New-DbaDbMailAccount @splat1 -Force
 
         $splat2 = @{
             SqlInstance         = $TestConfig.instance2
-            Name                = $profilename
-            Description         = $profile_description
+            Name                = $profileName
+            Description         = 'Mail profile for email alerts'
             MailAccountName     = $accountName
-            MailAccountPriority = $mailaccountpriority
+            MailAccountPriority = 1
         }
         $null = New-DbaDbMailProfile @splat2
+
+        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
     }
 
     AfterAll {
-        $servers = Connect-DbaInstance -SqlInstance $TestConfig.instance2, $TestConfig.instance3
+        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
 
-        foreach ($s in $servers) {
-            $mailAccountSettings = "EXEC msdb.dbo.sysmail_delete_account_sp @account_name = '$accountname';"
-            Invoke-DbaQuery -SqlInstance $s -Query $mailAccountSettings -Database msdb
-            $mailProfileSettings = "EXEC msdb.dbo.sysmail_delete_profile_sp @profile_name = '$profilename';"
-            Invoke-DbaQuery -SqlInstance $s -Query $mailProfileSettings -Database msdb
-        }
+        Invoke-DbaQuery -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Query "EXEC msdb.dbo.sysmail_delete_account_sp @account_name = '$accountName';"
+        Invoke-DbaQuery -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Query "EXEC msdb.dbo.sysmail_delete_profile_sp @profile_name = '$profileName';"
+
+        $null = Set-DbaSpConfigure -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Name 'Database Mail XPs' -Value 0
     }
 
-    Context "When copying DbMail to $($TestConfig.instance3)" {
+    Context "When copying DbMail" {
         BeforeAll {
             $results = Copy-DbaDbMail -Source $TestConfig.instance2 -Destination $TestConfig.instance3
         }
@@ -92,9 +78,32 @@ Describe "Copy-DbaDbMail" -Tags "IntegrationTests" {
             $results | Should -Not -BeNullOrEmpty
         }
 
-        It "Should have copied <_.type> from source to destination" -ForEach ($results | Where-Object type -in @('Mail Configuration', 'Mail Account', 'Mail Profile')) {
-            $PSItem.SourceServer | Should -Be $TestConfig.instance2
-            $PSItem.DestinationServer | Should -Be $TestConfig.instance3
+        It "Should have copied Mail Configuration from source to destination" {
+            $result = $results | Where-Object Type -eq 'Mail Configuration'
+            $result.SourceServer | Should -Be $TestConfig.instance2
+            $result.DestinationServer | Should -Be $TestConfig.instance3
+            $result.Status | Should -Be 'Successful'
+        }
+
+        It "Should have copied Mail Account from source to destination" {
+            $result = $results | Where-Object Type -eq 'Mail Account'
+            $result.SourceServer | Should -Be $TestConfig.instance2
+            $result.DestinationServer | Should -Be $TestConfig.instance3
+            $result.Status | Should -Be 'Successful'
+        }
+
+        It "Should have copied Mail Profile from source to destination" {
+            $result = $results | Where-Object Type -eq 'Mail Profile'
+            $result.SourceServer | Should -Be $TestConfig.instance2
+            $result.DestinationServer | Should -Be $TestConfig.instance3
+            $result.Status | Should -Be 'Successful'
+        }
+
+        It "Should have copied Mail Server from source to destination" {
+            $result = $results | Where-Object Type -eq 'Mail Server'
+            $result.SourceServer | Should -Be $TestConfig.instance2
+            $result.DestinationServer | Should -Be $TestConfig.instance3
+            $result.Status | Should -Be 'Successful'
         }
     }
 
@@ -107,10 +116,26 @@ Describe "Copy-DbaDbMail" -Tags "IntegrationTests" {
             $results | Should -Not -BeNullOrEmpty
         }
 
-        It "Should have skipped <_.type> copy operations" -ForEach $results {
-            $PSItem.SourceServer | Should -Be $TestConfig.instance2
-            $PSItem.DestinationServer | Should -Be $TestConfig.instance3
-            $PSItem.Status | Should -Be 'Skipped'
+        It "Should have not reported on Mail Configuration" {
+            $result = $results | Where-Object Type -eq 'Mail Configuration'
+            $result | Should -BeNullOrEmpty
+        }
+
+        It "Should have not reported on Mail Account" {
+            $result = $results | Where-Object Type -eq 'Mail Account'
+            $result | Should -BeNullOrEmpty
+        }
+
+        It "Should have not reported on Mail Profile" {
+            $result = $results | Where-Object Type -eq 'Mail Profile'
+            $result | Should -BeNullOrEmpty
+        }
+
+        It "Should have skipped Mail Server" {
+            $result = $results | Where-Object Type -eq 'Mail Server'
+            $result.SourceServer | Should -Be $TestConfig.instance2
+            $result.DestinationServer | Should -Be $TestConfig.instance3
+            $result.Status | Should -Be 'Skipped'
         }
     }
 }

--- a/tests/Get-DbaConnection.Tests.ps1
+++ b/tests/Get-DbaConnection.Tests.ps1
@@ -1,14 +1,23 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
-    Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+Describe $CommandName -Tag "UnitTests" {
+    Context "Parameter validation" {
+        BeforeAll {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                'SqlInstance',
+                'SqlCredential',
+                'EnableException'
+            )
+        }
+        It "Should have the expected parameters" {
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Get-DbaConnection.Tests.ps1
+++ b/tests/Get-DbaConnection.Tests.ps1
@@ -24,9 +24,12 @@ Describe $CommandName -Tag "UnitTests" {
 
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "returns the proper transport" {
-        $results = Get-DbaConnection -SqlInstance $TestConfig.instance1
-        foreach ($result in $results) {
-            It "returns an scheme" {
+        BeforeAll {
+            $results = Get-DbaConnection -SqlInstance $TestConfig.instance1
+        }
+
+        It "returns a valid AuthScheme" {
+            foreach ($result in $results) {
                 $result.AuthScheme | Should -BeIn 'NTLM', 'Kerberos', 'SQL'
             }
         }


### PR DESCRIPTION
We currently use `-ForEach` wrong. The used variable needs to be set during discovery, but we use a values that is set during the BeforAll - which is part of the run phase and thus too late.
So I removed the block with `$command | Should -HaveParameter $PSItem` as it was never executed. I think we should only use this if we not only test for the parameter name but also the type and other properties - that is what this is made for.

I added the `$CommandName` back in like we have it in pester 4 to avoid copy-paste errors in the Describe blocks.

Have done some more refactoring to clean the code.

If we agree on that syle we would have to copy it to all the other pester 5 tests...