### PR TITLE
Refactor Get-TestConfig for safety and better readability

### DIFF
--- a/private/testing/Get-TestConfig.ps1
+++ b/private/testing/Get-TestConfig.ps1
@@ -2,73 +2,77 @@ function Get-TestConfig {
     param(
         [string]$LocalConfigPath = "$script:PSModuleRoot/tests/constants.local.ps1"
     )
-    $config = [ordered]@{}
+
+    $config = [ordered]@{
+        CommonParameters = [System.Management.Automation.PSCmdlet]::CommonParameters
+        Defaults         = [System.Management.Automation.DefaultParameterDictionary]@{
+            # We want the tests as readable as possible so we want to set Confirm globally to $false.
+            '*:Confirm'         = $false
+            # We use a global warning variable so that we can always test
+            # that the command does not write a warning
+            # or that the command does write the expected warning.
+            '*:WarningVariable' = 'WarnVar'
+        }
+        # We want all the tests to only write to this location.
+        # When testing a remote SQL Server instance this must be a network share
+        # where both the SQL Server instance and the test script can write to.
+        Temp             = 'C:\Temp'
+    }
 
     if (Test-Path $LocalConfigPath) {
         . $LocalConfigPath
     } elseif ($env:CODESPACES -or ($env:TERM_PROGRAM -eq 'vscode' -and $env:REMOTE_CONTAINERS)) {
         $null = Set-DbatoolsInsecureConnection
+
         $config['Instance1'] = "dbatools1"
         $config['Instance2'] = "dbatools2"
         $config['Instance3'] = "dbatools3"
         $config['Instances'] = @($config['Instance1'], $config['Instance2'])
 
         $config['SqlCred'] = [PSCredential]::new('sa', (ConvertTo-SecureString $env:SA_PASSWORD -AsPlainText -Force))
-        $config['Defaults'] = [System.Management.Automation.DefaultParameterDictionary]@{
-            "*:SqlCredential" = $config['SqlCred']
-            "*:SourceSqlCredential" = $config['SqlCred']
-            "*:DestinationSqlCredential" = $config['SqlCred']
-        }
+        $config['Defaults']['*:SqlCredential'] = $config['SqlCred']
+        $config['Defaults']['*:SourceSqlCredential'] = $config['SqlCred']
+        $config['Defaults']['*:DestinationSqlCredential'] = $config['SqlCred']
     } elseif ($env:GITHUB_WORKSPACE) {
         $config['DbaToolsCi_Computer'] = "localhost"
+
         $config['Instance1'] = "localhost"
         $config['Instance2'] = "localhost:14333"
+        $config['Instance3'] = "localhost"
+        $config['Instances'] = @($config['Instance1'], $config['Instance2'])
+
         $config['Instance2SQLUserName'] = $null  # placeholders for -SqlCredential testing
         $config['Instance2SQLPassword'] = $null
-        $config['Instance3'] = "localhost"
         $config['Instance2_Detailed'] = "localhost,14333"  # Just to make sure things parse a port properly
+
         $config['AppveyorLabRepo'] = "/tmp/appveyor-lab"
-        $config['Instances'] = @($config['Instance1'], $config['Instance2'])
         $config['SsisServer'] = "localhost\sql2016"
         $config['AzureBlob'] = "https://dbatools.blob.core.windows.net/sql"
         $config['AzureBlobAccount'] = "dbatools"
         $config['AzureServer'] = 'psdbatools.database.windows.net'
         $config['AzureSqlDbLogin'] = "appveyor@clemairegmail.onmicrosoft.com"
     } else {
+        # This configuration is used for the automated test on AppVeyor
         $config['DbaToolsCi_Computer'] = "localhost"
+
         $config['Instance1'] = "localhost\sql2008r2sp2"
         $config['Instance2'] = "localhost\sql2016"
+        $config['Instance3'] = "localhost\sql2017"
+        $config['Instances'] = @($config['Instance1'], $config['Instance2'])
+
         $config['Instance2SQLUserName'] = $null  # placeholders for -SqlCredential testing
         $config['Instance2SQLPassword'] = $null
-        $config['Instance3'] = "localhost\sql2017"
         $config['Instance2_Detailed'] = "localhost,14333\sql2016"  # Just to make sure things parse a port properly
+
         $config['AppveyorLabRepo'] = "C:\github\appveyor-lab"
-        $config['Instances'] = @($config['Instance1'], $config['Instance2'])
         $config['SsisServer'] = "localhost\sql2016"
         $config['AzureBlob'] = "https://dbatools.blob.core.windows.net/sql"
         $config['AzureBlobAccount'] = "dbatools"
         $config['AzureServer'] = 'psdbatools.database.windows.net'
         $config['AzureSqlDbLogin'] = "appveyor@clemairegmail.onmicrosoft.com"
+
         $config['BigDatabaseBackup'] = 'C:\github\StackOverflowMini.bak'
         $config['BigDatabaseBackupSourceUrl'] = 'https://github.com/BrentOzarULTD/Stack-Overflow-Database/releases/download/20230114/StackOverflowMini.bak'
-    }
-
-    if ($env:appveyor) {
-        $config['Defaults'] = [System.Management.Automation.DefaultParameterDictionary]@{
-            '*:WarningAction' = 'SilentlyContinue'
-        }
-    }
-
-    $config['CommonParameters'] = [System.Management.Automation.PSCmdlet]::CommonParameters
-
-    # We want the tests as readable as possible so we want to set Confirm globally to $false
-    $config['Defaults']['*:Confirm'] = $false
-
-    # We use a global warning variable so that we can always test that the command does not write a warning
-    $config['Defaults']['*:WarningVariable'] = 'WarnVar'
-
-    if (-not $config['Temp']) {
-        $config['Temp'] = 'C:\Temp'
     }
 
     [pscustomobject]$config


### PR DESCRIPTION
Let's start with a $config that is filled with the required properties for safety.

I also rearranged some lines for better readability. We should later have a look at the different properties and see if they are all used in the tests and maybe rename some of them for more flexibility and readability.

For a test of the configs "$env:CODESPACES -or ($env:TERM_PROGRAM -eq 'vscode' -and $env:REMOTE_CONTAINERS" and "$env:GITHUB_WORKSPACE" someone has to setup a lab for that - who is using this?