### PR TITLE
Fix usage of EnableException  in pester 5 test

### DIFF
--- a/tests/Add-DbaAgDatabase.Tests.ps1
+++ b/tests/Add-DbaAgDatabase.Tests.ps1
@@ -81,7 +81,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When adding AG database" {

--- a/tests/Add-DbaAgListener.Tests.ps1
+++ b/tests/Add-DbaAgListener.Tests.ps1
@@ -74,7 +74,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When creating a listener" {

--- a/tests/Add-DbaAgReplica.Tests.ps1
+++ b/tests/Add-DbaAgReplica.Tests.ps1
@@ -72,7 +72,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $primaryAgName -Confirm:$false -ErrorAction SilentlyContinue
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When adding AG replicas" {

--- a/tests/Add-DbaDbRoleMember.Tests.ps1
+++ b/tests/Add-DbaDbRoleMember.Tests.ps1
@@ -93,7 +93,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname -Confirm:$false
         $null = Remove-DbaLogin -SqlInstance $TestConfig.instance2 -Login $user1, $user2 -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When adding a user to a role" {

--- a/tests/Add-DbaExtendedProperty.Tests.ps1
+++ b/tests/Add-DbaExtendedProperty.Tests.ps1
@@ -51,7 +51,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup the test database
         $null = $db | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When adding extended properties" {

