### PR TITLE
Cleanup AppVeyor configuration scripts

### DIFF
--- a/tests/Read-DbaXEFile.Tests.ps1
+++ b/tests/Read-DbaXEFile.Tests.ps1
@@ -18,26 +18,28 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Verifying command output" {
         BeforeAll {
             # Just to analyse problems on AppVeyor
-            $sessions = Get-DbaXESession -SqlInstance $TestConfig.instance3
+            $sessions = Get-DbaXESession -SqlInstance $TestConfig.instance2
             foreach ($session in $sessions) {
                 Write-Warning -Message "Status and AutoStart of $($session.Name): $($session.Status) / $($session.AutoStart)"
             }
-            $results = Get-DbaXESession -SqlInstance $TestConfig.instance3 -Session system_health | Read-DbaXEFile -Raw
+            $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
             if (-not $results) {
-                Write-Warning -Message "No results, so restarting service"
-                $null = Restart-DbaService -SqlInstance $TestConfig.instance3 -Type Engine -Force
-                $results = Get-DbaXESession -SqlInstance $TestConfig.instance3 -Session system_health | Read-DbaXEFile -Raw
+                Write-Warning -Message "No results, so trying an invalid login and restarting service"
+                $cred = [PSCredential]::new('invalid', (ConvertTo-SecureString -String 'invalid' -AsPlainText -Force))
+                try { $null = Connect-DbaInstance -SqlInstance $TestConfig.instance2 -SqlCredential $cred } catch { }
+                $null = Restart-DbaService -SqlInstance $TestConfig.instance2 -Type Engine -Force
+                $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
                 if (-not $results) {
                     Write-Warning -Message "Still no results..."
                 }
             }
         }
         It "returns some results" {
-            $results = Get-DbaXESession -SqlInstance $TestConfig.instance3 -Session system_health | Read-DbaXEFile -Raw
+            $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
             $results | Should -Not -BeNullOrEmpty
         }
         It "returns some results" {
-            $results = Get-DbaXESession -SqlInstance $TestConfig.instance3 -Session system_health | Read-DbaXEFile
+            $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile
             $results | Should -Not -BeNullOrEmpty
         }
     }

--- a/tests/Read-DbaXEFile.Tests.ps1
+++ b/tests/Read-DbaXEFile.Tests.ps1
@@ -18,26 +18,26 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Verifying command output" {
         BeforeAll {
             # Just to analyse problems on AppVeyor
-            $sessions = Get-DbaXESession -SqlInstance $TestConfig.instance2
+            $sessions = Get-DbaXESession -SqlInstance $TestConfig.instance3
             foreach ($session in $sessions) {
                 Write-Warning -Message "Status and AutoStart of $($session.Name): $($session.Status) / $($session.AutoStart)"
             }
-            $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
+            $results = Get-DbaXESession -SqlInstance $TestConfig.instance3 -Session system_health | Read-DbaXEFile -Raw
             if (-not $results) {
                 Write-Warning -Message "No results, so restarting service"
-                $null = Restart-DbaService -SqlInstance $TestConfig.instance2 -Type Engine -Force
-                $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
+                $null = Restart-DbaService -SqlInstance $TestConfig.instance3 -Type Engine -Force
+                $results = Get-DbaXESession -SqlInstance $TestConfig.instance3 -Session system_health | Read-DbaXEFile -Raw
                 if (-not $results) {
                     Write-Warning -Message "Still no results..."
                 }
             }
         }
         It "returns some results" {
-            $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
+            $results = Get-DbaXESession -SqlInstance $TestConfig.instance3 -Session system_health | Read-DbaXEFile -Raw
             $results | Should -Not -BeNullOrEmpty
         }
         It "returns some results" {
-            $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile
+            $results = Get-DbaXESession -SqlInstance $TestConfig.instance3 -Session system_health | Read-DbaXEFile
             $results | Should -Not -BeNullOrEmpty
         }
     }

