### PR TITLE
Remove redundant global variable

### DIFF
--- a/tests/Find-DbaBackup.Tests.ps1
+++ b/tests/Find-DbaBackup.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Find-DbaCommand.Tests.ps1
+++ b/tests/Find-DbaCommand.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Find-DbaDbDisabledIndex.Tests.ps1
+++ b/tests/Find-DbaDbDisabledIndex.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Find-DbaDbDuplicateIndex.Tests.ps1
+++ b/tests/Find-DbaDbDuplicateIndex.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Find-DbaLoginInGroup.Tests.ps1
+++ b/tests/Find-DbaLoginInGroup.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Find-DbaSimilarTable.Tests.ps1
+++ b/tests/Find-DbaSimilarTable.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Find-DbaStoredProcedure.Tests.ps1
+++ b/tests/Find-DbaStoredProcedure.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Find-DbaTrigger.Tests.ps1
+++ b/tests/Find-DbaTrigger.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Find-DbaView.Tests.ps1
+++ b/tests/Find-DbaView.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Format-DbaBackupInformation.Tests.ps1
+++ b/tests/Format-DbaBackupInformation.Tests.ps1
@@ -7,7 +7,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'BackupHistory', 'ReplaceDatabaseName', 'ReplaceDbNameInFile', 'DataFileDirectory', 'LogFileDirectory', 'DestinationFileStreamDirectory', 'DatabaseNamePrefix', 'DatabaseFilePrefix', 'DatabaseFileSuffix', 'RebaseBackupFolder', 'Continue', 'FileMapping', 'PathSep', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        It "Should only contain our specific parameters" {
+        It "Should have the expected parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }

--- a/tests/Get-DbaAgBackupHistory.Tests.ps1
+++ b/tests/Get-DbaAgBackupHistory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAgHadr.Tests.ps1
+++ b/tests/Get-DbaAgHadr.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAgentAlert.Tests.ps1
+++ b/tests/Get-DbaAgentAlert.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/Get-DbaAgentAlertCategory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAgentJob.Tests.ps1
+++ b/tests/Get-DbaAgentJob.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -26,9 +23,6 @@ Describe $CommandName -Tag UnitTests {
                 "IncludeExecution",
                 "Type"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Get-DbaAgentJobCategory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAgentJobOutputFile.Tests.ps1
+++ b/tests/Get-DbaAgentJobOutputFile.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAgentJobStep.Tests.ps1
+++ b/tests/Get-DbaAgentJobStep.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAgentLog.Tests.ps1
+++ b/tests/Get-DbaAgentLog.Tests.ps1
@@ -1,5 +1,5 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 $global:TestConfig = Get-TestConfig
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {

--- a/tests/Get-DbaAgentOperator.Tests.ps1
+++ b/tests/Get-DbaAgentOperator.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAgentProxy.Tests.ps1
+++ b/tests/Get-DbaAgentProxy.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAgentSchedule.Tests.ps1
+++ b/tests/Get-DbaAgentSchedule.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAgentServer.Tests.ps1
+++ b/tests/Get-DbaAgentServer.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/Get-DbaAvailabilityGroup.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaAvailableCollation.Tests.ps1
+++ b/tests/Get-DbaAvailableCollation.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaBackupDevice.Tests.ps1
+++ b/tests/Get-DbaBackupDevice.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaBinaryFileTable.Tests.ps1
+++ b/tests/Get-DbaBinaryFileTable.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaBuild.Tests.ps1
+++ b/tests/Get-DbaBuild.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaClientAlias.Tests.ps1
+++ b/tests/Get-DbaClientAlias.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        It "Should only contain our specific parameters" {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(

--- a/tests/Get-DbaClientProtocol.Tests.ps1
+++ b/tests/Get-DbaClientProtocol.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -18,9 +15,6 @@ Describe $CommandName -Tag UnitTests {
                 "Credential",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
@@ -28,11 +22,8 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     Context "Get some client protocols" {
-        BeforeAll {
-            $results = @(Get-DbaClientProtocol)
-        }
-
         It "Should return some protocols" {
+            $results = @(Get-DbaClientProtocol)
             $results.Status.Count | Should -BeGreaterThan 1
             $results | Where-Object ProtocolDisplayName -eq "TCP/IP" | Should -Not -BeNullOrEmpty
         }

--- a/tests/Get-DbaCmObject.Tests.ps1
+++ b/tests/Get-DbaCmObject.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaComputerCertificate.Tests.ps1
+++ b/tests/Get-DbaComputerCertificate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaComputerSystem.Tests.ps1
+++ b/tests/Get-DbaComputerSystem.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaConnectedInstance.Tests.ps1
+++ b/tests/Get-DbaConnectedInstance.Tests.ps1
@@ -5,13 +5,10 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         # fake tests, no parameters to validate
-        It "Should only contain our specific parameters" {
+        It "Should have the expected parameters" {
             $null | Should -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaCpuRingBuffer.Tests.ps1
+++ b/tests/Get-DbaCpuRingBuffer.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -19,21 +16,15 @@ Describe $CommandName -Tag UnitTests {
                 "CollectionMinutes",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
 Describe $CommandName -Tag IntegrationTests {
-    Context "Command returns proper info" {
-        BeforeAll {
+    Context "When retrieving CPU ring buffer data" {
+        It "Returns CPU performance metrics from ring buffer" {
             $results = @(Get-DbaCpuRingBuffer -SqlInstance $TestConfig.instance2 -CollectionMinutes 100)
-        }
-
-        It "returns results" {
             $results.Count | Should -BeGreaterThan 0
         }
     }

--- a/tests/Get-DbaCredential.Tests.ps1
+++ b/tests/Get-DbaCredential.Tests.ps1
@@ -5,10 +5,7 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
 . "$PSScriptRoot\..\private\functions\Invoke-Command2.ps1"
-
 
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {

--- a/tests/Get-DbaCustomError.Tests.ps1
+++ b/tests/Get-DbaCustomError.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDBFileGroup.Tests.ps1
+++ b/tests/Get-DbaDBFileGroup.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbAssembly.Tests.ps1
+++ b/tests/Get-DbaDbAssembly.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/Get-DbaDbAsymmetricKey.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbBackupHistory.Tests.ps1
+++ b/tests/Get-DbaDbBackupHistory.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -36,9 +33,6 @@ Describe $CommandName -Tag UnitTests {
                 "IgnoreDiffBackup",
                 "LsnSort"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaDbCertificate.Tests.ps1
+++ b/tests/Get-DbaDbCertificate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbCheckConstraint.Tests.ps1
+++ b/tests/Get-DbaDbCheckConstraint.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbCompatibility.Tests.ps1
+++ b/tests/Get-DbaDbCompatibility.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbCompression.Tests.ps1
+++ b/tests/Get-DbaDbCompression.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbDbccOpenTran.Tests.ps1
+++ b/tests/Get-DbaDbDbccOpenTran.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbDetachedFileInfo.Tests.ps1
+++ b/tests/Get-DbaDbDetachedFileInfo.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbEncryption.Tests.ps1
+++ b/tests/Get-DbaDbEncryption.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbEncryptionKey.Tests.ps1
+++ b/tests/Get-DbaDbEncryptionKey.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbExtentDiff.Tests.ps1
+++ b/tests/Get-DbaDbExtentDiff.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbFeatureUsage.Tests.ps1
+++ b/tests/Get-DbaDbFeatureUsage.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbFile.Tests.ps1
+++ b/tests/Get-DbaDbFile.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -22,19 +19,13 @@ Describe $CommandName -Tag UnitTests {
                 "InputObject",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 
     Context "Ensure array" {
-        BeforeAll {
-            $results = Get-Command -Name Get-DbaDbFile | Select-Object -ExpandProperty ScriptBlock
-        }
-
         It "Returns disks as an array" {
+            $results = Get-Command -Name Get-DbaDbFile | Select-Object -ExpandProperty ScriptBlock
             $results -match '\$disks \= \@\(' | Should -Be $true
         }
     }
@@ -42,21 +33,15 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     Context "Should return file information" {
-        BeforeAll {
-            $results = Get-DbaDbFile -SqlInstance $TestConfig.instance1
-        }
-
         It "Returns information about tempdb files" {
+            $results = Get-DbaDbFile -SqlInstance $TestConfig.instance1
             $results.Database -contains "tempdb" | Should -Be $true
         }
     }
 
     Context "Should return file information for only tempdb" {
-        BeforeAll {
-            $results = Get-DbaDbFile -SqlInstance $TestConfig.instance1 -Database tempdb
-        }
-
         It "Returns only tempdb files" {
+            $results = Get-DbaDbFile -SqlInstance $TestConfig.instance1 -Database tempdb
             foreach ($result in $results) {
                 $result.Database | Should -Be "tempdb"
             }
@@ -64,11 +49,8 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     Context "Should return file information for only tempdb primary filegroup" {
-        BeforeAll {
-            $results = Get-DbaDbFile -SqlInstance $TestConfig.instance1 -Database tempdb -FileGroup Primary
-        }
-
         It "Returns only tempdb files that are in Primary filegroup" {
+            $results = Get-DbaDbFile -SqlInstance $TestConfig.instance1 -Database tempdb -FileGroup Primary
             foreach ($result in $results) {
                 $result.Database | Should -Be "tempdb"
                 $result.FileGroupName | Should -Be "Primary"
@@ -77,11 +59,8 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     Context "Physical name is populated" {
-        BeforeAll {
-            $results = Get-DbaDbFile -SqlInstance $TestConfig.instance1 -Database master
-        }
-
         It "Master returns proper results" {
+            $results = Get-DbaDbFile -SqlInstance $TestConfig.instance1 -Database master
             $result = $results | Where-Object LogicalName -eq "master"
             $result.PhysicalName -match "master.mdf" | Should -Be $true
             $result = $results | Where-Object LogicalName -eq "mastlog"

--- a/tests/Get-DbaDbFileGrowth.Tests.ps1
+++ b/tests/Get-DbaDbFileGrowth.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbFileMapping.Tests.ps1
+++ b/tests/Get-DbaDbFileMapping.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -20,9 +17,6 @@ Describe $CommandName -Tag UnitTests {
                 "InputObject",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
@@ -30,22 +24,16 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     Context "Should return file information" {
-        BeforeAll {
-            $results = Get-DbaDbFileMapping -SqlInstance $TestConfig.instance1
-        }
-
         It "returns information about multiple databases" {
+            $results = Get-DbaDbFileMapping -SqlInstance $TestConfig.instance1
             $results.Database -contains "tempdb" | Should -Be $true
             $results.Database -contains "master" | Should -Be $true
         }
     }
 
     Context "Should return file information for a single database" {
-        BeforeAll {
-            $results = Get-DbaDbFileMapping -SqlInstance $TestConfig.instance1 -Database tempdb
-        }
-
         It "returns information about tempdb" {
+            $results = Get-DbaDbFileMapping -SqlInstance $TestConfig.instance1 -Database tempdb
             $results.Database -contains "tempdb" | Should -Be $true
             $results.Database -contains "master" | Should -Be $false
         }

--- a/tests/Get-DbaDbForeignKey.Tests.ps1
+++ b/tests/Get-DbaDbForeignKey.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbIdentity.Tests.ps1
+++ b/tests/Get-DbaDbIdentity.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbLogShipError.Tests.ps1
+++ b/tests/Get-DbaDbLogShipError.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbLogSpace.Tests.ps1
+++ b/tests/Get-DbaDbLogSpace.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbMail.Tests.ps1
+++ b/tests/Get-DbaDbMail.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbMailAccount.Tests.ps1
+++ b/tests/Get-DbaDbMailAccount.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbMailConfig.Tests.ps1
+++ b/tests/Get-DbaDbMailConfig.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbMailHistory.Tests.ps1
+++ b/tests/Get-DbaDbMailHistory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbMailLog.Tests.ps1
+++ b/tests/Get-DbaDbMailLog.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbMailProfile.Tests.ps1
+++ b/tests/Get-DbaDbMailProfile.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbMailServer.Tests.ps1
+++ b/tests/Get-DbaDbMailServer.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -21,9 +18,6 @@ Describe $CommandName -Tag UnitTests {
                 "InputObject",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaDbMemoryUsage.Tests.ps1
+++ b/tests/Get-DbaDbMemoryUsage.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbMirror.Tests.ps1
+++ b/tests/Get-DbaDbMirror.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbMirrorMonitor.Tests.ps1
+++ b/tests/Get-DbaDbMirrorMonitor.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbObjectTrigger.Tests.ps1
+++ b/tests/Get-DbaDbObjectTrigger.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbOrphanUser.Tests.ps1
+++ b/tests/Get-DbaDbOrphanUser.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbPageInfo.Tests.ps1
+++ b/tests/Get-DbaDbPageInfo.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        It "Should only contain our specific parameters" {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(

--- a/tests/Get-DbaDbPartitionFunction.Tests.ps1
+++ b/tests/Get-DbaDbPartitionFunction.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbPartitionScheme.Tests.ps1
+++ b/tests/Get-DbaDbPartitionScheme.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Get-DbaDbQueryStoreOption.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbRecoveryModel.Tests.ps1
+++ b/tests/Get-DbaDbRecoveryModel.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbRestoreHistory.Tests.ps1
+++ b/tests/Get-DbaDbRestoreHistory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbRole.Tests.ps1
+++ b/tests/Get-DbaDbRole.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbRoleMember.Tests.ps1
+++ b/tests/Get-DbaDbRoleMember.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbSchema.Tests.ps1
+++ b/tests/Get-DbaDbSchema.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbSequence.Tests.ps1
+++ b/tests/Get-DbaDbSequence.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbServiceBrokerQueue.Tests.ps1
+++ b/tests/Get-DbaDbServiceBrokerQueue.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbState.Tests.ps1
+++ b/tests/Get-DbaDbState.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbccHelp.Tests.ps1
+++ b/tests/Get-DbaDbccHelp.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbccMemoryStatus.Tests.ps1
+++ b/tests/Get-DbaDbccMemoryStatus.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbccStatistic.Tests.ps1
+++ b/tests/Get-DbaDbccStatistic.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDbccUserOption.Tests.ps1
+++ b/tests/Get-DbaDbccUserOption.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDefaultPath.Tests.ps1
+++ b/tests/Get-DbaDefaultPath.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaDiskSpace.Tests.ps1
+++ b/tests/Get-DbaDiskSpace.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaErrorLog.Tests.ps1
+++ b/tests/Get-DbaErrorLog.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaErrorLogConfig.Tests.ps1
+++ b/tests/Get-DbaErrorLogConfig.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaExtendedProtection.Tests.ps1
+++ b/tests/Get-DbaExtendedProtection.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaExternalProcess.Tests.ps1
+++ b/tests/Get-DbaExternalProcess.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaFeature.Tests.ps1
+++ b/tests/Get-DbaFeature.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaFile.Tests.ps1
+++ b/tests/Get-DbaFile.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaForceNetworkEncryption.Tests.ps1
+++ b/tests/Get-DbaForceNetworkEncryption.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaHelpIndex.Tests.ps1
+++ b/tests/Get-DbaHelpIndex.Tests.ps1
@@ -4,11 +4,6 @@ param(
     $CommandName = "Get-DbaHelpIndex",
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
-
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
-Write-Host -Object "${script:instance2}" -ForegroundColor Cyan
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaHideInstance.Tests.ps1
+++ b/tests/Get-DbaHideInstance.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaInstalledPatch.Tests.ps1
+++ b/tests/Get-DbaInstalledPatch.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaInstanceAuditSpecification.Tests.ps1
+++ b/tests/Get-DbaInstanceAuditSpecification.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaInstanceInstallDate.Tests.ps1
+++ b/tests/Get-DbaInstanceInstallDate.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -20,9 +17,6 @@ Describe $CommandName -Tag UnitTests {
                 "IncludeWindows",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
@@ -30,21 +24,15 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     Context "Gets SQL Server Install Date" {
-        BeforeAll {
-            $results = Get-DbaInstanceInstallDate -SqlInstance $TestConfig.instance2
-        }
-
         It "Gets results" {
+            $results = Get-DbaInstanceInstallDate -SqlInstance $TestConfig.instance2
             $results | Should -Not -BeNullOrEmpty
         }
     }
 
     Context "Gets SQL Server Install Date and Windows Install Date" {
-        BeforeAll {
-            $results = Get-DbaInstanceInstallDate -SqlInstance $TestConfig.instance2 -IncludeWindows
-        }
-
         It "Gets results" {
+            $results = Get-DbaInstanceInstallDate -SqlInstance $TestConfig.instance2 -IncludeWindows
             $results | Should -Not -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaInstanceProtocol.Tests.ps1
+++ b/tests/Get-DbaInstanceProtocol.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaInstanceTrigger.Tests.ps1
+++ b/tests/Get-DbaInstanceTrigger.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaInstanceUserOption.Tests.ps1
+++ b/tests/Get-DbaInstanceUserOption.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaKbUpdate.Tests.ps1
+++ b/tests/Get-DbaKbUpdate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaLastBackup.Tests.ps1
+++ b/tests/Get-DbaLastBackup.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaLatchStatistic.Tests.ps1
+++ b/tests/Get-DbaLatchStatistic.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaLinkedServer.Tests.ps1
+++ b/tests/Get-DbaLinkedServer.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaLocaleSetting.Tests.ps1
+++ b/tests/Get-DbaLocaleSetting.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaMemoryCondition.Tests.ps1
+++ b/tests/Get-DbaMemoryCondition.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaMsdtc.Tests.ps1
+++ b/tests/Get-DbaMsdtc.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaNetworkActivity.Tests.ps1
+++ b/tests/Get-DbaNetworkActivity.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaNetworkCertificate.Tests.ps1
+++ b/tests/Get-DbaNetworkCertificate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Get-DbaNetworkConfiguration.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaOleDbProvider.Tests.ps1
+++ b/tests/Get-DbaOleDbProvider.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaOpenTransaction.Tests.ps1
+++ b/tests/Get-DbaOpenTransaction.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaOperatingSystem.Tests.ps1
+++ b/tests/Get-DbaOperatingSystem.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -18,9 +15,6 @@ Describe $CommandName -Tag UnitTests {
                 "Credential",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaPageFileSetting.Tests.ps1
+++ b/tests/Get-DbaPageFileSetting.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaPbmCategory.Tests.ps1
+++ b/tests/Get-DbaPbmCategory.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -21,9 +18,6 @@ Describe $CommandName -Tag UnitTests {
                 "ExcludeSystemObject",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
@@ -31,31 +25,22 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     Context "Command actually works" {
-        BeforeAll {
-            $results = Get-DbaPbmCategory -SqlInstance $TestConfig.instance2
-        }
-
         It "Gets Results" {
+            $results = Get-DbaPbmCategory -SqlInstance $TestConfig.instance2
             $results | Should -Not -BeNullOrEmpty
         }
     }
 
     Context "Command actually works using -Category" {
-        BeforeAll {
-            $results = Get-DbaPbmCategory -SqlInstance $TestConfig.instance2 -Category "Availability database errors"
-        }
-
         It "Gets Results" {
+            $results = Get-DbaPbmCategory -SqlInstance $TestConfig.instance2 -Category "Availability database errors"
             $results | Should -Not -BeNullOrEmpty
         }
     }
 
     Context "Command actually works using -ExcludeSystemObject" {
-        BeforeAll {
-            $results = Get-DbaPbmCategory -SqlInstance $TestConfig.instance2 -ExcludeSystemObject
-        }
-
         It "Gets Results" {
+            $results = Get-DbaPbmCategory -SqlInstance $TestConfig.instance2 -ExcludeSystemObject
             $results | Should -Not -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaPbmCategorySubscription.Tests.ps1
+++ b/tests/Get-DbaPbmCategorySubscription.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaPbmObjectSet.Tests.ps1
+++ b/tests/Get-DbaPbmObjectSet.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaPbmStore.Tests.ps1
+++ b/tests/Get-DbaPbmStore.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaPermission.Tests.ps1
+++ b/tests/Get-DbaPermission.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaPfDataCollectorCounter.Tests.ps1
+++ b/tests/Get-DbaPfDataCollectorCounter.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -22,9 +19,6 @@ Describe $CommandName -Tag UnitTests {
                 "InputObject",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaPfDataCollectorSetTemplate.Tests.ps1
+++ b/tests/Get-DbaPfDataCollectorSetTemplate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaPlanCache.Tests.ps1
+++ b/tests/Get-DbaPlanCache.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -18,9 +15,6 @@ Describe $CommandName -Tag UnitTests {
                 "SqlCredential",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
@@ -28,11 +22,6 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     Context "When retrieving plan cache information" {
-        BeforeAll {
-            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-        }
-
         It "Returns correct datatypes" {
             $results = Get-DbaPlanCache -SqlInstance $TestConfig.instance1 | Clear-DbaPlanCache -Threshold 1024
             $results.Size -is [dbasize] | Should -Be $true

--- a/tests/Get-DbaPowerPlan.Tests.ps1
+++ b/tests/Get-DbaPowerPlan.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaPrivilege.Tests.ps1
+++ b/tests/Get-DbaPrivilege.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaProcess.Tests.ps1
+++ b/tests/Get-DbaProcess.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaRandomizedDatasetTemplate.Tests.ps1
+++ b/tests/Get-DbaRandomizedDatasetTemplate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaRandomizedType.Tests.ps1
+++ b/tests/Get-DbaRandomizedType.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaRandomizedValue.Tests.ps1
+++ b/tests/Get-DbaRandomizedValue.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaRegServer.Tests.ps1
+++ b/tests/Get-DbaRegServer.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaRegServerStore.Tests.ps1
+++ b/tests/Get-DbaRegServerStore.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaReplArticle.Tests.ps1
+++ b/tests/Get-DbaReplArticle.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Add-ReplicationLibrary
 
 Describe $CommandName -Tag UnitTests {

--- a/tests/Get-DbaReplArticleColumn.Tests.ps1
+++ b/tests/Get-DbaReplArticleColumn.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 
 Add-ReplicationLibrary
 

--- a/tests/Get-DbaReplPublication.Tests.ps1
+++ b/tests/Get-DbaReplPublication.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaReplSubscription.Tests.ps1
+++ b/tests/Get-DbaReplSubscription.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Add-ReplicationLibrary
 
 Describe $CommandName -Tag UnitTests {

--- a/tests/Get-DbaRgClassifierFunction.Tests.ps1
+++ b/tests/Get-DbaRgClassifierFunction.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaRgResourcePool.Tests.ps1
+++ b/tests/Get-DbaRgResourcePool.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -20,9 +17,6 @@ Describe $CommandName -Tag UnitTests {
                 "InputObject",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaService.Tests.ps1
+++ b/tests/Get-DbaService.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -23,9 +20,6 @@ Describe $CommandName -Tag UnitTests {
                 "AdvancedProperties",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaSpConfigure.Tests.ps1
+++ b/tests/Get-DbaSpConfigure.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaSpinLockStatistic.Tests.ps1
+++ b/tests/Get-DbaSpinLockStatistic.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -18,22 +15,16 @@ Describe $CommandName -Tag UnitTests {
                 "SqlCredential",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
 Describe $CommandName -Tag IntegrationTests {
-    Context "Command returns proper info" {
-        BeforeAll {
+    Context "When retrieving spinlock statistics" {
+        It "Returns spinlock contention metrics from SQL Server" {
             $results = @(Get-DbaSpinLockStatistic -SqlInstance $TestConfig.instance2)
-        }
-
-        It "Returns results" {
-            $results.Count -gt 0 | Should -Be $true
+            $results.Count | Should -BeGreaterThan 0
         }
     }
 }

--- a/tests/Get-DbaSsisExecutionHistory.Tests.ps1
+++ b/tests/Get-DbaSsisExecutionHistory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaStartupParameter.Tests.ps1
+++ b/tests/Get-DbaStartupParameter.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaStartupProcedure.Tests.ps1
+++ b/tests/Get-DbaStartupProcedure.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaSuspectPage.Tests.ps1
+++ b/tests/Get-DbaSuspectPage.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -19,9 +16,6 @@ Describe $CommandName -Tag UnitTests {
                 "SqlCredential",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaTempdbUsage.Tests.ps1
+++ b/tests/Get-DbaTempdbUsage.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaWaitResource.Tests.ps1
+++ b/tests/Get-DbaWaitResource.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaWaitStatistic.Tests.ps1
+++ b/tests/Get-DbaWaitStatistic.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaWsfcAvailableDisk.Tests.ps1
+++ b/tests/Get-DbaWsfcAvailableDisk.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaWsfcCluster.Tests.ps1
+++ b/tests/Get-DbaWsfcCluster.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaWsfcNetwork.Tests.ps1
+++ b/tests/Get-DbaWsfcNetwork.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaWsfcNetworkInterface.Tests.ps1
+++ b/tests/Get-DbaWsfcNetworkInterface.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaWsfcNode.Tests.ps1
+++ b/tests/Get-DbaWsfcNode.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaWsfcResource.Tests.ps1
+++ b/tests/Get-DbaWsfcResource.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaWsfcRole.Tests.ps1
+++ b/tests/Get-DbaWsfcRole.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaXEObject.Tests.ps1
+++ b/tests/Get-DbaXEObject.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaXESession.Tests.ps1
+++ b/tests/Get-DbaXESession.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaXESessionTemplate.Tests.ps1
+++ b/tests/Get-DbaXESessionTemplate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbaXEStore.Tests.ps1
+++ b/tests/Get-DbaXEStore.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbatoolsConfig.Tests.ps1
+++ b/tests/Get-DbatoolsConfig.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbatoolsError.Tests.ps1
+++ b/tests/Get-DbatoolsError.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbatoolsLog.Tests.ps1
+++ b/tests/Get-DbatoolsLog.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-DbatoolsPath.Tests.ps1
+++ b/tests/Get-DbatoolsPath.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Get-ObjectNameParts.Tests.ps1
+++ b/tests/Get-ObjectNameParts.Tests.ps1
@@ -1,5 +1,5 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 $global:TestConfig = Get-TestConfig
 . "$PSScriptRoot\..\private\functions\Get-DirectoryRestoreFile.ps1"
 

--- a/tests/Import-DbaSpConfigure.Tests.ps1
+++ b/tests/Import-DbaSpConfigure.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/InModule.Commands.Tests.ps1
+++ b/tests/InModule.Commands.Tests.ps1
@@ -1,5 +1,5 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 $global:TestConfig = Get-TestConfig
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {

--- a/tests/InModule.Help.Tests.ps1
+++ b/tests/InModule.Help.Tests.ps1
@@ -1,4 +1,4 @@
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 <#
     .NOTES
         ===========================================================================

--- a/tests/Install-DbaAgentAdminAlert.Tests.ps1
+++ b/tests/Install-DbaAgentAdminAlert.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Install-DbaDarlingData.Tests.ps1
+++ b/tests/Install-DbaDarlingData.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Install-DbaMultiTool.Tests.ps1
+++ b/tests/Install-DbaMultiTool.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Install-DbaWhoIsActive.Tests.ps1
+++ b/tests/Install-DbaWhoIsActive.Tests.ps1
@@ -4,9 +4,6 @@ param(
     $CommandName = "Install-DbaWhoIsActive",
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
-
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
 . "$PSScriptRoot\..\private\functions\Invoke-TlsWebRequest"
 
 Describe $CommandName -Tag UnitTests {

--- a/tests/Invoke-DbaAdvancedInstall.Tests.ps1
+++ b/tests/Invoke-DbaAdvancedInstall.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     BeforeAll {
         # Prevent the functions from executing dangerous stuff and getting right responses where needed

--- a/tests/Invoke-DbaAdvancedUpdate.Tests.ps1
+++ b/tests/Invoke-DbaAdvancedUpdate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 $exeDir = "C:\Temp\dbatools_$CommandName"
 
 Describe $CommandName -Tag UnitTests {

--- a/tests/Invoke-DbaAzSqlDbTip.Tests.ps1
+++ b/tests/Invoke-DbaAzSqlDbTip.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Invoke-DbaDbCorruption.Tests.ps1
+++ b/tests/Invoke-DbaDbCorruption.Tests.ps1
@@ -4,9 +4,6 @@ param(
     $CommandName = "Invoke-DbaDbCorruption",
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
-
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
 . "$PSScriptRoot\..\private\functions\Invoke-DbaDbCorruption.ps1"
 
 Describe $CommandName -Tag UnitTests {

--- a/tests/Invoke-DbaDbDataGenerator.Tests.ps1
+++ b/tests/Invoke-DbaDbDataGenerator.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Invoke-DbaDbDbccCheckConstraint.Tests.ps1
+++ b/tests/Invoke-DbaDbDbccCheckConstraint.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Invoke-DbaDbDbccCleanTable.Tests.ps1
+++ b/tests/Invoke-DbaDbDbccCleanTable.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -22,9 +19,6 @@ Describe $CommandName -Tag UnitTests {
                 "NoInformationalMessages",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Invoke-DbaDbMirrorFailover.Tests.ps1
+++ b/tests/Invoke-DbaDbMirrorFailover.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Invoke-DbaDbMirroring.Tests.ps1
+++ b/tests/Invoke-DbaDbMirroring.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Invoke-DbaDbccFreeCache.Tests.ps1
+++ b/tests/Invoke-DbaDbccFreeCache.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
+++ b/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Invoke-DbaPfRelog.Tests.ps1
+++ b/tests/Invoke-DbaPfRelog.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -7,8 +7,7 @@ param(
 
 Describe "Invoke-DbaQuery" -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
-            $command = Get-Command Invoke-DbaQuery
+        It "Should have the expected parameters" {
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
                 'SqlInstance',
@@ -29,62 +28,7 @@ Describe "Invoke-DbaQuery" -Tag UnitTests {
                 'NoExec',
                 'AppendConnectionString'
             )
-        }
-        It "Should only contain our specific parameters" {
-            $actualParameters = $command.Parameters.Keys | Where-Object { $PSItem -notin "WhatIf", "Confirm" }
-            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $actualParameters | Should -BeNullOrEmpty
-        }
-
-        It "Should have parameter SqlInstance" {
-            $command | Should -HaveParameter "SqlInstance"
-        }
-        It "Should have parameter SqlCredential" {
-            $command | Should -HaveParameter "SqlCredential"
-        }
-        It "Should have parameter Database" {
-            $command | Should -HaveParameter "Database"
-        }
-        It "Should have parameter Query" {
-            $command | Should -HaveParameter "Query"
-        }
-        It "Should have parameter QueryTimeout" {
-            $command | Should -HaveParameter "QueryTimeout"
-        }
-        It "Should have parameter File" {
-            $command | Should -HaveParameter "File"
-        }
-        It "Should have parameter SqlObject" {
-            $command | Should -HaveParameter "SqlObject"
-        }
-        It "Should have parameter As" {
-            $command | Should -HaveParameter "As"
-        }
-        It "Should have parameter SqlParameter" {
-            $command | Should -HaveParameter "SqlParameter"
-        }
-        It "Should have parameter AppendServerInstance" {
-            $command | Should -HaveParameter "AppendServerInstance"
-        }
-        It "Should have parameter MessagesToOutput" {
-            $command | Should -HaveParameter "MessagesToOutput"
-        }
-        It "Should have parameter InputObject" {
-            $command | Should -HaveParameter "InputObject"
-        }
-        It "Should have parameter ReadOnly" {
-            $command | Should -HaveParameter "ReadOnly"
-        }
-        It "Should have parameter EnableException" {
-            $command | Should -HaveParameter "EnableException"
-        }
-        It "Should have parameter CommandType" {
-            $command | Should -HaveParameter "CommandType"
-        }
-        It "Should have parameter NoExec" {
-            $command | Should -HaveParameter "NoExec"
-        }
-        It "Should have parameter AppendConnectionString" {
-            $command | Should -HaveParameter "AppendConnectionString"
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $expectedParameters | Should -BeNullOrEmpty
         }
     }
     Context "Validate alias" {

--- a/tests/Invoke-DbaWhoisActive.Tests.ps1
+++ b/tests/Invoke-DbaWhoisActive.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Invoke-DbatoolsFormatter.Tests.ps1
+++ b/tests/Invoke-DbatoolsFormatter.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Measure-DbaDbVirtualLogFile.Tests.ps1
+++ b/tests/Measure-DbaDbVirtualLogFile.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 <#
     Unit test is required for any command added
 #>

--- a/tests/Measure-DbaDiskSpaceRequirement.Tests.ps1
+++ b/tests/Measure-DbaDiskSpaceRequirement.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Mount-DbaDatabase.Tests.ps1
+++ b/tests/Mount-DbaDatabase.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaAgentAlert.Tests.ps1
+++ b/tests/New-DbaAgentAlert.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaAgentJobStep.Tests.ps1
+++ b/tests/New-DbaAgentJobStep.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaCmConnection.Tests.ps1
+++ b/tests/New-DbaCmConnection.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaCredential.Tests.ps1
+++ b/tests/New-DbaCredential.Tests.ps1
@@ -4,9 +4,6 @@ param(
     $CommandName = "New-DbaCredential",
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
-
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
 . "$PSScriptRoot\..\private\functions\Invoke-Command2.ps1"
 
 Describe $CommandName -Tag UnitTests {

--- a/tests/New-DbaDacOption.Tests.ps1
+++ b/tests/New-DbaDacOption.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaDacProfile.Tests.ps1
+++ b/tests/New-DbaDacProfile.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaDatabase.Tests.ps1
+++ b/tests/New-DbaDatabase.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaDbCertificate.Tests.ps1
+++ b/tests/New-DbaDbCertificate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaDbDataGeneratorConfig.Tests.ps1
+++ b/tests/New-DbaDbDataGeneratorConfig.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaDbEncryptionKey.Tests.ps1
+++ b/tests/New-DbaDbEncryptionKey.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaDbMasterKey.Tests.ps1
+++ b/tests/New-DbaDbMasterKey.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        It "Should only contain our specific parameters" {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(

--- a/tests/New-DbaDbRole.Tests.ps1
+++ b/tests/New-DbaDbRole.Tests.ps1
@@ -1,5 +1,5 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 $global:TestConfig = Get-TestConfig
 
 Describe "$CommandName Unit Tests" -Tags "UnitTests" {

--- a/tests/New-DbaDbSchema.Tests.ps1
+++ b/tests/New-DbaDbSchema.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaDbSequence.Tests.ps1
+++ b/tests/New-DbaDbSequence.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaDbTransfer.Tests.ps1
+++ b/tests/New-DbaDbTransfer.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaDirectory.Tests.ps1
+++ b/tests/New-DbaDirectory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaEndpoint.Tests.ps1
+++ b/tests/New-DbaEndpoint.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaLogin.Tests.ps1
+++ b/tests/New-DbaLogin.Tests.ps1
@@ -4,9 +4,6 @@ param(
     $CommandName = "New-DbaLogin",
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
-
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
 . "$PSScriptRoot\..\private\functions\Get-PasswordHash.ps1"
 . "$PSScriptRoot\..\private\functions\Convert-HexStringToByte.ps1"
 

--- a/tests/New-DbaReplPublication.Tests.ps1
+++ b/tests/New-DbaReplPublication.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 
 Add-ReplicationLibrary
 

--- a/tests/New-DbaReplSubscription.Tests.ps1
+++ b/tests/New-DbaReplSubscription.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Add-ReplicationLibrary
 
 Describe $CommandName -Tag UnitTests {

--- a/tests/New-DbaRgResourcePool.Tests.ps1
+++ b/tests/New-DbaRgResourcePool.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaScriptingOption.Tests.ps1
+++ b/tests/New-DbaScriptingOption.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It -Skip "Should have the expected parameters" {

--- a/tests/New-DbaServerRole.Tests.ps1
+++ b/tests/New-DbaServerRole.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaServiceMasterKey.Tests.ps1
+++ b/tests/New-DbaServiceMasterKey.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaSsisCatalog.Tests.ps1
+++ b/tests/New-DbaSsisCatalog.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/New-DbaXESession.Tests.ps1
+++ b/tests/New-DbaXESession.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Read-DbaBackupHeader.Tests.ps1
+++ b/tests/Read-DbaBackupHeader.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaAgDatabase.Tests.ps1
+++ b/tests/Remove-DbaAgDatabase.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaAgListener.Tests.ps1
+++ b/tests/Remove-DbaAgListener.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/Remove-DbaAgentAlertCategory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Remove-DbaAgentJobCategory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaAgentJobStep.Tests.ps1
+++ b/tests/Remove-DbaAgentJobStep.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaAgentOperator.Tests.ps1
+++ b/tests/Remove-DbaAgentOperator.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaComputerCertificate.Tests.ps1
+++ b/tests/Remove-DbaComputerCertificate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaCredential.Tests.ps1
+++ b/tests/Remove-DbaCredential.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaCustomError.Tests.ps1
+++ b/tests/Remove-DbaCustomError.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDatabaseSafely.Tests.ps1
+++ b/tests/Remove-DbaDatabaseSafely.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbBackupRestoreHistory.Tests.ps1
+++ b/tests/Remove-DbaDbBackupRestoreHistory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbCertificate.Tests.ps1
+++ b/tests/Remove-DbaDbCertificate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbData.Tests.ps1
+++ b/tests/Remove-DbaDbData.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbEncryptionKey.Tests.ps1
+++ b/tests/Remove-DbaDbEncryptionKey.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbFileGroup.Tests.ps1
+++ b/tests/Remove-DbaDbFileGroup.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbLogShipping.Tests.ps1
+++ b/tests/Remove-DbaDbLogShipping.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbMailProfile.Tests.ps1
+++ b/tests/Remove-DbaDbMailProfile.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbMasterKey.Tests.ps1
+++ b/tests/Remove-DbaDbMasterKey.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbMirror.Tests.ps1
+++ b/tests/Remove-DbaDbMirror.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbMirrorMonitor.Tests.ps1
+++ b/tests/Remove-DbaDbMirrorMonitor.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbPartitionFunction.Tests.ps1
+++ b/tests/Remove-DbaDbPartitionFunction.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbPartitionScheme.Tests.ps1
+++ b/tests/Remove-DbaDbPartitionScheme.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbSchema.Tests.ps1
+++ b/tests/Remove-DbaDbSchema.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbTable.Tests.ps1
+++ b/tests/Remove-DbaDbTable.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbTableData.Tests.ps1
+++ b/tests/Remove-DbaDbTableData.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbUser.Tests.ps1
+++ b/tests/Remove-DbaDbUser.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaDbView.Tests.ps1
+++ b/tests/Remove-DbaDbView.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaExtendedProperty.Tests.ps1
+++ b/tests/Remove-DbaExtendedProperty.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaLogin.Tests.ps1
+++ b/tests/Remove-DbaLogin.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaNetworkCertificate.Tests.ps1
+++ b/tests/Remove-DbaNetworkCertificate.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaPfDataCollectorCounter.Tests.ps1
+++ b/tests/Remove-DbaPfDataCollectorCounter.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaPfDataCollectorSet.Tests.ps1
+++ b/tests/Remove-DbaPfDataCollectorSet.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaRegServerGroup.Tests.ps1
+++ b/tests/Remove-DbaRegServerGroup.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaReplPublication.Tests.ps1
+++ b/tests/Remove-DbaReplPublication.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 
 Add-ReplicationLibrary
 

--- a/tests/Remove-DbaReplSubscription.Tests.ps1
+++ b/tests/Remove-DbaReplSubscription.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 
 Add-ReplicationLibrary
 

--- a/tests/Remove-DbaRgResourcePool.Tests.ps1
+++ b/tests/Remove-DbaRgResourcePool.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Remove-DbaXESession.Tests.ps1
+++ b/tests/Remove-DbaXESession.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Rename-DbaDatabase.Tests.ps1
+++ b/tests/Rename-DbaDatabase.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Repair-DbaDbMirror.Tests.ps1
+++ b/tests/Repair-DbaDbMirror.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Repair-DbaDbOrphanUser.Tests.ps1
+++ b/tests/Repair-DbaDbOrphanUser.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -23,9 +20,6 @@ Describe $CommandName -Tag UnitTests {
                 "Force",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Reset-DbaAdmin.Tests.ps1
+++ b/tests/Reset-DbaAdmin.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Reset-DbatoolsConfig.Tests.ps1
+++ b/tests/Reset-DbatoolsConfig.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Resolve-DbaPath.Tests.ps1
+++ b/tests/Resolve-DbaPath.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Restart-DbaService.Tests.ps1
+++ b/tests/Restart-DbaService.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -66,9 +63,6 @@ Describe $CommandName -Tag UnitTests {
                 "ExecuteAs",
                 "NoXpDirRecurse"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Revoke-DbaAgPermission.Tests.ps1
+++ b/tests/Revoke-DbaAgPermission.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Select-DbaBackupInformation.Tests.ps1
+++ b/tests/Select-DbaBackupInformation.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaAgReplica.Tests.ps1
+++ b/tests/Set-DbaAgReplica.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaAgentAlert.Tests.ps1
+++ b/tests/Set-DbaAgentAlert.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaAgentJob.Tests.ps1
+++ b/tests/Set-DbaAgentJob.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Set-DbaAgentJobCategory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaAgentJobOutputFile.Tests.ps1
+++ b/tests/Set-DbaAgentJobOutputFile.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaAgentJobOwner.Tests.ps1
+++ b/tests/Set-DbaAgentJobOwner.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaAgentOperator.Tests.ps1
+++ b/tests/Set-DbaAgentOperator.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaAgentSchedule.Tests.ps1
+++ b/tests/Set-DbaAgentSchedule.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/Set-DbaAvailabilityGroup.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaCmConnection.Tests.ps1
+++ b/tests/Set-DbaCmConnection.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaDbFileGroup.Tests.ps1
+++ b/tests/Set-DbaDbFileGroup.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaDbIdentity.Tests.ps1
+++ b/tests/Set-DbaDbIdentity.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Set-DbaDbQueryStoreOption.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaDbRecoveryModel.Tests.ps1
+++ b/tests/Set-DbaDbRecoveryModel.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaDbSchema.Tests.ps1
+++ b/tests/Set-DbaDbSchema.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaEndpoint.Tests.ps1
+++ b/tests/Set-DbaEndpoint.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaErrorLogConfig.Tests.ps1
+++ b/tests/Set-DbaErrorLogConfig.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -20,9 +17,6 @@ Describe $CommandName -Tag UnitTests {
                 "LogSize",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Set-DbaMaxMemory.Tests.ps1
+++ b/tests/Set-DbaMaxMemory.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         BeforeAll {

--- a/tests/Set-DbaPrivilege.Tests.ps1
+++ b/tests/Set-DbaPrivilege.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaRgWorkloadGroup.Tests.ps1
+++ b/tests/Set-DbaRgWorkloadGroup.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaSpConfigure.Tests.ps1
+++ b/tests/Set-DbaSpConfigure.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaTcpPort.Tests.ps1
+++ b/tests/Set-DbaTcpPort.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbaTempDbConfig.Tests.ps1
+++ b/tests/Set-DbaTempDbConfig.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbatoolsConfig.Tests.ps1
+++ b/tests/Set-DbatoolsConfig.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Set-DbatoolsInsecureConnection.Tests.ps1
+++ b/tests/Set-DbatoolsInsecureConnection.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Show-DbaDbList.Tests.ps1
+++ b/tests/Show-DbaDbList.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Show-DbaInstanceFileSystem.Tests.ps1
+++ b/tests/Show-DbaInstanceFileSystem.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Start-DbaAgentJob.Tests.ps1
+++ b/tests/Start-DbaAgentJob.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Start-DbaService.Tests.ps1
+++ b/tests/Start-DbaService.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -23,9 +20,6 @@ Describe $CommandName -Tag UnitTests {
                 "Credential",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Start-DbaTrace.Tests.ps1
+++ b/tests/Start-DbaTrace.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Stop-DbaAgentJob.Tests.ps1
+++ b/tests/Stop-DbaAgentJob.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Stop-DbaEndpoint.Tests.ps1
+++ b/tests/Stop-DbaEndpoint.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Stop-DbaPfDataCollectorSet.Tests.ps1
+++ b/tests/Stop-DbaPfDataCollectorSet.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Stop-DbaProcess.Tests.ps1
+++ b/tests/Stop-DbaProcess.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Stop-DbaService.Tests.ps1
+++ b/tests/Stop-DbaService.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Stop-DbaXESession.Tests.ps1
+++ b/tests/Stop-DbaXESession.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Stop-Function.Tests.ps1
+++ b/tests/Stop-Function.Tests.ps1
@@ -4,9 +4,6 @@ param(
     $CommandName = "Stop-Function",
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
-
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
 . "$PSScriptRoot\..\private\functions\flowcontrol\Stop-Function.ps1"
 
 Describe $CommandName -Tag UnitTests {

--- a/tests/Suspend-DbaAgDbDataMovement.Tests.ps1
+++ b/tests/Suspend-DbaAgDbDataMovement.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Sync-DbaLoginPermission.Tests.ps1
+++ b/tests/Sync-DbaLoginPermission.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Test-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/Test-DbaAvailabilityGroup.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Test-DbaComputerCertificateExpiration.Tests.ps1
+++ b/tests/Test-DbaComputerCertificateExpiration.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         BeforeAll {

--- a/tests/Test-DbaDbCollation.Tests.ps1
+++ b/tests/Test-DbaDbCollation.Tests.ps1
@@ -7,7 +7,7 @@ param(
 
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        It "Should only contain our specific parameters" {
+        It "Should have the expected parameters" {
             $command = Get-Command Test-DbaDbCollation
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(

--- a/tests/Test-DbaDbDataGeneratorConfig.Tests.ps1
+++ b/tests/Test-DbaDbDataGeneratorConfig.Tests.ps1
@@ -7,7 +7,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'FilePath', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        It "Should only contain our specific parameters" {
+        It "Should have the expected parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }

--- a/tests/Test-DbaDbDataMaskingConfig.Tests.ps1
+++ b/tests/Test-DbaDbDataMaskingConfig.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Test-DbaDbRecoveryModel.Tests.ps1
+++ b/tests/Test-DbaDbRecoveryModel.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe "$CommandName Unit Tests" -Tag "UnitTests" {
     Context "Parameter validation" {
-        It "Should only contain our specific parameters" {
+        It "Should have the expected parameters" {
             $command = Get-Command $CommandName
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(

--- a/tests/Test-DbaLinkedServerConnection.Tests.ps1
+++ b/tests/Test-DbaLinkedServerConnection.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Test-DbaLoginPassword.Tests.ps1
+++ b/tests/Test-DbaLoginPassword.Tests.ps1
@@ -4,9 +4,6 @@ param(
     $CommandName = "Test-DbaLoginPassword",
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
-
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
 . "$PSScriptRoot\..\private\functions\Get-PasswordHash.ps1"
 
 Describe $CommandName -Tag UnitTests {

--- a/tests/Test-DbaLsnChain.Tests.ps1
+++ b/tests/Test-DbaLsnChain.Tests.ps1
@@ -4,9 +4,6 @@ param(
     $CommandName = "Test-DbaLsnChain",
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
-
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
 . "$PSScriptRoot\..\private\functions\Test-DbaLsnChain.ps1"
 
 Describe $CommandName -Tag UnitTests {

--- a/tests/Test-DbaMaxDop.Tests.ps1
+++ b/tests/Test-DbaMaxDop.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Test-DbaMaxMemory.Tests.ps1
+++ b/tests/Test-DbaMaxMemory.Tests.ps1
@@ -5,12 +5,9 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag IntegrationTests {
     Context "Parameter validation" {
-        BeforeAll {
+        It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
@@ -19,9 +16,6 @@ Describe $CommandName -Tag IntegrationTests {
                 "Credential",
                 "EnableException"
             )
-        }
-
-        It "Should have the expected parameters" {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Test-DbaNetworkLatency.Tests.ps1
+++ b/tests/Test-DbaNetworkLatency.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Test-DbaOptimizeForAdHoc.Tests.ps1
+++ b/tests/Test-DbaOptimizeForAdHoc.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Test-DbaReplLatency.Tests.ps1
+++ b/tests/Test-DbaReplLatency.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Test-PSRemoting.Tests.ps1
+++ b/tests/Test-PSRemoting.Tests.ps1
@@ -4,9 +4,6 @@ param(
     $CommandName = "Test-PSRemoting",
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
-
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
 . "$PSScriptRoot\..\private\functions\Test-PSRemoting.ps1"
 
 Describe $CommandName -Tag UnitTests {

--- a/tests/Unregister-DbatoolsConfig.Tests.ps1
+++ b/tests/Unregister-DbatoolsConfig.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Update-DbaMaintenanceSolution.Tests.ps1
+++ b/tests/Update-DbaMaintenanceSolution.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Update-dbatools.Tests.ps1
+++ b/tests/Update-dbatools.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/Write-DbaDbTableData.Tests.ps1
+++ b/tests/Write-DbaDbTableData.Tests.ps1
@@ -5,9 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {

--- a/tests/appveyor.SQL2008R2SP2.ps1
+++ b/tests/appveyor.SQL2008R2SP2.ps1
@@ -1,5 +1,5 @@
 $indent = '...'
-Write-Host -Object "$indent Running $PSCommandpath" -ForegroundColor DarkGreen
+Write-Host -Object "$indent Running $PSCommandPath" -ForegroundColor DarkGreen
 
 # This script spins up the 2008R2SP2 instance and the relative setup
 

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -1,5 +1,5 @@
 $indent = '...'
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor DarkGreen
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor DarkGreen
 
 # This script spins up the 2016 instance and the relative setup
 

--- a/tests/appveyor.SQL2017.ps1
+++ b/tests/appveyor.SQL2017.ps1
@@ -1,5 +1,5 @@
 $indent = '...'
-Write-Host -Object "$indent Running $PSCommandpath" -ForegroundColor DarkGreen
+Write-Host -Object "$indent Running $PSCommandPath" -ForegroundColor DarkGreen
 
 # This script spins up the 2016 instance and the relative setup
 

--- a/tests/dbatools.Tests.ps1
+++ b/tests/dbatools.Tests.ps1
@@ -1,4 +1,4 @@
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 $Path = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ModulePath = (Get-Item $Path).Parent.FullName
 $ModuleName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"


### PR DESCRIPTION
Removed repeated Write-Host and Get-TestConfig statements from numerous test files to streamline test initialization. This reduces noise and improves maintainability of the test suite.