--- a/tests/Add-DbaRegServer.Tests.ps1
+++ b/tests/Add-DbaRegServer.Tests.ps1
@@ -52,7 +52,7 @@ Describe $CommandName -Tag IntegrationTests {
         Get-DbaRegServer -SqlInstance $TestConfig.instance1, $TestConfig.instance2 | Where-Object Name -match dbatoolsci | Remove-DbaRegServer -Confirm:$false
         Get-DbaRegServerGroup -SqlInstance $TestConfig.instance1, $TestConfig.instance2 | Where-Object Name -match dbatoolsci | Remove-DbaRegServerGroup -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When adding a registered server" {

--- a/tests/Add-DbaRegServerGroup.Tests.ps1
+++ b/tests/Add-DbaRegServerGroup.Tests.ps1
@@ -46,7 +46,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created objects.
         Get-DbaRegServerGroup -SqlInstance $TestConfig.instance1 | Where-Object Name -match dbatoolsci | Remove-DbaRegServerGroup -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When adding a registered server group" {

--- a/tests/Add-DbaServerRoleMember.Tests.ps1
+++ b/tests/Add-DbaServerRoleMember.Tests.ps1
@@ -60,7 +60,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaLogin @splatRemoveLogin
         $null = Remove-DbaServerRole -SqlInstance $TestConfig.instance2 -ServerRole $customServerRole -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Functionality" {

--- a/tests/Backup-DbaComputerCertificate.Tests.ps1
+++ b/tests/Backup-DbaComputerCertificate.Tests.ps1
@@ -57,7 +57,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Certificate is backed up properly" {

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -75,7 +75,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $DestBackupDir -Force -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Properly backups all databases" {

--- a/tests/Backup-DbaDbCertificate.Tests.ps1
+++ b/tests/Backup-DbaDbCertificate.Tests.ps1
@@ -67,7 +67,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Can backup a database certificate" {

--- a/tests/Backup-DbaDbMasterKey.Tests.ps1
+++ b/tests/Backup-DbaDbMasterKey.Tests.ps1
@@ -71,7 +71,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Can backup a database master key" {

--- a/tests/Backup-DbaServiceMasterKey.Tests.ps1
+++ b/tests/Backup-DbaServiceMasterKey.Tests.ps1
@@ -45,7 +45,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Can backup a service master key" {

--- a/tests/ConvertTo-DbaXESession.Tests.ps1
+++ b/tests/ConvertTo-DbaXESession.Tests.ps1
@@ -132,7 +132,7 @@ select TraceID=@TraceID
         $null = Remove-DbaTrace @splatRemoveTrace
         Remove-Item C:\windows\temp\temptrace.trc -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Test Trace Conversion" {

--- a/tests/Copy-DbaAgentAlert.Tests.ps1
+++ b/tests/Copy-DbaAgentAlert.Tests.ps1
@@ -83,7 +83,7 @@ Describe $CommandName -Tag IntegrationTests {
         $serverCleanup3 = Connect-DbaInstance -SqlInstance $TestConfig.instance3 -Database master
         $serverCleanup3.Query("EXEC msdb.dbo.sp_delete_alert @name=N'$($alert1)'")
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying alerts" {

--- a/tests/Copy-DbaAgentJob.Tests.ps1
+++ b/tests/Copy-DbaAgentJob.Tests.ps1
@@ -66,7 +66,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Parameter validation" {

--- a/tests/Copy-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Copy-DbaAgentJobCategory.Tests.ps1
@@ -47,7 +47,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaAgentJobCategory -SqlInstance $TestConfig.instance2 -Category "dbatoolsci test category" -Confirm:$false
         $null = Remove-DbaAgentJobCategory -SqlInstance $TestConfig.instance3 -Category "dbatoolsci test category" -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Parameter validation" {

--- a/tests/Copy-DbaAgentOperator.Tests.ps1
+++ b/tests/Copy-DbaAgentOperator.Tests.ps1
@@ -62,7 +62,7 @@ Describe $CommandName -Tag IntegrationTests {
         $sqlDeleteOp2Dest = "EXEC msdb.dbo.sp_delete_operator @name=N'$operatorName2'"
         $null = $destCleanupServer.Query($sqlDeleteOp2Dest)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying operators" {

--- a/tests/Copy-DbaAgentProxy.Tests.ps1
+++ b/tests/Copy-DbaAgentProxy.Tests.ps1
@@ -64,7 +64,7 @@ Describe $CommandName -Tag IntegrationTests {
         $sql = "DROP CREDENTIAL dbatoolsci_credential"
         $destServer.Query($sql)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying agent proxy between instances" {

--- a/tests/Copy-DbaAgentSchedule.Tests.ps1
+++ b/tests/Copy-DbaAgentSchedule.Tests.ps1
@@ -53,7 +53,7 @@ Describe $CommandName -Tag IntegrationTests {
         $sql = "EXEC msdb.dbo.sp_delete_schedule @schedule_name = 'dbatoolsci_DailySchedule'"
         $server.Query($sql)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying agent schedule between instances" {

--- a/tests/Copy-DbaBackupDevice.Tests.ps1
+++ b/tests/Copy-DbaBackupDevice.Tests.ps1
@@ -67,7 +67,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying backup device between instances" {

--- a/tests/Copy-DbaCredential.Tests.ps1
+++ b/tests/Copy-DbaCredential.Tests.ps1
@@ -93,7 +93,7 @@ Describe $CommandName -Tag IntegrationTests {
             $null = Invoke-Command2 -ScriptBlock { net user $args /delete *>&1 } -ArgumentList $login -ComputerName $TestConfig.instance2
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Create new credential" {

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -109,7 +109,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
         Remove-DbaDatabase @splatRemoveSupport -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Support databases are excluded when AllDatabase selected" {

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -80,7 +80,7 @@ Describe $CommandName -Tag IntegrationTests {
             # Remove the backup directory.
             Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Successfully copies a certificate" -Skip:$true {

--- a/tests/Copy-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Copy-DbaDbQueryStoreOption.Tests.ps1
@@ -42,7 +42,7 @@ Describe $CommandName -Tag IntegrationTests {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
             $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Copy the query store options from one db to another on the same instance" {

--- a/tests/Copy-DbaDbTableData.Tests.ps1
+++ b/tests/Copy-DbaDbTableData.Tests.ps1
@@ -82,7 +82,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $destinationDb.Query("DROP TABLE dbo.dbatoolsci_example")
         $null = $sourceDb.Query("DROP TABLE tempdb.dbo.dbatoolsci_willexist")
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying table data within same instance" {

--- a/tests/Copy-DbaDbViewData.Tests.ps1
+++ b/tests/Copy-DbaDbViewData.Tests.ps1
@@ -104,7 +104,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         Remove-TempObjects $db, $db2
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "copies the view data" {

--- a/tests/Copy-DbaEndpoint.Tests.ps1
+++ b/tests/Copy-DbaEndpoint.Tests.ps1
@@ -60,7 +60,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance2 -Type DatabaseMirroring | Remove-DbaEndpoint
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying endpoints between instances" {

--- a/tests/Copy-DbaInstanceTrigger.Tests.ps1
+++ b/tests/Copy-DbaInstanceTrigger.Tests.ps1
@@ -59,7 +59,7 @@ Describe $CommandName -Tag IntegrationTests {
             # Ignore cleanup errors
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying server triggers between instances" {

--- a/tests/Copy-DbaLinkedServer.Tests.ps1
+++ b/tests/Copy-DbaLinkedServer.Tests.ps1
@@ -53,7 +53,7 @@ Describe $CommandName -Tag IntegrationTests {
         $server1.Query($dropSql)
         $server2.Query($dropSql)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying linked server with the same properties" {

--- a/tests/Copy-DbaLogin.Tests.ps1
+++ b/tests/Copy-DbaLogin.Tests.ps1
@@ -93,7 +93,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaLogin -SqlInstance $TestConfig.instance1, $TestConfig.instance2 -Login 'claudio', 'port', 'tester'
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Copy login with the same properties." {

--- a/tests/Copy-DbaRegServer.Tests.ps1
+++ b/tests/Copy-DbaRegServer.Tests.ps1
@@ -67,7 +67,7 @@ Describe $CommandName -Tag IntegrationTests {
         $destGroupStore = $destDbStore.ServerGroups[$groupName]
         $destGroupStore.Drop()
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying registered servers" {

--- a/tests/Copy-DbaResourceGovernor.Tests.ps1
+++ b/tests/Copy-DbaResourceGovernor.Tests.ps1
@@ -75,7 +75,7 @@ Describe $CommandName -Tag IntegrationTests {
         Invoke-DbaQuery @splatCleanup -Query "DROP RESOURCE POOL [dbatoolsci_offhoursprocessing];ALTER RESOURCE GOVERNOR RECONFIGURE" -ErrorAction SilentlyContinue
         Invoke-DbaQuery @splatCleanup -Query "DROP RESOURCE POOL [dbatoolsci_prod];ALTER RESOURCE GOVERNOR RECONFIGURE" -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying resource governor settings" {

--- a/tests/Copy-DbaStartupProcedure.Tests.ps1
+++ b/tests/Copy-DbaStartupProcedure.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created objects.
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Database "master" -Query "DROP PROCEDURE dbatoolsci_test_startup" -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying startup procedures" {

--- a/tests/Disable-DbaAgHadr.Tests.ps1
+++ b/tests/Disable-DbaAgHadr.Tests.ps1
@@ -37,7 +37,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Re-enable HADR for future tests
         $null = Enable-DbaAgHadr -SqlInstance $TestConfig.instance3 -Force
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When disabling HADR" {

--- a/tests/Disable-DbaFilestream.Tests.ps1
+++ b/tests/Disable-DbaFilestream.Tests.ps1
@@ -42,7 +42,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Restore the original FileStream level
         Set-DbaFilestream -SqlInstance $TestConfig.instance1 -FileStreamLevel $originalFileStream.InstanceAccessLevel -Force
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When changing FileStream Level" {

--- a/tests/Disable-DbaHideInstance.Tests.ps1
+++ b/tests/Disable-DbaHideInstance.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag IntegrationTests {
 
             # No specific cleanup needed for this test
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Returns result with HideInstance set to false" {

--- a/tests/Disable-DbaStartupProcedure.Tests.ps1
+++ b/tests/Disable-DbaStartupProcedure.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Clean up test objects
         $null = $server.Query("DROP PROCEDURE $startupProc", $dbname)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When disabling a startup procedure" {

--- a/tests/Disable-DbaTraceFlag.Tests.ps1
+++ b/tests/Disable-DbaTraceFlag.Tests.ps1
@@ -53,7 +53,7 @@ Describe $CommandName -Tag IntegrationTests {
             $server.Query("DBCC TRACEON($safeTraceFlag,-1) WITH NO_INFOMSGS")
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When disabling trace flags" {

--- a/tests/Disconnect-DbaInstance.Tests.ps1
+++ b/tests/Disconnect-DbaInstance.Tests.ps1
@@ -38,7 +38,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup - disconnect any remaining connections
         $null = Get-DbaConnectedInstance | Disconnect-DbaInstance
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When disconnecting a server" {

--- a/tests/Dismount-DbaDatabase.Tests.ps1
+++ b/tests/Dismount-DbaDatabase.Tests.ps1
@@ -51,7 +51,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Mount-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbName -FileStructure $fileStructure
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbName | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When detaching a single database" {

--- a/tests/Enable-DbaAgHadr.Tests.ps1
+++ b/tests/Enable-DbaAgHadr.Tests.ps1
@@ -37,7 +37,7 @@ Describe $CommandName -Tag IntegrationTests {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
         $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When enabling HADR" {

--- a/tests/Enable-DbaDbEncryption.Tests.ps1
+++ b/tests/Enable-DbaDbEncryption.Tests.ps1
@@ -69,7 +69,7 @@ Describe $CommandName -Tag IntegrationTests {
             $masterkey | Remove-DbaDbMasterKey -ErrorAction SilentlyContinue
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When enabling encryption via pipeline" {

--- a/tests/Enable-DbaFilestream.Tests.ps1
+++ b/tests/Enable-DbaFilestream.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
             $null = Enable-DbaFilestream -SqlInstance $TestConfig.instance1 -FileStreamLevel $originalFileStream.InstanceAccessLevel -WarningAction SilentlyContinue
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When changing FileStream Level" {

--- a/tests/Enable-DbaForceNetworkEncryption.Tests.ps1
+++ b/tests/Enable-DbaForceNetworkEncryption.Tests.ps1
@@ -33,7 +33,7 @@ Describe $CommandName -Tag IntegrationTests {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When enabling force network encryption" {

--- a/tests/Enable-DbaStartupProcedure.Tests.ps1
+++ b/tests/Enable-DbaStartupProcedure.Tests.ps1
@@ -47,7 +47,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created objects.
         $null = $server.Query("DROP PROCEDURE $startupProc", $dbname)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When enabling a startup procedure" {

--- a/tests/Enable-DbaTraceFlag.Tests.ps1
+++ b/tests/Enable-DbaTraceFlag.Tests.ps1
@@ -47,7 +47,7 @@ Describe $CommandName -Tag IntegrationTests {
             $testInstance.Query("DBCC TRACEOFF($safeTraceFlag,-1)")
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When enabling a trace flag" {

--- a/tests/Expand-DbaDbLogFile.Tests.ps1
+++ b/tests/Expand-DbaDbLogFile.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance1 -Database $db1Name
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Ensure command functionality" {

--- a/tests/Export-DbaBinaryFile.Tests.ps1
+++ b/tests/Export-DbaBinaryFile.Tests.ps1
@@ -49,7 +49,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the export directory.
         Remove-Item -Path $exportPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When exporting binary files from database" {

--- a/tests/Export-DbaCredential.Tests.ps1
+++ b/tests/Export-DbaCredential.Tests.ps1
@@ -88,7 +88,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Should export all credentials" {

--- a/tests/Export-DbaDacPackage.Tests.ps1
+++ b/tests/Export-DbaDacPackage.Tests.ps1
@@ -94,7 +94,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $testFolder -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     # See https://github.com/dataplat/dbatools/issues/7038

--- a/tests/Export-DbaDbTableData.Tests.ps1
+++ b/tests/Export-DbaDbTableData.Tests.ps1
@@ -56,7 +56,7 @@ Describe $CommandName -Tag IntegrationTests {
             $null = 1
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When exporting table data" {

--- a/tests/Export-DbaDiagnosticQuery.Tests.ps1
+++ b/tests/Export-DbaDiagnosticQuery.Tests.ps1
@@ -45,7 +45,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Verifying output" {

--- a/tests/Export-DbaPfDataCollectorSetTemplate.Tests.ps1
+++ b/tests/Export-DbaPfDataCollectorSetTemplate.Tests.ps1
@@ -43,7 +43,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup
         $null = Get-DbaPfDataCollectorSet -CollectorSet "Long Running Queries" | Remove-DbaPfDataCollectorSet -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Verifying command returns all the required results" {

--- a/tests/Export-DbaScript.Tests.ps1
+++ b/tests/Export-DbaScript.Tests.ps1
@@ -49,7 +49,7 @@ Describe $CommandName -Tag IntegrationTests {
             # Remove the temp directory.
             Remove-Item -Path $tempPath -Recurse -ErrorAction SilentlyContinue
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should export some text matching create table" {

--- a/tests/Export-DbaServerRole.Tests.ps1
+++ b/tests/Export-DbaServerRole.Tests.ps1
@@ -72,7 +72,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove test files
         Remove-Item -Path $outputFile -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Check if output file was created" {

--- a/tests/Export-DbaSysDbUserObject.Tests.ps1
+++ b/tests/Export-DbaSysDbUserObject.Tests.ps1
@@ -75,7 +75,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "works as expected with passthru" {

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -117,7 +117,7 @@ Describe $CommandName -Tag IntegrationTests {
         Remove-Item -Path $outputFile -ErrorAction SilentlyContinue
         Remove-Item -Path $outputFile2 -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Check if output file was created" {

--- a/tests/Export-DbaXESession.Tests.ps1
+++ b/tests/Export-DbaXESession.Tests.ps1
@@ -59,7 +59,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Check if output file was created" {

--- a/tests/Export-DbaXESessionTemplate.Tests.ps1
+++ b/tests/Export-DbaXESessionTemplate.Tests.ps1
@@ -57,7 +57,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the temporary directory and any exported files.
         Remove-Item -Path $tempPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Test Importing Session Template" {

--- a/tests/Find-DbaDbDisabledIndex.Tests.ps1
+++ b/tests/Find-DbaDbDisabledIndex.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag IntegrationTests {
 
             $db1, $db2 | Remove-DbaDatabase -Confirm:$false
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should find disabled index: $indexName" {

--- a/tests/Find-DbaDbDuplicateIndex.Tests.ps1
+++ b/tests/Find-DbaDbDuplicateIndex.Tests.ps1
@@ -76,7 +76,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
         Remove-DbaDatabase @splatRemove -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets back some results" {

--- a/tests/Find-DbaDbGrowthEvent.Tests.ps1
+++ b/tests/Find-DbaDbGrowthEvent.Tests.ps1
@@ -63,7 +63,7 @@ DBCC SHRINKFILE ($($databaseName1)_Log, TRUNCATEONLY);
 
             $db1 | Remove-DbaDatabase -Confirm:$false -ErrorAction SilentlyContinue
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should find auto growth events in the default trace" {

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -80,7 +80,7 @@ Describe $CommandName -Tag IntegrationTests {
             Remove-Item "C:\$($backupFile.BackupFile)" -Force -ErrorAction SilentlyContinue
             Remove-Item $tmpBackupPath3 -Recurse -Force -ErrorAction SilentlyContinue
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
         It "Has the correct properties" {
             $null = Dismount-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname -Force

--- a/tests/Find-DbaSimilarTable.Tests.ps1
+++ b/tests/Find-DbaSimilarTable.Tests.ps1
@@ -49,7 +49,7 @@ Describe $CommandName -Tag IntegrationTests {
             $db.Query("DROP TABLE dbatoolsci_table1")
             $db.Query("DROP TABLE dbatoolsci_table2")
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "returns at least two rows" {

--- a/tests/Find-DbaStoredProcedure.Tests.ps1
+++ b/tests/Find-DbaStoredProcedure.Tests.ps1
@@ -117,7 +117,7 @@ AS
             }
             $null = Remove-DbaDatabase @splatRemoveDb
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should find a specific StoredProcedure named sp_dbatoolsci_custom" {

--- a/tests/Get-DbaAgDatabase.Tests.ps1
+++ b/tests/Get-DbaAgDatabase.Tests.ps1
@@ -73,7 +73,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "When getting AG database" {
         It "Returns correct database information" {

--- a/tests/Get-DbaAgListener.Tests.ps1
+++ b/tests/Get-DbaAgListener.Tests.ps1
@@ -59,7 +59,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agListenerName
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When getting AG listeners" {

--- a/tests/Get-DbaAgReplica.Tests.ps1
+++ b/tests/Get-DbaAgReplica.Tests.ps1
@@ -52,7 +52,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agName
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "gets ag replicas" {

--- a/tests/Get-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Get-DbaAgentJobCategory.Tests.ps1
@@ -40,7 +40,7 @@ Describe $CommandName -Tag IntegrationTests {
 
             $null = Remove-DbaAgentJobCategory -SqlInstance $TestConfig.instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should get at least 2 categories" {

--- a/tests/Get-DbaAgentOperator.Tests.ps1
+++ b/tests/Get-DbaAgentOperator.Tests.ps1
@@ -46,7 +46,7 @@ Describe $CommandName -Tag IntegrationTests {
         $sql = "EXEC msdb.dbo.sp_delete_operator @name=N'dbatoolsci_operator2'"
         $server.Query($sql)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Get back some operators" {

--- a/tests/Get-DbaAgentProxy.Tests.ps1
+++ b/tests/Get-DbaAgentProxy.Tests.ps1
@@ -77,7 +77,7 @@ Describe $CommandName -Tag IntegrationTests {
             $proxy.DROP()
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets the list of Proxy" {

--- a/tests/Get-DbaAgentSchedule.Tests.ps1
+++ b/tests/Get-DbaAgentSchedule.Tests.ps1
@@ -154,7 +154,7 @@ Describe $CommandName -Tag IntegrationTests {
             $schedules.DROP()
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets the list of Schedules" {

--- a/tests/Get-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/Get-DbaAvailabilityGroup.Tests.ps1
@@ -53,7 +53,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agName
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When retrieving availability groups" {

--- a/tests/Get-DbaBackupInformation.Tests.ps1
+++ b/tests/Get-DbaBackupInformation.Tests.ps1
@@ -112,7 +112,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname, $dbname2, $dbname3 | Remove-DbaDatabase
         Remove-Item -Path $DestBackupDir, $DestBackupDirOla -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Get history for all database" {

--- a/tests/Get-DbaBinaryFileTable.Tests.ps1
+++ b/tests/Get-DbaBinaryFileTable.Tests.ps1
@@ -70,7 +70,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "returns a table" {

--- a/tests/Get-DbaCredential.Tests.ps1
+++ b/tests/Get-DbaCredential.Tests.ps1
@@ -74,7 +74,7 @@ Describe $CommandName -Tag IntegrationTests {
             $null = Invoke-Command2 -ScriptBlock { net user $args /delete *>&1 } -ArgumentList $login -ComputerName $TestConfig.instance2
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Get credentials" {

--- a/tests/Get-DbaCustomError.Tests.ps1
+++ b/tests/Get-DbaCustomError.Tests.ps1
@@ -50,7 +50,7 @@ Describe $CommandName -Tag IntegrationTests {
         $sql = "EXEC msdb.dbo.sp_dropmessage 54321;"
         $server.Query($sql)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets the custom errors" {

--- a/tests/Get-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/Get-DbaDbAsymmetricKey.Tests.ps1
@@ -72,7 +72,7 @@ Describe $CommandName -Tag IntegrationTests {
             # Cleanup all created objects.
             $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $databaseName -Confirm:$false
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should Create new key in GetAsKey called test4" {

--- a/tests/Get-DbaDbBackupHistory.Tests.ps1
+++ b/tests/Get-DbaDbBackupHistory.Tests.ps1
@@ -73,7 +73,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname, $dbnameForked | Remove-DbaDatabase -Confirm:$false
         Remove-Item -Path $DestBackupDir -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Get last history for single database" {

--- a/tests/Get-DbaDbCertificate.Tests.ps1
+++ b/tests/Get-DbaDbCertificate.Tests.ps1
@@ -57,7 +57,7 @@ Describe $CommandName -Tag IntegrationTests {
             if ($tempdbmasterkey) { $tempdbmasterkey | Remove-DbaDbMasterKey -Confirm:$false }
             if ($masterKey) { $masterkey | Remove-DbaDbMasterKey -Confirm:$false }
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Returns database certificate created in default, master database" {

--- a/tests/Get-DbaDbCheckConstraint.Tests.ps1
+++ b/tests/Get-DbaDbCheckConstraint.Tests.ps1
@@ -52,7 +52,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup test database
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $testDbName | Remove-DbaDatabase -Confirm:$false -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Get-DbaDbCompression.Tests.ps1
+++ b/tests/Get-DbaDbCompression.Tests.ps1
@@ -46,7 +46,7 @@ Describe $CommandName -Tag IntegrationTests {
         Get-DbaProcess -SqlInstance $TestConfig.instance2 -Database $dbname | Stop-DbaProcess -WarningAction SilentlyContinue
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "Command handles heaps and clustered indexes" {
         BeforeAll {

--- a/tests/Get-DbaDbEncryptionKey.Tests.ps1
+++ b/tests/Get-DbaDbEncryptionKey.Tests.ps1
@@ -82,7 +82,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Get-DbaDbExtentDiff.Tests.ps1
+++ b/tests/Get-DbaDbExtentDiff.Tests.ps1
@@ -45,7 +45,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created object.
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets Changed Extents for Multiple Databases" {

--- a/tests/Get-DbaDbFeatureUsage.Tests.ps1
+++ b/tests/Get-DbaDbFeatureUsage.Tests.ps1
@@ -47,7 +47,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $server.Query("DROP Database [$dbname]")
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets Feature Usage" {

--- a/tests/Get-DbaDbFileGroup.Tests.ps1
+++ b/tests/Get-DbaDbFileGroup.Tests.ps1
@@ -58,7 +58,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Returns values for Instance" {

--- a/tests/Get-DbaDbForeignKey.Tests.ps1
+++ b/tests/Get-DbaDbForeignKey.Tests.ps1
@@ -49,7 +49,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Get-DbaDbLogSpace.Tests.ps1
+++ b/tests/Get-DbaDbLogSpace.Tests.ps1
@@ -57,7 +57,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Get-DbaDbMailAccount.Tests.ps1
+++ b/tests/Get-DbaDbMailAccount.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag IntegrationTests {
             @account_name = '$accountName';"
         $server.Query($mailAccountSettings)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets DbMail Account" {

--- a/tests/Get-DbaDbMailConfig.Tests.ps1
+++ b/tests/Get-DbaDbMailConfig.Tests.ps1
@@ -51,7 +51,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         # No specific cleanup needed for DbMail config tests
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets DbMail Settings" {

--- a/tests/Get-DbaDbMailHistory.Tests.ps1
+++ b/tests/Get-DbaDbMailHistory.Tests.ps1
@@ -83,7 +83,7 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query("DELETE FROM msdb.dbo.sysmail_profile WHERE profile_id = '$profile_id'")
         $server.Query("DELETE FROM msdb.dbo.sysmail_mailitems WHERE profile_id = '$profile_id'")
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets Db Mail History" {

--- a/tests/Get-DbaDbMailLog.Tests.ps1
+++ b/tests/Get-DbaDbMailLog.Tests.ps1
@@ -51,7 +51,7 @@ Describe $CommandName -Tag IntegrationTests {
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $server.Query("DELETE FROM msdb.[dbo].[sysmail_log] WHERE last_mod_user = 'dbatools\dbatoolssci'")
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets Db Mail Log" {

--- a/tests/Get-DbaDbMailProfile.Tests.ps1
+++ b/tests/Get-DbaDbMailProfile.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
             @profile_name='$profilename';"
         $server.Query($mailProfile)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets DbMail Profile" {

--- a/tests/Get-DbaDbMailServer.Tests.ps1
+++ b/tests/Get-DbaDbMailServer.Tests.ps1
@@ -56,7 +56,7 @@ Describe $CommandName -Tag IntegrationTests {
             @account_name = '$mailAccountName';"
         $cleanupServer.Query($mailAccountSettings)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets DbMailServer" {

--- a/tests/Get-DbaDbMirror.Tests.ps1
+++ b/tests/Get-DbaDbMirror.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Database $db1, $db2 | Remove-DbaDbMirror -Confirm:$false
         $null = Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Database $db1, $db2 -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "returns more than one database" -Skip:$true {

--- a/tests/Get-DbaDbObjectTrigger.Tests.ps1
+++ b/tests/Get-DbaDbObjectTrigger.Tests.ps1
@@ -73,7 +73,7 @@ CREATE TRIGGER $triggerviewname
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets Table Trigger" {

--- a/tests/Get-DbaDbOrphanUser.Tests.ps1
+++ b/tests/Get-DbaDbOrphanUser.Tests.ps1
@@ -59,7 +59,7 @@ CREATE USER [dbatoolsci_orphan3] FROM LOGIN [dbatoolsci_orphan3];
         $null = Remove-DbaLogin -SqlInstance $server -Login dbatoolsci_orphan1, dbatoolsci_orphan2, dbatoolsci_orphan3 -Force -ErrorAction SilentlyContinue
         $null = Remove-DbaDatabase -SqlInstance $server -Database dbatoolsci_orphan -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When checking for orphan users" {

--- a/tests/Get-DbaDbPageInfo.Tests.ps1
+++ b/tests/Get-DbaDbPageInfo.Tests.ps1
@@ -67,7 +67,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname -Confirm:$false -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "Count Pages" {
         It "returns the proper results" {

--- a/tests/Get-DbaDbPartitionScheme.Tests.ps1
+++ b/tests/Get-DbaDbPartitionScheme.Tests.ps1
@@ -69,7 +69,7 @@ DROP PARTITION FUNCTION [$PFName];
         }
         Invoke-DbaQuery @splatDrop -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Partition Schemes are correctly located" {

--- a/tests/Get-DbaDbRestoreHistory.Tests.ps1
+++ b/tests/Get-DbaDbRestoreHistory.Tests.ps1
@@ -89,7 +89,7 @@ Describe $CommandName -Tag IntegrationTests {
         Remove-Item -Path $logBackup.BackupPath -Force -ErrorAction SilentlyContinue
         Remove-Item -Path $diffBackup.BackupPath -Force -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "Preparation" {
         It "Should have prepared" {

--- a/tests/Get-DbaDbRoleMember.Tests.ps1
+++ b/tests/Get-DbaDbRoleMember.Tests.ps1
@@ -45,7 +45,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         # No specific cleanup needed for this test as we're only reading data
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Functionality" {

--- a/tests/Get-DbaDbSchema.Tests.ps1
+++ b/tests/Get-DbaDbSchema.Tests.ps1
@@ -66,7 +66,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $newDbs | Remove-DbaDatabase -Confirm:$false
         $null = $logins | Remove-DbaLogin -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "commands work as expected" {

--- a/tests/Get-DbaDbSequence.Tests.ps1
+++ b/tests/Get-DbaDbSequence.Tests.ps1
@@ -52,7 +52,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = $newDb, $newDb2 | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "commands work as expected" {

--- a/tests/Get-DbaDbServiceBrokerQueue.Tests.ps1
+++ b/tests/Get-DbaDbServiceBrokerQueue.Tests.ps1
@@ -45,7 +45,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $server.Query("DROP QUEUE $queuename", "tempdb")
         $null = $server.Query("DROP PROCEDURE $procname", "tempdb")
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets the service broker queue" {

--- a/tests/Get-DbaDbSharePoint.Tests.ps1
+++ b/tests/Get-DbaDbSharePoint.Tests.ps1
@@ -86,7 +86,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $spdb -Confirm:$false -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command gets SharePoint Databases" {

--- a/tests/Get-DbaDbSnapshot.Tests.ps1
+++ b/tests/Get-DbaDbSnapshot.Tests.ps1
@@ -57,7 +57,7 @@ Describe $CommandName -Tag IntegrationTests {
             Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -ErrorAction SilentlyContinue -Confirm:$false
             Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -ErrorAction SilentlyContinue
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Gets all snapshots by default" {

--- a/tests/Get-DbaDbSpace.Tests.ps1
+++ b/tests/Get-DbaDbSpace.Tests.ps1
@@ -46,7 +46,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created objects.
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbName -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
 

--- a/tests/Get-DbaDbState.Tests.ps1
+++ b/tests/Get-DbaDbState.Tests.ps1
@@ -86,7 +86,7 @@ Describe $CommandName -Tag IntegrationTests {
             }
             Remove-DbaDatabase @splatRemoveDbCleanup -ErrorAction SilentlyContinue
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Waits for BeforeAll to finish" -Skip:(-not $setupright) {

--- a/tests/Get-DbaDbStoredProcedure.Tests.ps1
+++ b/tests/Get-DbaDbStoredProcedure.Tests.ps1
@@ -53,7 +53,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $db1 | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Get-DbaDbSynonym.Tests.ps1
+++ b/tests/Get-DbaDbSynonym.Tests.ps1
@@ -52,7 +52,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname, $dbname2 -Confirm:$false
         $null = Remove-DbaDbSynonym -SqlInstance $TestConfig.instance2 -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Functionality" {

--- a/tests/Get-DbaDbTable.Tests.ps1
+++ b/tests/Get-DbaDbTable.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance1 -Database $dbname -Query "drop table $tablename"
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Should get the table" {

--- a/tests/Get-DbaDbUdf.Tests.ps1
+++ b/tests/Get-DbaDbUdf.Tests.ps1
@@ -67,7 +67,7 @@ END;
         $DropTestUDFunction = "DROP FUNCTION dbo.dbatoolssci_ISOweek;"
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query $DropTestUDFunction -Database master -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "User Functions are correctly located" {

--- a/tests/Get-DbaDbView.Tests.ps1
+++ b/tests/Get-DbaDbView.Tests.ps1
@@ -55,7 +55,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $server.Query("DROP VIEW [$schemaName].$viewNameWithSchema", "tempdb")
         $null = $server.Query("DROP SCHEMA [$schemaName]", "tempdb")
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Get-DbaDbVirtualLogFile.Tests.ps1
+++ b/tests/Get-DbaDbVirtualLogFile.Tests.ps1
@@ -46,7 +46,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $testDbName
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Get-DbaDbccMemoryStatus.Tests.ps1
+++ b/tests/Get-DbaDbccMemoryStatus.Tests.ps1
@@ -49,7 +49,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         # No cleanup needed for this read-only command
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Validate standard output" {

--- a/tests/Get-DbaDbccSessionBuffer.Tests.ps1
+++ b/tests/Get-DbaDbccSessionBuffer.Tests.ps1
@@ -40,7 +40,7 @@ Describe $CommandName -Tag IntegrationTests {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
         $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Validate standard output for all databases" {

--- a/tests/Get-DbaDbccStatistic.Tests.ps1
+++ b/tests/Get-DbaDbccStatistic.Tests.ps1
@@ -57,7 +57,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Validate standard output for StatHeader option" {

--- a/tests/Get-DbaEstimatedCompletionTime.Tests.ps1
+++ b/tests/Get-DbaEstimatedCompletionTime.Tests.ps1
@@ -66,7 +66,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:$(-not $TestConfig.BigDatabase
         $null = Get-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job checkdbTestJob | Remove-DbaAgentJob -Confirm:$false
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database checkdbTestDatabase | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets correct results" {

--- a/tests/Get-DbaInstanceTrigger.Tests.ps1
+++ b/tests/Get-DbaInstanceTrigger.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup the created triggers
         $sql = "DROP TRIGGER [$trigger1Name] ON ALL SERVER;DROP TRIGGER [$trigger2Name] ON ALL SERVER"
         $instance.query($sql)
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When retrieving instance triggers" {

--- a/tests/Get-DbaLastBackup.Tests.ps1
+++ b/tests/Get-DbaLastBackup.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
         Remove-Item -Path $backupdir -Recurse -Force -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Get null history for database" {

--- a/tests/Get-DbaLogin.Tests.ps1
+++ b/tests/Get-DbaLogin.Tests.ps1
@@ -53,7 +53,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaLogin -SqlInstance $TestConfig.instance1 -Login "testlogin1_$random", "testlogin2_$random" -Confirm:$false -Force
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Does sql instance have a SA account" {

--- a/tests/Get-DbaPbmCondition.Tests.ps1
+++ b/tests/Get-DbaPbmCondition.Tests.ps1
@@ -62,7 +62,7 @@ Describe $CommandName -Tag IntegrationTests {
         $dropQuery = "EXEC msdb.dbo.sp_syspolicy_delete_condition @condition_id=$conditionId"
         $null = $server.Query($dropQuery)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command returns results" {

--- a/tests/Get-DbaWaitResource.Tests.ps1
+++ b/tests/Get-DbaWaitResource.Tests.ps1
@@ -52,7 +52,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $WaitResourceDB | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Test getting a Page resource" {

--- a/tests/Install-DbaDarlingData.Tests.ps1
+++ b/tests/Install-DbaDarlingData.Tests.ps1
@@ -47,7 +47,7 @@ Describe $CommandName -Tag IntegrationTests {
 
             Remove-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $darlingDbDownload -Confirm:$false
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Installs to specified database: $darlingDbDownload" {
@@ -91,7 +91,7 @@ Describe $CommandName -Tag IntegrationTests {
 
             Remove-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $darlingDbLocalFile -Confirm:$false
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Installs to specified database: $darlingDbLocalFile" {

--- a/tests/Install-DbaMaintenanceSolution.Tests.ps1
+++ b/tests/Install-DbaMaintenanceSolution.Tests.ps1
@@ -53,7 +53,7 @@ Describe $CommandName -Tag IntegrationTests {
             $server.Databases['tempdb'].Query("DROP TABLE CommandLog")
             Invoke-DbaQuery -SqlInstance $TestConfig.instance3 -Database tempdb -Query "drop procedure CommandExecute; drop procedure DatabaseBackup; drop procedure DatabaseIntegrityCheck; drop procedure IndexOptimize;"
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "does not overwrite existing" {

--- a/tests/Invoke-DbaDbCorruption.Tests.ps1
+++ b/tests/Invoke-DbaDbCorruption.Tests.ps1
@@ -52,7 +52,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbNameCorruption -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Validating Database Input" {

--- a/tests/Invoke-DbaDbDataGenerator.Tests.ps1
+++ b/tests/Invoke-DbaDbDataGenerator.Tests.ps1
@@ -70,7 +70,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command works" {

--- a/tests/Invoke-DbaDbMirroring.Tests.ps1
+++ b/tests/Invoke-DbaDbMirroring.Tests.ps1
@@ -58,7 +58,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Database $dbName -Confirm:$false
         $null = Remove-DbaEndpoint -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -EndPoint $endpointName -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "returns success" {

--- a/tests/Invoke-DbaDbPiiScan.Tests.ps1
+++ b/tests/Invoke-DbaDbPiiScan.Tests.ps1
@@ -112,7 +112,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created objects.
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $piiscanDb -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When scanning for PII data" {

--- a/tests/Invoke-DbaDbShrink.Tests.ps1
+++ b/tests/Invoke-DbaDbShrink.Tests.ps1
@@ -47,7 +47,7 @@ Describe $CommandName -Tag IntegrationTests {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
         $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Verifying Database is shrunk" {

--- a/tests/Measure-DbaDbVirtualLogFile.Tests.ps1
+++ b/tests/Measure-DbaDbVirtualLogFile.Tests.ps1
@@ -47,7 +47,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance2 -Database $testDbName
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Mount-DbaDatabase.Tests.ps1
+++ b/tests/Mount-DbaDatabase.Tests.ps1
@@ -47,7 +47,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database detachattach | Remove-DbaDatabase -Confirm:$false
         Remove-Item -Path C:\Temp\detachattach.bak -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Attaches a single database and tests to ensure the alias still exists" {

--- a/tests/Move-DbaDbFile.Tests.ps1
+++ b/tests/Move-DbaDbFile.Tests.ps1
@@ -62,7 +62,7 @@ Describe $CommandName -Tag IntegrationTests {
         Remove-Item -Path "$global:physicalPathFolder\New" -Recurse -ErrorAction SilentlyContinue
         Remove-Item -Path "$global:physicalPathFolder\dbatoolsci_MoveDbFile.mdf" -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Should output current database structure" {

--- a/tests/New-DbaAgentAlert.Tests.ps1
+++ b/tests/New-DbaAgentAlert.Tests.ps1
@@ -58,7 +58,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Clean up all test alerts created during testing
         Get-DbaAgentAlert -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Alert $global:testAlertNames -ErrorAction SilentlyContinue | Remove-DbaAgentAlert -Confirm:$false -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Creating a new SQL Server Agent alert" {

--- a/tests/New-DbaAgentOperator.Tests.ps1
+++ b/tests/New-DbaAgentOperator.Tests.ps1
@@ -60,7 +60,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaAgentOperator -SqlInstance $server2 -Operator $email3
         $null = Remove-DbaAgentOperator -SqlInstance $server2 -Operator $email4
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "New Agent Operator is added properly" {

--- a/tests/New-DbaAgentProxy.Tests.ps1
+++ b/tests/New-DbaAgentProxy.Tests.ps1
@@ -79,7 +79,7 @@ Describe $CommandName -Tag IntegrationTests {
             if ($global:agentProxySSISDisabled) { $global:agentProxySSISDisabled.Drop() }
             if ($global:agentProxyLoginRole) { $global:agentProxyLoginRole.Drop() }
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "does not try to add the proxy without a valid credential" {

--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -97,7 +97,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When creating availability groups" {

--- a/tests/New-DbaDacProfile.Tests.ps1
+++ b/tests/New-DbaDacProfile.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created objects.
         Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "returns the right results" {

--- a/tests/New-DbaDbCertificate.Tests.ps1
+++ b/tests/New-DbaDbCertificate.Tests.ps1
@@ -74,7 +74,7 @@ Describe $CommandName -Tag IntegrationTests {
                 $masterkey | Remove-DbaDbMasterKey -Confirm:$false
             }
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Successfully creates a new database certificate in default, master database" {

--- a/tests/New-DbaDbDataGeneratorConfig.Tests.ps1
+++ b/tests/New-DbaDbDataGeneratorConfig.Tests.ps1
@@ -58,7 +58,7 @@ Describe $CommandName -Tag IntegrationTests {
         Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbNameGenerator -Confirm:$false -ErrorAction SilentlyContinue
         Remove-Item -Path $tempConfigPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command works" {

--- a/tests/New-DbaDbMailProfile.Tests.ps1
+++ b/tests/New-DbaDbMailProfile.Tests.ps1
@@ -57,7 +57,7 @@ Describe $CommandName -Tag IntegrationTests {
         $regularaccountsettings = "EXEC msdb.dbo.sysmail_delete_account_sp @account_name = '$mailaccountname';"
         $server.query($regularaccountsettings)
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Sets DbMail Profile" {

--- a/tests/New-DbaDbMaskingConfig.Tests.ps1
+++ b/tests/New-DbaDbMaskingConfig.Tests.ps1
@@ -84,7 +84,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command works" {

--- a/tests/New-DbaDbSchema.Tests.ps1
+++ b/tests/New-DbaDbSchema.Tests.ps1
@@ -61,7 +61,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $newDbs | Remove-DbaDatabase -Confirm:$false
         $null = $logins | Remove-DbaLogin -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "commands work as expected" {

--- a/tests/New-DbaLogin.Tests.ps1
+++ b/tests/New-DbaLogin.Tests.ps1
@@ -137,7 +137,7 @@ Describe $CommandName -Tag IntegrationTests {
             }
         } catch { <#nbd #> }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Create new logins" {

--- a/tests/New-DbaRgWorkloadGroup.Tests.ps1
+++ b/tests/New-DbaRgWorkloadGroup.Tests.ps1
@@ -57,7 +57,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaRgWorkloadGroup -SqlInstance $TestConfig.instance2 -WorkloadGroup $global:testWorkloadGroup, $global:testWorkloadGroup2 -ErrorAction SilentlyContinue
         $null = Remove-DbaRgResourcePool -SqlInstance $TestConfig.instance2 -ResourcePool $global:testResourcePool -Type $global:testResourcePoolType -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When creating workload groups" {

--- a/tests/New-DbaSqlParameter.Tests.ps1
+++ b/tests/New-DbaSqlParameter.Tests.ps1
@@ -62,7 +62,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup created objects.
         $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Database tempdb -Query "DROP PROCEDURE dbo.my_proc" -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     It "creates a usable sql parameter" {
         $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output

--- a/tests/Publish-DbaDacPackage.Tests.ps1
+++ b/tests/Publish-DbaDacPackage.Tests.ps1
@@ -80,7 +80,7 @@ Describe $CommandName -Tag IntegrationTests {
         Remove-DbaDatabase -SqlInstance $TestConfig.instance1, $TestConfig.instance2 -Database $dbname -Confirm:$false
         Remove-Item -Confirm:$false -Path $publishprofile.FileName -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterEach {

--- a/tests/Remove-DbaAgDatabase.Tests.ps1
+++ b/tests/Remove-DbaAgDatabase.Tests.ps1
@@ -61,7 +61,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname -Confirm:$false
         Remove-Item -Path "$($TestConfig.Temp)\$dbname.bak", "$($TestConfig.Temp)\$dbname.trn" -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "removes ag db" {

--- a/tests/Remove-DbaAgListener.Tests.ps1
+++ b/tests/Remove-DbaAgListener.Tests.ps1
@@ -57,7 +57,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agName -Confirm:$false
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When removing a listener" {

--- a/tests/Remove-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/Remove-DbaAgentAlertCategory.Tests.ps1
@@ -49,7 +49,7 @@ Describe $CommandName -Tag IntegrationTests {
                 $null = Remove-DbaAgentAlertCategory -SqlInstance $TestConfig.instance2 -Category $remainingCategories.Name -Confirm:$false
             }
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should have the right name" {

--- a/tests/Remove-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Remove-DbaAgentJobCategory.Tests.ps1
@@ -44,7 +44,7 @@ Describe $CommandName -Tag IntegrationTests {
             # Clean up any remaining test categories
             $null = Remove-DbaAgentJobCategory -SqlInstance $TestConfig.instance2 -Category "CategoryTest1", "CategoryTest2", "CategoryTest3" -Confirm:$false -ErrorAction SilentlyContinue
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should have the right name and category type" {

--- a/tests/Remove-DbaAgentSchedule.Tests.ps1
+++ b/tests/Remove-DbaAgentSchedule.Tests.ps1
@@ -59,7 +59,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup any remaining test schedules
         $null = Get-DbaAgentSchedule -SqlInstance $TestConfig.instance2 | Where-Object Name -like "dbatools*" | Remove-DbaAgentSchedule -Confirm:$false -Force
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When removing schedules" {

--- a/tests/Remove-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/Remove-DbaAvailabilityGroup.Tests.ps1
@@ -41,7 +41,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "removes the newly created ag" {

--- a/tests/Remove-DbaCredential.Tests.ps1
+++ b/tests/Remove-DbaCredential.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag IntegrationTests {
             $existingCredentials | Remove-DbaCredential -Confirm:$false -ErrorAction SilentlyContinue
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When removing SQL credentials" {

--- a/tests/Remove-DbaCustomError.Tests.ps1
+++ b/tests/Remove-DbaCustomError.Tests.ps1
@@ -64,7 +64,7 @@ Describe $CommandName -Tag IntegrationTests {
         $serverSecondary.Query("IF EXISTS (SELECT 1 FROM master.sys.messages WHERE message_id = 70001) BEGIN EXEC msdb.dbo.sp_dropmessage @msgnum = 70001, @lang = 'all'; END")
         $serverSecondary.Query("IF EXISTS (SELECT 1 FROM master.sys.messages WHERE message_id = 70002) BEGIN EXEC msdb.dbo.sp_dropmessage @msgnum = 70002, @lang = 'all'; END")
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Parameter validation tests" {

--- a/tests/Remove-DbaDbCertificate.Tests.ps1
+++ b/tests/Remove-DbaDbCertificate.Tests.ps1
@@ -31,7 +31,7 @@ Describe $CommandName -Tag IntegrationTests {
 
             if ($masterKey) { $masterkey | Remove-DbaDbMasterKey -Confirm:$false }
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Successfully removes database certificate in master" {

--- a/tests/Remove-DbaDbCheckConstraint.Tests.ps1
+++ b/tests/Remove-DbaDbCheckConstraint.Tests.ps1
@@ -50,7 +50,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname1, $dbname2 -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "commands work as expected" {

--- a/tests/Remove-DbaDbData.Tests.ps1
+++ b/tests/Remove-DbaDbData.Tests.ps1
@@ -61,7 +61,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname1 -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Functionality" {

--- a/tests/Remove-DbaDbFileGroup.Tests.ps1
+++ b/tests/Remove-DbaDbFileGroup.Tests.ps1
@@ -64,7 +64,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $newDb1, $newDb2, $newDb3 | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When removing filegroups" {

--- a/tests/Remove-DbaDbOrphanUser.Tests.ps1
+++ b/tests/Remove-DbaDbOrphanUser.Tests.ps1
@@ -77,7 +77,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname -Confirm:$false -ErrorAction SilentlyContinue
         $null = Invoke-Command2 -ScriptBlock { net user $args /delete *>&1 } -ArgumentList $loginWindows -ComputerName $TestConfig.instance2 -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "Removes Orphan Users" {

--- a/tests/Remove-DbaDbPartitionScheme.Tests.ps1
+++ b/tests/Remove-DbaDbPartitionScheme.Tests.ps1
@@ -51,7 +51,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname1, $dbname2 -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Commands work as expected" {

--- a/tests/Remove-DbaDbRole.Tests.ps1
+++ b/tests/Remove-DbaDbRole.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup created database
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname1 -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Functionality" {

--- a/tests/Remove-DbaDbRoleMember.Tests.ps1
+++ b/tests/Remove-DbaDbRoleMember.Tests.ps1
@@ -113,7 +113,7 @@ Describe $CommandName -Tag IntegrationTests {
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $testDatabase
         Remove-DbaLogin -SqlInstance $TestConfig.instance2 -Login $testUser1, $testUser2
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Functionality" {

--- a/tests/Remove-DbaDbSchema.Tests.ps1
+++ b/tests/Remove-DbaDbSchema.Tests.ps1
@@ -47,7 +47,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created objects.
         $null = $testDatabases | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When removing database schemas" {

--- a/tests/Remove-DbaDbSynonym.Tests.ps1
+++ b/tests/Remove-DbaDbSynonym.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname, $dbname2 -Confirm:$false
         $null = Remove-DbaDbSynonym -SqlInstance $TestConfig.instance2 -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Functionality" {

--- a/tests/Remove-DbaDbTable.Tests.ps1
+++ b/tests/Remove-DbaDbTable.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaDatabase -SqlInstance $instance2 -Database $dbname1 -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Commands work as expected" {

--- a/tests/Remove-DbaDbUdf.Tests.ps1
+++ b/tests/Remove-DbaDbUdf.Tests.ps1
@@ -52,7 +52,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname1 -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Commands work as expected" {

--- a/tests/Remove-DbaDbView.Tests.ps1
+++ b/tests/Remove-DbaDbView.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaDatabase -SqlInstance $instance2 -Database $dbname1 -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When removing views" {

--- a/tests/Remove-DbaLinkedServer.Tests.ps1
+++ b/tests/Remove-DbaLinkedServer.Tests.ps1
@@ -110,7 +110,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
         Remove-DbaLogin @splatRemoveLogin -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "ensure command works" {

--- a/tests/Remove-DbaLogin.Tests.ps1
+++ b/tests/Remove-DbaLogin.Tests.ps1
@@ -53,7 +53,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Clean up any remaining test login
         $null = Remove-DbaLogin -SqlInstance $TestConfig.instance1 -Login $testLogin -Confirm:$false -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When removing a login" {

--- a/tests/Remove-DbaRegServer.Tests.ps1
+++ b/tests/Remove-DbaRegServer.Tests.ps1
@@ -65,7 +65,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created registered servers.
         Get-DbaRegServer -SqlInstance $TestConfig.instance1 -Name $regSrvName, $regSrvName2 | Remove-DbaRegServer -Confirm:$false -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When removing registered servers" {

--- a/tests/Remove-DbaRegServerGroup.Tests.ps1
+++ b/tests/Remove-DbaRegServerGroup.Tests.ps1
@@ -48,7 +48,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created objects.
         Get-DbaRegServerGroup -SqlInstance $TestConfig.instance1 | Where-Object Name -match dbatoolsci | Remove-DbaRegServerGroup -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When removing registered server groups" {

--- a/tests/Remove-DbaServerRole.Tests.ps1
+++ b/tests/Remove-DbaServerRole.Tests.ps1
@@ -43,7 +43,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created objects.
         $null = Remove-DbaServerRole -SqlInstance $testInstance -ServerRole $testRoleExecutor -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Remove-DbaXESession.Tests.ps1
+++ b/tests/Remove-DbaXESession.Tests.ps1
@@ -40,7 +40,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session 'Profiler TSQL Duration' | Remove-DbaXESession
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Test Importing Session Template" {

--- a/tests/Rename-DbaLogin.Tests.ps1
+++ b/tests/Rename-DbaLogin.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Stop-DbaProcess -SqlInstance $TestConfig.instance1 -Login $renamedLogin
         $null = Remove-DbaLogin -SqlInstance $TestConfig.instance1 -Login $renamedLogin
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When renaming a login" {

--- a/tests/Reset-DbaAdmin.Tests.ps1
+++ b/tests/Reset-DbaAdmin.Tests.ps1
@@ -39,7 +39,7 @@ Describe $CommandName -Tag IntegrationTests {
         Get-DbaProcess -SqlInstance $TestConfig.instance2 -Login dbatoolsci_resetadmin | Stop-DbaProcess -WarningAction SilentlyContinue
         Get-DbaLogin -SqlInstance $TestConfig.instance2 -Login dbatoolsci_resetadmin | Remove-DbaLogin -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When adding a sql login" {

--- a/tests/Resume-DbaAgDbDataMovement.Tests.ps1
+++ b/tests/Resume-DbaAgDbDataMovement.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Get-DbaEndpoint -SqlInstance $server -Type DatabaseMirroring | Remove-DbaEndpoint
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "resumes  data movement" {

--- a/tests/Revoke-DbaAgPermission.Tests.ps1
+++ b/tests/Revoke-DbaAgPermission.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
         $null = Remove-DbaLogin -SqlInstance $TestConfig.instance3 -Login "claudio", "port", "tester" -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "revokes big perms" {
         It "returns results with proper data" {

--- a/tests/Set-DbaAgReplica.Tests.ps1
+++ b/tests/Set-DbaAgReplica.Tests.ps1
@@ -68,7 +68,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agName
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Sets AG properties" {

--- a/tests/Set-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/Set-DbaAvailabilityGroup.Tests.ps1
@@ -58,7 +58,7 @@ Describe $CommandName -Tag IntegrationTests {
         Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agname -Confirm:$false
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "sets ag properties" {

--- a/tests/Set-DbaDbFileGroup.Tests.ps1
+++ b/tests/Set-DbaDbFileGroup.Tests.ps1
@@ -58,7 +58,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created objects.
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $db1name -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When setting filegroup properties" {

--- a/tests/Set-DbaDbFileGrowth.Tests.ps1
+++ b/tests/Set-DbaDbFileGrowth.Tests.ps1
@@ -55,7 +55,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
         Remove-DbaDatabase @splatRemoveDatabase
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Should return file information for only test database" {

--- a/tests/Set-DbaDbIdentity.Tests.ps1
+++ b/tests/Set-DbaDbIdentity.Tests.ps1
@@ -51,7 +51,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Validate standard output" {

--- a/tests/Set-DbaDbRecoveryModel.Tests.ps1
+++ b/tests/Set-DbaDbRecoveryModel.Tests.ps1
@@ -46,7 +46,7 @@ Describe $CommandName -Tag IntegrationTests {
 
             Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "sets the proper recovery model" {

--- a/tests/Set-DbaDbSchema.Tests.ps1
+++ b/tests/Set-DbaDbSchema.Tests.ps1
@@ -84,7 +84,7 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $newDbs | Remove-DbaDatabase -Confirm:$false
         $null = $logins | Remove-DbaLogin -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "commands work as expected" {

--- a/tests/Set-DbaExtendedProperty.Tests.ps1
+++ b/tests/Set-DbaExtendedProperty.Tests.ps1
@@ -42,7 +42,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = $db | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Commands work as expected" {

--- a/tests/Set-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Set-DbaNetworkConfiguration.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag IntegrationTests {
             $null = Set-DbaNetworkConfiguration -SqlInstance $TestConfig.instance2 -DisableProtocol NamedPipes -Confirm:$false -WarningAction SilentlyContinue
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command works with piped input" {

--- a/tests/Set-DbaResourceGovernor.Tests.ps1
+++ b/tests/Set-DbaResourceGovernor.Tests.ps1
@@ -73,7 +73,7 @@ Describe $CommandName -Tag IntegrationTests {
             $dropUDFQuery = "DROP FUNCTION $qualifiedClassifierFunction;"
             Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query $dropUDFQuery -Database "master" -ErrorAction SilentlyContinue
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
     }
 }

--- a/tests/Set-DbaRgWorkloadGroup.Tests.ps1
+++ b/tests/Set-DbaRgWorkloadGroup.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag IntegrationTests {
             $null = Remove-DbaRgWorkloadGroup -SqlInstance $TestConfig.instance2 -WorkloadGroup $wklGroupCleanupNames -ErrorAction SilentlyContinue
             $null = Remove-DbaRgResourcePool -SqlInstance $TestConfig.instance2 -ResourcePool $resourcePoolCleanupName -Type "Internal" -ErrorAction SilentlyContinue
 
-            # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Sets a workload group in default resource pool" {

--- a/tests/Start-DbaDbEncryption.Tests.ps1
+++ b/tests/Start-DbaDbEncryption.Tests.ps1
@@ -69,7 +69,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Start-DbaEndpoint.Tests.ps1
+++ b/tests/Start-DbaEndpoint.Tests.ps1
@@ -42,7 +42,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Restore the endpoint to its original state
         Get-DbaEndpoint -SqlInstance $TestConfig.instance2 -Endpoint "TSQL Default TCP" | Start-DbaEndpoint -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "starts the endpoint" {

--- a/tests/Start-DbaMigration.Tests.ps1
+++ b/tests/Start-DbaMigration.Tests.ps1
@@ -113,7 +113,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context  "When using backup restore method" {

--- a/tests/Start-DbaXESession.Tests.ps1
+++ b/tests/Start-DbaXESession.Tests.ps1
@@ -77,7 +77,7 @@ Describe $CommandName -Tag IntegrationTests {
         $conn.ExecuteNonQuery("IF EXISTS(SELECT * FROM sys.server_event_sessions WHERE name = 'dbatoolsci_session_valid') DROP EVENT SESSION [dbatoolsci_session_valid] ON SERVER;")
         Get-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -Schedule "XE Session START - dbatoolsci_session_valid", "XE Session STOP - dbatoolsci_session_valid" | Remove-DbaAgentSchedule -Force -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Verifying command works" {

--- a/tests/Stop-DbaDbEncryption.Tests.ps1
+++ b/tests/Stop-DbaDbEncryption.Tests.ps1
@@ -62,7 +62,7 @@ Describe $CommandName -Tag IntegrationTests {
             $masterkey | Remove-DbaDbMasterKey
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Stop-DbaExternalProcess.Tests.ps1
+++ b/tests/Stop-DbaExternalProcess.Tests.ps1
@@ -66,7 +66,7 @@ Describe $CommandName -Tag IntegrationTests {
             RECONFIGURE;
             GO" -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Can stop an external process" {

--- a/tests/Stop-DbaTrace.Tests.ps1
+++ b/tests/Stop-DbaTrace.Tests.ps1
@@ -125,7 +125,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Test Stopping Trace" {

--- a/tests/Test-DbaDbDataMaskingConfig.Tests.ps1
+++ b/tests/Test-DbaDbDataMaskingConfig.Tests.ps1
@@ -129,7 +129,7 @@ Describe $CommandName -Tag IntegrationTests {
         Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbName -Confirm:$false
         Remove-Item -Path $tempPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "gives no errors with a correct json file" {

--- a/tests/Test-DbaEndpoint.Tests.ps1
+++ b/tests/Test-DbaEndpoint.Tests.ps1
@@ -38,7 +38,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaEndpoint -SqlInstance $TestConfig.instance2 -EndPoint dbatoolsci_MirroringEndpoint
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "returns success" {

--- a/tests/Test-DbaLastBackup.Tests.ps1
+++ b/tests/Test-DbaLastBackup.Tests.ps1
@@ -106,7 +106,7 @@ Describe $CommandName -Tag IntegrationTests {
         # Remove the backup directory.
         Remove-Item -Path $global:backupPath -Recurse -ErrorAction SilentlyContinue
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Test a single database" {

--- a/tests/Test-DbaLoginPassword.Tests.ps1
+++ b/tests/Test-DbaLoginPassword.Tests.ps1
@@ -46,7 +46,7 @@ Describe $CommandName -Tag IntegrationTests {
             # don't care
         }
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "making sure command works" {

--- a/tests/Uninstall-DbaSqlWatch.Tests.ps1
+++ b/tests/Uninstall-DbaSqlWatch.Tests.ps1
@@ -41,7 +41,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $database
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Testing SqlWatch uninstaller" {

--- a/tests/Write-DbaDbTableData.Tests.ps1
+++ b/tests/Write-DbaDbTableData.Tests.ps1
@@ -56,7 +56,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Get-DbaDatabase -SqlInstance $server -Database $dbName | Remove-DbaDatabase -Confirm:$false
 
-        # As this is the last block we do not need to reset the $PSDefaultParameterValues.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     # calling random function to throw data into a table


### PR DESCRIPTION
Pester 5 is sometimes reusing the same context between tests. So to be sure that nothing breaks, we DO reset the EnableException default parameter in every block where we set it. We can later use a test to make sure this is valid across all of the tests.