--- a/tests/Read-DbaXEFile.Tests.ps1
+++ b/tests/Read-DbaXEFile.Tests.ps1
@@ -16,6 +16,22 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Verifying command output" {
+        BeforeAll {
+            # Just to analyse problems on AppVeyor
+            $sessions = Get-DbaXESession -SqlInstance $TestConfig.instance2
+            foreach ($session in $sessions) {
+                Write-Warning -Message "Status and AutoStart of $($session.Name): $($session.Status) / $($session.AutoStart)"
+            }
+            $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
+            if (-not $results) {
+                Write-Warning -Message "No results, so restarting service"
+                $null = Restart-DbaService -SqlInstance $TestConfig.instance2 -Type Engine -Force
+                $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
+                if (-not $results) {
+                    Write-Warning -Message "Still no results..."
+                }
+            }
+        }
         It "returns some results" {
             $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
             $results | Should -Not -BeNullOrEmpty

--- a/tests/Read-DbaXEFile.Tests.ps1
+++ b/tests/Read-DbaXEFile.Tests.ps1
@@ -16,24 +16,6 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Verifying command output" {
-        BeforeAll {
-            # Just to analyse problems on AppVeyor
-            $sessions = Get-DbaXESession -SqlInstance $TestConfig.instance2
-            foreach ($session in $sessions) {
-                Write-Warning -Message "Status and AutoStart of $($session.Name): $($session.Status) / $($session.AutoStart)"
-            }
-            $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
-            if (-not $results) {
-                Write-Warning -Message "No results, so trying an invalid login and restarting service"
-                $cred = [PSCredential]::new('invalid', (ConvertTo-SecureString -String 'invalid' -AsPlainText -Force))
-                try { $null = Connect-DbaInstance -SqlInstance $TestConfig.instance2 -SqlCredential $cred } catch { }
-                $null = Restart-DbaService -SqlInstance $TestConfig.instance2 -Type Engine -Force
-                $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
-                if (-not $results) {
-                    Write-Warning -Message "Still no results..."
-                }
-            }
-        }
         It "returns some results" {
             $results = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health | Read-DbaXEFile -Raw
             $results | Should -Not -BeNullOrEmpty

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -7,37 +7,25 @@ $sqlinstance = "localhost\SQL2008R2SP2"
 $instance = "SQL2008R2SP2"
 $port = "1433"
 
-Write-Host -Object "$indent Setting up AppVeyor Services" -ForegroundColor DarkGreen
-
 Write-Host -Object "$indent SQLBrowser StartType: $((Get-Service -Name SQLBrowser).StartType) / Status: $((Get-Service -Name SQLBrowser).Status)" -ForegroundColor DarkGreen
 Write-Host -Object "$indent MSSQL`$$instance StartType: $((Get-Service -Name "MSSQL`$$instance").StartType) / Status: $((Get-Service -Name "MSSQL`$$instance").Status)" -ForegroundColor DarkGreen
 
-Set-Service -Name SQLBrowser -StartupType Automatic -WarningAction SilentlyContinue
-Start-Service SQLBrowser -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+
+Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundColor DarkGreen
+
+Set-Service -Name SQLBrowser -StartupType Automatic
+Start-Service -Name SQLBrowser
+
+Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
+Start-Service -Name "MSSQL`$$instance"
 
 
-Write-Host -Object "$indent Configuring instance $sqlinstance" -ForegroundColor DarkGreen
-Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -Confirm:$false
-Set-DbaNetworkConfiguration -SqlInstance client -EnableProtocol NamedPipes -RestartService -Confirm:$false
+Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen
 
+$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -EnableException -Confirm:$false
+$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -EnableProtocol NamedPipes -RestartService -EnableException -Confirm:$false
+$null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name RemoteDacConnectionsEnabled -Value $true -EnableException
+# To conserve resources, SQL Server Express doesn't listen on the DAC port unless started with a trace flag 7806.
+$null = Set-DbaStartupParameter -SqlInstance $sqlinstance -TraceFlagOverride -TraceFlag 7806 -EnableException -Confirm:$false
 
-Write-Host -Object "$indent Starting $sqlinstance" -ForegroundColor DarkGreen
-Restart-Service "MSSQL`$$instance" -WarningAction SilentlyContinue -Force
-
-$null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name RemoteDacConnectionsEnabled -Value $true
-$null = Set-DbaStartupParameter -SqlInstance $sqlinstance -TraceFlagOverride -TraceFlag 7806 -Confirm:$false -ErrorAction SilentlyContinue -EnableException
-Restart-Service "MSSQL`$SQL2008R2SP2" -WarningAction SilentlyContinue -Force
-
-do {
-    Start-Sleep 1
-    $null = (& sqlcmd -S "$sqlinstance" -b -Q "select 1" -d master)
-}
-while ($lastexitcode -ne 0 -and $t++ -lt 10)
-
-#Write-Host -Object "$indent Executing startup scripts for SQL Server 2008" -ForegroundColor DarkGreen
-# Add some jobs to the sql2008r2sp2 instance (1433 = default)
-#foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2008-startup\*.sql -Recurse -ErrorAction SilentlyContinue)) {
-#    Invoke-DbaQuery -SqlInstance $sqlinstance -InputFile $file
-#}
-
-#Import-Module C:\github\dbatools\dbatools.psm1 -Force
+$null = Restart-DbaService -SqlInstance $sqlinstance -Type Engine -Force -EnableException -Confirm:$false

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -1,53 +1,5 @@
-
-
-
-Function Install-ADAuthenticationLibraryforSQLServer {
-    # from https://bzzzt.io/post/2018-05-25-horrible-adalsql-issue/
-    $workingFolder = Join-Path $Env:TEMP ([System.IO.Path]::GetRandomFileName())
-    New-Item -ItemType Directory -Force -Path $workingFolder
-
-    $Installer = 'C:\github\appveyor-lab\azure\adalsql.msi'
-
-    If (!(Test-Path $Installer)) {
-        Throw "$Installer does not exist"
-    }
-    try {
-        #Write-Host "attempting to uninstall..."
-        #Write-Host "Running MsiExec.exe /uninstall {4EE99065-01C6-49DD-9EC6-E08AA5B13491} /quiet"
-        Start-Process -FilePath "MsiExec.exe" -ArgumentList  "/uninstall {4EE99065-01C6-49DD-9EC6-E08AA5B13491} /quiet" -Wait -NoNewWindow
-    } catch {
-        #Write-Host "oh dear install did not work"
-        $fail = $_.Exception
-        Write-Error $fail
-        Throw
-    }
-    try {
-        $DataStamp = get-date -Format yyyyMMddTHHmmss
-        $logFile = '{0}-{1}.log' -f $Installer, $DataStamp
-        $MSIArguments = @(
-            "/i"
-            ('"{0}"' -f $Installer)
-            "/qn"
-            "/norestart"
-            "/L*v"
-            $logFile
-        )
-        #Write-Host "Attempting to install.."
-        #Write-Host " Running msiexec.exe $($MSIArguments)"
-        Start-Process "msiexec.exe" -ArgumentList $MSIArguments -Wait -NoNewWindow
-    } catch {
-        $fail = $_.Exception
-        Write-Error $fail
-        Throw
-    }
-}
-
-#$null = Install-ADAuthenticationLibraryforSQLServer
-
 $indent = '...'
 Write-Host -Object "$indent Running $PSCommandpath" -ForegroundColor DarkGreen
-#Import-Module C:\github\dbatools\dbatools.psm1 -Force
-#$null = Set-DbatoolsInsecureConnection
 
 # This script spins up the 2008R2SP2 instance and the relative setup
 
@@ -56,35 +8,25 @@ $instance = "SQL2008R2SP2"
 $port = "1433"
 
 Write-Host -Object "$indent Setting up AppVeyor Services" -ForegroundColor DarkGreen
+
+Write-Host -Object "$indent SQLBrowser StartType: $((Get-Service -Name SQLBrowser).StartType) / Status: $((Get-Service -Name SQLBrowser).Status)" -ForegroundColor DarkGreen
+Write-Host -Object "$indent MSSQL`$$instance StartType: $((Get-Service -Name "MSSQL`$$instance").StartType) / Status: $((Get-Service -Name "MSSQL`$$instance").Status)" -ForegroundColor DarkGreen
+
 Set-Service -Name SQLBrowser -StartupType Automatic -WarningAction SilentlyContinue
 Start-Service SQLBrowser -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
 
 
-Write-Host -Object "$indent Changing the port on $instance to $port" -ForegroundColor DarkGreen
-$wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
-$uri = "ManagedComputer[@Name='$env:COMPUTERNAME']/ServerInstance[@Name='$instance']/ServerProtocol[@Name='Tcp']"
-$Tcp = $wmi.GetSmoObject($uri)
-foreach ($ipAddress in $Tcp.IPAddresses) {
-    $ipAddress.IPAddressProperties["TcpDynamicPorts"].Value = ""
-    $ipAddress.IPAddressProperties["TcpPort"].Value = $port
-}
-$Tcp.Alter()
+Write-Host -Object "$indent Configuring instance $sqlinstance" -ForegroundColor DarkGreen
+Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -Confirm:$false
+Set-DbaNetworkConfiguration -SqlInstance client -EnableProtocol NamedPipes -RestartService -Confirm:$false
 
-$uri = "ManagedComputer[@Name='$env:COMPUTERNAME']/ServerInstance[@Name='$instance']/ServerProtocol[@Name='Np']"
-$Np = $wmi.GetSmoObject($uri)
-$Np.IsEnabled = $true
-$Np.Alter()
 
-Write-Host -Object "$indent Starting $instance" -ForegroundColor DarkGreen
+Write-Host -Object "$indent Starting $sqlinstance" -ForegroundColor DarkGreen
 Restart-Service "MSSQL`$$instance" -WarningAction SilentlyContinue -Force
-$server = Connect-DbaInstance -SqlInstance $sqlinstance
-$server.Configuration.RemoteDacConnectionsEnabled.ConfigValue = $true
-$server.Configuration.Alter()
+
+$null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name RemoteDacConnectionsEnabled -Value $true
 $null = Set-DbaStartupParameter -SqlInstance $sqlinstance -TraceFlagOverride -TraceFlag 7806 -Confirm:$false -ErrorAction SilentlyContinue -EnableException
 Restart-Service "MSSQL`$SQL2008R2SP2" -WarningAction SilentlyContinue -Force
-$server = Connect-DbaInstance -SqlInstance $sqlinstance
-$server.Configuration.RemoteDacConnectionsEnabled.ConfigValue = $true
-$server.Configuration.Alter()
 
 do {
     Start-Sleep 1

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -7,21 +7,15 @@ $sqlinstance = "localhost\SQL2008R2SP2"
 $instance = "SQL2008R2SP2"
 $port = "1433"
 
-Write-Host -Object "$indent SQLBrowser StartType: $((Get-Service -Name SQLBrowser).StartType) / Status: $((Get-Service -Name SQLBrowser).Status)" -ForegroundColor DarkGreen
-Write-Host -Object "$indent MSSQL`$$instance StartType: $((Get-Service -Name "MSSQL`$$instance").StartType) / Status: $((Get-Service -Name "MSSQL`$$instance").Status)" -ForegroundColor DarkGreen
+Write-Host -Object "$indent Setting up AppVeyor Services" -ForegroundColor DarkGreen
+Set-Service -Name SQLBrowser -StartupType Automatic
+Start-Service -Name SQLBrowser
 
 
-Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundColor DarkGreen
-
-# We need to configure the port first to be able to start the instances in any order.
+Write-Host -Object "$indent Changing the port on $instance to $port" -ForegroundColor DarkGreen
 $null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -EnableException -Confirm:$false -WarningAction SilentlyContinue
 
-# SQL2008R2SP2 is an Express Edition and has no Agent to be started.
-Set-Service -Name SQLBrowser -StartupType Automatic
-Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
-# Start-DbaService can not start service because Get-DbaService does not get the service - we have to fix this bug and then change this script
-Start-Service -Name SQLBrowser
-Start-DbaService -SqlInstance $sqlinstance -Type Engine -EnableException -Confirm:$false
+Restart-Service -Name "MSSQL`$SQL2008R2SP2" -Force
 
 
 Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen
@@ -30,5 +24,4 @@ $null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -EnableProtocol Na
 $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name RemoteDacConnectionsEnabled -Value $true -EnableException
 # To conserve resources, SQL Server Express doesn't listen on the DAC port unless started with a trace flag 7806.
 $null = Set-DbaStartupParameter -SqlInstance $sqlinstance -TraceFlagOverride -TraceFlag 7806 -EnableException -Confirm:$false
-
-$null = Restart-DbaService -SqlInstance $sqlinstance -Type Engine -Force -EnableException -Confirm:$false
+Restart-Service -Name "MSSQL`$SQL2008R2SP2" -Force

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -16,7 +16,9 @@ Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundCol
 # We need to configure the port first to be able to start the instances in any order.
 $null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -EnableException -Confirm:$false -WarningAction SilentlyContinue
 
-# SQL2008R2SP2 is an Express Edition and has no Agent to be configured or started.
+# SQL2008R2SP2 is an Express Edition and has no Agent to be started.
+Set-Service -Name "SQLBrowser" -StartupType Automatic
+Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
 Start-DbaService -SqlInstance $sqlinstance -Type Browser, Engine -EnableException -Confirm:$false
 
 

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -17,9 +17,11 @@ Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundCol
 $null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -EnableException -Confirm:$false -WarningAction SilentlyContinue
 
 # SQL2008R2SP2 is an Express Edition and has no Agent to be started.
-Set-Service -Name "SQLBrowser" -StartupType Automatic
+Set-Service -Name SQLBrowser -StartupType Automatic
 Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
-Start-DbaService -SqlInstance $sqlinstance -Type Browser, Engine -EnableException -Confirm:$false
+# Start-DbaService can not start service because Get-DbaService does not get the service - we have to fix this bug and then change this script
+Start-Service -Name SQLBrowser
+Start-DbaService -SqlInstance $sqlinstance -Type Engine -EnableException -Confirm:$false
 
 
 Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -13,16 +13,11 @@ Write-Host -Object "$indent MSSQL`$$instance StartType: $((Get-Service -Name "MS
 
 Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundColor DarkGreen
 
-Start-Service -Name SQLBrowser
+# We need to configure the port first to be able to start the instances in any order.
+$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -EnableException -Confirm:$false -WarningAction SilentlyContinue
 
-# We need to configure the port first to be able to start the instances in any order. This will not start the instance on SQL2008R2SP2.
-$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -EnableException -Confirm:$false
-
-Write-Host -Object "$indent SQLBrowser StartType: $((Get-Service -Name SQLBrowser).StartType) / Status: $((Get-Service -Name SQLBrowser).Status)" -ForegroundColor DarkGreen
-Write-Host -Object "$indent MSSQL`$$instance StartType: $((Get-Service -Name "MSSQL`$$instance").StartType) / Status: $((Get-Service -Name "MSSQL`$$instance").Status)" -ForegroundColor DarkGreen
-
-# We have to start the instance?
-Start-DbaService -SqlInstance $sqlinstance -Type Engine -EnableException -Confirm:$false
+# SQL2008R2SP2 is an Express Edition and has no Agent to be configured or started.
+Start-DbaService -SqlInstance $sqlinstance -Type Browser, Engine -EnableException -Confirm:$false
 
 
 Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -15,8 +15,14 @@ Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundCol
 
 Start-Service -Name SQLBrowser
 
-# We need to configure the port first to be able to start the instances in any order. This will also start the instance.
+# We need to configure the port first to be able to start the instances in any order. This will not start the instance on SQL2008R2SP2.
 $null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -EnableException -Confirm:$false
+
+Write-Host -Object "$indent SQLBrowser StartType: $((Get-Service -Name SQLBrowser).StartType) / Status: $((Get-Service -Name SQLBrowser).Status)" -ForegroundColor DarkGreen
+Write-Host -Object "$indent MSSQL`$$instance StartType: $((Get-Service -Name "MSSQL`$$instance").StartType) / Status: $((Get-Service -Name "MSSQL`$$instance").Status)" -ForegroundColor DarkGreen
+
+# We have to start the instance?
+Start-DbaService -SqlInstance $sqlinstance -Type Engine -EnableException -Confirm:$false
 
 
 Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -46,8 +46,8 @@ Function Install-ADAuthenticationLibraryforSQLServer {
 
 $indent = '...'
 Write-Host -Object "$indent Running $PSCommandpath" -ForegroundColor DarkGreen
-Import-Module C:\github\dbatools\dbatools.psm1 -Force
-$null = Set-DbatoolsInsecureConnection
+#Import-Module C:\github\dbatools\dbatools.psm1 -Force
+#$null = Set-DbatoolsInsecureConnection
 
 # This script spins up the 2008R2SP2 instance and the relative setup
 
@@ -98,4 +98,4 @@ while ($lastexitcode -ne 0 -and $t++ -lt 10)
 #    Invoke-DbaQuery -SqlInstance $sqlinstance -InputFile $file
 #}
 
-Import-Module C:\github\dbatools\dbatools.psm1 -Force
+#Import-Module C:\github\dbatools\dbatools.psm1 -Force

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -92,10 +92,10 @@ do {
 }
 while ($lastexitcode -ne 0 -and $t++ -lt 10)
 
-Write-Host -Object "$indent Executing startup scripts for SQL Server 2008" -ForegroundColor DarkGreen
+#Write-Host -Object "$indent Executing startup scripts for SQL Server 2008" -ForegroundColor DarkGreen
 # Add some jobs to the sql2008r2sp2 instance (1433 = default)
-foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2008-startup\*.sql -Recurse -ErrorAction SilentlyContinue)) {
-    Invoke-DbaQuery -SqlInstance $sqlinstance -InputFile $file
-}
+#foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2008-startup\*.sql -Recurse -ErrorAction SilentlyContinue)) {
+#    Invoke-DbaQuery -SqlInstance $sqlinstance -InputFile $file
+#}
 
 Import-Module C:\github\dbatools\dbatools.psm1 -Force

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -42,7 +42,7 @@ Function Install-ADAuthenticationLibraryforSQLServer {
     }
 }
 
-$null = Install-ADAuthenticationLibraryforSQLServer
+#$null = Install-ADAuthenticationLibraryforSQLServer
 
 $indent = '...'
 Write-Host -Object "$indent Running $PSCommandpath" -ForegroundColor DarkGreen

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -13,16 +13,14 @@ Write-Host -Object "$indent MSSQL`$$instance StartType: $((Get-Service -Name "MS
 
 Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundColor DarkGreen
 
-Set-Service -Name SQLBrowser -StartupType Automatic
 Start-Service -Name SQLBrowser
 
-Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
-Start-Service -Name "MSSQL`$$instance"
+# We need to configure the port first to be able to start the instances in any order. This will also start the instance.
+$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -EnableException -Confirm:$false
 
 
 Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen
 
-$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -EnableException -Confirm:$false
 $null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -EnableProtocol NamedPipes -RestartService -EnableException -Confirm:$false
 $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name RemoteDacConnectionsEnabled -Value $true -EnableException
 # To conserve resources, SQL Server Express doesn't listen on the DAC port unless started with a trace flag 7806.

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -7,72 +7,28 @@ $sqlinstance = "localhost\SQL2016"
 $instance = "SQL2016"
 $port = "14333"
 
-Write-Host -Object "$indent Setting up AppVeyor Services" -ForegroundColor DarkGreen
-
 Write-Host -Object "$indent SQLBrowser StartType: $((Get-Service -Name SQLBrowser).StartType) / Status: $((Get-Service -Name SQLBrowser).Status)" -ForegroundColor DarkGreen
 Write-Host -Object "$indent MSSQL`$$instance StartType: $((Get-Service -Name "MSSQL`$$instance").StartType) / Status: $((Get-Service -Name "MSSQL`$$instance").Status)" -ForegroundColor DarkGreen
 Write-Host -Object "$indent SQLAgent`$$instance StartType: $((Get-Service -Name "SQLAgent`$$instance").StartType) / Status: $((Get-Service -Name "SQLAgent`$$instance").Status)" -ForegroundColor DarkGreen
 
 
-Set-Service -Name SQLBrowser -StartupType Automatic -WarningAction SilentlyContinue
-Start-Service SQLBrowser -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
-Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic -WarningAction SilentlyContinue
+Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundColor DarkGreen
 
-Write-Host -Object "$indent Changing the port on $instance to $port" -ForegroundColor DarkGreen
-$wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
-$uri = "ManagedComputer[@Name='$env:COMPUTERNAME']/ServerInstance[@Name='$instance']/ServerProtocol[@Name='Tcp']"
-$Tcp = $wmi.GetSmoObject($uri)
-foreach ($ipAddress in $Tcp.IPAddresses) {
-    $ipAddress.IPAddressProperties["TcpDynamicPorts"].Value = ""
-    $ipAddress.IPAddressProperties["TcpPort"].Value = $port
-}
-$Tcp.Alter()
+Set-Service -Name SQLBrowser -StartupType Automatic
+Start-Service -Name SQLBrowser
+
+Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
+Start-Service -Name "SQLAgent`$$instance"
+
+Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
+Start-Service -Name "SQLAgent`$$instance"
 
 
+Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen
 
+$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -EnableException -Confirm:$false
+$null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name RemoteDacConnectionsEnabled -Value $true -EnableException
+$null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true -EnableException
+Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE CRYPTOGRAPHIC PROVIDER dbatoolsci_AKV FROM FILE = 'C:\github\appveyor-lab\keytests\ekm\Microsoft.AzureKeyVaultService.EKM.dll'" -EnableException
 
-
-
-Write-Host -Object "$indent Starting $instance" -ForegroundColor DarkGreen
-Restart-Service "MSSQL`$$instance" -WarningAction SilentlyContinue -Force
-Restart-Service "SQLAgent`$$instance" -WarningAction SilentlyContinue -Force
-
-do {
-    Start-Sleep 1
-    $null = (& sqlcmd -S "$sqlinstance" -b -Q "select 1" -d master)
-}
-while ($lastexitcode -ne 0 -and $t++ -lt 10)
-
-# Agent sometimes takes a moment to start
-do {
-    Write-Host -Object "$indent Waiting for SQL Agent to start" -ForegroundColor DarkGreen
-    Start-Sleep 1
-}
-while ((Get-Service "SQLAgent`$$instance").Status -ne 'Running' -and $z++ -lt 10)
-
-# Whatever, just sleep an extra 5
-Start-Sleep 5
-
-# this needs to be moved out. Tests that require these things need to run this in a BeforeAll stanza and remove the cruft in an AfterAll one
-# so everybody can run tests without needing this too (which should be used strictly as appveyor-setup-related activities)
-# when this fails for resource contention, the whole build stops for no reason. At most, it should fail only tests that are in the need of the reqs
-#Write-Host -Object "$indent Executing startup scripts for SQL Server 2016" -ForegroundColor DarkGreen
-#$sql2016Startup = 0
-#foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2016-startup\*.sql -Recurse -ErrorAction SilentlyContinue)) {
-#    try {
-#        Invoke-DbaQuery -SqlInstance $sqlinstance -InputFile $file -ErrorAction Stop
-#    } catch {
-#        $sql2016Startup = 1
-#    }
-#}
-try {
-
-    $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true
-    $sql = "CREATE CRYPTOGRAPHIC PROVIDER dbatoolsci_AKV FROM FILE = 'C:\github\appveyor-lab\keytests\ekm\Microsoft.AzureKeyVaultService.EKM.dll'"
-    Invoke-DbaQuery -SqlInstance $sqlinstance -Query $sql
-} catch {
-    $sql2016Startup = 1
-}
-if ($sql2016Startup -eq 1) {
-    Write-Host -Object "$indent something went wrong with startup scripts" -ForegroundColor DarkGreen
-}
+$null = Restart-DbaService -SqlInstance $sqlinstance -Type Engine -Force -EnableException -Confirm:$false

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -66,6 +66,7 @@ Write-Host -Object "$indent Starting $instance" -ForegroundColor DarkGreen
 Restart-Service "MSSQL`$$instance" -WarningAction SilentlyContinue -Force
 Restart-Service "SQLAgent`$$instance" -WarningAction SilentlyContinue -Force
 
+<#
 do {
     Start-Sleep 1
     $null = (& sqlcmd -S "$sqlinstance" -b -Q "select 1" -d master)
@@ -78,10 +79,8 @@ do {
     Start-Sleep 1
 }
 while ((Get-Service "SQLAgent`$$instance").Status -ne 'Running' -and $z++ -lt 10)
-
 # Whatever, just sleep an extra 5
 Start-Sleep 5
-<#
 
 # this needs to be moved out. Tests that require these things need to run this in a BeforeAll stanza and remove the cruft in an AfterAll one
 # so everybody can run tests without needing this too (which should be used strictly as appveyor-setup-related activities)

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -19,6 +19,9 @@ Write-Host -Object "$indent Starting $instance" -ForegroundColor DarkGreen
 Restart-Service "MSSQL`$$instance" -Force
 Restart-Service "SQLAgent`$$instance" -Force
 
+# Sometimes enabling ExtensibleKeyManagement failes, so try this:
+Start-Sleep -Seconds 5
+
 Write-Host -Object "$indent Configuring $instance" -ForegroundColor DarkGreen
 $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true -EnableException
 Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE CRYPTOGRAPHIC PROVIDER dbatoolsci_AKV FROM FILE = 'C:\github\appveyor-lab\keytests\ekm\Microsoft.AzureKeyVaultService.EKM.dll'" -EnableException

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -37,10 +37,10 @@ $null = Restart-DbaService -SqlInstance $sqlinstance -Type Engine -Force -Enable
 
 $indent = '...'
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor DarkGreen
-$dbatools_serialimport = $true
-Import-Module C:\github\dbatools\dbatools.psd1
-Start-Sleep 5
-$null = Set-DbatoolsInsecureConnection
+#$dbatools_serialimport = $true
+#Import-Module C:\github\dbatools\dbatools.psd1
+#Start-Sleep 5
+#$null = Set-DbatoolsInsecureConnection
 # This script spins up the 2016 instance and the relative setup
 
 $sqlinstance = "localhost\SQL2016"

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -14,14 +14,13 @@ Write-Host -Object "$indent SQLAgent`$$instance StartType: $((Get-Service -Name 
 
 Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundColor DarkGreen
 
-Start-Service -Name SQLBrowser
+# We need to configure the port first to be able to start the instances in any order.
+$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -EnableException -Confirm:$false -WarningAction SilentlyContinue
 
-# We need to configure the port first to be able to start the instances in any order. This will also start the instance.
-$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -EnableException -Confirm:$false
-
-# Agent Service is "Disabled", so we need to change the StartupType before starting
+# Agent Service on SQL2016 is "Disabled", so we need to change the StartupType before starting.
 Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
-Start-Service -Name "SQLAgent`$$instance"
+
+Start-DbaService -SqlInstance $sqlinstance -Type Browser, Engine, Agent -EnableException -Confirm:$false
 
 
 Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -17,9 +17,9 @@ Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundCol
 # We need to configure the port first to be able to start the instances in any order.
 $null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -EnableException -Confirm:$false -WarningAction SilentlyContinue
 
-# Agent Service on SQL2016 is "Disabled", so we need to change the StartupType before starting.
+Set-Service -Name "SQLBrowser" -StartupType Automatic
+Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
 Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
-
 Start-DbaService -SqlInstance $sqlinstance -Type Browser, Engine, Agent -EnableException -Confirm:$false
 
 

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -48,15 +48,15 @@ Start-Sleep 5
 # this needs to be moved out. Tests that require these things need to run this in a BeforeAll stanza and remove the cruft in an AfterAll one
 # so everybody can run tests without needing this too (which should be used strictly as appveyor-setup-related activities)
 # when this fails for resource contention, the whole build stops for no reason. At most, it should fail only tests that are in the need of the reqs
-Write-Host -Object "$indent Executing startup scripts for SQL Server 2016" -ForegroundColor DarkGreen
-$sql2016Startup = 0
-foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2016-startup\*.sql -Recurse -ErrorAction SilentlyContinue)) {
-    try {
-        Invoke-DbaQuery -SqlInstance $sqlinstance -InputFile $file -ErrorAction Stop
-    } catch {
-        $sql2016Startup = 1
-    }
-}
+#Write-Host -Object "$indent Executing startup scripts for SQL Server 2016" -ForegroundColor DarkGreen
+#$sql2016Startup = 0
+#foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2016-startup\*.sql -Recurse -ErrorAction SilentlyContinue)) {
+#    try {
+#        Invoke-DbaQuery -SqlInstance $sqlinstance -InputFile $file -ErrorAction Stop
+#    } catch {
+#        $sql2016Startup = 1
+#    }
+#}
 try {
 
     $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -14,19 +14,18 @@ Write-Host -Object "$indent SQLAgent`$$instance StartType: $((Get-Service -Name 
 
 Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundColor DarkGreen
 
-Set-Service -Name SQLBrowser -StartupType Automatic
 Start-Service -Name SQLBrowser
 
-Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
-Start-Service -Name "MSSQL`$$instance"
+# We need to configure the port first to be able to start the instances in any order. This will also start the instance.
+$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -EnableException -Confirm:$false
 
+# Agent Service is "Disabled", so we need to change the StartupType before starting
 Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
 Start-Service -Name "SQLAgent`$$instance"
 
 
 Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen
 
-$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -EnableException -Confirm:$false
 $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name RemoteDacConnectionsEnabled -Value $true -EnableException
 $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true -EnableException
 Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE CRYPTOGRAPHIC PROVIDER dbatoolsci_AKV FROM FILE = 'C:\github\appveyor-lab\keytests\ekm\Microsoft.AzureKeyVaultService.EKM.dll'" -EnableException

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -1,9 +1,9 @@
 $indent = '...'
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor DarkGreen
-$dbatools_serialimport = $true
-Import-Module C:\github\dbatools\dbatools.psd1
-Start-Sleep 5
-$null = Set-DbatoolsInsecureConnection
+#$dbatools_serialimport = $true
+#Import-Module C:\github\dbatools\dbatools.psd1
+#Start-Sleep 5
+#$null = Set-DbatoolsInsecureConnection
 # This script spins up the 2016 instance and the relative setup
 
 $sqlinstance = "localhost\SQL2016"

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -20,7 +20,9 @@ $null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAl
 Set-Service -Name "SQLBrowser" -StartupType Automatic
 Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
 Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
-Start-DbaService -SqlInstance $sqlinstance -Type Browser, Engine, Agent -EnableException -Confirm:$false
+# Start-DbaService can not start service because Get-DbaService does not get the service - we have to fix this bug and then change this script
+Start-Service -Name SQLBrowser
+Start-DbaService -SqlInstance $sqlinstance -Type Engine, Agent -EnableException -Confirm:$false
 
 
 Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -1,3 +1,4 @@
+<#
 $indent = '...'
 Write-Host -Object "$indent Running $PSCommandpath" -ForegroundColor DarkGreen
 
@@ -32,3 +33,75 @@ $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManageme
 Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE CRYPTOGRAPHIC PROVIDER dbatoolsci_AKV FROM FILE = 'C:\github\appveyor-lab\keytests\ekm\Microsoft.AzureKeyVaultService.EKM.dll'" -EnableException
 
 $null = Restart-DbaService -SqlInstance $sqlinstance -Type Engine -Force -EnableException -Confirm:$false
+#>
+
+$indent = '...'
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor DarkGreen
+$dbatools_serialimport = $true
+Import-Module C:\github\dbatools\dbatools.psd1
+Start-Sleep 5
+$null = Set-DbatoolsInsecureConnection
+# This script spins up the 2016 instance and the relative setup
+
+$sqlinstance = "localhost\SQL2016"
+$instance = "SQL2016"
+$port = "14333"
+
+Write-Host -Object "$indent Setting up AppVeyor Services" -ForegroundColor DarkGreen
+Set-Service -Name SQLBrowser -StartupType Automatic -WarningAction SilentlyContinue
+Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic -WarningAction SilentlyContinue
+Start-Service SQLBrowser -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+
+
+Write-Host -Object "$indent Changing the port on $instance to $port" -ForegroundColor DarkGreen
+$wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
+$uri = "ManagedComputer[@Name='$env:COMPUTERNAME']/ ServerInstance[@Name='$instance']/ServerProtocol[@Name='Tcp']"
+$Tcp = $wmi.GetSmoObject($uri)
+foreach ($ipAddress in $Tcp.IPAddresses) {
+    $ipAddress.IPAddressProperties["TcpDynamicPorts"].Value = ""
+    $ipAddress.IPAddressProperties["TcpPort"].Value = $port
+}
+$Tcp.Alter()
+Write-Host -Object "$indent Starting $instance" -ForegroundColor DarkGreen
+Restart-Service "MSSQL`$$instance" -WarningAction SilentlyContinue -Force
+Restart-Service "SQLAgent`$$instance" -WarningAction SilentlyContinue -Force
+
+do {
+    Start-Sleep 1
+    $null = (& sqlcmd -S "$sqlinstance" -b -Q "select 1" -d master)
+}
+while ($lastexitcode -ne 0 -and $t++ -lt 10)
+
+# Agent sometimes takes a moment to start
+do {
+    Write-Host -Object "$indent Waiting for SQL Agent to start" -ForegroundColor DarkGreen
+    Start-Sleep 1
+}
+while ((Get-Service "SQLAgent`$$instance").Status -ne 'Running' -and $z++ -lt 10)
+
+# Whatever, just sleep an extra 5
+Start-Sleep 5
+
+# this needs to be moved out. Tests that require these things need to run this in a BeforeAll stanza and remove the cruft in an AfterAll one
+# so everybody can run tests without needing this too (which should be used strictly as appveyor-setup-related activities)
+# when this fails for resource contention, the whole build stops for no reason. At most, it should fail only tests that are in the need of the reqs
+Write-Host -Object "$indent Executing startup scripts for SQL Server 2016" -ForegroundColor DarkGreen
+$sql2016Startup = 0
+foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2016-startup\*.sql -Recurse -ErrorAction SilentlyContinue)) {
+    try {
+        Invoke-DbaQuery -SqlInstance $sqlinstance -InputFile $file -ErrorAction Stop
+    } catch {
+        $sql2016Startup = 1
+    }
+}
+try {
+
+    $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true
+    $sql = "CREATE CRYPTOGRAPHIC PROVIDER dbatoolsci_AKV FROM FILE = 'C:\github\appveyor-lab\keytests\ekm\Microsoft.AzureKeyVaultService.EKM.dll'"
+    Invoke-DbaQuery -SqlInstance $sqlinstance -Query $sql
+} catch {
+    $sql2016Startup = 1
+}
+if ($sql2016Startup -eq 1) {
+    Write-Host -Object "$indent something went wrong with startup scripts" -ForegroundColor DarkGreen
+}

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -87,6 +87,7 @@ Start-Sleep 5
 # when this fails for resource contention, the whole build stops for no reason. At most, it should fail only tests that are in the need of the reqs
 Write-Host -Object "$indent Executing startup scripts for SQL Server 2016" -ForegroundColor DarkGreen
 $sql2016Startup = 0
