### PR TITLE
More tests in the new pester 5 design

### DIFF
--- a/tests/Add-DbaComputerCertificate.Tests.ps1
+++ b/tests/Add-DbaComputerCertificate.Tests.ps1
@@ -8,9 +8,9 @@ param(
 Describe $CommandName -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
-            $command = Get-Command Add-DbaComputerCertificate
-            $expected = $TestConfig.CommonParameters
-            $expected += @(
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "ComputerName",
                 "Credential",
                 "SecurePassword",
@@ -19,19 +19,12 @@ Describe $CommandName -Tag "UnitTests" {
                 "Store",
                 "Folder",
                 "Flag",
-                "EnableException",
-                "Confirm",
-                "WhatIf"
+                "EnableException"
             )
         }
 
-        It "Has parameter: <_>" -ForEach $expected {
-            $command | Should -HaveParameter $PSItem
-        }
-
-        It "Should have exactly the number of expected parameters ($($expected.Count))" {
-            $hasparms = $command.Parameters.Values.Name
-            Compare-Object -ReferenceObject $expected -DifferenceObject $hasparms | Should -BeNullOrEmpty
+        It "Should have the expected parameters" {
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
@@ -40,19 +33,20 @@ Describe $CommandName -Tag "IntegrationTests" {
     Context "Certificate is added properly" {
         BeforeAll {
             $certPath = "$($TestConfig.appveyorlabrepo)\certificates\localhost.crt"
-            $results = Add-DbaComputerCertificate -Path $certPath -Confirm:$false
+            $certThumbprint = "29C469578D6C6211076A09CEE5C5797EEA0C2713"
+            $results = Add-DbaComputerCertificate -Path $certPath
+        }
+
+        AfterAll {
+            Remove-DbaComputerCertificate -Thumbprint $certThumbprint
         }
 
         It "Should show the proper thumbprint has been added" {
-            $results.Thumbprint | Should -Be "29C469578D6C6211076A09CEE5C5797EEA0C2713"
+            $results.Thumbprint | Should -Be $certThumbprint
         }
 
         It "Should be in LocalMachine\My Cert Store" {
             $results.PSParentPath | Should -Be "Microsoft.PowerShell.Security\Certificate::LocalMachine\My"
-        }
-
-        AfterAll {
-            Remove-DbaComputerCertificate -Thumbprint 29C469578D6C6211076A09CEE5C5797EEA0C2713 -Confirm:$false
         }
     }
 }

--- a/tests/Add-DbaDbMirrorMonitor.Tests.ps1
+++ b/tests/Add-DbaDbMirrorMonitor.Tests.ps1
@@ -8,36 +8,29 @@ param(
 Describe $CommandName -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
-            $command = Get-Command Add-DbaDbMirrorMonitor
-            $expected = $TestConfig.CommonParameters
-            $expected += @(
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "SqlInstance",
                 "SqlCredential",
-                "EnableException",
-                "Confirm",
-                "WhatIf"
+                "EnableException"
             )
         }
 
-        It "Has parameter: <_>" -ForEach $expected {
-            $command | Should -HaveParameter $PSItem
-        }
-
-        It "Should have exactly the number of expected parameters ($($expected.Count))" {
-            $hasparms = $command.Parameters.Values.Name
-            Compare-Object -ReferenceObject $expected -DifferenceObject $hasparms | Should -BeNullOrEmpty
+        It "Should have the expected parameters" {
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
 Describe $CommandName -Tag "IntegrationTests" {
-    AfterAll {
-        $null = Remove-DbaDbMirrorMonitor -SqlInstance $TestConfig.instance2 -WarningAction SilentlyContinue
-    }
-
     Context "When adding mirror monitor" {
         BeforeAll {
-            $results = Add-DbaDbMirrorMonitor -SqlInstance $TestConfig.instance2 -WarningAction SilentlyContinue
+            $results = Add-DbaDbMirrorMonitor -SqlInstance $TestConfig.instance2
+        }
+
+        AfterAll {
+            $null = Remove-DbaDbMirrorMonitor -SqlInstance $TestConfig.instance2
         }
 
         It "Adds the mirror monitor" {

--- a/tests/Add-DbaExtendedProperty.Tests.ps1
+++ b/tests/Add-DbaExtendedProperty.Tests.ps1
@@ -1,34 +1,28 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
-    $ModuleName = "dbatools",
-    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+    $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
+    $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
 Describe "Add-DbaExtendedProperty" -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
-            $command = Get-Command Add-DbaExtendedProperty
-            $expected = $TestConfig.CommonParameters
-            $expected += @(
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "SqlInstance",
                 "SqlCredential",
                 "Database",
                 "Name",
                 "Value",
                 "InputObject",
-                "EnableException",
-                "Confirm",
-                "WhatIf"
+                "EnableException"
             )
         }
 
-        It "Has parameter: <_>" -ForEach $expected {
-            $command | Should -HaveParameter $PSItem
-        }
-
-        It "Should have exactly the number of expected parameters ($($expected.Count))" {
-            $hasparms = $command.Parameters.Values.Name
-            Compare-Object -ReferenceObject $expected -DifferenceObject $hasparms | Should -BeNullOrEmpty
+        It "Should have the expected parameters" {
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Add-DbaPfDataCollectorCounter.Tests.ps1
+++ b/tests/Add-DbaPfDataCollectorCounter.Tests.ps1
@@ -1,34 +1,28 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
-    $ModuleName = "dbatools",
-    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+    $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
+    $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
 Describe "Add-DbaPfDataCollectorCounter" -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
-            $command = Get-Command Add-DbaPfDataCollectorCounter
-            $expected = $TestConfig.CommonParameters
-            $expected += @(
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "ComputerName",
                 "Credential",
                 "CollectorSet",
                 "Collector",
                 "Counter",
                 "InputObject",
-                "EnableException",
-                "Confirm",
-                "WhatIf"
+                "EnableException"
             )
         }
 
-        It "Has parameter: <_>" -ForEach $expected {
-            $command | Should -HaveParameter $PSItem
-        }
-
-        It "Should have exactly the number of expected parameters ($($expected.Count))" {
-            $hasparms = $command.Parameters.Values.Name
-            Compare-Object -ReferenceObject $expected -DifferenceObject $hasparms | Should -BeNullOrEmpty
+        It "Should have the expected parameters" {
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Add-DbaRegServer.Tests.ps1
+++ b/tests/Add-DbaRegServer.Tests.ps1
@@ -1,15 +1,16 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
-    $ModuleName = "dbatools",
-    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+    $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
+    $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
 Describe "Add-DbaRegServer" -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
-            $command = Get-Command Add-DbaRegServer
-            $expected = $TestConfig.CommonParameters
-            $expected += @(
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "SqlInstance",
                 "SqlCredential",
                 "ServerName",
@@ -22,19 +23,12 @@ Describe "Add-DbaRegServer" -Tag "UnitTests" {
                 "OtherParams",
                 "InputObject",
                 "ServerObject",
-                "EnableException",
-                "Confirm",
-                "WhatIf"
+                "EnableException"
             )
         }
 
-        It "Has parameter: <_>" -ForEach $expected {
-            $command | Should -HaveParameter $PSItem
-        }
-
-        It "Should have exactly the number of expected parameters ($($expected.Count))" {
-            $hasparms = $command.Parameters.Values.Name
-            Compare-Object -ReferenceObject $expected -DifferenceObject $hasparms | Should -BeNullOrEmpty
+        It "Should have the expected parameters" {
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Add-DbaRegServerGroup.Tests.ps1
+++ b/tests/Add-DbaRegServerGroup.Tests.ps1
@@ -1,34 +1,28 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
-    $ModuleName = "dbatools",
-    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+    $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
+    $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
 Describe "Add-DbaRegServerGroup" -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
-            $command = Get-Command Add-DbaRegServerGroup
-            $expected = $TestConfig.CommonParameters
-            $expected += @(
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "SqlInstance",
                 "SqlCredential",
                 "Name",
                 "Description",
                 "Group",
                 "InputObject",
-                "EnableException",
-                "Confirm",
-                "WhatIf"
+                "EnableException"
             )
         }
 
-        It "Has parameter: <_>" -ForEach $expected {
-            $command | Should -HaveParameter $PSItem
-        }
-
-        It "Should have exactly the number of expected parameters ($($expected.Count))" {
-            $hasparms = $command.Parameters.Values.Name
-            Compare-Object -ReferenceObject $expected -DifferenceObject $hasparms | Should -BeNullOrEmpty
+        It "Should have the expected parameters" {
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Add-DbaReplArticle.Tests.ps1
+++ b/tests/Add-DbaReplArticle.Tests.ps1
@@ -1,15 +1,16 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
-    $ModuleName = "dbatools",
-    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+    $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
+    $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
 Describe "Add-DbaReplArticle" -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
-            $command = Get-Command Add-DbaReplArticle
-            $expected = $TestConfig.CommonParameters
-            $expected += @(
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "SqlInstance",
                 "SqlCredential",
                 "Database",
@@ -18,19 +19,12 @@ Describe "Add-DbaReplArticle" -Tag "UnitTests" {
                 "Name",
                 "Filter",
                 "CreationScriptOptions",
-                "EnableException",
-                "WhatIf",
-                "Confirm"
+                "EnableException"
             )
         }
 
-        It "Has parameter: <_>" -ForEach $expected {
-            $command | Should -HaveParameter $PSItem
-        }
-
-        It "Should have exactly the number of expected parameters ($($expected.Count))" {
-            $hasparms = $command.Parameters.Values.Name
-            Compare-Object -ReferenceObject $expected -DifferenceObject $hasparms | Should -BeNullOrEmpty
+        It "Should have the expected parameters" {
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Add-DbaServerRoleMember.Tests.ps1
+++ b/tests/Add-DbaServerRoleMember.Tests.ps1
@@ -1,34 +1,28 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
-    $ModuleName = "dbatools",
-    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+    $ModuleName               = "dbatools",
+    $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),
+    $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
 Describe "Add-DbaServerRoleMember" -Tag "UnitTests" {
     Context "Parameter validation" {
         BeforeAll {
-            $command = Get-Command Add-DbaServerRoleMember
-            $expected = $TestConfig.CommonParameters
-            $expected += @(
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "SqlInstance",
                 "SqlCredential",
                 "ServerRole",
                 "Login",
                 "Role",
                 "InputObject",
-                "EnableException",
-                "Confirm",
-                "WhatIf"
+                "EnableException"
             )
         }
 
-        It "Has parameter: <_>" -ForEach $expected {
-            $command | Should -HaveParameter $PSItem
-        }
-
-        It "Should have exactly the number of expected parameters ($($expected.Count))" {
-            $hasparms = $command.Parameters.Values.Name
-            Compare-Object -ReferenceObject $expected -DifferenceObject $hasparms | Should -BeNullOrEmpty
+        It "Should have the expected parameters" {
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -19,6 +19,11 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    AfterAll {
+        Get-DbaConnectedInstance | Disconnect-DbaInstance
+        Clear-DbaConnectionPool
+    }
+
     if ($env:azuredbpasswd -eq "failstoooften") {
         Context "Connect to Azure" {
             $securePassword = ConvertTo-SecureString $env:azuredbpasswd -AsPlainText -Force
@@ -174,6 +179,10 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     Context "connection is properly cloned from an existing connection" {
         BeforeAll {
             $server = Connect-DbaInstance -SqlInstance $TestConfig.instance1
+        }
+
+        AfterAll {
+            $server | Disconnect-DbaInstance
         }
 
         It "clones when using parameter Database" {

--- a/tests/Copy-DbaDbMail.Tests.ps1
+++ b/tests/Copy-DbaDbMail.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
     $ModuleName               = "dbatools",
     $CommandName              = [System.IO.Path]::GetFileName($PSCommandPath.Replace('.Tests.ps1', '')),

--- a/tests/Export-DbaRegServer.Tests.ps1
+++ b/tests/Export-DbaRegServer.Tests.ps1
@@ -100,13 +100,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     It "Ensure the Overwrite param is working" {
         $outputFileName = "$newDirectory\dbatoolsci-regsrvr-export-$random.xml"
-        $results = Export-DbaRegServer -SqlInstance $TestConfig.instance2 -FilePath $outputFileName -WarningAction SilentlyContinue
-        # TODO: Test for [Export-DbaRegServer] Use the -Overwrite parameter if the file C:\temp\539615200\dbatoolsci-regsrvr-export-539615200.xml should be overwritten.
+        $results = Export-DbaRegServer -SqlInstance $TestConfig.instance2 -FilePath $outputFileName
         $results -is [System.IO.FileInfo] | Should -Be $true
         $results.FullName | Should -Be $outputFileName
 
         # test without -Overwrite
-        $invalidResults = Export-DbaRegServer -SqlInstance $TestConfig.instance2 -FilePath $outputFileName
+        $invalidResults = Export-DbaRegServer -SqlInstance $TestConfig.instance2 -FilePath $outputFileName -WarningAction SilentlyContinue
+        # TODO: Test for [Export-DbaRegServer] Use the -Overwrite parameter if the file C:\temp\539615200\dbatoolsci-regsrvr-export-539615200.xml should be overwritten.
         $invalidResults.length | Should -Be 0
 
         # test with -Overwrite

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -1,12 +1,10 @@
 #Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+param(
+    $ModuleName               = "dbatools",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-BeforeAll {
-    $CommandName = (Get-Item $PSCommandPath).Name.Replace(".Tests.ps1", "")
-    $global:TestConfig = Get-TestConfig
-}
-
-
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe "Invoke-DbaQuery" -Tag 'UnitTests' {
     Context "Validate parameters" {
         BeforeAll {
             $command = Get-Command Invoke-DbaQuery
@@ -47,12 +45,18 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     }
 }
 
-Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+Describe "Invoke-DbaQuery" -Tag "IntegrationTests" {
     BeforeAll {
+        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+
         $db = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database tempdb
         $null = $db.Query("CREATE PROCEDURE dbo.dbatoolsci_procedure_example @p1 [INT] = 0 AS BEGIN SET NOCOUNT OFF; SELECT TestColumn = @p1; END")
+
+        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
     }
     AfterAll {
+        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+
         try {
             $null = $db.Query("DROP PROCEDURE dbo.dbatoolsci_procedure_example")
             $null = $db.Query("DROP PROCEDURE dbo.my_proc")

--- a/tests/Start-DbaDbEncryption.Tests.ps1
+++ b/tests/Start-DbaDbEncryption.Tests.ps1
@@ -25,6 +25,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         if ($alldbs) {
             $alldbs | Remove-DbaDatabase
         }
+        Remove-Item -Path "C:\temp\*"
     }
 
     Context "Command actually works" {


### PR DESCRIPTION
All `Add-` tests have the new pester 5 design for param block (except for the `$CommandName`) and the UnitTest Describe bock.

The first tests have a good design, the later tests maybe need some more refactoring.

All non-`Add-` tests are just some more fixes that I included here...