### PR TITLE
Another round of fixes for tests

### DIFF
--- a/tests/Add-DbaDbMirrorMonitor.Tests.ps1
+++ b/tests/Add-DbaDbMirrorMonitor.Tests.ps1
@@ -31,9 +31,6 @@ Describe $CommandName -Tag "UnitTests" {
 }
 
 Describe $CommandName -Tag "IntegrationTests" {
-    BeforeAll {
-        $null = Remove-DbaDbMirrorMonitor -SqlInstance $TestConfig.instance2 -WarningAction SilentlyContinue
-    }
     AfterAll {
         $null = Remove-DbaDbMirrorMonitor -SqlInstance $TestConfig.instance2 -WarningAction SilentlyContinue
     }

--- a/tests/Export-DbaRegServer.Tests.ps1
+++ b/tests/Export-DbaRegServer.Tests.ps1
@@ -86,7 +86,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     It "Try to create an invalid file using FilePath" {
         $outputFileName = "$newDirectory\dbatoolsci-regsrvr-export-$random.txt"
-        $results = Export-DbaRegServer -SqlInstance $TestConfig.instance2 -FilePath $outputFileName
+        $results = Export-DbaRegServer -SqlInstance $TestConfig.instance2 -FilePath $outputFileName -WarningAction SilentlyContinue
+        # TODO: Test for [Export-DbaRegServer] The FilePath specified must end with either .xml or .regsrvr
         $results.length | Should -Be 0
     }
 
@@ -99,7 +100,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     It "Ensure the Overwrite param is working" {
         $outputFileName = "$newDirectory\dbatoolsci-regsrvr-export-$random.xml"
-        $results = Export-DbaRegServer -SqlInstance $TestConfig.instance2 -FilePath $outputFileName
+        $results = Export-DbaRegServer -SqlInstance $TestConfig.instance2 -FilePath $outputFileName -WarningAction SilentlyContinue
+        # TODO: Test for [Export-DbaRegServer] Use the -Overwrite parameter if the file C:\temp\539615200\dbatoolsci-regsrvr-export-539615200.xml should be overwritten.
         $results -is [System.IO.FileInfo] | Should -Be $true
         $results.FullName | Should -Be $outputFileName
 

--- a/tests/Export-DbaScript.Tests.ps1
+++ b/tests/Export-DbaScript.Tests.ps1
@@ -32,13 +32,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
         It "should not accept non-SMO objects" {
             $null = Get-DbaDbTable -SqlInstance $TestConfig.instance2 -Database msdb | Select-Object -First 1 | Export-DbaScript -Passthru -BatchSeparator "MakeItSo"
-            $null = [pscustomobject]@{ Invalid = $true } | Export-DbaScript -WarningVariable invalid -WarningAction Continue
+            $null = [pscustomobject]@{ Invalid = $true } | Export-DbaScript -WarningVariable invalid -WarningAction SilentlyContinue
             $invalid -match "not a SQL Management Object"
         }
 
         It "should not accept non-SMO objects" {
             $null = Get-DbaDbTable -SqlInstance $TestConfig.instance2 -Database msdb | Select-Object -First 1 | Export-DbaScript -Passthru -BatchSeparator "MakeItSo"
-            $null = [pscustomobject]@{ Invalid = $true } | Export-DbaScript -WarningVariable invalid -WarningAction Continue
+            $null = [pscustomobject]@{ Invalid = $true } | Export-DbaScript -WarningVariable invalid -WarningAction SilentlyContinue
             $invalid -match "not a SQL Management Object"
         }
         It "should not append when using NoPrefix (#7455)" {

--- a/tests/Find-DbaDbUnusedIndex.Tests.ps1
+++ b/tests/Find-DbaDbUnusedIndex.Tests.ps1
@@ -23,7 +23,6 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Verify basics of the Find-DbaDbUnusedIndex command" {
         BeforeAll {
-            Write-Message -Level Warning -Message "Find-DbaDbUnusedIndex testing connection to $($TestConfig.instance2)"
             Test-DbaConnection -SqlInstance $TestConfig.instance2
 
             $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -31,7 +30,6 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $random = Get-Random
             $dbName = "dbatoolsci_$random"
 
-            Write-Message -Level Warning -Message "Find-DbaDbUnusedIndex setting up the new database $dbName"
             Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbName -Confirm:$false
             $newDB = New-DbaDatabase -SqlInstance $TestConfig.instance2 -Name $dbName
 
@@ -48,7 +46,6 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         AfterAll {
-            Write-Message -Level Warning -Message "Find-DbaDbUnusedIndex removing the database $dbName"
             Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbName -Confirm:$false
         }
 
@@ -61,10 +58,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
             foreach ($row in $results) {
                 if ($row["IndexName"] -eq $indexName) {
-                    Write-Message -Level Debug -Message "$($indexName) was found on $($TestConfig.instance2) in database $($dbName)"
                     $testSQLinstance = $true
-                } else {
-                    Write-Message -Level Warning -Message "$($indexName) was not found on $($TestConfig.instance2) in database $($dbName)"
                 }
             }
 
@@ -87,7 +81,6 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 } elseif ($results -is [Object[]] -and $results.Count -gt 0) {
                     $row = $results[0]
                 } else {
-                    Write-Message -Level Warning -Message "Unexpected results returned from $($SqlInstance): $($results)"
                     $testSQLinstance = $false
                 }
 
@@ -95,10 +88,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                     [object[]]$columnNamesReturned = @($row | Get-Member -MemberType Property | Select-Object -Property Name | ForEach-Object { $_.Name })
 
                     if ( @(Compare-Object -ReferenceObject $expectedColumnArray -DifferenceObject $columnNamesReturned).Count -eq 0 ) {
-                        Write-Message -Level Debug -Message "Columns matched on $($TestConfig.instance2)"
                         $testSQLinstance = $true
-                    } else {
-                        Write-Message -Level Warning -Message "The columns specified in the expectedColumnList variable do not match these returned columns from $($TestConfig.instance2): $($columnNamesReturned)"
                     }
                 }
             }

--- a/tests/Get-DbaAgDatabase.Tests.ps1
+++ b/tests/Get-DbaAgDatabase.Tests.ps1
@@ -15,19 +15,23 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
+        $backupPath = "$($TestConfig.Temp)\$CommandName"
+        $null = New-Item -Path $backupPath -ItemType Directory
+
         $null = Get-DbaProcess -SqlInstance $TestConfig.instance3 -Program 'dbatools PowerShell module - dbatools.io' | Stop-DbaProcess -WarningAction SilentlyContinue
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance3
         $agname = "dbatoolsci_getagdb_agroup"
         $dbname = "dbatoolsci_getagdb_agroupdb"
         $server.Query("create database $dbname")
-        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase
-        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -Type Log
+        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -Path $backupPath
+        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -Path $backupPath -Type Log
         $ag = New-DbaAvailabilityGroup -Primary $TestConfig.instance3 -Name $agname -ClusterType None -FailoverMode Manual -Database $dbname -Confirm:$false -Certificate dbatoolsci_AGCert -UseLastBackup
     }
     AfterAll {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname -Confirm:$false
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname -Confirm:$false
+        Remove-Item -Path $backupPath -Recurse
     }
     Context "gets ag db" {
         It "returns results" {

--- a/tests/Get-DbaAgentSchedule.Tests.ps1
+++ b/tests/Get-DbaAgentSchedule.Tests.ps1
@@ -15,15 +15,11 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$commandname Integration Tests" -Tags "UnitTests" {
     BeforeAll {
-        Write-Message -Level Warning -Message "BeforeAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance3=$($TestConfig.instance3) and instance2=$($TestConfig.instance2)"
         $server3 = Connect-DbaInstance -SqlInstance $TestConfig.instance3
         $server2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
 
         $sqlAgentServer3 = Get-DbaService -ComputerName $server3.ComputerName -InstanceName $server3.DbaInstanceName -Type Agent
-        Write-Message -Level Warning -Message "The SQL Agent service for instance3 has state=$($sqlAgentServer3.State) and start mode=$($sqlAgentServer3.StartMode)"
-
         $sqlAgentServer2 = Get-DbaService -ComputerName $server2.ComputerName -InstanceName $server2.DbaInstanceName -Type Agent
-        Write-Message -Level Warning -Message "The SQL Agent service for instance2 has state=$($sqlAgentServer2.State) and start mode=$($sqlAgentServer2.StartMode)"
 
         $null = New-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -Schedule dbatoolsci_MonthlyTest -FrequencyType Monthly -FrequencyInterval 10 -FrequencyRecurrenceFactor 1 -Force
         $null = New-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -Schedule dbatoolsci_WeeklyTest -FrequencyType Weekly -FrequencyInterval 2 -FrequencyRecurrenceFactor 1 -StartTime 020000  -Force
@@ -104,29 +100,19 @@ Describe "$commandname Integration Tests" -Tags "UnitTests" {
         }
 
         $null = New-DbaAgentSchedule @ScheduleParams -Force
-
-        Write-Message -Level Warning -Message "BeforeAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance3=$($TestConfig.instance3) and instance2=$($TestConfig.instance2)"
     }
     AfterAll {
-        Write-Message -Level Warning -Message "AfterAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance3=$($TestConfig.instance3) and instance2=$($TestConfig.instance2)"
-
         $schedules = Get-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -Schedule dbatoolsci_WeeklyTest, dbatoolsci_MonthlyTest, Issue_6636_Once, Issue_6636_Once_Copy, Issue_6636_Hour, Issue_6636_Hour_Copy, Issue_6636_Minute, Issue_6636_Minute_Copy, Issue_6636_Second, Issue_6636_Second_Copy, Issue_6636_OneTime, Issue_6636_OneTime_Copy, Issue_6636_AutoStart, Issue_6636_AutoStart_Copy, Issue_6636_OnIdle, Issue_6636_OnIdle_Copy
 
         if ($null -ne $schedules) {
             $schedules.DROP()
-        } else {
-            Write-Message -Level Warning -Message "The schedules from $TestConfig.instance2 were returned as null"
         }
 
         $schedules = Get-DbaAgentSchedule -SqlInstance $TestConfig.instance3 -Schedule dbatoolsci_MonthlyTest
 
         if ($null -ne $schedules) {
             $schedules.DROP()
-        } else {
-            Write-Message -Level Warning -Message "The schedules from $TestConfig.instance3 were returned as null"
         }
-
-        Write-Message -Level Warning -Message "AfterAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance3=$($TestConfig.instance3) and instance2=$($TestConfig.instance2)"
     }
 
     Context "Gets the list of Schedules" {

--- a/tests/Get-DbaDbSchema.Tests.ps1
+++ b/tests/Get-DbaDbSchema.Tests.ps1
@@ -18,7 +18,6 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $random = Get-Random
         $server1 = Connect-DbaInstance -SqlInstance $TestConfig.instance1
         $server2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
-        $null = Get-DbaProcess -SqlInstance $server1, $server2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
         $newDbName = "dbatoolsci_newdb_$random"
         $newDbs = New-DbaDatabase -SqlInstance $server1, $server2 -Name $newDbName
 

--- a/tests/Get-DbaDbSchema.Tests.ps1
+++ b/tests/Get-DbaDbSchema.Tests.ps1
@@ -18,6 +18,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $random = Get-Random
         $server1 = Connect-DbaInstance -SqlInstance $TestConfig.instance1
         $server2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
+        $null = Get-DbaProcess -SqlInstance $server1, $server2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false -WarningAction SilentlyContinue
         $newDbName = "dbatoolsci_newdb_$random"
         $newDbs = New-DbaDatabase -SqlInstance $server1, $server2 -Name $newDbName
 

--- a/tests/Get-DbaDependency.Tests.ps1
+++ b/tests/Get-DbaDependency.Tests.ps1
@@ -133,7 +133,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     It "Test with a tables that have circular dependencies" {
         # this causes infinite loop when circular dependencies exist in dependency tree.
-        $results = Get-DbaDbTable -SqlInstance $TestConfig.instance1 -Database $dbname -Table dbo.dbatoolsci_circrefA | Get-DbaDependency
+        $results = Get-DbaDbTable -SqlInstance $TestConfig.instance1 -Database $dbname -Table dbo.dbatoolsci_circrefA | Get-DbaDependency -WarningAction SilentlyContinue
+        # TODO: Test for "Circular Reference detected
         $results.length | Should -Be 2
         $results[0].Dependent   | Should -Be "dbatoolsci_circrefB"
         $results[0].Tier        | Should -Be 1
@@ -143,7 +144,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     It "Test with a tables that have circular dependencies and use -IncludeSelf" {
         # this causes infinite loop when circular dependencies exist in dependency tree.
-        $results = Get-DbaDbTable -SqlInstance $TestConfig.instance1 -Database $dbname -Table dbo.dbatoolsci_circrefA | Get-DbaDependency -IncludeSelf
+        $results = Get-DbaDbTable -SqlInstance $TestConfig.instance1 -Database $dbname -Table dbo.dbatoolsci_circrefA | Get-DbaDependency -IncludeSelf -WarningAction SilentlyContinue
+        # TODO: Test for "Circular Reference detected
         $results.length | Should -Be 3
         $results[0].Dependent   | Should -Be "dbatoolsci_circrefA"
         $results[0].Tier        | Should -Be 0

--- a/tests/Get-DbaExtendedProperty.Tests.ps1
+++ b/tests/Get-DbaExtendedProperty.Tests.ps1
@@ -17,7 +17,6 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $random = Get-Random
         $server2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
-        $null = Get-DbaProcess -SqlInstance $server2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
         $newDbName = "dbatoolsci_newdb_$random"
         $db = New-DbaDatabase -SqlInstance $server2 -Name $newDbName
         $db.Query("EXEC sys.sp_addextendedproperty @name=N'dbatoolz', @value=N'woo'")

--- a/tests/Get-DbaLastBackup.Tests.ps1
+++ b/tests/Get-DbaLastBackup.Tests.ps1
@@ -19,7 +19,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         $dbname = "dbatoolsci_getlastbackup$random"
         $server.Query("CREATE DATABASE $dbname")
         $server.Query("ALTER DATABASE $dbname SET RECOVERY FULL WITH NO_WAIT")
-        $backupdir = Join-Path $server.BackupDirectory $dbname
+        $backupdir = Join-Path $TestConfig.Temp $dbname
         if (-not (Test-Path $backupdir -PathType Container)) {
             $null = New-Item -Path $backupdir -ItemType Container
         }
@@ -62,7 +62,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
     Context "Get last history for one split database" {
         It "supports multi-file backups" {
-            $null = Backup-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname -FileCount 4
+            $null = Backup-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname -BackupDirectory $backupdir -FileCount 4
             $results = Get-DbaLastBackup -SqlInstance $TestConfig.instance2 -Database $dbname | Select-Object -First 1
             $results.LastFullBackup.GetType().Name | Should -Be "DbaDateTime"
         }

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -15,6 +15,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     AfterAll {
+        # TODO: WARNING: [12:43:16][Invoke-DbaQuery] [CLIENT\SQLInstance2] Failed during execution | Cannot drop the table 'CommaSeparatedWithHeader', because it does not exist or you do not have permission.
         Invoke-DbaQuery -SqlInstance $TestConfig.instance1, $TestConfig.instance2 -Database tempdb -Query "drop table SuperSmall; drop table CommaSeparatedWithHeader"
     }
 
@@ -26,7 +27,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
 
     Context "Works as expected" {
-        $results = $path | Import-DbaCsv -SqlInstance $TestConfig.instance1 -Database tempdb -Delimiter `t -NotifyAfter 50000 -WarningVariable warn
+        $results = $path | Import-DbaCsv -SqlInstance $TestConfig.instance1 -Database tempdb -Delimiter `t -NotifyAfter 50000 -WarningVariable warn -WarningAction SilentlyContinue
+        # TODO: Test for "Table or view SuperSmall does not exist and AutoCreateTable was not specified"
         It "accepts piped input and doesn't add rows if the table does not exist" {
             $results | Should -Be $null
         }
@@ -75,7 +77,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
         It "Catches the scenario where the database param does not match the server object passed into the command" {
             $server = Connect-DbaInstance $TestConfig.instance1 -Database tempdb
-            $result = Import-DbaCsv -Path $path -SqlInstance $server -Database InvalidDB -Delimiter `t -Table SuperSmall -Truncate -AutoCreateTable
+            $result = Import-DbaCsv -Path $path -SqlInstance $server -Database InvalidDB -Delimiter `t -Table SuperSmall -Truncate -AutoCreateTable -WarningAction SilentlyContinue
+            # TODO: test for Cannot open database "InvalidDB" requested by the login. The login failed.
             $result | Should -BeNullOrEmpty
 
             $server = Connect-DbaInstance $TestConfig.instance1 -Database tempdb
@@ -86,6 +89,9 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "Catches the scenario where the header is not properly parsed causing param errors" {
+            # TODO: WARNING: [12:43:13][Invoke-DbaQuery] [CLIENT] Failed during execution | Cannot drop the table 'NoHeaderRow', because it does not exist or you do not have permission.
+            # TODO: What line writes the warning? Is this correct?
+
             # create the table using AutoCreate
             $server = Connect-DbaInstance $TestConfig.instance1 -Database tempdb
             $null = Import-DbaCsv -Path $CommaSeparatedWithHeader -SqlInstance $server -Database tempdb -AutoCreateTable

--- a/tests/Measure-DbaBackupThroughput.Tests.ps1
+++ b/tests/Measure-DbaBackupThroughput.Tests.ps1
@@ -19,10 +19,11 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $null = Get-DbaProcess -SqlInstance $TestConfig.instance2 | Where-Object Program -Match dbatools | Stop-DbaProcess -Confirm:$false -WarningAction SilentlyContinue
             $random = Get-Random
             $db = "dbatoolsci_measurethruput$random"
-            $null = New-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $db | Backup-DbaDatabase
+            $null = New-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $db | Backup-DbaDatabase -FilePath "$($TestConfig.Temp)\$($db.Name).bak"
         }
         AfterAll {
             $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $db -Confirm:$false
+            Remove-Item -Path "$($TestConfig.Temp)\$($db.Name).bak"
         }
 
         $results = Measure-DbaBackupThroughput -SqlInstance $TestConfig.instance2 -Database $db

--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -18,7 +18,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $null = Get-DbaProcess -SqlInstance $TestConfig.instance3 -Program 'dbatools PowerShell module - dbatools.io' | Stop-DbaProcess -WarningAction SilentlyContinue
         $dbname = "dbatoolsci_addag_agroupdb"
         $agname = "dbatoolsci_addag_agroup"
-        $null = New-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase
+        $null = New-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -FilePath "$($TestConfig.Temp)\$dbname.bak"
     }
     AfterEach {
         $result = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agname -Confirm:$false
@@ -26,6 +26,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     }
     AfterAll {
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname -Confirm:$false
+        Remove-Item -Path "$($TestConfig.Temp)\$dbname.bak"
     }
     Context "adds an ag" {
         It "returns an ag with a db named" {

--- a/tests/Remove-DbaAgDatabase.Tests.ps1
+++ b/tests/Remove-DbaAgDatabase.Tests.ps1
@@ -20,14 +20,15 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $agname = "dbatoolsci_removeagdb_agroup"
         $dbname = "dbatoolsci_removeagdb_agroupdb"
         $server.Query("create database $dbname")
-        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase
-        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -Type Log
+        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -FilePath "$($TestConfig.Temp)\$dbname.bak"
+        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -FilePath "$($TestConfig.Temp)\$dbname.trn" -Type Log
         $ag = New-DbaAvailabilityGroup -Primary $TestConfig.instance3 -Name $agname -ClusterType None -FailoverMode Manual -Database $dbname -Confirm:$false -Certificate dbatoolsci_AGCert -UseLastBackup
     }
     AfterAll {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname -Confirm:$false
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname -Confirm:$false
+        Remove-Item -Path "$($TestConfig.Temp)\$dbname.bak", "$($TestConfig.Temp)\$dbname.trn"
     }
     Context "removes ag db" {
         It "returns removed results" {

--- a/tests/Remove-DbaDbTableData.Tests.ps1
+++ b/tests/Remove-DbaDbTableData.Tests.ps1
@@ -36,8 +36,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $newDbSimpleModel, $newDbFullModel, $newDbBulkLoggedModel, $newDbSimpleModelServer2 | Invoke-DbaQuery -Query "CREATE TABLE dbo.Test (Id INTEGER); CREATE TABLE dbo.Test2 (Id INTEGER)"
 
         # do a full backup so that log backups can be done
-        $backupDbFull = Backup-DbaDatabase -SqlInstance $server -Database $dbnameFullModel
-        $backupDbBulkLogged = Backup-DbaDatabase -SqlInstance $server -Database $dbnameBulkLoggedModel
+        $backupDbFull = Backup-DbaDatabase -SqlInstance $server -Database $dbnameFullModel -FilePath "$($TestConfig.Temp)\$dbnameFullModel.bak"
+        $backupDbBulkLogged = Backup-DbaDatabase -SqlInstance $server -Database $dbnameBulkLoggedModel -FilePath "$($TestConfig.Temp)\$dbnameBulkLoggedModel.bak"
         $logBackupPath = $backupDbFull.BackupFolder
 
         # SQL to populate some data for testing
@@ -55,6 +55,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     }
     AfterAll {
         $newDbSimpleModel, $newDbFullModel, $newDbBulkLoggedModel, $newDbSimpleModelServer2 | Remove-DbaDatabase -Confirm:$false
+        Remove-Item -Path "$($TestConfig.Temp)\$dbnameFullModel*", "$($TestConfig.Temp)\$dbnameBulkLoggedModel*"
     }
 
     Context "Param validation" {

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -198,6 +198,9 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         It "Should prefix the script with the Execute As statement" {
             $results6 | Should BeLike "EXECUTE AS LOGIN='$RestoreAsUser'*"
         }
+
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database Pestering -Confirm:$false
+        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance2 -Login $RestoreAsUser -Confirm:$false
     }
 
     Get-DbaProcess $TestConfig.instance2 -ExcludeSystemSpids | Stop-DbaProcess -WarningVariable warn -WarningAction SilentlyContinue
@@ -859,7 +862,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         It "Should backup and restore cleanly" {
             ($results | Where-Object { $_.RestoreComplete -eq $True }).count | Should Be $Results.count
         }
-        $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database StripeTest
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database StripeTest -Confirm:$false
     }
 
     Context "Don't try to create/test folders with OutputScriptOnly (Issue 4046)" {
@@ -881,7 +884,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $securePass = ConvertTo-SecureString "estBackupDir\master\script:instance1).split('\')[1])\Full\master-Full.bak" -AsPlainText -Force
         New-DbaDbMasterKey -SqlInstance $TestConfig.instance2 -Database Master -SecurePassword $securePass -confirm:$false
         $cert = New-DbaDbCertificate -SqlInstance $TestConfig.instance2 -Database Master -Name RestoreTestCert -Subject RestoreTestCert
-        $encBackupResults = Backup-DbaDatabase -SqlInstance $TestConfig.instance2 -Database EncRestTest -EncryptionAlgorithm AES128 -EncryptionCertificate RestoreTestCert
+        $encBackupResults = Backup-DbaDatabase -SqlInstance $TestConfig.instance2 -Database EncRestTest -EncryptionAlgorithm AES128 -EncryptionCertificate RestoreTestCert -FilePath "$($TestConfig.Temp)\EncRestTest.bak"
         It "Should encrypt the backup" {
             $encBackupResults.EncryptorType | Should Be "CERTIFICATE"
             $encBackupResults.KeyAlgorithm | Should Be "aes_128"
@@ -902,7 +905,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         It "Should have stoped at mark" {
             $sqlOut.ms | Should -Be 9876
         }
-        $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database StopAt2
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database StopAt2 -Confirm:$false
     }
 
     Context "Test restoring with StopAtBefore" {
@@ -912,7 +915,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         It "Should have stoped at mark" {
             $sqlOut.ms | Should -Be 8764
         }
-        $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database StopAt2
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database StopAt2 -Confirm:$false
     }
 
     Context "Test restoring with StopAt and StopAfterDate" {
@@ -922,7 +925,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         It "Should have stoped at mark" {
             $sqlOut.ms | Should -Be 29876
         }
-        $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database StopAt2
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database StopAt2 -Confirm:$false
     }
 
     Context "Warn if OutputScriptOnly and VerifyOnly specified together #6987" {
@@ -930,7 +933,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         It "Should return a warning" {
             $warnvar | Should -BeLike '*The switches OutputScriptOnly and VerifyOnly cannot both be specified at the same time, stopping'
         }
-        $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database StopAt2
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database StopAt2 -Confirm:$false
     }
     if ($env:azurepasswd) {
         Context "Restores From Azure using SAS" {
@@ -1003,5 +1006,6 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             }
         }
     }
-    #>
+
+    Remove-Item -Path C:\temp\* -Recurse -Force
 }

--- a/tests/Resume-DbaAgDbDataMovement.Tests.ps1
+++ b/tests/Resume-DbaAgDbDataMovement.Tests.ps1
@@ -20,14 +20,16 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $agname = "dbatoolsci_resumeagdb_agroup"
         $dbname = "dbatoolsci_resumeagdb_agroupdb"
         $server.Query("create database $dbname")
-        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase
-        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -Type Log
+        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -FilePath "$($TestConfig.Temp)\$dbname.bak"
+        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -FilePath "$($TestConfig.Temp)\$dbname.trn" -Type Log
         $ag = New-DbaAvailabilityGroup -Primary $TestConfig.instance3 -Name $agname -ClusterType None -FailoverMode Manual -Database $dbname -Confirm:$false -Certificate dbatoolsci_AGCert -UseLastBackup
         $null = Get-DbaAgDatabase -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agname | Suspend-DbaAgDbDataMovement -Confirm:$false
     }
     AfterAll {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname -Confirm:$false
+        $null = Get-DbaEndpoint -SqlInstance $server -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname -Confirm:$false
+        Remove-Item -Path "$($TestConfig.Temp)\$dbname.bak", "$($TestConfig.Temp)\$dbname.trn"
     }
     Context "resumes  data movement" {
         It "returns resumed results" {

--- a/tests/Revoke-DbaAgPermission.Tests.ps1
+++ b/tests/Revoke-DbaAgPermission.Tests.ps1
@@ -21,6 +21,8 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     }
     AfterAll {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agname -Confirm:$false
+        $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
+        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance3 -Login 'claudio', 'port', 'tester' -Confirm:$false
     }
     Context "revokes big perms" {
         It "returns results with proper data" {

--- a/tests/Set-DbaAgReplica.Tests.ps1
+++ b/tests/Set-DbaAgReplica.Tests.ps1
@@ -21,6 +21,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     }
     AfterAll {
         Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agname -Confirm:$false
+        $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
     }
     Context "sets ag properties" {
         It "returns modified results" {

--- a/tests/Set-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/Set-DbaAvailabilityGroup.Tests.ps1
@@ -20,6 +20,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     }
     AfterAll {
         Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agname -Confirm:$false
+        $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
     }
     Context "sets ag properties" {
         It "returns modified results" {

--- a/tests/Suspend-DbaAgDbDataMovement.Tests.ps1
+++ b/tests/Suspend-DbaAgDbDataMovement.Tests.ps1
@@ -15,19 +15,23 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
+        $backupPath = "$($TestConfig.Temp)\$CommandName"
+        $null = New-Item -Path $backupPath -ItemType Directory
         $null = Get-DbaProcess -SqlInstance $TestConfig.instance3 -Program 'dbatools PowerShell module - dbatools.io' | Stop-DbaProcess -WarningAction SilentlyContinue
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance3
         $agname = "dbatoolsci_resumeagdb_agroup"
         $dbname = "dbatoolsci_resumeagdb_agroupdb"
         $server.Query("create database $dbname")
-        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase
-        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -Type Log
+        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -BackupDirectory $backupPath
+        $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbname | Backup-DbaDatabase -BackupDirectory $backupPath -Type Log
         $ag = New-DbaAvailabilityGroup -Primary $TestConfig.instance3 -Name $agname -ClusterType None -FailoverMode Manual -Database $dbname -Confirm:$false -Certificate dbatoolsci_AGCert -UseLastBackup
         $null = Get-DbaAgDatabase -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agname | Resume-DbaAgDbDataMovement -Confirm:$false
     }
     AfterAll {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname -Confirm:$false
+        $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname -Confirm:$false
+        Remove-Item -Path $backupPath -Recurse
     }
     Context "resumes  data movement" {
         It "returns resumed results" {

--- a/tests/Test-DbaBackupEncrypted.Tests.ps1
+++ b/tests/Test-DbaBackupEncrypted.Tests.ps1
@@ -17,6 +17,10 @@ Describe "$CommandName Unit Tests" -Tags "UnitTests" {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
         $PSDefaultParameterValues["*:Confirm"] = $false
+
+        $backupPath = "$($TestConfig.Temp)\$CommandName"
+        $null = New-Item -Path $backupPath -ItemType Directory
+
         $alldbs = @()
         1..2 | ForEach-Object { $alldbs += New-DbaDatabase -SqlInstance $TestConfig.instance2 }
     }
@@ -25,6 +29,9 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         if ($alldbs) {
             $alldbs | Remove-DbaDatabase
         }
+        Remove-Item -Path $backupPath -Recurse
+        # TODO: Should be refactored next to only remove the created databases.
+        Get-DbaDatabase -SqlInstance $TestConfig.instance2 -ExcludeSystem | Remove-DbaDatabase
     }
 
     Context "Command actually works" {
@@ -33,22 +40,22 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $splat = @{
                 MasterKeySecurePassword = $passwd
                 BackupSecurePassword    = $passwd
-                BackupPath              = "C:\temp"
+                BackupPath              = $backupPath
                 EnableException         = $true
             }
             $null = $alldbs | Start-DbaDbEncryption @splat
-            $backups = $alldbs | Select-Object -First 1 | Backup-DbaDatabase -Path C:\temp
+            $backups = $alldbs | Select-Object -First 1 | Backup-DbaDatabase -Path $backupPath
             $results = $backups | Test-DbaBackupEncrypted -SqlInstance $TestConfig.instance2
             $results.Encrypted | Should -Be $true
         }
         It "should detect encryption from piped file" {
-            $backups = $alldbs | Select-Object -First 1 | Backup-DbaDatabase -Path C:\temp
+            $backups = $alldbs | Select-Object -First 1 | Backup-DbaDatabase -Path $backupPath
             $results = Test-DbaBackupEncrypted -SqlInstance $TestConfig.instance2 -FilePath $backups.BackupPath
             $results.Encrypted | Should -Be $true
         }
 
         It "should say a non-encryted file is not encrypted" {
-            $backups = New-DbaDatabase -SqlInstance $TestConfig.instance2 | Backup-DbaDatabase -Path C:\temp
+            $backups = New-DbaDatabase -SqlInstance $TestConfig.instance2 | Backup-DbaDatabase -Path $backupPath
             $results = Test-DbaBackupEncrypted -SqlInstance $TestConfig.instance2 -FilePath $backups.BackupPath
             $results.Encrypted | Should -Be $false
         }
@@ -56,7 +63,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         It "should say a non-encryted file is not encrypted" {
             $encryptor = (Get-DbaDbCertificate -SqlInstance $TestConfig.instance2 -Database master | Where-Object Name -notmatch "#" | Select-Object -First 1).Name
             $db = New-DbaDatabase -SqlInstance $TestConfig.instance2
-            $backup = Backup-DbaDatabase -SqlInstance $TestConfig.instance2 -Path C:\temp -EncryptionAlgorithm AES192 -EncryptionCertificate $encryptor -Database $db.Name
+            $backup = Backup-DbaDatabase -SqlInstance $TestConfig.instance2 -Path $backupPath -EncryptionAlgorithm AES192 -EncryptionCertificate $encryptor -Database $db.Name
             $results = Test-DbaBackupEncrypted -SqlInstance $TestConfig.instance2 -FilePath $backup.BackupPath
             $results.Encrypted | Should -Be $true
         }

--- a/tests/Test-DbaDbDataGeneratorConfig.Tests.ps1
+++ b/tests/Test-DbaDbDataGeneratorConfig.Tests.ps1
@@ -41,6 +41,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     }
     AfterAll {
         Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname -Confirm:$false
+        Remove-Item -Path "C:\temp\datageneration" -Recurse
     }
 
     It "gives no errors with a correct json file" {

--- a/tests/Test-DbaDbDataMaskingConfig.Tests.ps1
+++ b/tests/Test-DbaDbDataMaskingConfig.Tests.ps1
@@ -107,6 +107,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     }
     AfterAll {
         Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname -Confirm:$false
+        Remove-Item -Path "C:\temp\datamasking" -Recurse
     }
 
     It "gives no errors with a correct json file" {


### PR DESCRIPTION
Mainly to suppress expected warning messages. Sometimes to remove created objects.

There are some more fixes to come, but we are near the end...

But I have noticed some tests that output warnings that indicate that we don't test what we want to test - so they need some special care. Will probably rewrite them in pester 5...