+<#
 foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2016-startup\*.sql -Recurse -ErrorAction SilentlyContinue)) {
     try {
         Invoke-DbaQuery -SqlInstance $sqlinstance -InputFile $file -ErrorAction Stop
@@ -94,6 +95,7 @@ foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2016-startup\*.sql -R
         $sql2016Startup = 1
     }
 }
+#>
 try {
 
     $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -37,10 +37,7 @@ $null = Restart-DbaService -SqlInstance $sqlinstance -Type Engine -Force -Enable
 
 $indent = '...'
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor DarkGreen
-#$dbatools_serialimport = $true
-#Import-Module C:\github\dbatools\dbatools.psd1
-#Start-Sleep 5
-#$null = Set-DbatoolsInsecureConnection
+
 # This script spins up the 2016 instance and the relative setup
 
 $sqlinstance = "localhost\SQL2016"
@@ -52,63 +49,12 @@ Set-Service -Name SQLBrowser -StartupType Automatic -WarningAction SilentlyConti
 Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic -WarningAction SilentlyContinue
 Start-Service SQLBrowser -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
 
-
 Write-Host -Object "$indent Changing the port on $instance to $port" -ForegroundColor DarkGreen
-$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -EnableException -Confirm:$false #-WarningAction SilentlyContinue
-<#
-$wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
-$uri = "ManagedComputer[@Name='$env:COMPUTERNAME']/ ServerInstance[@Name='$instance']/ServerProtocol[@Name='Tcp']"
-$Tcp = $wmi.GetSmoObject($uri)
-foreach ($ipAddress in $Tcp.IPAddresses) {
-    $ipAddress.IPAddressProperties["TcpDynamicPorts"].Value = ""
-    $ipAddress.IPAddressProperties["TcpPort"].Value = $port
-}
-$Tcp.Alter()
-#>
+$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -EnableException -Confirm:$false -WarningAction SilentlyContinue
+
 Write-Host -Object "$indent Starting $instance" -ForegroundColor DarkGreen
 Restart-Service "MSSQL`$$instance" -WarningAction SilentlyContinue -Force
 Restart-Service "SQLAgent`$$instance" -WarningAction SilentlyContinue -Force
-
-<#
-do {
-    Start-Sleep 1
-    $null = (& sqlcmd -S "$sqlinstance" -b -Q "select 1" -d master)
-}
-while ($lastexitcode -ne 0 -and $t++ -lt 10)
-
-# Agent sometimes takes a moment to start
-do {
-    Write-Host -Object "$indent Waiting for SQL Agent to start" -ForegroundColor DarkGreen
-    Start-Sleep 1
-}
-while ((Get-Service "SQLAgent`$$instance").Status -ne 'Running' -and $z++ -lt 10)
-# Whatever, just sleep an extra 5
-Start-Sleep 5
-
-# this needs to be moved out. Tests that require these things need to run this in a BeforeAll stanza and remove the cruft in an AfterAll one
-# so everybody can run tests without needing this too (which should be used strictly as appveyor-setup-related activities)
-# when this fails for resource contention, the whole build stops for no reason. At most, it should fail only tests that are in the need of the reqs
-Write-Host -Object "$indent Executing startup scripts for SQL Server 2016" -ForegroundColor DarkGreen
-$sql2016Startup = 0
-foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2016-startup\*.sql -Recurse -ErrorAction SilentlyContinue)) {
-    try {
-        Invoke-DbaQuery -SqlInstance $sqlinstance -InputFile $file -ErrorAction Stop
-    } catch {
-        $sql2016Startup = 1
-    }
-}
-try {
-
-    $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true
-    $sql = "CREATE CRYPTOGRAPHIC PROVIDER dbatoolsci_AKV FROM FILE = 'C:\github\appveyor-lab\keytests\ekm\Microsoft.AzureKeyVaultService.EKM.dll'"
-    Invoke-DbaQuery -SqlInstance $sqlinstance -Query $sql
-} catch {
-    $sql2016Startup = 1
-}
-if ($sql2016Startup -eq 1) {
-    Write-Host -Object "$indent something went wrong with startup scripts" -ForegroundColor DarkGreen
-}
-#>
 
 $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true -EnableException
 Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE CRYPTOGRAPHIC PROVIDER dbatoolsci_AKV FROM FILE = 'C:\github\appveyor-lab\keytests\ekm\Microsoft.AzureKeyVaultService.EKM.dll'" -EnableException

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -81,13 +81,13 @@ while ((Get-Service "SQLAgent`$$instance").Status -ne 'Running' -and $z++ -lt 10
 
 # Whatever, just sleep an extra 5
 Start-Sleep 5
+<#
 
 # this needs to be moved out. Tests that require these things need to run this in a BeforeAll stanza and remove the cruft in an AfterAll one
 # so everybody can run tests without needing this too (which should be used strictly as appveyor-setup-related activities)
 # when this fails for resource contention, the whole build stops for no reason. At most, it should fail only tests that are in the need of the reqs
 Write-Host -Object "$indent Executing startup scripts for SQL Server 2016" -ForegroundColor DarkGreen
 $sql2016Startup = 0
-<#
 foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2016-startup\*.sql -Recurse -ErrorAction SilentlyContinue)) {
     try {
         Invoke-DbaQuery -SqlInstance $sqlinstance -InputFile $file -ErrorAction Stop
@@ -95,7 +95,6 @@ foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2016-startup\*.sql -R
         $sql2016Startup = 1
     }
 }
