### PR TITLE
Availability is misspelled

### DIFF
--- a/public/Add-DbaAgDatabase.ps1
+++ b/public/Add-DbaAgDatabase.ps1
@@ -454,14 +454,14 @@ function Add-DbaAgDatabase {
                             $replicaAgDb.Refresh()
                         }
 
-                        # With automatic seeding, .JoinAvailablityGroup() is not needed, just wait for the magic to happen
+                        # With automatic seeding, .JoinAvailabilityGroup() is not needed, just wait for the magic to happen
                         if ($ag.AvailabilityReplicas[$replicaName].SeedingMode -ne 'Automatic') {
                             try {
                                 $progress['CurrentOperation'] = "Joining database $($db.Name) on replica $replicaName"
                                 Write-Message -Level Verbose -Message $progress['CurrentOperation']
                                 Write-Progress @progress
 
-                                $replicaAgDb.JoinAvailablityGroup()
+                                $replicaAgDb.JoinAvailabilityGroup()
                             } catch {
                                 $failure = $true
                                 Stop-Function -Message "Failed to join database $($db.Name) on replica $replicaName." -ErrorRecord $_ -Continue


### PR DESCRIPTION
Availability is misspelled in two locations, one matters and one is just in comments.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Availability is misspelled in two locations, one matters and one is just in comments.