-#>
 try {
 
     $null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true
@@ -107,3 +106,7 @@ try {
 if ($sql2016Startup -eq 1) {
     Write-Host -Object "$indent something went wrong with startup scripts" -ForegroundColor DarkGreen
 }
+#>
+
+$null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true -EnableException
+Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE CRYPTOGRAPHIC PROVIDER dbatoolsci_AKV FROM FILE = 'C:\github\appveyor-lab\keytests\ekm\Microsoft.AzureKeyVaultService.EKM.dll'" -EnableException

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -17,8 +17,8 @@ Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundCol
 Set-Service -Name SQLBrowser -StartupType Automatic
 Start-Service -Name SQLBrowser
 
-Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
-Start-Service -Name "SQLAgent`$$instance"
+Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
+Start-Service -Name "MSSQL`$$instance"
 
 Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
 Start-Service -Name "SQLAgent`$$instance"

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -54,6 +54,8 @@ Start-Service SQLBrowser -ErrorAction SilentlyContinue -WarningAction SilentlyCo
 
 
 Write-Host -Object "$indent Changing the port on $instance to $port" -ForegroundColor DarkGreen
+$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -EnableException -Confirm:$false #-WarningAction SilentlyContinue
+<#
 $wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
 $uri = "ManagedComputer[@Name='$env:COMPUTERNAME']/ ServerInstance[@Name='$instance']/ServerProtocol[@Name='Tcp']"
 $Tcp = $wmi.GetSmoObject($uri)
@@ -62,6 +64,7 @@ foreach ($ipAddress in $Tcp.IPAddresses) {
     $ipAddress.IPAddressProperties["TcpPort"].Value = $port
 }
 $Tcp.Alter()
+#>
 Write-Host -Object "$indent Starting $instance" -ForegroundColor DarkGreen
 Restart-Service "MSSQL`$$instance" -WarningAction SilentlyContinue -Force
 Restart-Service "SQLAgent`$$instance" -WarningAction SilentlyContinue -Force

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -1,9 +1,6 @@
 $indent = '...'
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor DarkGreen
-#$dbatools_serialimport = $true
-#Import-Module C:\github\dbatools\dbatools.psd1
-#Start-Sleep 5
-#$null = Set-DbatoolsInsecureConnection
+Write-Host -Object "$indent Running $PSCommandpath" -ForegroundColor DarkGreen
+
 # This script spins up the 2016 instance and the relative setup
 
 $sqlinstance = "localhost\SQL2016"
@@ -11,20 +8,31 @@ $instance = "SQL2016"
 $port = "14333"
 
 Write-Host -Object "$indent Setting up AppVeyor Services" -ForegroundColor DarkGreen
-Set-Service -Name SQLBrowser -StartupType Automatic -WarningAction SilentlyContinue
-Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic -WarningAction SilentlyContinue
-Start-Service SQLBrowser -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
 
+Write-Host -Object "$indent SQLBrowser StartType: $((Get-Service -Name SQLBrowser).StartType) / Status: $((Get-Service -Name SQLBrowser).Status)" -ForegroundColor DarkGreen
+Write-Host -Object "$indent MSSQL`$$instance StartType: $((Get-Service -Name "MSSQL`$$instance").StartType) / Status: $((Get-Service -Name "MSSQL`$$instance").Status)" -ForegroundColor DarkGreen
+Write-Host -Object "$indent SQLAgent`$$instance StartType: $((Get-Service -Name "SQLAgent`$$instance").StartType) / Status: $((Get-Service -Name "SQLAgent`$$instance").Status)" -ForegroundColor DarkGreen
+
+
+Set-Service -Name SQLBrowser -StartupType Automatic -WarningAction SilentlyContinue
+Start-Service SQLBrowser -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic -WarningAction SilentlyContinue
 
 Write-Host -Object "$indent Changing the port on $instance to $port" -ForegroundColor DarkGreen
 $wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
-$uri = "ManagedComputer[@Name='$env:COMPUTERNAME']/ ServerInstance[@Name='$instance']/ServerProtocol[@Name='Tcp']"
+$uri = "ManagedComputer[@Name='$env:COMPUTERNAME']/ServerInstance[@Name='$instance']/ServerProtocol[@Name='Tcp']"
 $Tcp = $wmi.GetSmoObject($uri)
 foreach ($ipAddress in $Tcp.IPAddresses) {
     $ipAddress.IPAddressProperties["TcpDynamicPorts"].Value = ""
     $ipAddress.IPAddressProperties["TcpPort"].Value = $port
 }
 $Tcp.Alter()
+
+
+
+
+
+
 Write-Host -Object "$indent Starting $instance" -ForegroundColor DarkGreen
 Restart-Service "MSSQL`$$instance" -WarningAction SilentlyContinue -Force
 Restart-Service "SQLAgent`$$instance" -WarningAction SilentlyContinue -Force

--- a/tests/appveyor.SQL2017.ps1
+++ b/tests/appveyor.SQL2017.ps1
@@ -1,9 +1,6 @@
 $indent = '...'
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor DarkGreen
-#$dbatools_serialimport = $true
-#Import-Module C:\github\dbatools\dbatools.psd1
-#Start-Sleep 5
-#$null = Set-DbatoolsInsecureConnection
+Write-Host -Object "$indent Running $PSCommandpath" -ForegroundColor DarkGreen
+
 # This script spins up the 2016 instance and the relative setup
 
 $sqlinstance = "localhost\SQL2017"
@@ -11,19 +8,31 @@ $instance = "SQL2017"
 $port = "14334"
 
 Write-Host -Object "$indent Setting up AppVeyor Services" -ForegroundColor DarkGreen
+
+Write-Host -Object "$indent SQLBrowser StartType: $((Get-Service -Name SQLBrowser).StartType) / Status: $((Get-Service -Name SQLBrowser).Status)" -ForegroundColor DarkGreen
+Write-Host -Object "$indent MSSQL`$$instance StartType: $((Get-Service -Name "MSSQL`$$instance").StartType) / Status: $((Get-Service -Name "MSSQL`$$instance").Status)" -ForegroundColor DarkGreen
+Write-Host -Object "$indent SQLAgent`$$instance StartType: $((Get-Service -Name "SQLAgent`$$instance").StartType) / Status: $((Get-Service -Name "SQLAgent`$$instance").Status)" -ForegroundColor DarkGreen
+
+
 Set-Service -Name SQLBrowser -StartupType Automatic -WarningAction SilentlyContinue
-Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic -WarningAction SilentlyContinue
 Start-Service SQLBrowser -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic -WarningAction SilentlyContinue
 
 Write-Host -Object "$indent Changing the port on $instance to $port" -ForegroundColor DarkGreen
 $wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
-$uri = "ManagedComputer[@Name='$env:COMPUTERNAME']/ ServerInstance[@Name='$instance']/ServerProtocol[@Name='Tcp']"
+$uri = "ManagedComputer[@Name='$env:COMPUTERNAME']/ServerInstance[@Name='$instance']/ServerProtocol[@Name='Tcp']"
 $Tcp = $wmi.GetSmoObject($uri)
 foreach ($ipAddress in $Tcp.IPAddresses) {
     $ipAddress.IPAddressProperties["TcpDynamicPorts"].Value = ""
     $ipAddress.IPAddressProperties["TcpPort"].Value = $port
 }
 $Tcp.Alter()
+
+
+
+
+
+
 Write-Host -Object "$indent Starting $instance" -ForegroundColor DarkGreen
 #Restart-Service "MSSQL`$$instance" -WarningAction SilentlyContinue -Force
 #Restart-Service "SQLAgent`$$instance" -WarningAction SilentlyContinue -Force

--- a/tests/appveyor.SQL2017.ps1
+++ b/tests/appveyor.SQL2017.ps1
@@ -1,9 +1,9 @@
 $indent = '...'
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor DarkGreen
-$dbatools_serialimport = $true
-Import-Module C:\github\dbatools\dbatools.psd1
-Start-Sleep 5
-$null = Set-DbatoolsInsecureConnection
+#$dbatools_serialimport = $true
+#Import-Module C:\github\dbatools\dbatools.psd1
+#Start-Sleep 5
+#$null = Set-DbatoolsInsecureConnection
 # This script spins up the 2016 instance and the relative setup
 
 $sqlinstance = "localhost\SQL2017"

--- a/tests/appveyor.SQL2017.ps1
+++ b/tests/appveyor.SQL2017.ps1
@@ -20,7 +20,9 @@ $null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAl
 Set-Service -Name "SQLBrowser" -StartupType Automatic
 Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
 Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
-Start-DbaService -SqlInstance $sqlinstance -Type Browser, Engine, Agent -EnableException -Confirm:$false
+# Start-DbaService can not start service because Get-DbaService does not get the service - we have to fix this bug and then change this script
+Start-Service -Name SQLBrowser
+Start-DbaService -SqlInstance $sqlinstance -Type Engine, Agent -EnableException -Confirm:$false
 
 
 Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen

--- a/tests/appveyor.SQL2017.ps1
+++ b/tests/appveyor.SQL2017.ps1
@@ -17,9 +17,9 @@ Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundCol
 # We need to configure the port first to be able to start the instances in any order.
 $null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -EnableException -Confirm:$false -WarningAction SilentlyContinue
 
-# Agent Service on SQL2017 is "Manual". Do we need to set it to Automatic? We try leaving it on Manual...
-# Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
-
+Set-Service -Name "SQLBrowser" -StartupType Automatic
+Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
+Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
 Start-DbaService -SqlInstance $sqlinstance -Type Browser, Engine, Agent -EnableException -Confirm:$false
 
 

--- a/tests/appveyor.SQL2017.ps1
+++ b/tests/appveyor.SQL2017.ps1
@@ -7,67 +7,30 @@ $sqlinstance = "localhost\SQL2017"
 $instance = "SQL2017"
 $port = "14334"
 
-Write-Host -Object "$indent Setting up AppVeyor Services" -ForegroundColor DarkGreen
-
 Write-Host -Object "$indent SQLBrowser StartType: $((Get-Service -Name SQLBrowser).StartType) / Status: $((Get-Service -Name SQLBrowser).Status)" -ForegroundColor DarkGreen
 Write-Host -Object "$indent MSSQL`$$instance StartType: $((Get-Service -Name "MSSQL`$$instance").StartType) / Status: $((Get-Service -Name "MSSQL`$$instance").Status)" -ForegroundColor DarkGreen
 Write-Host -Object "$indent SQLAgent`$$instance StartType: $((Get-Service -Name "SQLAgent`$$instance").StartType) / Status: $((Get-Service -Name "SQLAgent`$$instance").Status)" -ForegroundColor DarkGreen
 
 
-Set-Service -Name SQLBrowser -StartupType Automatic -WarningAction SilentlyContinue
-Start-Service SQLBrowser -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
-Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic -WarningAction SilentlyContinue
+Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundColor DarkGreen
 
-Write-Host -Object "$indent Changing the port on $instance to $port" -ForegroundColor DarkGreen
-$wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
-$uri = "ManagedComputer[@Name='$env:COMPUTERNAME']/ServerInstance[@Name='$instance']/ServerProtocol[@Name='Tcp']"
-$Tcp = $wmi.GetSmoObject($uri)
-foreach ($ipAddress in $Tcp.IPAddresses) {
-    $ipAddress.IPAddressProperties["TcpDynamicPorts"].Value = ""
-    $ipAddress.IPAddressProperties["TcpPort"].Value = $port
-}
-$Tcp.Alter()
+Set-Service -Name SQLBrowser -StartupType Automatic
+Start-Service -Name SQLBrowser
+
+Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
+Start-Service -Name "SQLAgent`$$instance"
+
+Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
+Start-Service -Name "SQLAgent`$$instance"
 
 
+Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen
 
+$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -EnableException -Confirm:$false
+$null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true -EnableException
+Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE CRYPTOGRAPHIC PROVIDER dbatoolsci_AKV FROM FILE = 'C:\github\appveyor-lab\keytests\ekm\Microsoft.AzureKeyVaultService.EKM.dll'" -EnableException
+$null = Enable-DbaAgHadr -SqlInstance $sqlinstance -Force -EnableException -Confirm:$false
+Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE MASTER KEY ENCRYPTION BY PASSWORD = '<StrongPassword>'" -EnableException
+Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE CERTIFICATE dbatoolsci_AGCert WITH SUBJECT = 'AG Certificate'" -EnableException
 
-
-
-Write-Host -Object "$indent Starting $instance" -ForegroundColor DarkGreen
-#Restart-Service "MSSQL`$$instance" -WarningAction SilentlyContinue -Force
-#Restart-Service "SQLAgent`$$instance" -WarningAction SilentlyContinue -Force
-
-$null = Enable-DbaAgHadr -SqlInstance $sqlinstance -Confirm:$false -Force
-
-do {
-    Start-Sleep 1
-    $null = (& sqlcmd -S "$sqlinstance" -b -Q "select 1" -d master)
-}
-while ($lastexitcode -ne 0 -and $t++ -lt 10)
-
-# Agent sometimes takes a moment to start
-do {
-    Write-Host -Object "$indent Waiting for SQL Agent to start" -ForegroundColor DarkGreen
-    Start-Sleep 1
-}
-while ((Get-Service "SQLAgent`$$instance").Status -ne 'Running' -and $z++ -lt 10)
-
-
-$server = Connect-DbaInstance -SqlInstance $sqlinstance
-$computername = $server.NetName
-$servicename = $server.ServiceName
-if ($servicename -eq 'MSSQLSERVER') {
-    $instancename = "$computername"
-} else {
-    $instancename = "$computername\$servicename"
-}
-
-$server = Connect-DbaInstance -SqlInstance $sqlinstance
-$server.Query("IF NOT EXISTS (select * from sys.symmetric_keys where name like '%DatabaseMasterKey%') CREATE MASTER KEY ENCRYPTION BY PASSWORD = '<StrongPassword>'")
-$server.Query("IF EXISTS ( SELECT * FROM sys.tcp_endpoints WHERE name = 'End_Mirroring') DROP ENDPOINT endpoint_mirroring")
-$server.Query("CREATE CERTIFICATE dbatoolsci_AGCert WITH SUBJECT = 'AG Certificate'")
-
-
-$null = Set-DbaSpConfigure -SqlInstance $sqlinstance -Name ExtensibleKeyManagementEnabled -Value $true
-$sql = "CREATE CRYPTOGRAPHIC PROVIDER dbatoolsci_AKV FROM FILE = 'C:\github\appveyor-lab\keytests\ekm\Microsoft.AzureKeyVaultService.EKM.dll'"
-Invoke-DbaQuery -SqlInstance $sqlinstance -Query $sql
+$null = Restart-DbaService -SqlInstance $sqlinstance -Type Engine -Force -EnableException -Confirm:$false

--- a/tests/appveyor.SQL2017.ps1
+++ b/tests/appveyor.SQL2017.ps1
@@ -14,14 +14,13 @@ Write-Host -Object "$indent SQLAgent`$$instance StartType: $((Get-Service -Name 
 
 Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundColor DarkGreen
 
-Start-Service -Name SQLBrowser
+# We need to configure the port first to be able to start the instances in any order.
+$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -EnableException -Confirm:$false -WarningAction SilentlyContinue
 
-# We need to configure the port first to be able to start the instances in any order. This will also start the instance.
-$null = Set-DbaNetworkConfiguration -SqlInstance $sqlinstance -StaticPortForIPAll $port -RestartService -EnableException -Confirm:$false
+# Agent Service on SQL2017 is "Manual". Do we need to set it to Automatic? We try leaving it on Manual...
+# Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
 
-# Agent Service is "Manual", so we may not need to change the StartupType before starting
-#Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
-Start-Service -Name "SQLAgent`$$instance"
+Start-DbaService -SqlInstance $sqlinstance -Type Browser, Engine, Agent -EnableException -Confirm:$false
 
 
 Write-Host -Object "$indent Configuring $sqlinstance" -ForegroundColor DarkGreen

--- a/tests/appveyor.SQL2017.ps1
+++ b/tests/appveyor.SQL2017.ps1
@@ -17,8 +17,8 @@ Write-Host -Object "$indent Setting up and starting $sqlinstance" -ForegroundCol
 Set-Service -Name SQLBrowser -StartupType Automatic
 Start-Service -Name SQLBrowser
 
-Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
-Start-Service -Name "SQLAgent`$$instance"
+Set-Service -Name "MSSQL`$$instance" -StartupType Automatic
+Start-Service -Name "MSSQL`$$instance"
 
 Set-Service -Name "SQLAgent`$$instance" -StartupType Automatic
 Start-Service -Name "SQLAgent`$$instance"


### PR DESCRIPTION
Some settings are not needed anymore because they are set by appveyor.prep.ps1.

I have aligned all three instance specific files to have a better overview of the needed settings in case a testlab shuld be setup in another environment.

Let's see if everything works as expected. Feedback is welcome.