### PR TITLE
Move the last tests from pester 4 to pester 5

### DIFF
--- a/private/testing/Get-TestConfig.ps1
+++ b/private/testing/Get-TestConfig.ps1
@@ -7,11 +7,11 @@ function Get-TestConfig {
         CommonParameters = [System.Management.Automation.PSCmdlet]::CommonParameters
         Defaults         = [System.Management.Automation.DefaultParameterDictionary]@{
             # We want the tests as readable as possible so we want to set Confirm globally to $false.
-            '*:Confirm'         = $false
+            '*-Dba*:Confirm'         = $false
             # We use a global warning variable so that we can always test
             # that the command does not write a warning
             # or that the command does write the expected warning.
-            '*:WarningVariable' = 'WarnVar'
+            '*-Dba*:WarningVariable' = 'WarnVar'
         }
         # We want all the tests to only write to this location.
         # When testing a remote SQL Server instance this must be a network share

--- a/tests/Add-DbaAgReplica.Tests.ps1
+++ b/tests/Add-DbaAgReplica.Tests.ps1
@@ -101,6 +101,8 @@ Describe $CommandName -Tag IntegrationTests {
 
             # Cleanup all created objects.
             $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $replicaAgName -Confirm:$false -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Returns results with proper data" {

--- a/tests/Add-DbaExtendedProperty.Tests.ps1
+++ b/tests/Add-DbaExtendedProperty.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Create unique database name for this test run
         $random = Get-Random
@@ -41,12 +41,12 @@ Describe $CommandName -Tag IntegrationTests {
         $db = New-DbaDatabase -SqlInstance $server2 -Name $newDbName
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup the test database
         $null = $db | Remove-DbaDatabase -Confirm:$false

--- a/tests/Add-DbaRegServer.Tests.ps1
+++ b/tests/Add-DbaRegServer.Tests.ps1
@@ -33,7 +33,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $srvName = "dbatoolsci-server1"
         $group = "dbatoolsci-group1"
@@ -42,12 +42,12 @@ Describe $CommandName -Tag IntegrationTests {
         $groupobject = Add-DbaRegServerGroup -SqlInstance $TestConfig.instance1 -Name $group
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Get-DbaRegServer -SqlInstance $TestConfig.instance1, $TestConfig.instance2 | Where-Object Name -match dbatoolsci | Remove-DbaRegServer -Confirm:$false
         Get-DbaRegServerGroup -SqlInstance $TestConfig.instance1, $TestConfig.instance2 | Where-Object Name -match dbatoolsci | Remove-DbaRegServerGroup -Confirm:$false

--- a/tests/Add-DbaRegServerGroup.Tests.ps1
+++ b/tests/Add-DbaRegServerGroup.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $group = "dbatoolsci-group1"
@@ -36,12 +36,12 @@ Describe $CommandName -Tag IntegrationTests {
         $descriptionUpdated = "group description updated"
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         Get-DbaRegServerGroup -SqlInstance $TestConfig.instance1 | Where-Object Name -match dbatoolsci | Remove-DbaRegServerGroup -Confirm:$false

--- a/tests/Add-DbaServerRoleMember.Tests.ps1
+++ b/tests/Add-DbaServerRoleMember.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $login1 = "dbatoolsci_login1_$(Get-Random)"
@@ -46,11 +46,11 @@ Describe $CommandName -Tag IntegrationTests {
         $null = New-DbaServerRole -SqlInstance $TestConfig.instance2 -ServerRole $customServerRole -Owner sa
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $splatRemoveLogin = @{
             SqlInstance = $TestConfig.instance2

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         $DestBackupDir = "$($TestConfig.Temp)\$CommandName-$(Get-Random)"
@@ -64,12 +64,12 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues['Backup-DbaDatabase:Path'] = $DestBackupDir
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
         $PSDefaultParameterValues.Remove('Backup-DbaDatabase:Path')
 
         # Remove the backup directory.

--- a/tests/Backup-DbaDbMasterKey.Tests.ps1
+++ b/tests/Backup-DbaDbMasterKey.Tests.ps1
@@ -30,7 +30,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -58,12 +58,12 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         Get-DbaDbMasterKey -SqlInstance $testInstance -Database $testDatabase | Remove-DbaDbMasterKey -Confirm:$false

--- a/tests/Copy-DbaAgentAlert.Tests.ps1
+++ b/tests/Copy-DbaAgentAlert.Tests.ps1
@@ -29,7 +29,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables for test alerts and operator
         $alert1 = "dbatoolsci test alert"
@@ -67,12 +67,12 @@ Describe $CommandName -Tag IntegrationTests {
         @notification_method = 1 ;")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Clean up test objects
         $serverCleanup2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2 -Database master

--- a/tests/Copy-DbaAgentProxy.Tests.ps1
+++ b/tests/Copy-DbaAgentProxy.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set up test proxy on source instance
         $sourceServer = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -43,12 +43,12 @@ Describe $CommandName -Tag IntegrationTests {
         $destServer.Query($sql)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Clean up source instance
         $sourceServer = Connect-DbaInstance -SqlInstance $TestConfig.instance2

--- a/tests/Copy-DbaAgentSchedule.Tests.ps1
+++ b/tests/Copy-DbaAgentSchedule.Tests.ps1
@@ -29,7 +29,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Create the schedule on the source instance
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -37,12 +37,12 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query($sql)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Clean up the schedules from both instances
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2

--- a/tests/Copy-DbaBackupDevice.Tests.ps1
+++ b/tests/Copy-DbaBackupDevice.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -49,12 +49,12 @@ Describe $CommandName -Tag IntegrationTests {
         $sourceServer.Query("BACKUP DATABASE master TO DISK = '$backupFileName'")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $sourceServer.Query("EXEC master.dbo.sp_dropdevice @logicalname = N'$deviceName'")

--- a/tests/Copy-DbaCustomError.Tests.ps1
+++ b/tests/Copy-DbaCustomError.Tests.ps1
@@ -45,6 +45,8 @@ Describe $CommandName -Tag IntegrationTests {
             $cleanupServer = Connect-DbaInstance -SqlInstance $serverInstance -Database master
             $cleanupServer.Query("IF EXISTS (SELECT 1 FROM sys.messages WHERE message_id = 60000) EXEC sp_dropmessage @msgnum = 60000, @lang = 'all'") | Out-Null
         }
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying custom errors" {

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -51,7 +51,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -88,12 +88,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Set-DbaDbOwner @splatSetOwner
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $splatRemoveFinal = @{
             SqlInstance = $TestConfig.instance2, $TestConfig.instance3

--- a/tests/Copy-DbaDbCertificate.Tests.ps1
+++ b/tests/Copy-DbaDbCertificate.Tests.ps1
@@ -34,7 +34,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Can create a database certificate" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
             $backupPath = "$($TestConfig.Temp)\$CommandName-$(Get-Random)"
@@ -65,12 +65,12 @@ Describe $CommandName -Tag IntegrationTests {
             }
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $null = $testDatabases | Remove-DbaDatabase -Confirm:$false -ErrorAction SilentlyContinue
             if ($masterKey) {

--- a/tests/Copy-DbaDbMail.Tests.ps1
+++ b/tests/Copy-DbaDbMail.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # TODO: Maybe remove "-EnableException:$false -WarningAction SilentlyContinue" when we can rely on the setting beeing 0 when entering the test
         $null = Set-DbaSpConfigure -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Name "Database Mail XPs" -Value 1 -EnableException:$false -WarningAction SilentlyContinue
@@ -54,16 +54,18 @@ Describe $CommandName -Tag IntegrationTests {
         }
         $null = New-DbaDbMailProfile @splatProfile
 
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Query "EXEC msdb.dbo.sysmail_delete_account_sp @account_name = '$accountName';"
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Query "EXEC msdb.dbo.sysmail_delete_profile_sp @profile_name = '$profileName';"
 
         $null = Set-DbaSpConfigure -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Name "Database Mail XPs" -Value 0
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When copying DbMail" {

--- a/tests/Copy-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Copy-DbaDbQueryStoreOption.Tests.ps1
@@ -30,17 +30,17 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Verifying query store options are copied" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $server2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }

--- a/tests/Copy-DbaDbTableData.Tests.ps1
+++ b/tests/Copy-DbaDbTableData.Tests.ps1
@@ -44,7 +44,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $sourceDb = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database tempdb
         $destinationDb = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database tempdb
@@ -66,12 +66,12 @@ Describe $CommandName -Tag IntegrationTests {
             FROM sys.objects")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = $sourceDb.Query("DROP TABLE dbo.dbatoolsci_example")
         $null = $sourceDb.Query("DROP TABLE dbo.dbatoolsci_example2")

--- a/tests/Copy-DbaDbViewData.Tests.ps1
+++ b/tests/Copy-DbaDbViewData.Tests.ps1
@@ -41,7 +41,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         function Remove-TempObjects {
             param ($dbs)
@@ -95,12 +95,12 @@ Describe $CommandName -Tag IntegrationTests {
             FROM sys.objects")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Remove-TempObjects $db, $db2
 

--- a/tests/Copy-DbaEndpoint.Tests.ps1
+++ b/tests/Copy-DbaEndpoint.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Explain what needs to be set up for the test:
         # To test copying endpoints, we need to create a test endpoint on the source instance.
@@ -49,12 +49,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = New-DbaEndpoint @splatEndpoint
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance2 -Type DatabaseMirroring | Remove-DbaEndpoint

--- a/tests/Copy-DbaInstanceTrigger.Tests.ps1
+++ b/tests/Copy-DbaInstanceTrigger.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $triggerName = "dbatoolsci-trigger"
@@ -42,12 +42,12 @@ Describe $CommandName -Tag IntegrationTests {
         $sourceServer.Query($sql)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $sourceServer.Query("DROP TRIGGER [$triggerName] ON ALL SERVER")

--- a/tests/Copy-DbaLinkedServer.Tests.ps1
+++ b/tests/Copy-DbaLinkedServer.Tests.ps1
@@ -30,7 +30,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server1 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $server2 = Connect-DbaInstance -SqlInstance $TestConfig.instance3
@@ -41,12 +41,12 @@ Describe $CommandName -Tag IntegrationTests {
         $server1.Query($createSql)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $dropSql = "EXEC master.dbo.sp_dropserver @server=N'dbatoolsci_localhost', @droplogins='droplogins'"
 

--- a/tests/Copy-DbaRegServer.Tests.ps1
+++ b/tests/Copy-DbaRegServer.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $serverName = "dbatoolsci-server1"
@@ -52,12 +52,12 @@ Describe $CommandName -Tag IntegrationTests {
         $newServer.Create()
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $newGroup.Drop()

--- a/tests/Copy-DbaResourceGovernor.Tests.ps1
+++ b/tests/Copy-DbaResourceGovernor.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Explain what needs to be set up for the test:
         # To test copying resource governor settings, we need to create resource pools, workload groups, and a classifier function on the source instance.
@@ -53,12 +53,12 @@ Describe $CommandName -Tag IntegrationTests {
         Invoke-DbaQuery @splatQuery -Query "ALTER RESOURCE GOVERNOR with (CLASSIFIER_FUNCTION = dbo.dbatoolsci_fnRG); ALTER RESOURCE GOVERNOR RECONFIGURE;"
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $splatCleanup = @{
             SqlInstance   = $TestConfig.instance2, $TestConfig.instance3

--- a/tests/Disable-DbaAgHadr.Tests.ps1
+++ b/tests/Disable-DbaAgHadr.Tests.ps1
@@ -24,15 +24,15 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Re-enable HADR for future tests
         $null = Enable-DbaAgHadr -SqlInstance $TestConfig.instance3 -Force

--- a/tests/Disable-DbaFilestream.Tests.ps1
+++ b/tests/Disable-DbaFilestream.Tests.ps1
@@ -26,18 +26,18 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Store the original FileStream level to restore after testing
         $originalFileStream = Get-DbaFilestream -SqlInstance $TestConfig.instance1
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Restore the original FileStream level
         Set-DbaFilestream -SqlInstance $TestConfig.instance1 -FileStreamLevel $originalFileStream.InstanceAccessLevel -Force

--- a/tests/Disable-DbaHideInstance.Tests.ps1
+++ b/tests/Disable-DbaHideInstance.Tests.ps1
@@ -24,7 +24,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "When disabling hide instance" {
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # No specific cleanup needed for this test
 
@@ -33,12 +33,12 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "Returns result with HideInstance set to false" {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $hideInstanceResults = Disable-DbaHideInstance -SqlInstance $TestConfig.instance1
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
 
             $hideInstanceResults.HideInstance | Should -BeFalse
         }

--- a/tests/Disable-DbaStartupProcedure.Tests.ps1
+++ b/tests/Disable-DbaStartupProcedure.Tests.ps1
@@ -25,7 +25,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set up test environment
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -38,12 +38,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $server.Query("EXEC sp_procoption '$startupProc', 'startup', 'on'", $dbname)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Clean up test objects
         $null = $server.Query("DROP PROCEDURE $startupProc", $dbname)

--- a/tests/Disable-DbaTraceFlag.Tests.ps1
+++ b/tests/Disable-DbaTraceFlag.Tests.ps1
@@ -24,7 +24,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Explain what needs to be set up for the test:
         # To test disabling trace flags, we need to ensure a trace flag is enabled first.
@@ -41,12 +41,12 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created object.
         if ($startingTraceFlags.TraceFlag -contains $safeTraceFlag) {

--- a/tests/Dismount-DbaDatabase.Tests.ps1
+++ b/tests/Dismount-DbaDatabase.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Get-DbaProcess -SqlInstance $TestConfig.instance3 -Program "dbatools PowerShell module - dbatools.io" | Stop-DbaProcess -WarningAction SilentlyContinue
 
@@ -41,12 +41,12 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Mount-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbName -FileStructure $fileStructure
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $dbName | Remove-DbaDatabase -Confirm:$false

--- a/tests/Enable-DbaAgHadr.Tests.ps1
+++ b/tests/Enable-DbaAgHadr.Tests.ps1
@@ -24,18 +24,18 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Disable HADR to ensure clean state for testing
         Disable-DbaAgHadr -SqlInstance $TestConfig.instance3 -Force
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }

--- a/tests/Enable-DbaDbEncryption.Tests.ps1
+++ b/tests/Enable-DbaDbEncryption.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $passwd = ConvertTo-SecureString "dbatools.IO" -AsPlainText -Force
 
@@ -52,12 +52,12 @@ Describe $CommandName -Tag IntegrationTests {
         $testDb | New-DbaDbEncryptionKey -Force
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         if ($testDb) {
             $testDb | Remove-DbaDatabase -ErrorAction SilentlyContinue

--- a/tests/Enable-DbaHideInstance.Tests.ps1
+++ b/tests/Enable-DbaHideInstance.Tests.ps1
@@ -34,6 +34,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Disable-DbaHideInstance -SqlInstance $testInstance -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "Returns an object with HideInstance property set to true" {

--- a/tests/Enable-DbaTraceFlag.Tests.ps1
+++ b/tests/Enable-DbaTraceFlag.Tests.ps1
@@ -24,7 +24,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables for the test
         $testInstance = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -36,12 +36,12 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         if ($startingTraceFlags.TraceFlag -notcontains $safeTraceFlag) {
             $testInstance.Query("DBCC TRACEOFF($safeTraceFlag,-1)")

--- a/tests/Expand-DbaDbLogFile.Tests.ps1
+++ b/tests/Expand-DbaDbLogFile.Tests.ps1
@@ -32,19 +32,19 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $db1Name = "dbatoolsci_expand"
         $db1 = New-DbaDatabase -SqlInstance $TestConfig.instance1 -Name $db1Name
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance1 -Database $db1Name
 

--- a/tests/Export-DbaDacPackage.Tests.ps1
+++ b/tests/Export-DbaDacPackage.Tests.ps1
@@ -33,7 +33,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Check if SqlPackage is available, skip tests if not found
         $sqlPackagePath = Get-DbaSqlPackagePath
@@ -76,12 +76,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = New-DbaDatabase -SqlInstance $TestConfig.instance1 -Name $dbName2
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created object.
         $splatRemoveDb = @{

--- a/tests/Export-DbaDbRole.Tests.ps1
+++ b/tests/Export-DbaDbRole.Tests.ps1
@@ -37,7 +37,7 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $altExportPath = "$env:USERPROFILE\Documents"
         $outputFile1 = "$altExportPath\Dbatoolsci_DbRole_CustomFile1.sql"
@@ -63,11 +63,11 @@ Describe $CommandName -Tag IntegrationTests {
             # Ignore setup errors for now
         }
 
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         try {
             Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname1 -Confirm:$false
@@ -77,6 +77,8 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         Remove-Item -Path $resourcesToCleanup -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Check if output file was created" {

--- a/tests/Export-DbaDbTableData.Tests.ps1
+++ b/tests/Export-DbaDbTableData.Tests.ps1
@@ -30,7 +30,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set up test database connection and test tables
         $db = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database tempdb
@@ -41,12 +41,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $db.Query("Select * into dbatoolsci_temp from sys.databases")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup test tables
         try {

--- a/tests/Export-DbaDiagnosticQuery.Tests.ps1
+++ b/tests/Export-DbaDiagnosticQuery.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -35,12 +35,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = New-Item -Path $backupPath -ItemType Directory
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue

--- a/tests/Export-DbaPfDataCollectorSetTemplate.Tests.ps1
+++ b/tests/Export-DbaPfDataCollectorSetTemplate.Tests.ps1
@@ -27,18 +27,18 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set up collector set for testing
         $null = Get-DbaPfDataCollectorSetTemplate -Template "Long Running Queries" | Import-DbaPfDataCollectorSetTemplate
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup
         $null = Get-DbaPfDataCollectorSet -CollectorSet "Long Running Queries" | Remove-DbaPfDataCollectorSet -Confirm:$false

--- a/tests/Export-DbaRegServer.Tests.ps1
+++ b/tests/Export-DbaRegServer.Tests.ps1
@@ -67,6 +67,8 @@ Describe $CommandName -Tag IntegrationTests {
         $results, $results2, $results3 | Remove-Item -ErrorAction SilentlyContinue
 
         Remove-Item $newDirectory -ErrorAction SilentlyContinue -Recurse -Force
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "should create an xml file" {

--- a/tests/Export-DbaServerRole.Tests.ps1
+++ b/tests/Export-DbaServerRole.Tests.ps1
@@ -37,7 +37,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Create a directory for test output files
         $AltExportPath = "$env:USERPROFILE\Documents"
@@ -58,12 +58,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $server.Query("GRANT VIEW ANY DATABASE TO [$svRole]")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $null = Remove-DbaServerRole -SqlInstance $TestConfig.instance2 -ServerRole $svRole

--- a/tests/Export-DbaSysDbUserObject.Tests.ps1
+++ b/tests/Export-DbaSysDbUserObject.Tests.ps1
@@ -31,7 +31,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -56,12 +56,12 @@ Describe $CommandName -Tag IntegrationTests {
         $server.query("CREATE RULE dbo.$ruleName AS @range>= 1 AND @range <10;", "master")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2 -SqlCredential $SqlCredential
         $server.query("DROP TABLE dbo.$tableName", "master")

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -37,7 +37,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -100,12 +100,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $db.Query("GRANT SELECT ON OBJECT::$table TO [$user2];")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created object.
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname

--- a/tests/Export-DbaXESessionTemplate.Tests.ps1
+++ b/tests/Export-DbaXESessionTemplate.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -44,12 +44,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session $sessionName | Remove-DbaXESession
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $null = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session $sessionName | Remove-DbaXESession

--- a/tests/Find-DbaCommand.Tests.ps1
+++ b/tests/Find-DbaCommand.Tests.ps1
@@ -26,11 +26,6 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     Context "Command finds jobs using all parameters" {
-        BeforeAll {
-            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
-        }
-
         It "Should find more than 5 snapshot commands" {
             $results = @(Find-DbaCommand -Pattern "snapshot")
             $results.Count | Should -BeGreaterThan 5

--- a/tests/Find-DbaDbDisabledIndex.Tests.ps1
+++ b/tests/Find-DbaDbDisabledIndex.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Command actually works" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $server = Connect-DbaInstance -SqlInstance $TestConfig.instance1
             $random = Get-Random
@@ -45,12 +45,12 @@ Describe $CommandName -Tag IntegrationTests {
             $null = $db2.Query($sql)
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $db1, $db2 | Remove-DbaDatabase -Confirm:$false
 

--- a/tests/Find-DbaDbDuplicateIndex.Tests.ps1
+++ b/tests/Find-DbaDbDuplicateIndex.Tests.ps1
@@ -25,7 +25,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set up test database and table with duplicate indexes
         $dbName = "dbatools_dupeindex"
@@ -61,12 +61,12 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query($sql)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup test database
         $splatRemove = @{

--- a/tests/Find-DbaDbGrowthEvent.Tests.ps1
+++ b/tests/Find-DbaDbGrowthEvent.Tests.ps1
@@ -29,7 +29,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Command actually works" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $server = Connect-DbaInstance -SqlInstance $TestConfig.instance1
             $random = Get-Random
@@ -55,11 +55,11 @@ DBCC SHRINKFILE ($($databaseName1)_Log, TRUNCATEONLY);
             $null = $db1.Query($sqlGrowthAndShrink)
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $db1 | Remove-DbaDatabase -Confirm:$false -ErrorAction SilentlyContinue
 

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -29,7 +29,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Orphaned files are correctly identified" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $dbname = "dbatoolsci_orphanedfile_$(Get-Random)"
             $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -69,11 +69,11 @@ Describe $CommandName -Tag IntegrationTests {
             $null = New-Item -Path $tmpBackupPath3 -ItemType Directory
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
             Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname, $dbname2 | Remove-DbaDatabase -Confirm:$false
             Remove-Item $tmpdir -Recurse -Force -ErrorAction SilentlyContinue
             Remove-Item $tmpdir2 -Recurse -Force -ErrorAction SilentlyContinue

--- a/tests/Find-DbaSimilarTable.Tests.ps1
+++ b/tests/Find-DbaSimilarTable.Tests.ps1
@@ -31,19 +31,19 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Testing if similar tables are discovered" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $db = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database tempdb
             $db.Query("CREATE TABLE dbatoolsci_table1 (id int identity, fname varchar(20), lname char(5), lol bigint, whatever datetime)")
             $db.Query("CREATE TABLE dbatoolsci_table2 (id int identity, fname varchar(20), lname char(5), lol bigint, whatever datetime)")
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $db = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database tempdb
             $db.Query("DROP TABLE dbatoolsci_table1")

--- a/tests/Find-DbaStoredProcedure.Tests.ps1
+++ b/tests/Find-DbaStoredProcedure.Tests.ps1
@@ -29,7 +29,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Command finds Procedures in a System Database" {
         BeforeAll {
             # We want to run all commands in the setup with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $ServerProcedure = @"
 CREATE PROCEDURE dbo.cp_dbatoolsci_sysadmin
@@ -46,12 +46,12 @@ FROM [master].[sys].[syslogins];
             $null = Invoke-DbaQuery @splatCreateProc
 
             # We want to run the test command without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # Cleanup - We want to run all commands in the cleanup with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $DropProcedure = "DROP PROCEDURE dbo.cp_dbatoolsci_sysadmin;"
             $splatDropProc = @{
@@ -60,6 +60,8 @@ FROM [master].[sys].[syslogins];
                 Query       = $DropProcedure
             }
             $null = Invoke-DbaQuery @splatDropProc
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should find a specific StoredProcedure named cp_dbatoolsci_sysadmin" {
@@ -76,7 +78,7 @@ FROM [master].[sys].[syslogins];
     Context "Command finds Procedures in a User Database" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # Set variables. They are available in all the It blocks.
             $testDbName = "dbatoolsci_storedproceduredb"
@@ -103,12 +105,12 @@ AS
             $null = Invoke-DbaQuery @splatCreateProc
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $splatRemoveDb = @{
                 SqlInstance = $TestConfig.instance2

--- a/tests/Find-DbaUserObject.Tests.ps1
+++ b/tests/Find-DbaUserObject.Tests.ps1
@@ -23,17 +23,19 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = New-DbaDatabase -SqlInstance $TestConfig.instance2 -Name "dbatoolsci_userObject" -Owner "sa"
 
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database "dbatoolsci_userObject"
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command finds User Objects for SA" {

--- a/tests/Get-DbaAgDatabase.Tests.ps1
+++ b/tests/Get-DbaAgDatabase.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -59,11 +59,11 @@ Describe $CommandName -Tag IntegrationTests {
         $ag = New-DbaAvailabilityGroup @splatAg
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $null = Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agName

--- a/tests/Get-DbaAgListener.Tests.ps1
+++ b/tests/Get-DbaAgListener.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $agListenerName = "dbatoolsci_ag_listener"
@@ -48,12 +48,12 @@ Describe $CommandName -Tag IntegrationTests {
         $ag | Add-DbaAgListener @splatAddListener
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agListenerName

--- a/tests/Get-DbaAgentAlert.Tests.ps1
+++ b/tests/Get-DbaAgentAlert.Tests.ps1
@@ -24,7 +24,7 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $splatAddAlert = @{
             SqlInstance = $TestConfig.instance2
@@ -33,11 +33,11 @@ Describe $CommandName -Tag IntegrationTests {
         $server = Connect-DbaInstance @splatAddAlert
         $server.Query("EXEC msdb.dbo.sp_add_alert @name=N'dbatoolsci test alert',@message_id=0,@severity=6,@enabled=1,@delay_between_responses=0,@include_event_description_in=0,@category_name=N'[Uncategorized]',@job_id=N'00000000-0000-0000-0000-000000000000'")
 
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $splatDeleteAlert = @{
             SqlInstance = $TestConfig.instance2
@@ -45,6 +45,8 @@ Describe $CommandName -Tag IntegrationTests {
         }
         $server = Connect-DbaInstance @splatDeleteAlert
         $server.Query("EXEC msdb.dbo.sp_delete_alert @name=N'dbatoolsci test alert'")
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When getting agent alerts" {

--- a/tests/Get-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/Get-DbaAgentAlertCategory.Tests.ps1
@@ -24,17 +24,19 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     Context "Command gets alert categories" {
         BeforeAll {
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $null = New-DbaAgentAlertCategory -SqlInstance $TestConfig.instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
 
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $null = Remove-DbaAgentAlertCategory -SqlInstance $TestConfig.instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2 -Confirm:$false
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should get at least 2 categories" {

--- a/tests/Get-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Get-DbaAgentJobCategory.Tests.ps1
@@ -26,17 +26,17 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Command gets job categories" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $null = New-DbaAgentJobCategory -SqlInstance $TestConfig.instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $null = Remove-DbaAgentJobCategory -SqlInstance $TestConfig.instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
 

--- a/tests/Get-DbaAgentOperator.Tests.ps1
+++ b/tests/Get-DbaAgentOperator.Tests.ps1
@@ -25,7 +25,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $sql = "EXEC msdb.dbo.sp_add_operator @name=N'dbatoolsci_operator', @enabled=1, @pager_days=0"
@@ -34,12 +34,12 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query($sql)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $sql = "EXEC msdb.dbo.sp_delete_operator @name=N'dbatoolsci_operator'"
         $server.Query($sql)

--- a/tests/Get-DbaAgentProxy.Tests.ps1
+++ b/tests/Get-DbaAgentProxy.Tests.ps1
@@ -25,7 +25,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $tPassword = ConvertTo-SecureString "ThisIsThePassword1" -AsPlainText -Force
         $tUserName = "dbatoolsci_proxytest"
@@ -56,12 +56,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = New-DbaAgentProxy @splatProxy2
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $tUserName = "dbatoolsci_proxytest"
         $proxyName1 = "STIG"

--- a/tests/Get-DbaAgentSchedule.Tests.ps1
+++ b/tests/Get-DbaAgentSchedule.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server3 = Connect-DbaInstance -SqlInstance $TestConfig.instance3
         $server2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -116,12 +116,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = New-DbaAgentSchedule @splatScheduleOnIdle -Force
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $schedulesToRemove = @(
             "dbatoolsci_WeeklyTest",

--- a/tests/Get-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/Get-DbaAvailabilityGroup.Tests.ps1
@@ -25,7 +25,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $agName = "dbatoolsci_agroup"
@@ -42,12 +42,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = New-DbaAvailabilityGroup @splatAg
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agName

--- a/tests/Get-DbaBackupDevice.Tests.ps1
+++ b/tests/Get-DbaBackupDevice.Tests.ps1
@@ -22,21 +22,23 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $sql = "EXEC sp_addumpdevice 'tape', 'dbatoolsci_tape', '\\.\tape0';"
         $server.Query($sql)
 
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $sql = "EXEC sp_dropdevice 'dbatoolsci_tape';"
         $server.Query($sql)
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets the backup devices" {

--- a/tests/Get-DbaBackupInformation.Tests.ps1
+++ b/tests/Get-DbaBackupInformation.Tests.ps1
@@ -38,7 +38,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $DestBackupDir = "$($TestConfig.Temp)\GetBackups"
         if (-Not(Test-Path $DestBackupDir)) {
@@ -102,12 +102,12 @@ Describe $CommandName -Tag IntegrationTests {
         $db3 | Backup-DbaDatabase -Type Log -BackupDirectory "$DestBackupDirOla\LOG"
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname, $dbname2, $dbname3 | Remove-DbaDatabase
         Remove-Item -Path $DestBackupDir, $DestBackupDirOla -Recurse -ErrorAction SilentlyContinue

--- a/tests/Get-DbaBinaryFileTable.Tests.ps1
+++ b/tests/Get-DbaBinaryFileTable.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -56,12 +56,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Get-ChildItem "$($TestConfig.appveyorlabrepo)\certificates" | Import-DbaBinaryFile -SqlInstance $TestConfig.instance2 -Database $database -Table $tableName
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $db = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database tempdb

--- a/tests/Get-DbaCredential.Tests.ps1
+++ b/tests/Get-DbaCredential.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $logins = "thor", "thorsmomma"
         $plaintext = "BigOlPassword!"
@@ -54,11 +54,11 @@ Describe $CommandName -Tag IntegrationTests {
         $null = New-DbaCredential @splatThorsmormmaCred
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         try {
             $splatGetCred = @{

--- a/tests/Get-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/Get-DbaDbAsymmetricKey.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Gets a certificate" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # Set variables. They are available in all the It blocks.
             $keyName = "test4"
@@ -62,12 +62,12 @@ Describe $CommandName -Tag IntegrationTests {
             $null = New-DbaDbAsymmetricKey @splatFirstKey
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # Cleanup all created objects.
             $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $databaseName -Confirm:$false

--- a/tests/Get-DbaDbCertificate.Tests.ps1
+++ b/tests/Get-DbaDbCertificate.Tests.ps1
@@ -29,7 +29,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Can get a database certificate" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # Check and create master key if needed
             if (-not (Get-DbaDbMasterKey -SqlInstance $TestConfig.instance1 -Database master)) {
@@ -44,12 +44,12 @@ Describe $CommandName -Tag IntegrationTests {
             $cert2 = New-DbaDbCertificate -SqlInstance $TestConfig.instance1 -Name $certificateName2 -Database tempdb -Confirm:$false
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # Cleanup all created objects
             $null = $cert1 | Remove-DbaDbCertificate -Confirm:$false

--- a/tests/Get-DbaDbCheckConstraint.Tests.ps1
+++ b/tests/Get-DbaDbCheckConstraint.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set up test database and tables for check constraint testing
         $testServer = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -42,12 +42,12 @@ Describe $CommandName -Tag IntegrationTests {
         $testServer.Query("ALTER TABLE $testTableName2 ADD CONSTRAINT $testCkName CHECK (id3 > 10)", $testDbName)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup test database
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $testDbName | Remove-DbaDatabase -Confirm:$false -ErrorAction SilentlyContinue

--- a/tests/Get-DbaDbCompression.Tests.ps1
+++ b/tests/Get-DbaDbCompression.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $dbname = "dbatoolsci_test_$(Get-Random)"
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -37,11 +37,11 @@ Describe $CommandName -Tag IntegrationTests {
                                 create nonclustered index NC_syscols on syscols (precision) include (collation_name)", $dbname)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Get-DbaProcess -SqlInstance $TestConfig.instance2 -Database $dbname | Stop-DbaProcess -WarningAction SilentlyContinue
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname -ErrorAction SilentlyContinue

--- a/tests/Get-DbaDbEncryptionKey.Tests.ps1
+++ b/tests/Get-DbaDbEncryptionKey.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -61,12 +61,12 @@ Describe $CommandName -Tag IntegrationTests {
         $testDb | New-DbaDbEncryptionKey -Force
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         if ($testDb) {

--- a/tests/Get-DbaDbFileGroup.Tests.ps1
+++ b/tests/Get-DbaDbFileGroup.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -45,12 +45,12 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query("CREATE DATABASE $multifgdb; ALTER DATABASE $multifgdb ADD FILEGROUP [Test1]; ALTER DATABASE $multifgdb ADD FILEGROUP [Test2];")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance2 -Database $multifgdb -ErrorAction SilentlyContinue

--- a/tests/Get-DbaDbForeignKey.Tests.ps1
+++ b/tests/Get-DbaDbForeignKey.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $random = Get-Random
@@ -40,12 +40,12 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query("ALTER TABLE $tableName2 ADD CONSTRAINT $fkName FOREIGN KEY (idTbl1) REFERENCES $tableName (idTbl1) ON UPDATE NO ACTION ON DELETE NO ACTION ", $dbname)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
 

--- a/tests/Get-DbaDbIdentity.Tests.ps1
+++ b/tests/Get-DbaDbIdentity.Tests.ps1
@@ -24,7 +24,7 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $db = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database tempdb
         $null = $db.Query("CREATE TABLE dbo.dbatoolsci_example (Id int NOT NULL IDENTITY (125, 1), Value varchar(5));
@@ -32,14 +32,16 @@ Describe $CommandName -Tag IntegrationTests {
         CREATE TABLE dbo.dbatoolsci_example2 (Id int NOT NULL IDENTITY (5, 1), Value varchar(5));
         INSERT INTO dbo.dbatoolsci_example2(Value) Select 1;")
 
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = $db.Query("DROP TABLE dbo.dbatoolsci_example;
         DROP TABLE dbo.dbatoolsci_example2")
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Validate standard output" {

--- a/tests/Get-DbaDbLogShipError.Tests.ps1
+++ b/tests/Get-DbaDbLogShipError.Tests.ps1
@@ -30,10 +30,10 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Return values" {

--- a/tests/Get-DbaDbLogSpace.Tests.ps1
+++ b/tests/Get-DbaDbLogSpace.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -44,12 +44,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Database master -Query $dbCreate
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created object.
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $db1

--- a/tests/Get-DbaDbMail.Tests.ps1
+++ b/tests/Get-DbaDbMail.Tests.ps1
@@ -23,7 +23,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -41,7 +41,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets DbMail Settings" {

--- a/tests/Get-DbaDbMailAccount.Tests.ps1
+++ b/tests/Get-DbaDbMailAccount.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $accountName = "dbatoolsci_test_$(Get-Random)"
@@ -41,12 +41,12 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query($mailAccountSettings)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created object.
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2

--- a/tests/Get-DbaDbMailConfig.Tests.ps1
+++ b/tests/Get-DbaDbMailConfig.Tests.ps1
@@ -25,7 +25,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $mailSettings = @{
@@ -42,12 +42,12 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # No specific cleanup needed for DbMail config tests
 

--- a/tests/Get-DbaDbMailHistory.Tests.ps1
+++ b/tests/Get-DbaDbMailHistory.Tests.ps1
@@ -25,7 +25,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $server.Query("INSERT INTO msdb.[dbo].[sysmail_profile]
@@ -73,12 +73,12 @@ Describe $CommandName -Tag IntegrationTests {
         )
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server.Query("DELETE FROM msdb.dbo.sysmail_profile WHERE profile_id = '$profile_id'")
         $server.Query("DELETE FROM msdb.dbo.sysmail_mailitems WHERE profile_id = '$profile_id'")

--- a/tests/Get-DbaDbMailLog.Tests.ps1
+++ b/tests/Get-DbaDbMailLog.Tests.ps1
@@ -25,7 +25,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $server.Query("INSERT INTO msdb.[dbo].[sysmail_log]
@@ -41,12 +41,12 @@ Describe $CommandName -Tag IntegrationTests {
         (1,'2018-12-09 12:18:14.920','DatabaseMail process is started',4890,NULL,NULL,'2018-12-09 12:18:14.920','dbatools\dbatoolssci')")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $server.Query("DELETE FROM msdb.[dbo].[sysmail_log] WHERE last_mod_user = 'dbatools\dbatoolssci'")

--- a/tests/Get-DbaDbMirror.Tests.ps1
+++ b/tests/Get-DbaDbMirror.Tests.ps1
@@ -25,7 +25,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $db1 = "dbatoolsci_mirroring"
@@ -43,12 +43,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $server.Query("CREATE DATABASE $db2")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Database $db1, $db2 | Remove-DbaDbMirror -Confirm:$false

--- a/tests/Get-DbaDbObjectTrigger.Tests.ps1
+++ b/tests/Get-DbaDbObjectTrigger.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $dbname = "dbatoolsci_addtriggertoobject"
         $tablename = "dbo.dbatoolsci_trigger"
@@ -65,11 +65,11 @@ CREATE TRIGGER $triggerviewname
         $systemDbs = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -ExcludeUser
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
 

--- a/tests/Get-DbaDbOrphanUser.Tests.ps1
+++ b/tests/Get-DbaDbOrphanUser.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $loginsq = @"
 CREATE LOGIN [dbatoolsci_orphan1] WITH PASSWORD = N'password1', CHECK_EXPIRATION = OFF, CHECK_POLICY = OFF;
@@ -48,12 +48,12 @@ CREATE USER [dbatoolsci_orphan3] FROM LOGIN [dbatoolsci_orphan3];
         Invoke-DbaQuery -SqlInstance $server -Query $dropOrphan
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance1
         $null = Remove-DbaLogin -SqlInstance $server -Login dbatoolsci_orphan1, dbatoolsci_orphan2, dbatoolsci_orphan3 -Force -ErrorAction SilentlyContinue

--- a/tests/Get-DbaDbPageInfo.Tests.ps1
+++ b/tests/Get-DbaDbPageInfo.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $random = Get-Random
         $dbname = "dbatoolsci_pageinfo_$random"
@@ -59,11 +59,11 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Databases[$dbname].Query($query)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname -Confirm:$false -ErrorAction SilentlyContinue
 

--- a/tests/Get-DbaDbPartitionFunction.Tests.ps1
+++ b/tests/Get-DbaDbPartitionFunction.Tests.ps1
@@ -25,21 +25,23 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $tempguid = [guid]::newguid()
         $PFName = "dbatoolssci_$($tempguid.guid)"
         $CreateTestPartitionFunction = "CREATE PARTITION FUNCTION [$PFName] (int) AS RANGE LEFT FOR VALUES (1, 100, 1000, 10000, 100000);"
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query $CreateTestPartitionFunction -Database master
 
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $DropTestPartitionFunction = "DROP PARTITION FUNCTION [$PFName];"
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query $DropTestPartitionFunction -Database master -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Partition Functions are correctly located" {

--- a/tests/Get-DbaDbPartitionScheme.Tests.ps1
+++ b/tests/Get-DbaDbPartitionScheme.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $tempguid = [guid]::newguid()
@@ -48,12 +48,12 @@ CREATE PARTITION SCHEME $PFScheme AS PARTITION [$PFName] ALL TO ( [PRIMARY] );
         Invoke-DbaQuery @splatCreate
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $DropTestPartitionScheme = @"

--- a/tests/Get-DbaDbRestoreHistory.Tests.ps1
+++ b/tests/Get-DbaDbRestoreHistory.Tests.ps1
@@ -31,7 +31,7 @@ Describe $CommandName -Tag IntegrationTests {
 
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $random = Get-Random
         $dbname1 = "dbatoolsci_restorehistory1_$random"
@@ -77,12 +77,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Restore-DbaDatabase @splatRestoreFinal
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname1, $dbname2 | Remove-DbaDatabase -Confirm:$false
         Remove-Item -Path $fullBackup.BackupPath -Force -ErrorAction SilentlyContinue

--- a/tests/Get-DbaDbRole.Tests.ps1
+++ b/tests/Get-DbaDbRole.Tests.ps1
@@ -29,13 +29,13 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $instance = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $allDatabases = $instance.Databases
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Functionality" {

--- a/tests/Get-DbaDbSequence.Tests.ps1
+++ b/tests/Get-DbaDbSequence.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag IntegrationTests {
 
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $random = Get-Random
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -43,12 +43,12 @@ Describe $CommandName -Tag IntegrationTests {
         $sequence5 = New-DbaDbSequence -SqlInstance $server -Database $newDbName2 -Sequence "Sequence1_$random" -Schema "Schema_$random"
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = $newDb, $newDb2 | Remove-DbaDatabase -Confirm:$false
 

--- a/tests/Get-DbaDbServiceBrokerQueue.Tests.ps1
+++ b/tests/Get-DbaDbServiceBrokerQueue.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $procname = "dbatools_$(Get-Random)"
@@ -35,12 +35,12 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query("CREATE QUEUE $queuename WITH STATUS = ON , RETENTION = OFF , ACTIVATION (  STATUS = ON , PROCEDURE_NAME = $procname , MAX_QUEUE_READERS = 1 , EXECUTE AS OWNER  ), POISON_MESSAGE_HANDLING (STATUS = ON)", "tempdb")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = $server.Query("DROP QUEUE $queuename", "tempdb")
         $null = $server.Query("DROP PROCEDURE $procname", "tempdb")

--- a/tests/Get-DbaDbServiceBrokerService.Tests.ps1
+++ b/tests/Get-DbaDbServiceBrokerService.Tests.ps1
@@ -50,6 +50,8 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $global:testServer.Query("DROP SERVICE $global:testServiceName", "tempdb")
         $null = $global:testServer.Query("DROP QUEUE $global:testQueueName", "tempdb")
         $null = $global:testServer.Query("DROP PROCEDURE $global:testProcName", "tempdb")
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets the service broker service" {

--- a/tests/Get-DbaDbSharePoint.Tests.ps1
+++ b/tests/Get-DbaDbSharePoint.Tests.ps1
@@ -25,7 +25,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $skip = $false
         $spdb = @(
@@ -77,12 +77,12 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $spdb -Confirm:$false -ErrorAction SilentlyContinue
 

--- a/tests/Get-DbaDbState.Tests.ps1
+++ b/tests/Get-DbaDbState.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Reading db statuses" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
             $db1 = "dbatoolsci_dbstate_online"
@@ -62,12 +62,12 @@ Describe $CommandName -Tag IntegrationTests {
             }
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $splatSetState = @{
                 SqlInstance = $TestConfig.instance2

--- a/tests/Get-DbaDbStoredProcedure.Tests.ps1
+++ b/tests/Get-DbaDbStoredProcedure.Tests.ps1
@@ -29,7 +29,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $random = Get-Random
@@ -44,12 +44,12 @@ Describe $CommandName -Tag IntegrationTests {
         $db1.Query("CREATE PROCEDURE $schemaName.$procName2 AS SELECT 1")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $db1 | Remove-DbaDatabase -Confirm:$false
 

--- a/tests/Get-DbaDbTrigger.Tests.ps1
+++ b/tests/Get-DbaDbTrigger.Tests.ps1
@@ -53,6 +53,8 @@ CREATE TRIGGER dbatoolsci_safety
         $serverInstance = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $dropTrigger = "DROP TRIGGER dbatoolsci_safety ON DATABASE;"
         $serverInstance.Query("$dropTrigger")
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets Database Trigger" {

--- a/tests/Get-DbaDbUdf.Tests.ps1
+++ b/tests/Get-DbaDbUdf.Tests.ps1
@@ -30,7 +30,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         #Test Function adapted from examples at:
         #https://docs.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-2017#examples
@@ -57,12 +57,12 @@ END;
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query $CreateTestUDFunction -Database master
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $DropTestUDFunction = "DROP FUNCTION dbo.dbatoolssci_ISOweek;"
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query $DropTestUDFunction -Database master -ErrorAction SilentlyContinue

--- a/tests/Get-DbaDbUser.Tests.ps1
+++ b/tests/Get-DbaDbUser.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $tempguid = [guid]::newguid()
         $DBUserName = "dbatoolssci_$($tempguid.guid)"
@@ -46,11 +46,11 @@ CREATE USER [$dbUserName2] FOR LOGIN [$dbUserName2]
 "@
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query $CreateTestUser -Database master
 
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $DropTestUser = @"
 DROP USER [$DBUserName];
@@ -59,6 +59,8 @@ DROP LOGIN [$DBUserName];
 DROP LOGIN [$DBUserName2];
 "@
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query $DropTestUser -Database master -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Users are correctly located" {

--- a/tests/Get-DbaDbUserDefinedTableType.Tests.ps1
+++ b/tests/Get-DbaDbUserDefinedTableType.Tests.ps1
@@ -41,6 +41,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = $server.Query("DROP TYPE $tabletypename", "tempdb")
         $null = $server.Query("DROP TYPE $tabletypename1", "tempdb")
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets a Db User Defined Table Type" {

--- a/tests/Get-DbaDbView.Tests.ps1
+++ b/tests/Get-DbaDbView.Tests.ps1
@@ -29,7 +29,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -43,12 +43,12 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query("CREATE VIEW [$schemaName].$viewNameWithSchema AS (SELECT 1 as col1)", "tempdb")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $null = $server.Query("DROP VIEW $viewName", "tempdb")

--- a/tests/Get-DbaDbccSessionBuffer.Tests.ps1
+++ b/tests/Get-DbaDbccSessionBuffer.Tests.ps1
@@ -27,18 +27,18 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $db = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database tempdb
         $queryResult = $db.Query("SELECT top 10 object_id, @@Spid as MySpid FROM sys.objects")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }

--- a/tests/Get-DbaDbccStatistic.Tests.ps1
+++ b/tests/Get-DbaDbccStatistic.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $random = Get-Random
@@ -48,12 +48,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $server.Query("UPDATE STATISTICS $tableName", $dbname)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
 

--- a/tests/Get-DbaErrorLog.Tests.ps1
+++ b/tests/Get-DbaErrorLog.Tests.ps1
@@ -73,6 +73,8 @@ Describe $CommandName -Tag IntegrationTests {
                 Get-DbaProcess -SqlInstance $TestConfig.instance1 -Login $login | Stop-DbaProcess -ErrorAction SilentlyContinue
                 $testLogin.Drop()
             }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Has the correct default properties" {

--- a/tests/Get-DbaExtendedProperty.Tests.ps1
+++ b/tests/Get-DbaExtendedProperty.Tests.ps1
@@ -46,6 +46,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = $db | Remove-DbaDatabase -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "commands work as expected" {

--- a/tests/Get-DbaExternalProcess.Tests.ps1
+++ b/tests/Get-DbaExternalProcess.Tests.ps1
@@ -63,6 +63,8 @@ Describe $CommandName -Tag IntegrationTests {
         GO
         RECONFIGURE;
         GO" -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Can get an external process" {

--- a/tests/Get-DbaFile.Tests.ps1
+++ b/tests/Get-DbaFile.Tests.ps1
@@ -38,7 +38,10 @@ Describe $CommandName -Tag IntegrationTests {
 
         AfterAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
             $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $testDbName | Remove-DbaDatabase -Confirm:$false
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should find the new database file" {

--- a/tests/Get-DbaForceNetworkEncryption.Tests.ps1
+++ b/tests/Get-DbaForceNetworkEncryption.Tests.ps1
@@ -23,10 +23,10 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When connecting to SQL Server" {

--- a/tests/Get-DbaHelpIndex.Tests.ps1
+++ b/tests/Get-DbaHelpIndex.Tests.ps1
@@ -53,6 +53,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "Command works for indexes" {
         BeforeAll {

--- a/tests/Get-DbaInstanceAudit.Tests.ps1
+++ b/tests/Get-DbaInstanceAudit.Tests.ps1
@@ -52,6 +52,8 @@ Describe $CommandName -Tag IntegrationTests {
                 DROP SERVER AUDIT LoginAudit"
         $server.Query($sql)
         Remove-Item -Path "C:\temp\LoginAudit*sqlaudit" -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Verifying command output" {

--- a/tests/Get-DbaLastGoodCheckDb.Tests.ps1
+++ b/tests/Get-DbaLastGoodCheckDb.Tests.ps1
@@ -53,6 +53,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Get-DbaLinkedServer.Tests.ps1
+++ b/tests/Get-DbaLinkedServer.Tests.ps1
@@ -41,6 +41,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = $server.Query("EXEC master.dbo.sp_dropserver '$($TestConfig.instance3)', 'droplogins';  ")
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Gets Linked Servers" {

--- a/tests/Get-DbaLinkedServerLogin.Tests.ps1
+++ b/tests/Get-DbaLinkedServerLogin.Tests.ps1
@@ -136,6 +136,8 @@ Describe $CommandName -Tag IntegrationTests {
             Confirm         = $false
         }
         Remove-DbaLogin @splatRemoveRemoteLogin -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When testing linked server login functionality" {

--- a/tests/Get-DbaLogin.Tests.ps1
+++ b/tests/Get-DbaLogin.Tests.ps1
@@ -34,7 +34,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $SkipLocalTest = $true # Change to $false to run the local-only tests on a local instance. This is being used because the 'locked' test makes assumptions the password policy configuration is enabled for the Windows OS.
         $random = Get-Random
@@ -44,12 +44,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = New-DbaLogin -SqlInstance $TestConfig.instance1 -Login "testlogin2_$random" -Password $password
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaLogin -SqlInstance $TestConfig.instance1 -Login "testlogin1_$random", "testlogin2_$random" -Confirm:$false -Force
 

--- a/tests/Get-DbaPbmPolicy.Tests.ps1
+++ b/tests/Get-DbaPbmPolicy.Tests.ps1
@@ -76,6 +76,8 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query("EXEC msdb.dbo.sp_syspolicy_delete_policy @policy_id=$global:policyid")
         $server.Query("EXEC msdb.dbo.sp_syspolicy_delete_object_set @object_set_id=$global:objectsetid")
         $server.Query("EXEC msdb.dbo.sp_syspolicy_delete_condition @condition_id=$global:conditionid")
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When retrieving PBM policies" {

--- a/tests/Get-DbaPermission.Tests.ps1
+++ b/tests/Get-DbaPermission.Tests.ps1
@@ -92,6 +92,8 @@ Describe $CommandName -Tag IntegrationTests {
         $removedDBOwner = Remove-DbaLogin -SqlInstance $server -Login $loginNameDBOwner -Confirm:$false -ErrorAction SilentlyContinue
         $removedUser1 = Remove-DbaLogin -SqlInstance $server -Login $loginNameUser1 -Confirm:$false -ErrorAction SilentlyContinue
         $removedUser2 = Remove-DbaLogin -SqlInstance $server -Login $loginNameUser2 -Confirm:$false -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "parameters work" {

--- a/tests/Get-DbaRegServer.Tests.ps1
+++ b/tests/Get-DbaRegServer.Tests.ps1
@@ -88,6 +88,8 @@ Describe $CommandName -Tag IntegrationTests {
 
             Get-DbaRegServer -SqlInstance $TestConfig.instance1 | Where-Object Name -match dbatoolsci | Remove-DbaRegServer -Confirm:$false -ErrorAction SilentlyContinue
             Get-DbaRegServerGroup -SqlInstance $TestConfig.instance1 | Where-Object Name -match dbatoolsci | Remove-DbaRegServerGroup -Confirm:$false -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should return multiple objects" {

--- a/tests/Get-DbaRegServerGroup.Tests.ps1
+++ b/tests/Get-DbaRegServerGroup.Tests.ps1
@@ -96,6 +96,8 @@ Describe $CommandName -Tag IntegrationTests {
             $subGroupServer.ServerName = $subGroupSrvName
             $subGroupServer.Description = $subGroupRegSrvDesc
             $subGroupServer.Create()
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {

--- a/tests/Get-DbaRgClassifierFunction.Tests.ps1
+++ b/tests/Get-DbaRgClassifierFunction.Tests.ps1
@@ -49,6 +49,8 @@ END
 
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query "ALTER RESOURCE GOVERNOR WITH (CLASSIFIER_FUNCTION = NULL); ALTER RESOURCE GOVERNOR RECONFIGURE"
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query "DROP FUNCTION [dbo].[dbatoolsci_fnRG]"
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command works" {

--- a/tests/Get-DbaServerRoleMember.Tests.ps1
+++ b/tests/Get-DbaServerRoleMember.Tests.ps1
@@ -95,5 +95,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         Remove-DbaLogin -SqlInstance $server2 -Login $testLogin -Force -ErrorAction SilentlyContinue
         Remove-DbaLogin -SqlInstance $server1 -Login $testLogin -Force -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 }

--- a/tests/Get-DbaStartupProcedure.Tests.ps1
+++ b/tests/Get-DbaStartupProcedure.Tests.ps1
@@ -43,6 +43,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = $server.Query("DROP PROCEDURE $startupProc", $dbname)
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When retrieving all startup procedures" {

--- a/tests/Get-DbaTrace.Tests.ps1
+++ b/tests/Get-DbaTrace.Tests.ps1
@@ -56,6 +56,8 @@ Describe $CommandName -Tag IntegrationTests {
             $server.Query("RECONFIGURE WITH OVERRIDE")
             #$null = Set-DbaSpConfigure -SqlInstance $TestConfig.instance2 -ConfigName DefaultTraceEnabled -Value $false
         }
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Test Check Default Trace" {

--- a/tests/Get-DbaTraceFlag.Tests.ps1
+++ b/tests/Get-DbaTraceFlag.Tests.ps1
@@ -47,6 +47,8 @@ Describe $CommandName -Tag IntegrationTests {
             if ($startingTfs.TraceFlag -notcontains $safeTraceFlag) {
                 $server.Query("DBCC TRACEOFF($safeTraceFlag,-1)")
             }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Has the right default properties" {

--- a/tests/Get-DbaUserPermission.Tests.ps1
+++ b/tests/Get-DbaUserPermission.Tests.ps1
@@ -50,6 +50,8 @@ exec sp_addrolemember 'userrole','bob';
         AfterAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
             Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbName -Confirm:$false
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "returns results" {
@@ -86,7 +88,10 @@ exec sp_addrolemember 'userrole','bob';
 
         AfterAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
             Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbName -Confirm:$false
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should not warn about collation conflict" {

--- a/tests/Get-DbaWaitingTask.Tests.ps1
+++ b/tests/Get-DbaWaitingTask.Tests.ps1
@@ -55,6 +55,8 @@ Describe $CommandName -Tag IntegrationTests {
             }
         }
         Get-Job -Name $global:waitingTaskJobName -ErrorAction SilentlyContinue | Remove-Job -Force -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command functionality with waiting task" {

--- a/tests/Grant-DbaAgPermission.Tests.ps1
+++ b/tests/Grant-DbaAgPermission.Tests.ps1
@@ -51,14 +51,12 @@ Describe $CommandName -Tag IntegrationTests {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-        $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agName -Confirm:$false
-        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+        $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agName
+        $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint
+        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance3 -Login "claudio", "port", "tester"
+        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance3 -Login "claudio", "port", "tester"
 
-        $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agName -Confirm:$false
-        $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
-        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance3 -Login "claudio", "port", "tester" -Confirm:$false
-        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance3 -Login "claudio", "port", "tester" -Confirm:$false
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "grants big perms" {

--- a/tests/Import-DbaBinaryFile.Tests.ps1
+++ b/tests/Import-DbaBinaryFile.Tests.ps1
@@ -58,6 +58,8 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.instance3 -AvailabilityGroup $agName -Confirm:$false
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false
         $null = Remove-DbaLogin -SqlInstance $TestConfig.instance3 -Login "claudio", "port", "tester" -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "grants big perms" {

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -76,6 +76,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Cleanup test tables
         Get-DbaDbTable -SqlInstance $TestConfig.instance1, $TestConfig.instance2 -Database tempdb -Table SuperSmall, CommaSeparatedWithHeader -ErrorAction SilentlyContinue | Remove-DbaDbTable -Confirm:$false -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Works as expected" {

--- a/tests/Import-DbaPfDataCollectorSetTemplate.Tests.ps1
+++ b/tests/Import-DbaPfDataCollectorSetTemplate.Tests.ps1
@@ -55,6 +55,8 @@ Describe $CommandName -Tag IntegrationTests {
     AfterAll {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
         $null = Get-DbaPfDataCollectorSet -CollectorSet $collectorSetName | Remove-DbaPfDataCollectorSet -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Verifying command returns all the required results with pipe" {

--- a/tests/Install-DbaFirstResponderKit.Tests.ps1
+++ b/tests/Install-DbaFirstResponderKit.Tests.ps1
@@ -45,6 +45,8 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $database -Confirm:$false
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Installs to specified database: $database" {
@@ -98,6 +100,8 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             Remove-DbaDatabase -SqlInstance $TestConfig.instance3 -Database $database -Confirm:$false
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Installs to specified database: $database" {

--- a/tests/Install-DbaSqlWatch.Tests.ps1
+++ b/tests/Install-DbaSqlWatch.Tests.ps1
@@ -42,6 +42,8 @@ Describe $CommandName -Tag IntegrationTests {
 
             Uninstall-DbaSqlWatch -SqlInstance $TestConfig.instance2 -Database $database -ErrorAction SilentlyContinue
             Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $database -Confirm:$false -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Installs to specified database: $database" {

--- a/tests/Install-DbaWhoIsActive.Tests.ps1
+++ b/tests/Install-DbaWhoIsActive.Tests.ps1
@@ -40,6 +40,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbName -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Should install sp_WhoIsActive" {

--- a/tests/Invoke-DbaDbDataMasking.Tests.ps1
+++ b/tests/Invoke-DbaDbDataMasking.Tests.ps1
@@ -98,6 +98,8 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaDatabase @splatRemoveDb -ErrorAction SilentlyContinue
 
         Remove-Item -Path $tempPath -Recurse -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command works" {

--- a/tests/Invoke-DbaDbDbccCheckConstraint.Tests.ps1
+++ b/tests/Invoke-DbaDbDbccCheckConstraint.Tests.ps1
@@ -53,6 +53,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Validate standard output" {

--- a/tests/Invoke-DbaDbDbccCleanTable.Tests.ps1
+++ b/tests/Invoke-DbaDbDbccCleanTable.Tests.ps1
@@ -46,6 +46,8 @@ Describe $CommandName -Tag IntegrationTests {
         } catch {
             $null = 1
         }
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Validate standard output" {

--- a/tests/Invoke-DbaDbDbccUpdateUsage.Tests.ps1
+++ b/tests/Invoke-DbaDbDbccUpdateUsage.Tests.ps1
@@ -44,6 +44,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname | Remove-DbaDatabase -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Validate standard output" {

--- a/tests/Invoke-DbaDbDecryptObject.Tests.ps1
+++ b/tests/Invoke-DbaDbDecryptObject.Tests.ps1
@@ -222,6 +222,8 @@ SELECT 'áéíñóú¡¿' as SampleUTF8;"
         # Set the original configuration
         Set-DbaSpConfigure -SqlInstance $TestConfig.instance1 -ConfigName RemoteDacConnectionsEnabled -Value $config.ConfiguredValue -WarningAction SilentlyContinue
         Set-DbaSpConfigure -SqlInstance $TestConfig.instance2 -SqlCredential $instance2SqlCredential -ConfigName RemoteDacConnectionsEnabled -Value $instance2Config.ConfiguredValue -WarningAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     # these tests are marked as skip to ensure the AppVeyor sql instances are not impacted negatively. These tests can be run locally.

--- a/tests/Invoke-DbaDbMirroring.Tests.ps1
+++ b/tests/Invoke-DbaDbMirroring.Tests.ps1
@@ -34,7 +34,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set variables. They are available in all the It blocks.
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -47,11 +47,11 @@ Describe $CommandName -Tag IntegrationTests {
         $null = New-DbaEndpoint -SqlInstance $TestConfig.instance3 -Name $endpointName -Type DatabaseMirroring -Port 5023 -Owner sa
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         $null = Remove-DbaDbMirror -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Database $dbName -Confirm:$false

--- a/tests/Invoke-DbaDbShrink.Tests.ps1
+++ b/tests/Invoke-DbaDbShrink.Tests.ps1
@@ -34,18 +34,18 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $defaultPath = $server | Get-DbaDefaultPath
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -41,15 +41,15 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $db = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database tempdb
         $null = $db.Query("CREATE PROCEDURE dbo.dbatoolsci_procedure_example @p1 [INT] = 0 AS BEGIN SET NOCOUNT OFF; SELECT TestColumn = @p1; END")
 
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     AfterAll {
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         try {
             $null = $db.Query("DROP PROCEDURE dbo.dbatoolsci_procedure_example")
@@ -60,6 +60,8 @@ Describe $CommandName -Tag IntegrationTests {
             $null = 1
         }
         Remove-Item ".\hellorelative.sql" -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     It "supports pipable instances" {
         $results = $TestConfig.instance2, $TestConfig.instance3 | Invoke-DbaQuery -Database tempdb -Query "Select 'hello' as TestColumn"

--- a/tests/Invoke-DbaWhoIsActive.Tests.ps1
+++ b/tests/Invoke-DbaWhoIsActive.Tests.ps1
@@ -64,6 +64,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         Invoke-DbaQuery -SqlInstance $TestConfig.instance1 -Database master -Query "DROP PROCEDURE [dbo].[sp_WhoIsActive];" -ErrorAction SilentlyContinue
         Invoke-DbaQuery -SqlInstance $TestConfig.instance1 -Database tempdb -Query "DROP PROCEDURE [dbo].[sp_WhoIsActive];" -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "Should have SPWhoisActive installed correctly" {
         It "Should be installed to master" {

--- a/tests/Measure-DbaBackupThroughput.Tests.ps1
+++ b/tests/Measure-DbaBackupThroughput.Tests.ps1
@@ -53,6 +53,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Returns output for single database" {

--- a/tests/Move-DbaRegServer.Tests.ps1
+++ b/tests/Move-DbaRegServer.Tests.ps1
@@ -68,6 +68,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         Get-DbaRegServer -SqlInstance $TestConfig.instance1 -Name $regSrvName, $regSrvName2, $regSrvName3, $regSrvNameHR, $regSrvNameFinance | Remove-DbaRegServer -Confirm:$false
         Get-DbaRegServerGroup -SqlInstance $TestConfig.instance1 -Group $group, $group2, $testGroupHR, $testGroupFinance | Remove-DbaRegServerGroup -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "moves a piped server" {

--- a/tests/Move-DbaRegServerGroup.Tests.ps1
+++ b/tests/Move-DbaRegServerGroup.Tests.ps1
@@ -52,6 +52,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         Get-DbaRegServer -SqlInstance $TestConfig.instance1 -Name $regSrvName | Remove-DbaRegServer -Confirm:$false -ErrorAction SilentlyContinue
         Get-DbaRegServerGroup -SqlInstance $TestConfig.instance1 -Group $group, $group2, $group3 | Remove-DbaRegServerGroup -Confirm:$false -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When moving registered server groups" {

--- a/tests/New-DbaAgentAlert.Tests.ps1
+++ b/tests/New-DbaAgentAlert.Tests.ps1
@@ -39,7 +39,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set test alert names for cleanup tracking
         $global:testAlertNames = @("Test Alert", "Another Alert")
@@ -48,12 +48,12 @@ Describe $CommandName -Tag IntegrationTests {
         Get-DbaAgentAlert -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Alert $global:testAlertNames -ErrorAction SilentlyContinue | Remove-DbaAgentAlert -Confirm:$false -ErrorAction SilentlyContinue
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Clean up all test alerts created during testing
         Get-DbaAgentAlert -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Alert $global:testAlertNames -ErrorAction SilentlyContinue | Remove-DbaAgentAlert -Confirm:$false -ErrorAction SilentlyContinue

--- a/tests/New-DbaAgentJob.Tests.ps1
+++ b/tests/New-DbaAgentJob.Tests.ps1
@@ -55,6 +55,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Cleanup and ignore all output
         Remove-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job $jobName -Confirm:$false -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "New Agent Job is added properly" {

--- a/tests/New-DbaAgentJobCategory.Tests.ps1
+++ b/tests/New-DbaAgentJobCategory.Tests.ps1
@@ -25,8 +25,6 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-
         $testCategory1 = "CategoryTest1"
         $testCategory2 = "CategoryTest2"
         $categoriesToCleanup = @()
@@ -34,14 +32,13 @@ Describe $CommandName -Tag IntegrationTests {
 
     AfterAll {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         Remove-DbaAgentJobCategory -SqlInstance $TestConfig.instance2 -Category $testCategory1, $testCategory2 -Confirm:$false -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "New Agent Job Category is added properly" {
-        BeforeAll {
-            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-        }
-
         It "Should have the right name and category type" {
             $results = New-DbaAgentJobCategory -SqlInstance $TestConfig.instance2 -Category $testCategory1
             $results.Name | Should -Be $testCategory1

--- a/tests/New-DbaAgentJobStep.Tests.ps1
+++ b/tests/New-DbaAgentJobStep.Tests.ps1
@@ -61,6 +61,8 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             Remove-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job "dbatoolsci_job_1_$random", "dbatoolsci_job_2_$random", "dbatoolsci_job_3_$random" -Confirm:$false
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should have the right name and description" {

--- a/tests/New-DbaCustomError.Tests.ps1
+++ b/tests/New-DbaCustomError.Tests.ps1
@@ -27,10 +27,17 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance1
         $server2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
+
     AfterAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         $server.Query("IF EXISTS (SELECT 1 FROM master.sys.messages WHERE message_id = 70000) BEGIN EXEC msdb.dbo.sp_dropmessage @msgnum = 70000, @lang = 'all'; END")
         $server.Query("IF EXISTS (SELECT 1 FROM master.sys.messages WHERE message_id = 70001) BEGIN EXEC msdb.dbo.sp_dropmessage @msgnum = 70001, @lang = 'all'; END")
         $server.Query("IF EXISTS (SELECT 1 FROM master.sys.messages WHERE message_id = 70002) BEGIN EXEC msdb.dbo.sp_dropmessage @msgnum = 70002, @lang = 'all'; END")
@@ -39,6 +46,8 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query("IF EXISTS (SELECT 1 FROM master.sys.messages WHERE message_id = 70005) BEGIN EXEC msdb.dbo.sp_dropmessage @msgnum = 70005, @lang = 'all'; END")
         $server.Query("IF EXISTS (SELECT 1 FROM master.sys.messages WHERE message_id = 70006) BEGIN EXEC msdb.dbo.sp_dropmessage @msgnum = 70006, @lang = 'all'; END")
         $server2.Query("IF EXISTS (SELECT 1 FROM master.sys.messages WHERE message_id = 70006) BEGIN EXEC msdb.dbo.sp_dropmessage @msgnum = 70006, @lang = 'all'; END")
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Validate params" {

--- a/tests/New-DbaDatabase.Tests.ps1
+++ b/tests/New-DbaDatabase.Tests.ps1
@@ -75,6 +75,8 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created databases.
         $null = Remove-DbaDatabase -SqlInstance $instance2 -Database $randomDb.Name, $newDbName, $newDb1Name, $newDb2Name, $bug6780DbName, $collationDbName, $simpleRecoveryModelDbName, $fullRecoveryModelDbName, $bulkLoggedRecoveryModelDbName -Confirm:$false -ErrorAction SilentlyContinue
         $null = Remove-DbaDatabase -SqlInstance $instance3 -Database $newDbName, $newDb1Name, $newDb2Name, $secondaryFileTestDbName, $secondaryFileCountTestDbName, $primaryFileGroupDbName, $secondaryFileGroupDbName -Confirm:$false -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When creating databases" {

--- a/tests/New-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/New-DbaDbAsymmetricKey.Tests.ps1
@@ -45,6 +45,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database enctest -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "commands work as expected" {

--- a/tests/New-DbaDbEncryptionKey.Tests.ps1
+++ b/tests/New-DbaDbEncryptionKey.Tests.ps1
@@ -31,7 +31,6 @@ Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-        $PSDefaultParameterValues["*:Confirm"] = $false
 
         $passwd = ConvertTo-SecureString "dbatools.IO" -AsPlainText -Force
         $cred = New-Object System.Management.Automation.PSCredential "sqladmin", $passwd
@@ -66,6 +65,8 @@ Describe $CommandName -Tag IntegrationTests {
         if ($delmasterkey) {
             $masterkey | Remove-DbaDbMasterKey -ErrorAction SilentlyContinue
         }
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {
@@ -87,7 +88,6 @@ Describe $CommandName -Tag IntegrationTests {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-            $PSDefaultParameterValues["*:Confirm"] = $false
 
             $passwd = ConvertTo-SecureString "dbatools.IO" -AsPlainText -Force
             $masterkey = Get-DbaDbMasterKey -SqlInstance $TestConfig.instance2 -Database master
@@ -124,6 +124,8 @@ Describe $CommandName -Tag IntegrationTests {
             if ($delmasterkey) {
                 $masterkey | Remove-DbaDbMasterKey -ErrorAction SilentlyContinue
             }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         # TODO: I think I need some background on this. Was the intention to create the key or not to creeate the key?

--- a/tests/New-DbaDbFileGroup.Tests.ps1
+++ b/tests/New-DbaDbFileGroup.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $random = Get-Random
         $db1name = "dbatoolsci_filegroup_test_$random"
@@ -47,18 +47,20 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $newDb1, $newDb2 | Remove-DbaDatabase -Confirm:$false
 
         if ($resetFileStream) {
             Disable-DbaFilestream -SqlInstance $TestConfig.instance2 -Confirm:$false -Force
         }
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "ensure command works" {

--- a/tests/New-DbaDbMasterKey.Tests.ps1
+++ b/tests/New-DbaDbMasterKey.Tests.ps1
@@ -66,6 +66,8 @@ Describe $CommandName -Tag IntegrationTests {
         if ($delmasterkey) {
             $masterkey | Remove-DbaDbMasterKey
         }
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/New-DbaDbRole.Tests.ps1
+++ b/tests/New-DbaDbRole.Tests.ps1
@@ -27,18 +27,26 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         $instance = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $dbname = "dbatoolsci_adddb_newrole"
         $instance.Query("create database $dbname")
         $roleExecutor = "dbExecuter"
         $roleSPAccess = "dbSPAccess"
         $owner = 'dbo'
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     AfterEach {
         $null = Remove-DbaDbRole -SqlInstance $instance -Database $dbname -Role $roleExecutor, $roleSPAccess -Confirm:$false
     }
     AfterAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         $null = Remove-DbaDatabase -SqlInstance $instance -Database $dbname -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Functionality" {

--- a/tests/New-DbaDbRole.Tests.ps1
+++ b/tests/New-DbaDbRole.Tests.ps1
@@ -1,19 +1,31 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "New-DbaDbRole",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tags "UnitTests" {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Role', 'Owner', 'InputObject', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Database",
+                "ExcludeDatabase",
+                "Role",
+                "Owner",
+                "InputObject",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         $instance = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $dbname = "dbatoolsci_adddb_newrole"
@@ -33,35 +45,35 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         It 'Add new role and returns results' {
             $result = New-DbaDbRole -SqlInstance $instance -Database $dbname -Role $roleExecutor
 
-            $result.Count | Should Be 1
-            $result.Name | Should Be $roleExecutor
-            $result.Parent | Should Be $dbname
+            $result.Count | Should -Be 1
+            $result.Name | Should -Be $roleExecutor
+            $result.Parent | Should -Be $dbname
         }
 
         It 'Add new role with specificied owner' {
             $result = New-DbaDbRole -SqlInstance $instance -Database $dbname -Role $roleExecutor -Owner $owner
 
-            $result.Count | Should Be 1
-            $result.Name | Should Be $roleExecutor
-            $result.Owner | Should Be $owner
-            $result.Parent | Should Be $dbname
+            $result.Count | Should -Be 1
+            $result.Name | Should -Be $roleExecutor
+            $result.Owner | Should -Be $owner
+            $result.Parent | Should -Be $dbname
         }
 
         It 'Add two new roles and returns results' {
             $result = New-DbaDbRole -SqlInstance $instance -Database $dbname -Role $roleExecutor, $roleSPAccess
 
-            $result.Count | Should Be 2
-            $result.Name | Should Contain $roleExecutor
-            $result.Name | Should Contain $roleSPAccess
-            $result.Parent | Select-Object -Unique | Should Be $dbname
+            $result.Count | Should -Be 2
+            $result.Name | Should -Contain $roleExecutor
+            $result.Name | Should -Contain $roleSPAccess
+            $result.Parent | Select-Object -Unique | Should -Be $dbname
         }
 
         It 'Accept database as inputObject' {
             $result = $instance.Databases[$dbname] | New-DbaDbRole -Role $roleExecutor
 
-            $result.Count | Should Be 1
-            $result.Name | Should Be $roleExecutor
-            $result.Parent | Should Be $dbname
+            $result.Count | Should -Be 1
+            $result.Name | Should -Be $roleExecutor
+            $result.Parent | Should -Be $dbname
         }
     }
 }

--- a/tests/New-DbaDbSequence.Tests.ps1
+++ b/tests/New-DbaDbSequence.Tests.ps1
@@ -55,6 +55,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = $newDb | Remove-DbaDatabase -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "commands work as expected" {

--- a/tests/New-DbaDbSnapshot.Tests.ps1
+++ b/tests/New-DbaDbSnapshot.Tests.ps1
@@ -88,6 +88,8 @@ Describe $CommandName -Tag IntegrationTests {
 
             Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1, $db2, $db3, $db4 -Confirm:$false -ErrorAction SilentlyContinue
             Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance2 -Database $db1, $db2, $db3, $db4 -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Skips over offline databases nicely" {

--- a/tests/New-DbaDbSynonym.Tests.ps1
+++ b/tests/New-DbaDbSynonym.Tests.ps1
@@ -51,6 +51,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname, $dbname2 -Confirm:$false
         $null = Remove-DbaDbSynonym -SqlInstance $TestConfig.instance2 -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Functionality" {

--- a/tests/New-DbaDbTable.Tests.ps1
+++ b/tests/New-DbaDbTable.Tests.ps1
@@ -1,19 +1,81 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "New-DbaDbTable",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
-        [array]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Name', 'Schema', 'ColumnMap', 'ColumnObject', 'AnsiNullsStatus', 'ChangeTrackingEnabled', 'DataSourceName', 'Durability', 'ExternalTableDistribution', 'FileFormatName', 'FileGroup', 'FileStreamFileGroup', 'FileStreamPartitionScheme', 'FileTableDirectoryName', 'FileTableNameColumnCollation', 'FileTableNamespaceEnabled', 'HistoryTableName', 'HistoryTableSchema', 'IsExternal', 'IsFileTable', 'IsMemoryOptimized', 'IsSystemVersioned', 'Location', 'LockEscalation', 'Owner', 'PartitionScheme', 'QuotedIdentifierStatus', 'RejectSampleValue', 'RejectType', 'RejectValue', 'RemoteDataArchiveDataMigrationState', 'RemoteDataArchiveEnabled', 'RemoteDataArchiveFilterPredicate', 'RemoteObjectName', 'RemoteSchemaName', 'RemoteTableName', 'RemoteTableProvisioned', 'ShardingColumnName', 'TextFileGroup', 'TrackColumnsUpdatedEnabled', 'HistoryRetentionPeriod', 'HistoryRetentionPeriodUnit', 'DwTableDistribution', 'RejectedRowLocation', 'OnlineHeapOperation', 'LowPriorityMaxDuration', 'DataConsistencyCheck', 'LowPriorityAbortAfterWait', 'MaximumDegreeOfParallelism', 'IsNode', 'IsEdge', 'IsVarDecimalStorageFormatEnabled', 'Passthru', 'InputObject', 'EnableException'
-
-        It "Should only contain our specific parameters" {
-            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Database",
+                "Name",
+                "Schema",
+                "ColumnMap",
+                "ColumnObject",
+                "AnsiNullsStatus",
+                "ChangeTrackingEnabled",
+                "DataSourceName",
+                "Durability",
+                "ExternalTableDistribution",
+                "FileFormatName",
+                "FileGroup",
+                "FileStreamFileGroup",
+                "FileStreamPartitionScheme",
+                "FileTableDirectoryName",
+                "FileTableNameColumnCollation",
+                "FileTableNamespaceEnabled",
+                "HistoryTableName",
+                "HistoryTableSchema",
+                "IsExternal",
+                "IsFileTable",
+                "IsMemoryOptimized",
+                "IsSystemVersioned",
+                "Location",
+                "LockEscalation",
+                "Owner",
+                "PartitionScheme",
+                "QuotedIdentifierStatus",
+                "RejectSampleValue",
+                "RejectType",
+                "RejectValue",
+                "RemoteDataArchiveDataMigrationState",
+                "RemoteDataArchiveEnabled",
+                "RemoteDataArchiveFilterPredicate",
+                "RemoteObjectName",
+                "RemoteSchemaName",
+                "RemoteTableName",
+                "RemoteTableProvisioned",
+                "ShardingColumnName",
+                "TextFileGroup",
+                "TrackColumnsUpdatedEnabled",
+                "HistoryRetentionPeriod",
+                "HistoryRetentionPeriodUnit",
+                "DwTableDistribution",
+                "RejectedRowLocation",
+                "OnlineHeapOperation",
+                "LowPriorityMaxDuration",
+                "DataConsistencyCheck",
+                "LowPriorityAbortAfterWait",
+                "MaximumDegreeOfParallelism",
+                "IsNode",
+                "IsEdge",
+                "IsVarDecimalStorageFormatEnabled",
+                "Passthru",
+                "InputObject",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         $dbname = "dbatoolsscidb_$(Get-Random)"
         $null = New-DbaDatabase -SqlInstance $TestConfig.instance1 -Name $dbname

--- a/tests/New-DbaDbTable.Tests.ps1
+++ b/tests/New-DbaDbTable.Tests.ps1
@@ -77,6 +77,8 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         $dbname = "dbatoolsscidb_$(Get-Random)"
         $null = New-DbaDatabase -SqlInstance $TestConfig.instance1 -Name $dbname
         $tablename = "dbatoolssci_$(Get-Random)"
@@ -84,11 +86,19 @@ Describe $CommandName -Tag IntegrationTests {
         $tablename3 = "dbatoolssci2_$(Get-Random)"
         $tablename4 = "dbatoolssci2_$(Get-Random)"
         $tablename5 = "dbatoolssci2_$(Get-Random)"
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
+
     AfterAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance1 -Database $dbname -Query "drop table $tablename, $tablename2"
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
+
     Context "Should create the table" {
         BeforeEach {
             $map = @{

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -57,6 +57,8 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname -Confirm:$false
         $null = Remove-DbaLogin -SqlInstance $TestConfig.instance2 -Login $userName -Confirm:$false
         $null = Set-DbaSpConfigure -SqlInstance $TestConfig.instance2 -Name ContainmentEnabled -Value $dbContainmentSpValue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "Test error handling" {
         It "Tries to create the user with an invalid default schema" {
@@ -110,6 +112,8 @@ Describe $CommandName -Tag IntegrationTests {
 
             $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbs -Confirm:$false
             $null = Remove-DbaLogin -SqlInstance $TestConfig.instance2 -Login $loginName -Confirm:$false
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
         It "Should add login to all databases provided" {
             $results = New-DbaDbUser -SqlInstance $TestConfig.instance2 -Login $loginName -Database $dbs -Force -EnableException

--- a/tests/New-DbaEndpoint.Tests.ps1
+++ b/tests/New-DbaEndpoint.Tests.ps1
@@ -34,8 +34,6 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-
         $endpointName = "dbatoolsci_MirroringEndpoint"
     }
 
@@ -43,12 +41,12 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaEndpoint -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -EndPoint $endpointName -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When creating database mirroring endpoints" {
         BeforeAll {
-            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-
             $results = New-DbaEndpoint -SqlInstance $TestConfig.instance2 -Type DatabaseMirroring -Role Partner -Name $endpointName -Confirm:$false | Start-DbaEndpoint -Confirm:$false
         }
 

--- a/tests/New-DbaFirewallRule.Tests.ps1
+++ b/tests/New-DbaFirewallRule.Tests.ps1
@@ -47,6 +47,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaFirewallRule -SqlInstance $TestConfig.instance2 -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     # If remote DAC is enabled, also creates rule for DAC.

--- a/tests/New-DbaLinkedServer.Tests.ps1
+++ b/tests/New-DbaLinkedServer.Tests.ps1
@@ -61,6 +61,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Cleanup test login.
         Remove-DbaLogin -SqlInstance $instance3 -Login $loginName -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "ensure command works" {

--- a/tests/New-DbaLinkedServerLogin.Tests.ps1
+++ b/tests/New-DbaLinkedServerLogin.Tests.ps1
@@ -59,6 +59,8 @@ Describe $CommandName -Tag IntegrationTests {
         Remove-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServer1Name, $linkedServer2Name -Confirm:$false -Force -ErrorAction SilentlyContinue
         Remove-DbaLogin -SqlInstance $instance2 -Login $localLogin1Name, $localLogin2Name -Confirm:$false -ErrorAction SilentlyContinue
         Remove-DbaLogin -SqlInstance $instance3 -Login $remoteLoginName -Confirm:$false -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "ensure command works" {

--- a/tests/New-DbaLogin.Tests.ps1
+++ b/tests/New-DbaLogin.Tests.ps1
@@ -42,7 +42,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $credLogin = "credologino"
         $certificateName = "dbatoolsPesterlogincertificate"
@@ -106,12 +106,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = New-DbaDbCertificate $server1 -Name $certificateName -Password $null -Confirm:$false
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         try {
             foreach ($instance in $servers) {

--- a/tests/New-DbaSsisCatalog.Tests.ps1
+++ b/tests/New-DbaSsisCatalog.Tests.ps1
@@ -62,6 +62,8 @@ Describe $CommandName -Tag IntegrationTests {
             if ($shouldRunTests -and $database) {
                 Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.ssisserver -Database $database -ErrorAction SilentlyContinue
             }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "uses the specified database" -Skip:(-not $shouldRunTests) {

--- a/tests/Publish-DbaDacPackage.Tests.ps1
+++ b/tests/Publish-DbaDacPackage.Tests.ps1
@@ -34,7 +34,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Check if SqlPackage is available since Export-DbaDacPackage is used in these tests
         $sqlPackagePath = Get-DbaSqlPackagePath
@@ -70,12 +70,12 @@ Describe $CommandName -Tag IntegrationTests {
         $publishprofile = New-DbaDacProfile -SqlInstance $TestConfig.instance1 -Database $dbname -Path C:\temp
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Remove-DbaDatabase -SqlInstance $TestConfig.instance1, $TestConfig.instance2 -Database $dbname -Confirm:$false
         Remove-Item -Confirm:$false -Path $publishprofile.FileName -ErrorAction SilentlyContinue

--- a/tests/Read-DbaAuditFile.Tests.ps1
+++ b/tests/Read-DbaAuditFile.Tests.ps1
@@ -58,6 +58,8 @@ Describe $CommandName -Tag IntegrationTests {
                 DROP SERVER AUDIT SPECIFICATION $specName
                 DROP SERVER AUDIT $auditName"
         $server.Query($sql)
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "Verifying command output" {
         It "returns some results with Raw parameter" {

--- a/tests/Read-DbaTraceFile.Tests.ps1
+++ b/tests/Read-DbaTraceFile.Tests.ps1
@@ -33,15 +33,6 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
-    BeforeAll {
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-
-        # TODO: Should not be needed as the default trace should always be enabled
-        Set-DbaSpConfigure -SqlInstance $TestConfig.instance1, $TestConfig.instance2 -Name DefaultTraceEnabled -Value $true -WarningAction SilentlyContinue
-
-        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-    }
-
     Context "Verifying command output" {
         It "returns results" {
             $results = Get-DbaTrace -SqlInstance $TestConfig.instance2 -Id 1 | Read-DbaTraceFile

--- a/tests/Read-DbaTraceFile.Tests.ps1
+++ b/tests/Read-DbaTraceFile.Tests.ps1
@@ -1,19 +1,38 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Read-DbaTraceFile",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('WhatIf', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Path', 'Database', 'Login', 'Spid', 'EventClass', 'ObjectType', 'ErrorId', 'EventSequence', 'TextData', 'ApplicationName', 'ObjectName', 'Where', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Path",
+                "Database",
+                "Login",
+                "Spid",
+                "EventClass",
+                "ObjectType",
+                "ErrorId",
+                "EventSequence",
+                "TextData",
+                "ApplicationName",
+                "ObjectName",
+                "Where",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # TODO: Should not be needed as the default trace should always be enabled
         Set-DbaSpConfigure -SqlInstance $TestConfig.instance1, $TestConfig.instance2 -Name DefaultTraceEnabled -Value $true -WarningAction SilentlyContinue
@@ -36,21 +55,21 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
             # Collect the results into a variable so that the bulk import is super fast
             Get-DbaTrace -SqlInstance $TestConfig.instance2 -Id 1 | Read-DbaTraceFile -Where $where -WarningAction SilentlyContinue -WarningVariable warn > $null
-            $warn | Should -Be $null
+            $warn | Should -BeNullOrEmpty
         }
     }
     Context "Verify Parameter Use" {
         It "Should execute using parameters Database, Login, Spid" {
             $results = Get-DbaTrace -SqlInstance $TestConfig.instance2 -Id 1 | Read-DbaTraceFile -Database Master -Login sa -Spid 7 -WarningAction SilentlyContinue -WarningVariable warn
-            $warn | Should -Be $null
+            $warn | Should -BeNullOrEmpty
         }
         It "Should execute using parameters EventClass, ObjectType, ErrorId" {
             $results = Get-DbaTrace -SqlInstance $TestConfig.instance2 -Id 1 | Read-DbaTraceFile -EventClass 4 -ObjectType 4 -ErrorId 4 -WarningAction SilentlyContinue -WarningVariable warn
-            $warn | Should -Be $null
+            $warn | Should -BeNullOrEmpty
         }
         It "Should execute using parameters EventSequence, TextData, ApplicationName, ObjectName" {
             $results = Get-DbaTrace -SqlInstance $TestConfig.instance2 -Id 1 | Read-DbaTraceFile -EventSequence 4 -TextData "Text" -ApplicationName "Application" -ObjectName "Name" -WarningAction SilentlyContinue -WarningVariable warn
-            $warn | Should -Be $null
+            $warn | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Read-DbaTraceFile.Tests.ps1
+++ b/tests/Read-DbaTraceFile.Tests.ps1
@@ -34,8 +34,12 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         # TODO: Should not be needed as the default trace should always be enabled
         Set-DbaSpConfigure -SqlInstance $TestConfig.instance1, $TestConfig.instance2 -Name DefaultTraceEnabled -Value $true -WarningAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Verifying command output" {

--- a/tests/Remove-DbaAgDatabase.Tests.ps1
+++ b/tests/Remove-DbaAgDatabase.Tests.ps1
@@ -49,12 +49,12 @@ Describe $CommandName -Tag IntegrationTests {
         $ag = New-DbaAvailabilityGroup @splatAvailabilityGroup
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname -Confirm:$false
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.instance3 -Type DatabaseMirroring | Remove-DbaEndpoint -Confirm:$false

--- a/tests/Remove-DbaAgentJob.Tests.ps1
+++ b/tests/Remove-DbaAgentJob.Tests.ps1
@@ -45,6 +45,8 @@ Describe $CommandName -Tag IntegrationTests {
             if (Get-DbaAgentSchedule -SqlInstance $TestConfig.instance3 -Schedule dbatoolsci_daily) {
                 Remove-DbaAgentSchedule -SqlInstance $TestConfig.instance3 -Schedule dbatoolsci_daily -Confirm:$false
             }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should have deleted job: dbatoolsci_testjob" {
@@ -79,6 +81,8 @@ Describe $CommandName -Tag IntegrationTests {
             if (Get-DbaAgentSchedule -SqlInstance $TestConfig.instance3 -Schedule dbatoolsci_weekly) {
                 Remove-DbaAgentSchedule -SqlInstance $TestConfig.instance3 -Schedule dbatoolsci_weekly -Confirm:$false
             }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should have deleted job: dbatoolsci_testjob_schedule" {
@@ -106,6 +110,8 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $server.Query("delete from sysjobhistory where job_id = '$jobId'", "msdb")
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should have deleted job: dbatoolsci_testjob_history" {

--- a/tests/Remove-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Remove-DbaAgentJobCategory.Tests.ps1
@@ -27,19 +27,19 @@ Describe $CommandName -Tag IntegrationTests {
     Context "New Agent Job Category is changed properly" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # Create test job categories
             $testCategories = @("CategoryTest1", "CategoryTest2", "CategoryTest3")
             $null = New-DbaAgentJobCategory -SqlInstance $TestConfig.instance2 -Category $testCategories
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # Clean up any remaining test categories
             $null = Remove-DbaAgentJobCategory -SqlInstance $TestConfig.instance2 -Category "CategoryTest1", "CategoryTest2", "CategoryTest3" -Confirm:$false -ErrorAction SilentlyContinue

--- a/tests/Remove-DbaAgentOperator.Tests.ps1
+++ b/tests/Remove-DbaAgentOperator.Tests.ps1
@@ -53,6 +53,8 @@ Describe $CommandName -Tag IntegrationTests {
         foreach ($operatorName in $operatorsToCleanup) {
             $null = Remove-DbaAgentOperator @splatCleanup -Operator $operatorName -ErrorAction SilentlyContinue
         }
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Remove Agent Operator is removed properly" {

--- a/tests/Remove-DbaAgentProxy.Tests.ps1
+++ b/tests/Remove-DbaAgentProxy.Tests.ps1
@@ -40,6 +40,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Invoke-DbaQuery -SqlInstance $server -Query "DROP CREDENTIAL proxyCred;"
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     BeforeEach {

--- a/tests/Remove-DbaDatabase.Tests.ps1
+++ b/tests/Remove-DbaDatabase.Tests.ps1
@@ -1,60 +1,70 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Remove-DbaDatabase",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'InputObject', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Database",
+                "InputObject",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+Describe $CommandName -Tag IntegrationTests {
     Context "Should not munge system databases." {
-
-        $dbs = @( "master", "model", "tempdb", "msdb" )
+        BeforeAll {
+            $dbs = @( "master", "model", "tempdb", "msdb" )
+        }
 
         It "Should not attempt to remove system databases." {
             foreach ($db in $dbs) {
                 $db1 = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $db
-                Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance1 -Database $db
+                Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $db
                 $db2 = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $db
-                $db2.Name | Should Be $db1.Name
+                $db2.Name | Should -Be $db1.Name
             }
         }
 
         It "Should not take system databases offline or change their status." {
             foreach ($db in $dbs) {
                 $db1 = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $db
-                Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance1 -Database $db
+                Remove-DbaDatabase SqlInstance $TestConfig.instance1 -Database $db
                 $db2 = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $db
-                $db2.Status | Should Be $db1.Status
-                $db2.IsAccessible | Should Be $db1.IsAccessible
+                $db2.Status | Should -Be $db1.Status
+                $db2.IsAccessible | Should -Be $db1.IsAccessible
             }
         }
     }
     Context "Should remove user databases and return useful errors if it cannot." {
         It "Should remove a non system database." {
-            Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance1 -Database singlerestore
+            Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database singlerestore
             Get-DbaProcess -SqlInstance $TestConfig.instance1 -Database singlerestore | Stop-DbaProcess
             Restore-DbaDatabase -SqlInstance $TestConfig.instance1 -Path "$($TestConfig.appveyorlabrepo)\singlerestore\singlerestore.bak" -WithReplace
-            (Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database singlerestore).IsAccessible | Should Be $true
-            Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance1 -Database singlerestore
-            Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database singlerestore | Should Be $null
+            (Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database singlerestore).IsAccessible | Should -BeTrue
+            Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database singlerestore
+            Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database singlerestore | Should -BeNullOrEmpty
         }
     }
     Context "Should remove restoring database and return useful errors if it cannot." {
         It "Should remove a non system database." {
-            Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance1 -Database singlerestore
+            Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database singlerestore
             Get-DbaProcess -SqlInstance $TestConfig.instance1 -Database singlerestore | Stop-DbaProcess
             Restore-DbaDatabase -SqlInstance $TestConfig.instance1 -Path "$($TestConfig.appveyorlabrepo)\singlerestore\singlerestore.bak" -WithReplace -NoRecovery
-            (Connect-DbaInstance -SqlInstance $TestConfig.instance1).Databases['singlerestore'].IsAccessible | Should Be $false
-            Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance1 -Database singlerestore
-            Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database singlerestore | Should Be $null
+            (Connect-DbaInstance -SqlInstance $TestConfig.instance1).Databases['singlerestore'].IsAccessible | Should -BeFalse
+            Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database singlerestore
+            Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database singlerestore | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Remove-DbaDatabase.Tests.ps1
+++ b/tests/Remove-DbaDatabase.Tests.ps1
@@ -44,7 +44,7 @@ Describe $CommandName -Tag IntegrationTests {
         It "Should not take system databases offline or change their status." {
             foreach ($db in $dbs) {
                 $db1 = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $db
-                Remove-DbaDatabase SqlInstance $TestConfig.instance1 -Database $db
+                Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $db
                 $db2 = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $db
                 $db2.Status | Should -Be $db1.Status
                 $db2.IsAccessible | Should -Be $db1.IsAccessible

--- a/tests/Remove-DbaDatabase.Tests.ps1
+++ b/tests/Remove-DbaDatabase.Tests.ps1
@@ -25,7 +25,11 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     Context "Should not munge system databases." {
         BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
             $dbs = @( "master", "model", "tempdb", "msdb" )
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should not attempt to remove system databases." {

--- a/tests/Remove-DbaDatabaseSafely.Tests.ps1
+++ b/tests/Remove-DbaDatabaseSafely.Tests.ps1
@@ -60,6 +60,8 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaAgentJob -Confirm:$false -SqlInstance $TestConfig.instance2 -Job "Rationalised Database Restore Script for dbatoolsci_safely" -ErrorAction SilentlyContinue
         $null = Remove-DbaAgentJob -Confirm:$false -SqlInstance $TestConfig.instance3 -Job "Rationalised Database Restore Script for dbatoolsci_safely_otherInstance" -ErrorAction SilentlyContinue
         Remove-Item -Path "$($TestConfig.Temp)\$global:db1*", "$($TestConfig.Temp)\$global:db2*" -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "Command actually works" {
         It "Should have database name of $global:db1" {

--- a/tests/Remove-DbaDbData.Tests.ps1
+++ b/tests/Remove-DbaDbData.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $dbname1 = "dbatoolsci_$(Get-Random)"
@@ -53,11 +53,11 @@ Describe $CommandName -Tag IntegrationTests {
         "
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname1 -Confirm:$false
 

--- a/tests/Remove-DbaDbEncryptionKey.Tests.ps1
+++ b/tests/Remove-DbaDbEncryptionKey.Tests.ps1
@@ -62,6 +62,8 @@ Describe $CommandName -Tag IntegrationTests {
         if ($delmasterkey) {
             $masterKeyExists | Remove-DbaDbMasterKey
         }
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command actually works" {

--- a/tests/Remove-DbaDbLogShipping.Tests.ps1
+++ b/tests/Remove-DbaDbLogShipping.Tests.ps1
@@ -59,6 +59,8 @@ Describe $CommandName -Tag UnitTests {
         Remove-Item -Path $localPath -Recurse -ErrorAction SilentlyContinue
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbName -ErrorAction SilentlyContinue
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database "$($dbName)_LS" -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Remove database from log shipping without removing secondary database" {

--- a/tests/Remove-DbaDbMirrorMonitor.Tests.ps1
+++ b/tests/Remove-DbaDbMirrorMonitor.Tests.ps1
@@ -44,6 +44,8 @@ Describe $CommandName -Tag IntegrationTests {
             # add it back
             $results = Add-DbaDbMirrorMonitor -SqlInstance $TestConfig.instance2 -WarningAction SilentlyContinue
         }
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "removes the mirror monitor" {

--- a/tests/Remove-DbaDbPartitionFunction.Tests.ps1
+++ b/tests/Remove-DbaDbPartitionFunction.Tests.ps1
@@ -48,6 +48,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname1, $dbname2 -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When removing partition functions" {

--- a/tests/Remove-DbaDbSnapshot.Tests.ps1
+++ b/tests/Remove-DbaDbSnapshot.Tests.ps1
@@ -1,43 +1,55 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Remove-DbaDbSnapshot",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Snapshot', 'InputObject', 'AllSnapshots', 'Force', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Database",
+                "ExcludeDatabase",
+                "Snapshot",
+                "InputObject",
+                "AllSnapshots",
+                "Force",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-# Targets only instance2 because it's the only one where Snapshots can happen
-Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        Get-DbaProcess -SqlInstance $TestConfig.instance2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false -WarningAction SilentlyContinue
+        Get-DbaProcess -SqlInstance $TestConfig.instance2 | Where-Object Program -match dbatools | Stop-DbaProcess -WarningAction SilentlyContinue
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $db1 = "dbatoolsci_RemoveSnap"
         $db1_snap1 = "dbatoolsci_RemoveSnap_snapshotted1"
         $db1_snap2 = "dbatoolsci_RemoveSnap_snapshotted2"
         $db2 = "dbatoolsci_RemoveSnap2"
         $db2_snap1 = "dbatoolsci_RemoveSnap2_snapshotted"
-        Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -Confirm:$false
-        Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $db1, $db2 | Remove-DbaDatabase -Confirm:$false
+        Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1, $db2
+        Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $db1, $db2 | Remove-DbaDatabase
         $server.Query("CREATE DATABASE $db1")
         $server.Query("CREATE DATABASE $db2")
     }
     AfterAll {
-        Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -Confirm:$false -ErrorAction SilentlyContinue
-        Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -ErrorAction SilentlyContinue
+        Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -ErrorAction SilentlyContinue
+        Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -ErrorAction SilentlyContinue
     }
     Context "Parameters validation" {
         It "Stops if no Database or AllDatabases" {
-            { Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -EnableException -WarningAction SilentlyContinue } | Should Throw "You must pipe"
+            { Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -EnableException -WarningAction SilentlyContinue } | Should -Throw "You must pipe"
         }
         It "Is nice by default" {
-            { Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 *> $null } | Should Not Throw "You must pipe"
+            { Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 *> $null } | Should -Not -Throw "You must pipe"
         }
     }
 
@@ -48,35 +60,35 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $null = New-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db2 -Name $db2_snap1 -ErrorAction SilentlyContinue
         }
         AfterEach {
-            Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -Confirm:$false -ErrorAction SilentlyContinue
+            Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -ErrorAction SilentlyContinue
         }
 
         It "Honors the Database parameter, dropping only snapshots of that database" {
-            $results = Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1 -Confirm:$false
-            $results.Count | Should Be 2
-            $result = Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db2 -Confirm:$false
-            $result.Name | Should Be $db2_snap1
+            $results = Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1
+            $results.Count | Should -Be 2
+            $result = Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db2
+            $result.Name | Should -Be $db2_snap1
         }
 
         It "Honors the ExcludeDatabase parameter, returning relevant snapshots" {
             $alldbs = (Get-DbaDatabase -SqlInstance $TestConfig.instance2 | Where-Object IsDatabaseSnapShot -eq $false | Where-Object Name -notin @($db1, $db2)).Name
-            $results = Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -ExcludeDatabase $alldbs -Confirm:$false
-            $results.Count | Should Be 3
+            $results = Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -ExcludeDatabase $alldbs
+            $results.Count | Should -Be 3
         }
         It "Honors the Snapshot parameter" {
-            $result = Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Snapshot $db1_snap1 -Confirm:$false
-            $result.Name | Should Be $db1_snap1
+            $result = Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Snapshot $db1_snap1
+            $result.Name | Should -Be $db1_snap1
         }
         It "Works with piped snapshots" {
-            $result = Get-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Snapshot $db1_snap1 | Remove-DbaDbSnapshot -Confirm:$false
-            $result.Name | Should Be $db1_snap1
+            $result = Get-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Snapshot $db1_snap1 | Remove-DbaDbSnapshot
+            $result.Name | Should -Be $db1_snap1
             $result = Get-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Snapshot $db1_snap1
-            $result | Should Be $null
+            $result | Should -BeNullOrEmpty
         }
         It "Has the correct default properties" {
-            $result = Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db2 -Confirm:$false
+            $result = Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db2
             $ExpectedPropsDefault = 'ComputerName', 'Name', 'InstanceName', 'SqlInstance', 'Status'
-            ($result.PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames | Sort-Object) | Should Be ($ExpectedPropsDefault | Sort-Object)
+            ($result.PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames | Sort-Object) | Should -Be ($ExpectedPropsDefault | Sort-Object)
         }
     }
 }

--- a/tests/Remove-DbaDbSnapshot.Tests.ps1
+++ b/tests/Remove-DbaDbSnapshot.Tests.ps1
@@ -28,6 +28,8 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         Get-DbaProcess -SqlInstance $TestConfig.instance2 | Where-Object Program -match dbatools | Stop-DbaProcess -WarningAction SilentlyContinue
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $db1 = "dbatoolsci_RemoveSnap"
@@ -39,17 +41,25 @@ Describe $CommandName -Tag IntegrationTests {
         Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $db1, $db2 | Remove-DbaDatabase
         $server.Query("CREATE DATABASE $db1")
         $server.Query("CREATE DATABASE $db2")
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
+
     AfterAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -ErrorAction SilentlyContinue
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
+
     Context "Parameters validation" {
         It "Stops if no Database or AllDatabases" {
-            { Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -EnableException -WarningAction SilentlyContinue } | Should -Throw "You must pipe"
+            { Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -EnableException -WarningAction SilentlyContinue } | Should -Throw "You must pipe*"
         }
         It "Is nice by default" {
-            { Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 *> $null } | Should -Not -Throw "You must pipe"
+            { Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 *> $null } | Should -Not -Throw "You must pipe*"
         }
     }
 

--- a/tests/Remove-DbaDbTableData.Tests.ps1
+++ b/tests/Remove-DbaDbTableData.Tests.ps1
@@ -86,6 +86,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Remove backup files.
         Remove-Item -Path "$($TestConfig.Temp)\$global:dbnameFullModel*", "$($TestConfig.Temp)\$global:dbnameBulkLoggedModel*" -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Param validation" {

--- a/tests/Remove-DbaDbTableData.Tests.ps1
+++ b/tests/Remove-DbaDbTableData.Tests.ps1
@@ -32,7 +32,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $global:server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $global:server2 = Connect-DbaInstance -SqlInstance $TestConfig.instance3
@@ -74,11 +74,11 @@ Describe $CommandName -Tag IntegrationTests {
                 END;"
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         Get-DbaDatabase -SqlInstance $global:server -Database $global:dbnameSimpleModel, $global:dbnameFullModel, $global:dbnameBulkLoggedModel | Remove-DbaDatabase

--- a/tests/Remove-DbaDbView.Tests.ps1
+++ b/tests/Remove-DbaDbView.Tests.ps1
@@ -26,7 +26,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $instance2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $null = Get-DbaProcess -SqlInstance $instance2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false -WarningAction SilentlyContinue
@@ -39,12 +39,12 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $instance2.Query("CREATE VIEW $view2 (b) AS (SELECT 1);", $dbname1)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaDatabase -SqlInstance $instance2 -Database $dbname1 -Confirm:$false
 

--- a/tests/Remove-DbaExtendedProperty.Tests.ps1
+++ b/tests/Remove-DbaExtendedProperty.Tests.ps1
@@ -39,6 +39,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = $db | Remove-DbaDatabase -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "commands work as expected" {

--- a/tests/Remove-DbaLinkedServerLogin.Tests.ps1
+++ b/tests/Remove-DbaLinkedServerLogin.Tests.ps1
@@ -25,6 +25,8 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         $random = Get-Random
         $instance2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $instance3 = Connect-DbaInstance -SqlInstance $TestConfig.instance3
@@ -55,11 +57,18 @@ Describe $CommandName -Tag IntegrationTests {
         $linkedServerLogin5 = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin5Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
         $linkedServerLogin6 = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin6Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
         $linkedServerLogin7 = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name, $linkedServer2Name -LocalLogin $localLogin7Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
+
     AfterAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         Remove-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServer1Name, $linkedServer2Name -Confirm:$false -Force
         Remove-DbaLogin -SqlInstance $instance2 -Login $localLogin1Name, $localLogin2Name, $localLogin3Name, $localLogin4Name, $localLogin5Name, $localLogin6Name, $localLogin7Name -Confirm:$false
         Remove-DbaLogin -SqlInstance $instance3 -Login $remoteLoginName -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "ensure command works" {

--- a/tests/Remove-DbaLinkedServerLogin.Tests.ps1
+++ b/tests/Remove-DbaLinkedServerLogin.Tests.ps1
@@ -1,19 +1,29 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Remove-DbaLinkedServerLogin",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'LinkedServer', 'LocalLogin', 'InputObject', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "LinkedServer",
+                "LocalLogin",
+                "InputObject",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         $random = Get-Random
         $instance2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2

--- a/tests/Remove-DbaLinkedServerLogin.Tests.ps1
+++ b/tests/Remove-DbaLinkedServerLogin.Tests.ps1
@@ -75,8 +75,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "Check the validation for a linked server" {
             $results = Remove-DbaLinkedServerLogin -SqlInstance $instance2 -LocalLogin $localLogin1Name -Confirm:$false -WarningVariable WarnVar -WarningAction SilentlyContinue
-            $results | Should -BeNullOrEmpty
             $WarnVar | Should -Match "LinkedServer is required"
+            $results | Should -BeNullOrEmpty
         }
 
         It "Remove a linked server login" {

--- a/tests/Remove-DbaPfDataCollectorCounter.Tests.ps1
+++ b/tests/Remove-DbaPfDataCollectorCounter.Tests.ps1
@@ -34,6 +34,8 @@ Describe $CommandName -Tag IntegrationTests {
     AfterAll {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
         $null = Get-DbaPfDataCollectorSet -CollectorSet "Long Running Queries" | Remove-DbaPfDataCollectorSet -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Verifying command returns all the required results" {

--- a/tests/Remove-DbaPfDataCollectorSet.Tests.ps1
+++ b/tests/Remove-DbaPfDataCollectorSet.Tests.ps1
@@ -25,18 +25,18 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Set up the data collector set for testing
         $null = Get-DbaPfDataCollectorSetTemplate -Template "Long Running Queries" | Import-DbaPfDataCollectorSetTemplate
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Clean up any remaining data collector sets
         $null = Remove-DbaPfDataCollectorSet -CollectorSet "Long Running Queries" -Confirm:$false -ErrorAction SilentlyContinue

--- a/tests/Remove-DbaPfDataCollectorSet.Tests.ps1
+++ b/tests/Remove-DbaPfDataCollectorSet.Tests.ps1
@@ -40,6 +40,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Clean up any remaining data collector sets
         $null = Remove-DbaPfDataCollectorSet -CollectorSet "Long Running Queries" -Confirm:$false -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Verifying command return the proper results" {

--- a/tests/Remove-DbaRgResourcePool.Tests.ps1
+++ b/tests/Remove-DbaRgResourcePool.Tests.ps1
@@ -45,6 +45,8 @@ Describe $CommandName -Tag IntegrationTests {
             if ($testPools) {
                 $null = $testPools | Remove-DbaRgResourcePool
             }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Removes a resource pool" {

--- a/tests/Remove-DbaServerRoleMember.Tests.ps1
+++ b/tests/Remove-DbaServerRoleMember.Tests.ps1
@@ -57,6 +57,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaLogin -SqlInstance $TestConfig.instance2 -Login $global:login1, $global:login2 -Confirm:$false
         $null = Remove-DbaServerRole -SqlInstance $TestConfig.instance2 -ServerRole $global:customServerRole -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Functionality" {

--- a/tests/Remove-DbaXESession.Tests.ps1
+++ b/tests/Remove-DbaXESession.Tests.ps1
@@ -26,17 +26,17 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session 'Profiler TSQL Duration' | Remove-DbaXESession
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Get-DbaXESession -SqlInstance $TestConfig.instance2 -Session 'Profiler TSQL Duration' | Remove-DbaXESession
 

--- a/tests/Rename-DbaDatabase.Tests.ps1
+++ b/tests/Rename-DbaDatabase.Tests.ps1
@@ -58,6 +58,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database "test_dbatoolsci_rename2_$($global:testDate)", "Dbatoolsci_filemove", "dbatoolsci_logicname", "dbatoolsci_filegroupname" -Confirm:$false -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Should preview a rename of a database" {

--- a/tests/Repair-DbaDbOrphanUser.Tests.ps1
+++ b/tests/Repair-DbaDbOrphanUser.Tests.ps1
@@ -66,6 +66,8 @@ CREATE LOGIN [dbatoolsci_orphan2] WITH PASSWORD = N'password2', CHECK_EXPIRATION
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance1
         $null = Remove-DbaLogin -SqlInstance $server -Login dbatoolsci_orphan1, dbatoolsci_orphan2, dbatoolsci_orphan3 -Force -Confirm:$false
         $null = Remove-DbaDatabase -SqlInstance $server -Database dbatoolsci_orphan -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "shows time taken for preparation" {

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -92,6 +92,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Remove temporary directories
         Remove-Item -Path "C:\temp\*" -Recurse -Force -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Properly restores a database on the local drive using Path" {

--- a/tests/Restore-DbaDbCertificate.Tests.ps1
+++ b/tests/Restore-DbaDbCertificate.Tests.ps1
@@ -50,6 +50,8 @@ Describe $CommandName -Tag IntegrationTests {
 
             $null = $masterkey | Remove-DbaDbMasterKey
             $null = Remove-Item -Path $backup.ExportPath, $backup.ExportKey -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "restores the db cert when passing in a .cer file" {

--- a/tests/Restore-DbaDbSnapshot.Tests.ps1
+++ b/tests/Restore-DbaDbSnapshot.Tests.ps1
@@ -27,6 +27,8 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         Get-DbaProcess -SqlInstance $TestConfig.instance2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false -WarningAction SilentlyContinue
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $db1 = "dbatoolsci_RestoreSnap1"
@@ -43,17 +45,25 @@ Describe $CommandName -Tag IntegrationTests {
         $server.Query("INSERT INTO [$db1].[dbo].[Example] values ('sample')")
         $server.Query("CREATE TABLE [$db2].[dbo].[Example] (id int identity, name nvarchar(max))")
         $server.Query("INSERT INTO [$db2].[dbo].[Example] values ('sample')")
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
+
     AfterAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         Remove-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -Confirm:$false -ErrorAction SilentlyContinue
         Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance2 -Database $db1, $db2 -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
+
     Context "Parameters validation" {
         It "Stops if no Database or Snapshot" {
-            { Restore-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -EnableException } | Should -Throw "You must specify"
+            { Restore-DbaDbSnapshot -SqlInstance $TestConfig.instance2 -EnableException } | Should -Throw "You must specify*"
         }
         It "Is nice by default" {
-            { Restore-DbaDbSnapshot -SqlInstance $TestConfig.instance2 *> $null } | Should -Not -Throw "You must specify"
+            { Restore-DbaDbSnapshot -SqlInstance $TestConfig.instance2 *> $null } | Should -Not -Throw "You must specify*"
         }
     }
     Context "Operations on snapshots" {

--- a/tests/Select-DbaDbSequenceNextValue.Tests.ps1
+++ b/tests/Select-DbaDbSequenceNextValue.Tests.ps1
@@ -45,6 +45,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = $newDb | Remove-DbaDatabase -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "commands work as expected" {

--- a/tests/Set-DbaAgentAlert.Tests.ps1
+++ b/tests/Set-DbaAgentAlert.Tests.ps1
@@ -49,6 +49,8 @@ Describe $CommandName -Tag IntegrationTests {
         }
         $server = Connect-DbaInstance @splatConnection
         $server.Query("EXEC msdb.dbo.sp_delete_alert @name=N'dbatoolsci test alert NEW'")
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When modifying agent alerts" {

--- a/tests/Set-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Set-DbaAgentJobCategory.Tests.ps1
@@ -45,6 +45,8 @@ Describe $CommandName -Tag IntegrationTests {
             # Cleanup and ignore all output
             Remove-DbaAgentJobCategory -SqlInstance $TestConfig.instance2 -Category $newCategoryName -Confirm:$false -ErrorAction SilentlyContinue
             Remove-DbaAgentJobCategory -SqlInstance $TestConfig.instance2 -Category $testCategoryName -Confirm:$false -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should have the right name and category type" {

--- a/tests/Set-DbaAgentJobStep.Tests.ps1
+++ b/tests/Set-DbaAgentJobStep.Tests.ps1
@@ -88,6 +88,8 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Invoke-Command2 -ScriptBlock { net user $args /delete *>&1 } -ArgumentList $login -ComputerName $instance2.ComputerName
         $credential.Drop()
         $agentProxyInstance2.Drop()
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "command works" {
         It "Change the job step name" {

--- a/tests/Set-DbaAgentServer.Tests.ps1
+++ b/tests/Set-DbaAgentServer.Tests.ps1
@@ -60,6 +60,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Invoke-DbaQuery -SqlInstance $testServer -Database master -Query "EXECUTE msdb.dbo.sysmail_delete_profile_sp @profile_name = '$mailProfileName'"
         $null = Invoke-DbaQuery -SqlInstance $testServer -Database master -Query "EXEC msdb.dbo.sp_set_sqlagent_properties @local_host_server=N''"
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     It "changes agent server job history properties to 10000 / 100" {

--- a/tests/Set-DbaDbCompression.Tests.ps1
+++ b/tests/Set-DbaDbCompression.Tests.ps1
@@ -54,6 +54,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         Get-DbaProcess -SqlInstance $TestConfig.instance2 -Database $dbName | Stop-DbaProcess -WarningAction SilentlyContinue
         Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbName -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command gets results" {

--- a/tests/Set-DbaDbOwner.Tests.ps1
+++ b/tests/Set-DbaDbOwner.Tests.ps1
@@ -48,6 +48,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $dbname, $dbnametwo -Confirm:$false
         $null = Remove-DbaLogin -SqlInstance $TestConfig.instance1 -Login $owner, $ownertwo -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "Should set the database owner" {
         It "Sets the database owner on a specific database" {

--- a/tests/Set-DbaDbRecoveryModel.Tests.ps1
+++ b/tests/Set-DbaDbRecoveryModel.Tests.ps1
@@ -29,7 +29,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Recovery model is correctly set" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
             $dbname = "dbatoolsci_recoverymodel"
@@ -37,12 +37,12 @@ Describe $CommandName -Tag IntegrationTests {
             $server.Query("CREATE DATABASE $dbname")
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
 

--- a/tests/Set-DbaDbSequence.Tests.ps1
+++ b/tests/Set-DbaDbSequence.Tests.ps1
@@ -1,19 +1,36 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Set-DbaDbSequence",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Sequence', 'Schema', 'RestartWith', 'IncrementBy', 'MinValue', 'MaxValue', 'Cycle', 'CacheSize', 'InputObject', 'EnableException'
-        It "Should only contain our specific parameters" {
-            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Database",
+                "Sequence",
+                "Schema",
+                "RestartWith",
+                "IncrementBy",
+                "MinValue",
+                "MaxValue",
+                "Cycle",
+                "CacheSize",
+                "InputObject",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
-
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         $random = Get-Random
         $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -24,19 +41,19 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     }
 
     AfterAll {
-        $null = $newDb | Remove-DbaDatabase -Confirm:$false
+        $null = $newDb | Remove-DbaDatabase
     }
 
     Context "commands work as expected" {
 
         It "validates required Database param" {
-            $sequence = Set-DbaDbSequence -SqlInstance $server -Sequence "Sequence1_$random" -Schema "Schema_$random" -Confirm:$false -WarningVariable WarnVar -WarningAction SilentlyContinue
+            $sequence = Set-DbaDbSequence -SqlInstance $server -Sequence "Sequence1_$random" -Schema "Schema_$random" -WarningAction SilentlyContinue
             $sequence | Should -BeNullOrEmpty
             $WarnVar | Should -Match "Database is required when SqlInstance is specified"
         }
 
         It "supports piping databases" {
-            $sequence = Get-DbaDatabase -SqlInstance $server -Database $newDbName | Set-DbaDbSequence -Sequence "Sequence1_$random" -Schema "Schema_$random" -Cycle -Confirm:$false
+            $sequence = Get-DbaDatabase -SqlInstance $server -Database $newDbName | Set-DbaDbSequence -Sequence "Sequence1_$random" -Schema "Schema_$random" -Cycle
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.Parent.Name | Should -Be $newDbName
@@ -47,7 +64,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $startValues = @(-100000, -10, 0, 1, 1000)
 
             foreach ($startValue in $startValues) {
-                $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -RestartWith $startValue -Confirm:$false
+                $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -RestartWith $startValue
                 $sequence.Name | Should -Be "Sequence1_$random"
                 $sequence.Schema | Should -Be "Schema_$random"
                 $sequence.StartValue | Should -Be $startValue
@@ -59,7 +76,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $incrementByValues = @(-1, 1, 10)
 
             foreach ($incrementByValue in $incrementByValues) {
-                $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -IncrementBy $incrementByValue -Confirm:$false
+                $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -IncrementBy $incrementByValue
                 $sequence.Name | Should -Be "Sequence1_$random"
                 $sequence.Schema | Should -Be "Schema_$random"
                 $sequence.IncrementValue | Should -Be $incrementByValue
@@ -68,7 +85,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "updates a sequence with min and max values" {
-            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -MinValue 0 -MaxValue 100000 -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -MinValue 0 -MaxValue 100000
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.MinValue | Should -Be 0
@@ -77,13 +94,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "updates a sequence with cycle options" {
-            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -Cycle -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -Cycle
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.IsCycleEnabled | Should -Be $true
             $sequence.Parent.Name | Should -Be $newDbName
 
-            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -Cycle:$false -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -Cycle:$false
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.IsCycleEnabled | Should -Be $false
@@ -91,19 +108,19 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "updates a sequence with cache options" {
-            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -CacheSize 0 -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -CacheSize 0
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.SequenceCacheType | Should -Be NoCache
             $sequence.Parent.Name | Should -Be $newDbName
 
-            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random"
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.SequenceCacheType | Should -Be DefaultCache
             $sequence.Parent.Name | Should -Be $newDbName
 
-            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -CacheSize 1000 -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -CacheSize 1000
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.SequenceCacheType | Should -Be CacheWithSize
@@ -112,7 +129,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "validates IncrementBy param cannot be 0" {
-            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -IncrementBy 0 -Confirm:$false -WarningAction SilentlyContinue -WarningVariable WarnVar
+            $sequence = Set-DbaDbSequence -SqlInstance $server -Database $newDbName -Sequence "Sequence1_$random" -Schema "Schema_$random" -IncrementBy 0 -WarningAction SilentlyContinue
             $sequence | Should -BeNullOrEmpty
             $WarnVar | Should -Match "cannot be zero"
         }

--- a/tests/Set-DbaDefaultPath.Tests.ps1
+++ b/tests/Set-DbaDefaultPath.Tests.ps1
@@ -38,6 +38,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Set-DbaDefaultPath -SqlInstance $TestConfig.instance1 -Type Backup -Path $oldBackupDirectory
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "returns proper information" {

--- a/tests/Set-DbaErrorLogConfig.Tests.ps1
+++ b/tests/Set-DbaErrorLogConfig.Tests.ps1
@@ -60,6 +60,8 @@ Describe $CommandName -Tag IntegrationTests {
         $cleanupServer2.NumberOfLogFiles = $originalLogFiles2
         $cleanupServer2.ErrorLogSizeKb = $originalLogSize2
         $cleanupServer2.Alter()
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Apply LogCount to multiple instances" {

--- a/tests/Set-DbaExtendedProperty.Tests.ps1
+++ b/tests/Set-DbaExtendedProperty.Tests.ps1
@@ -23,7 +23,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $random = Get-Random
         $instance2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
@@ -33,12 +33,12 @@ Describe $CommandName -Tag IntegrationTests {
         $db | Add-DbaExtendedProperty -Name "Test_Database_Name" -Value $newDbName
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = $db | Remove-DbaDatabase -Confirm:$false
 

--- a/tests/Set-DbaLogin.Tests.ps1
+++ b/tests/Set-DbaLogin.Tests.ps1
@@ -171,7 +171,7 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
         It "Enforces password policy on login" {
             $result = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced
 
-            $result.PasswordPolicyEnforced | Should Be $true
+            $result.PasswordPolicyEnforced | Should -Be $true
         }
 
         It "Catches errors when password can't be changed" {
@@ -190,10 +190,10 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
 
         It "Disables enforcing password policy on login" {
             $result = Get-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random"
-            $result.PasswordPolicyEnforced | Should Be $true
+            $result.PasswordPolicyEnforced | Should -Be $true
 
             $result = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced:$false
-            $result.PasswordPolicyEnforced | Should Be $false
+            $result.PasswordPolicyEnforced | Should -Be $false
         }
 
         It "Add roles to login" {
@@ -223,19 +223,19 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
 
         It "PasswordExpirationEnabled" {
             $result = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin2_$random" -PasswordPolicyEnforced
-            $result.PasswordPolicyEnforced | Should Be $true
+            $result.PasswordPolicyEnforced | Should -Be $true
 
             # testlogin1_$random will get skipped since it does not have PasswordPolicyEnforced set to true (check_policy = ON)
             $result = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random", "testlogin2_$random" -PasswordExpirationEnabled -WarningAction SilentlyContinue
             $WarnVar | Should -Match "Couldn't set check_expiration = ON because check_policy = OFF for \[testlogin1_$random\]"
             $result.Count | Should -Be 1
             $result.Name | Should -Be "testlogin2_$random"
-            $result.PasswordExpirationEnabled | Should Be $true
+            $result.PasswordExpirationEnabled | Should -Be $true
 
             # set both params for this login
             $result = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced -PasswordExpirationEnabled
             $result.PasswordExpirationEnabled | Should -Be $true
-            $result.PasswordPolicyEnforced | Should Be $true
+            $result.PasswordPolicyEnforced | Should -Be $true
 
             # disable the setting for this login
             $result = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random" -PasswordExpirationEnabled:$false
@@ -245,11 +245,11 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
         It "Ensure both password policy settings can be disabled at the same time" {
             $result = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced -PasswordExpirationEnabled
             $result.PasswordExpirationEnabled | Should -Be $true
-            $result.PasswordPolicyEnforced | Should Be $true
+            $result.PasswordPolicyEnforced | Should -Be $true
 
             $result = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced:$false -PasswordExpirationEnabled:$false
             $result.PasswordExpirationEnabled | Should -Be $false
-            $result.PasswordPolicyEnforced | Should Be $false
+            $result.PasswordPolicyEnforced | Should -Be $false
         }
 
         It -Skip:$SkipLocalTest "Unlock" {
@@ -305,12 +305,12 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
             # ensure the policy settings are off
             $result = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced:$false -PasswordExpirationEnabled:$false
             $result.PasswordExpirationEnabled | Should -Be $false
-            $result.PasswordPolicyEnforced | Should Be $false
+            $result.PasswordPolicyEnforced | Should -Be $false
 
             # set the policy options separately for testlogin2
             $changeResult = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin2_$random" -PasswordPolicyEnforced -PasswordExpirationEnabled
-            $changeResult.PasswordPolicyEnforced | Should Be $true
-            $changeResult.PasswordExpirationEnabled | Should Be $true
+            $changeResult.PasswordPolicyEnforced | Should -Be $true
+            $changeResult.PasswordExpirationEnabled | Should -Be $true
 
             # check_policy and check_expiration must be set on the login
             $changeResult = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random", "testlogin2_$random" -PasswordMustChange -Password $password1 -WarningAction SilentlyContinue
@@ -321,8 +321,8 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
             $changeResult = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random" -PasswordMustChange -Password $password1 -PasswordPolicyEnforced -PasswordExpirationEnabled
             $changeResult.MustChangePassword | Should -Be $true
             $changeResult.PasswordChanged | Should -Be $true
-            $changeResult.PasswordPolicyEnforced | Should Be $true
-            $changeResult.PasswordExpirationEnabled | Should Be $true
+            $changeResult.PasswordPolicyEnforced | Should -Be $true
+            $changeResult.PasswordExpirationEnabled | Should -Be $true
 
             # now change the password and set the must_change
             $changeResult = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin2_$random" -PasswordMustChange -Password $password1

--- a/tests/Set-DbaLogin.Tests.ps1
+++ b/tests/Set-DbaLogin.Tests.ps1
@@ -90,7 +90,6 @@ Describe $CommandName -Tag IntegrationTests {
 Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
     Context "verify command functions" {
         BeforeAll {
-            $SkipLocalTest = $true # Change to $false to run the local-only tests on a local instance. This is being used because the 'locked' test makes assumptions the password policy configuration is enabled for the Windows OS.
             $random = Get-Random
 
             # Create the new password
@@ -252,7 +251,8 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
             $result.PasswordPolicyEnforced | Should -Be $false
         }
 
-        It -Skip:$SkipLocalTest "Unlock" {
+        # TODO: The 'locked' test makes assumptions the password policy configuration is enabled for the Windows OS.
+        It -Skip "Unlock" {
             $results = Set-DbaLogin -SqlInstance $TestConfig.instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced -EnableException
             $results.PasswordPolicyEnforced | Should -Be $true
 

--- a/tests/Set-DbaMaxDop.Tests.ps1
+++ b/tests/Set-DbaMaxDop.Tests.ps1
@@ -58,6 +58,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database $global:dbs | Remove-DbaDatabase -Confirm:$false
         Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $global:dbs | Remove-DbaDatabase -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Apply to multiple instances" {

--- a/tests/Set-DbaResourceGovernor.Tests.ps1
+++ b/tests/Set-DbaResourceGovernor.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Command actually works" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $classifierFunction = "dbatoolsci_fnRGClassifier"
             $qualifiedClassifierFunction = "[dbo].[$classifierFunction]"
@@ -43,7 +43,7 @@ Describe $CommandName -Tag IntegrationTests {
             Set-DbaResourceGovernor -SqlInstance $TestConfig.instance2 -Disabled -Confirm:$false
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "enables resource governor" {
@@ -68,7 +68,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $dropUDFQuery = "DROP FUNCTION $qualifiedClassifierFunction;"
             Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Query $dropUDFQuery -Database "master" -ErrorAction SilentlyContinue

--- a/tests/Set-DbaRgWorkloadGroup.Tests.ps1
+++ b/tests/Set-DbaRgWorkloadGroup.Tests.ps1
@@ -35,17 +35,17 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Functionality" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $null = Set-DbaResourceGovernor -SqlInstance $TestConfig.instance2 -Enabled
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # Cleanup any remaining workload groups
             $wklGroupCleanupNames = @("dbatoolssci_wklgroupTest", "dbatoolssci_wklgroupTest2")

--- a/tests/Set-DbaTcpPort.Tests.ps1
+++ b/tests/Set-DbaTcpPort.Tests.ps1
@@ -46,6 +46,8 @@ Describe $CommandName -Tag IntegrationTests {
             # Restore the original port configuration
             $null = Set-DbaTcpPort -SqlInstance $TestConfig.instance2 -Port $originalPort -Confirm:$false -WarningAction SilentlyContinue
             $null = Restart-DbaService -ComputerName $instance.ComputerName -InstanceName $instance.InstanceName -Type Engine -Force -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should change the port" {

--- a/tests/Set-DbaTcpPort.Tests.ps1
+++ b/tests/Set-DbaTcpPort.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "When changing TCP port configuration" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # Get the current port before making any changes
             $originalPortInfo = Get-DbaTcpPort -SqlInstance $TestConfig.instance2
@@ -36,12 +36,12 @@ Describe $CommandName -Tag IntegrationTests {
             $instance = [DbaInstance]$TestConfig.instance2
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # Restore the original port configuration
             $null = Set-DbaTcpPort -SqlInstance $TestConfig.instance2 -Port $originalPort -Confirm:$false -WarningAction SilentlyContinue

--- a/tests/Set-DbaTempDbConfig.Tests.ps1
+++ b/tests/Set-DbaTempDbConfig.Tests.ps1
@@ -60,6 +60,8 @@ Describe $CommandName -Tag IntegrationTests {
         Remove-Item -Path "$global:tempdbDataFilePath\DataDir1_$global:random" -Force -ErrorAction SilentlyContinue
         Remove-Item -Path "$global:tempdbDataFilePath\DataDir2_$global:random" -Force -ErrorAction SilentlyContinue
         Remove-Item -Path "$global:tempdbDataFilePath\Log_$global:random" -Force -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "Command actually works" {
 

--- a/tests/Start-DbaAgentJob.Tests.ps1
+++ b/tests/Start-DbaAgentJob.Tests.ps1
@@ -33,7 +33,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Start a job" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $jobNames = "dbatoolsci_job_$(Get-Random)", "dbatoolsci_job_$(Get-Random)", "dbatoolsci_job_$(Get-Random)"
             $jobName1, $jobName2, $jobName3 = $jobNames
@@ -47,11 +47,11 @@ Describe $CommandName -Tag IntegrationTests {
             $global:startJobResults = Get-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job $jobName1 | Start-DbaAgentJob
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
         AfterAll {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $null = Remove-DbaAgentJob -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Job $jobNames -Confirm:$false
         }

--- a/tests/Start-DbaAgentJob.Tests.ps1
+++ b/tests/Start-DbaAgentJob.Tests.ps1
@@ -54,6 +54,8 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $null = Remove-DbaAgentJob -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Job $jobNames -Confirm:$false
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "returns a CurrentRunStatus of not Idle and supports pipe" {

--- a/tests/Start-DbaDbEncryption.Tests.ps1
+++ b/tests/Start-DbaDbEncryption.Tests.ps1
@@ -37,7 +37,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
@@ -54,12 +54,12 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created objects.
         if ($testDatabases) {

--- a/tests/Start-DbaService.Tests.ps1
+++ b/tests/Start-DbaService.Tests.ps1
@@ -28,13 +28,13 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     Context "Command actually works" {
         BeforeAll {
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
             $instanceName = $server.ServiceName
             $computerName = $server.NetName
 
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         Context "Single service restart" {

--- a/tests/Start-DbaTrace.Tests.ps1
+++ b/tests/Start-DbaTrace.Tests.ps1
@@ -118,6 +118,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaTrace -SqlInstance $TestConfig.instance1 -Id $traceid
         Remove-Item C:\windows\temp\temptrace.trc -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Test Starting Trace" {

--- a/tests/Stop-DbaAgentJob.Tests.ps1
+++ b/tests/Stop-DbaAgentJob.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Command execution and functionality" {
         It -Skip "Should stop an agent job and return CurrentRunStatus of Idle" {
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
             $results = Get-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job 'DatabaseBackup - SYSTEM_DATABASES - FULL' | Start-DbaAgentJob | Stop-DbaAgentJob
             $results.CurrentRunStatus | Should -Be 'Idle'
         }

--- a/tests/Stop-DbaAgentJob.Tests.ps1
+++ b/tests/Stop-DbaAgentJob.Tests.ps1
@@ -27,8 +27,6 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     Context "Command execution and functionality" {
         It -Skip "Should stop an agent job and return CurrentRunStatus of Idle" {
-            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
             $results = Get-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job 'DatabaseBackup - SYSTEM_DATABASES - FULL' | Start-DbaAgentJob | Stop-DbaAgentJob
             $results.CurrentRunStatus | Should -Be 'Idle'
         }

--- a/tests/Stop-DbaDbEncryption.Tests.ps1
+++ b/tests/Stop-DbaDbEncryption.Tests.ps1
@@ -24,7 +24,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $passwd = ConvertTo-SecureString "dbatools.IO" -AsPlainText -Force
         $masterkey = Get-DbaDbMasterKey -SqlInstance $TestConfig.instance2 -Database master
@@ -45,12 +45,12 @@ Describe $CommandName -Tag IntegrationTests {
         $db | Enable-DbaDbEncryption -EncryptorName $mastercert.Name -Force
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         if ($db) {
             $db | Remove-DbaDatabase

--- a/tests/Stop-DbaEndpoint.Tests.ps1
+++ b/tests/Stop-DbaEndpoint.Tests.ps1
@@ -32,12 +32,12 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "Should stop the endpoint" {
             # We want to run all commands in the setup with EnableException to ensure that the test fails if the setup fails.
-            $PSDefaultParameterValues['*-Dba*:EnableException'] = $true
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             Get-DbaEndpoint -SqlInstance $TestConfig.instance2 -Endpoint 'TSQL Default TCP' | Start-DbaEndpoint
 
             # We want to run all commands outside of the setup without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
 
             $endpoint = Get-DbaEndpoint -SqlInstance $TestConfig.instance2 -Endpoint 'TSQL Default TCP'
             $results = $endpoint | Stop-DbaEndpoint

--- a/tests/Stop-DbaPfDataCollectorSet.Tests.ps1
+++ b/tests/Stop-DbaPfDataCollectorSet.Tests.ps1
@@ -31,7 +31,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "Should return a result with the right computername and name is not null" {
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
             $script:set = Get-DbaPfDataCollectorSet | Select-Object -First 1
             $script:set | Start-DbaPfDataCollectorSet -WarningAction SilentlyContinue
             Start-Sleep 2

--- a/tests/Stop-DbaPfDataCollectorSet.Tests.ps1
+++ b/tests/Stop-DbaPfDataCollectorSet.Tests.ps1
@@ -28,7 +28,11 @@ Describe $CommandName -Tag IntegrationTests {
         BeforeAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-            $set = Get-DbaPfDataCollectorSet | Select-Object -First 1
+
+            foreach ($set in Get-DbaPfDataCollectorSet) {
+                write-warning -Message "DbaPfDataCollectorSet: $($set.Name) is $($set.State)"
+            }
+            $set = Get-DbaPfDataCollectorSet | Where-Object State -eq 'Running' | Select-Object -First 1
             $set | Start-DbaPfDataCollectorSet -WarningAction SilentlyContinue
             Start-Sleep 2
 
@@ -36,11 +40,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         AfterAll {
-            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-
             $set | Stop-DbaPfDataCollectorSet -WarningAction SilentlyContinue
-
-            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should return a result with the right computername and name is not null" {

--- a/tests/Stop-DbaProcess.Tests.ps1
+++ b/tests/Stop-DbaProcess.Tests.ps1
@@ -31,7 +31,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Command execution and functionality" {
         BeforeAll {
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "kills only this specific process" {

--- a/tests/Stop-DbaProcess.Tests.ps1
+++ b/tests/Stop-DbaProcess.Tests.ps1
@@ -29,11 +29,6 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     Context "Command execution and functionality" {
-        BeforeAll {
-            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-        }
-
         It "kills only this specific process" {
             $fakeapp = Connect-DbaInstance -SqlInstance $TestConfig.instance1 -ClientName 'dbatoolsci test app'
             $results = Stop-DbaProcess -SqlInstance $TestConfig.instance1 -Program 'dbatoolsci test app'

--- a/tests/Stop-DbaService.Tests.ps1
+++ b/tests/Stop-DbaService.Tests.ps1
@@ -29,9 +29,6 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     Context "Command execution and functionality" {
         BeforeAll {
-            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-
             $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
             $instanceName = $server.ServiceName
             $computerName = $server.NetName

--- a/tests/Stop-DbaService.Tests.ps1
+++ b/tests/Stop-DbaService.Tests.ps1
@@ -30,7 +30,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Command execution and functionality" {
         BeforeAll {
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
 
             $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
             $instanceName = $server.ServiceName

--- a/tests/Sync-DbaLoginPermission.Tests.ps1
+++ b/tests/Sync-DbaLoginPermission.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
 
         $tempguid = [guid]::newguid()
         $DBUserName = "dbatoolssci_$($tempguid.guid)"

--- a/tests/Sync-DbaLoginPermission.Tests.ps1
+++ b/tests/Sync-DbaLoginPermission.Tests.ps1
@@ -26,9 +26,6 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-
         $tempguid = [guid]::newguid()
         $DBUserName = "dbatoolssci_$($tempguid.guid)"
         $CreateTestUser = @"

--- a/tests/Test-DbaBackupEncrypted.Tests.ps1
+++ b/tests/Test-DbaBackupEncrypted.Tests.ps1
@@ -1,20 +1,27 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Test-DbaBackupEncrypted",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'FilePath', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "FilePath",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-
-Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         $PSDefaultParameterValues["*:Confirm"] = $false
 

--- a/tests/Test-DbaBackupInformation.Tests.ps1
+++ b/tests/Test-DbaBackupInformation.Tests.ps1
@@ -1,19 +1,31 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Test-DbaBackupInformation",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'BackupHistory', 'SqlInstance', 'SqlCredential', 'WithReplace', 'Continue', 'VerifyOnly', 'OutputScriptOnly', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "BackupHistory",
+                "SqlInstance",
+                "SqlCredential",
+                "WithReplace",
+                "Continue",
+                "VerifyOnly",
+                "OutputScriptOnly",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         $PSDefaultParameterValues["*:Confirm"] = $false
     }

--- a/tests/Test-DbaBackupInformation.Tests.ps1
+++ b/tests/Test-DbaBackupInformation.Tests.ps1
@@ -26,52 +26,48 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
-    BeforeAll {
-        $PSDefaultParameterValues["*:Confirm"] = $false
-    }
-
     InModuleScope dbatools {
         Context "Everything as it should" {
-            $BackupHistory = Import-Clixml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
-            $BackupHistory = $BackupHistory | Format-DbaBackupInformation
-            Mock Connect-DbaInstance -MockWith {
-                $obj = [PSCustomObject]@{
-                    Name                 = 'BASEName'
-                    NetName              = 'BASENetName'
-                    ComputerName         = 'BASEComputerName'
-                    InstanceName         = 'BASEInstanceName'
-                    DomainInstanceName   = 'BASEDomainInstanceName'
-                    InstallDataDirectory = 'BASEInstallDataDirectory'
-                    ErrorLogPath         = 'BASEErrorLog_{0}_{1}_{2}_Path' -f "'", '"', ']'
-                    ServiceName          = 'BASEServiceName'
-                    VersionMajor         = 9
-                    ConnectionContext    = New-Object PSObject
+            It "Should pass as all systems Green" {
+                $BackupHistory = Import-Clixml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
+                $BackupHistory = $BackupHistory | Format-DbaBackupInformation
+                Mock Connect-DbaInstance -MockWith {
+                    $obj = [PSCustomObject]@{
+                        Name                 = 'BASEName'
+                        NetName              = 'BASENetName'
+                        ComputerName         = 'BASEComputerName'
+                        InstanceName         = 'BASEInstanceName'
+                        DomainInstanceName   = 'BASEDomainInstanceName'
+                        InstallDataDirectory = 'BASEInstallDataDirectory'
+                        ErrorLogPath         = 'BASEErrorLog_{0}_{1}_{2}_Path' -f "'", '"', ']'
+                        ServiceName          = 'BASEServiceName'
+                        VersionMajor         = 9
+                        ConnectionContext    = New-Object PSObject
+                    }
+                    Add-Member -InputObject $obj.ConnectionContext -Name ConnectionString  -MemberType NoteProperty -Value 'put=an=equal=in=it'
+                    Add-Member -InputObject $obj -Name Query -MemberType ScriptMethod -Value {
+                        param($query)
+                        if ($query -eq "SELECT DB_NAME(database_id) AS Name, physical_name AS PhysicalName FROM sys.master_files") {
+                            return @(
+                                @{ "Name"          = "master"
+                                    "PhysicalName" = "C:\temp\master.mdf"
+                                }
+                            )
+                        }
+                    }
+                    $obj.PSObject.TypeNames.Clear()
+                    $obj.PSObject.TypeNames.Add("Microsoft.SqlServer.Management.Smo.Server")
+                    return $obj
                 }
-                Add-Member -InputObject $obj.ConnectionContext -Name ConnectionString  -MemberType NoteProperty -Value 'put=an=equal=in=it'
-                Add-Member -InputObject $obj -Name Query -MemberType ScriptMethod -Value {
-                    param($query)
-                    if ($query -eq "SELECT DB_NAME(database_id) AS Name, physical_name AS PhysicalName FROM sys.master_files") {
-                        return @(
-                            @{ "Name"          = "master"
-                                "PhysicalName" = "C:\temp\master.mdf"
-                            }
-                        )
+                Mock Get-DbaDatabase { $null }
+
+                Mock New-DbaDirectory { $true }
+                Mock Test-DbaPath { [PSCustomObject]@{
+                        FilePath   = 'does\exists'
+                        FileExists = $true
                     }
                 }
-                $obj.PSObject.TypeNames.Clear()
-                $obj.PSObject.TypeNames.Add("Microsoft.SqlServer.Management.Smo.Server")
-                return $obj
-            }
-            Mock Get-DbaDatabase { $null }
-
-            Mock New-DbaDirectory { $true }
-            Mock Test-DbaPath { [PSCustomObject]@{
-                    FilePath   = 'does\exists'
-                    FileExists = $true
-                }
-            }
-            Mock New-DbaDirectory { $True }
-            It "Should pass as all systems Green" {
+                Mock New-DbaDirectory { $True }
                 $output = $BackupHistory | Test-DbaBackupInformation -SqlInstance NotExist -WarningVariable warnvar -WarningAction SilentlyContinue
                 ($output.Count) -gt 0 | Should -Be $true
                 "False" -in ($Output.IsVerified) | Should -Be $False
@@ -79,45 +75,45 @@ Describe $CommandName -Tag IntegrationTests {
             }
         }
         Context "Not being able to see backups is bad" {
-            $BackupHistory = Import-Clixml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
-            $BackupHistory = $BackupHistory | Format-DbaBackupInformation
-            Mock Connect-DbaInstance -MockWith {
-                $obj = [PSCustomObject]@{
-                    Name                 = 'BASEName'
-                    NetName              = 'BASENetName'
-                    ComputerName         = 'BASEComputerName'
-                    InstanceName         = 'BASEInstanceName'
-                    DomainInstanceName   = 'BASEDomainInstanceName'
-                    InstallDataDirectory = 'BASEInstallDataDirectory'
-                    ErrorLogPath         = 'BASEErrorLog_{0}_{1}_{2}_Path' -f "'", '"', ']'
-                    ServiceName          = 'BASEServiceName'
-                    VersionMajor         = 9
-                    ConnectionContext    = New-Object PSObject
+            It "Should return fail as backup files don't exist" {
+                $BackupHistory = Import-Clixml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
+                $BackupHistory = $BackupHistory | Format-DbaBackupInformation
+                Mock Connect-DbaInstance -MockWith {
+                    $obj = [PSCustomObject]@{
+                        Name                 = 'BASEName'
+                        NetName              = 'BASENetName'
+                        ComputerName         = 'BASEComputerName'
+                        InstanceName         = 'BASEInstanceName'
+                        DomainInstanceName   = 'BASEDomainInstanceName'
+                        InstallDataDirectory = 'BASEInstallDataDirectory'
+                        ErrorLogPath         = 'BASEErrorLog_{0}_{1}_{2}_Path' -f "'", '"', ']'
+                        ServiceName          = 'BASEServiceName'
+                        VersionMajor         = 9
+                        ConnectionContext    = New-Object PSObject
+                    }
+                    Add-Member -InputObject $obj.ConnectionContext -Name ConnectionString  -MemberType NoteProperty -Value 'put=an=equal=in=it'
+                    Add-Member -InputObject $obj -Name Query -MemberType ScriptMethod -Value {
+                        param($query)
+                        if ($query -eq "SELECT DB_NAME(database_id) AS Name, physical_name AS PhysicalName FROM sys.master_files") {
+                            return @(
+                                @{ "Name"          = "master"
+                                    "PhysicalName" = "C:\temp\master.mdf"
+                                }
+                            )
+                        }
+                    }
+                    $obj.PSObject.TypeNames.Clear()
+                    $obj.PSObject.TypeNames.Add("Microsoft.SqlServer.Management.Smo.Server")
+                    return $obj
                 }
-                Add-Member -InputObject $obj.ConnectionContext -Name ConnectionString  -MemberType NoteProperty -Value 'put=an=equal=in=it'
-                Add-Member -InputObject $obj -Name Query -MemberType ScriptMethod -Value {
-                    param($query)
-                    if ($query -eq "SELECT DB_NAME(database_id) AS Name, physical_name AS PhysicalName FROM sys.master_files") {
-                        return @(
-                            @{ "Name"          = "master"
-                                "PhysicalName" = "C:\temp\master.mdf"
-                            }
-                        )
+                Mock Get-DbaDatabase { $null }
+                Mock New-DbaDirectory { $true }
+                Mock Test-DbaPath { [PSCustomObject]@{
+                        FilePath   = 'does\not\exists'
+                        FileExists = $false
                     }
                 }
-                $obj.PSObject.TypeNames.Clear()
-                $obj.PSObject.TypeNames.Add("Microsoft.SqlServer.Management.Smo.Server")
-                return $obj
-            }
-            Mock Get-DbaDatabase { $null }
-            Mock New-DbaDirectory { $true }
-            Mock Test-DbaPath { [PSCustomObject]@{
-                    FilePath   = 'does\not\exists'
-                    FileExists = $false
-                }
-            }
-            Mock New-DbaDirectory { $True }
-            It "Should return fail as backup files don't exist" {
+                Mock New-DbaDirectory { $True }
                 $output = $BackupHistory | Test-DbaBackupInformation -SqlInstance NotExist -WarningVariable warnvar -WarningAction SilentlyContinue
                 ($output.Count) -gt 0 | Should -Be $true
                 $true -in ($Output.IsVerified) | Should -Be $false
@@ -125,46 +121,46 @@ Describe $CommandName -Tag IntegrationTests {
             }
         }
         Context "Multiple source dbs for restore is bad" {
-            $BackupHistory = Import-Clixml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
-            $BackupHistory = $BackupHistory | Format-DbaBackupInformation
-            $BackupHistory[1].OriginalDatabase = 'Error'
-            Mock Connect-DbaInstance -MockWith {
-                $obj = [PSCustomObject]@{
-                    Name                 = 'BASEName'
-                    NetName              = 'BASENetName'
-                    ComputerName         = 'BASEComputerName'
-                    InstanceName         = 'BASEInstanceName'
-                    DomainInstanceName   = 'BASEDomainInstanceName'
-                    InstallDataDirectory = 'BASEInstallDataDirectory'
-                    ErrorLogPath         = 'BASEErrorLog_{0}_{1}_{2}_Path' -f "'", '"', ']'
-                    ServiceName          = 'BASEServiceName'
-                    VersionMajor         = 9
-                    ConnectionContext    = New-Object PSObject
+            It "Should return fail as 2 origin dbs" {
+                $BackupHistory = Import-Clixml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
+                $BackupHistory = $BackupHistory | Format-DbaBackupInformation
+                $BackupHistory[1].OriginalDatabase = 'Error'
+                Mock Connect-DbaInstance -MockWith {
+                    $obj = [PSCustomObject]@{
+                        Name                 = 'BASEName'
+                        NetName              = 'BASENetName'
+                        ComputerName         = 'BASEComputerName'
+                        InstanceName         = 'BASEInstanceName'
+                        DomainInstanceName   = 'BASEDomainInstanceName'
+                        InstallDataDirectory = 'BASEInstallDataDirectory'
+                        ErrorLogPath         = 'BASEErrorLog_{0}_{1}_{2}_Path' -f "'", '"', ']'
+                        ServiceName          = 'BASEServiceName'
+                        VersionMajor         = 9
+                        ConnectionContext    = New-Object PSObject
+                    }
+                    Add-Member -InputObject $obj.ConnectionContext -Name ConnectionString  -MemberType NoteProperty -Value 'put=an=equal=in=it'
+                    Add-Member -InputObject $obj -Name Query -MemberType ScriptMethod -Value {
+                        param($query)
+                        if ($query -eq "SELECT DB_NAME(database_id) AS Name, physical_name AS PhysicalName FROM sys.master_files") {
+                            return @(
+                                @{ "Name"          = "master"
+                                    "PhysicalName" = "C:\temp\master.mdf"
+                                }
+                            )
+                        }
+                    }
+                    $obj.PSObject.TypeNames.Clear()
+                    $obj.PSObject.TypeNames.Add("Microsoft.SqlServer.Management.Smo.Server")
+                    return $obj
                 }
-                Add-Member -InputObject $obj.ConnectionContext -Name ConnectionString  -MemberType NoteProperty -Value 'put=an=equal=in=it'
-                Add-Member -InputObject $obj -Name Query -MemberType ScriptMethod -Value {
-                    param($query)
-                    if ($query -eq "SELECT DB_NAME(database_id) AS Name, physical_name AS PhysicalName FROM sys.master_files") {
-                        return @(
-                            @{ "Name"          = "master"
-                                "PhysicalName" = "C:\temp\master.mdf"
-                            }
-                        )
+                Mock Get-DbaDatabase { $null }
+                Mock New-DbaDirectory { $true }
+                Mock Test-DbaPath { [PSCustomObject]@{
+                        FilePath   = 'does\exists'
+                        FileExists = $true
                     }
                 }
-                $obj.PSObject.TypeNames.Clear()
-                $obj.PSObject.TypeNames.Add("Microsoft.SqlServer.Management.Smo.Server")
-                return $obj
-            }
-            Mock Get-DbaDatabase { $null }
-            Mock New-DbaDirectory { $true }
-            Mock Test-DbaPath { [PSCustomObject]@{
-                    FilePath   = 'does\exists'
-                    FileExists = $true
-                }
-            }
-            Mock New-DbaDirectory { $True }
-            It "Should return fail as 2 origin dbs" {
+                Mock New-DbaDirectory { $True }
                 $output = $BackupHistory | Test-DbaBackupInformation -SqlInstance NotExist -WarningVariable warnvar -WarningAction SilentlyContinue
                 ($output.Count) -gt 0 | Should -Be $true
                 $true -in ($Output.IsVerified) | Should -Be $False
@@ -172,46 +168,46 @@ Describe $CommandName -Tag IntegrationTests {
             }
         }
         Context "Fail if Destination db exists" {
-            $BackupHistory = Import-Clixml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
-            $BackupHistory = $BackupHistory | Format-DbaBackupInformation
-            $BackupHistory[1].OriginalDatabase = 'Error'
-            Mock Connect-DbaInstance -MockWith {
-                $obj = [PSCustomObject]@{
-                    Name                 = 'BASEName'
-                    NetName              = 'BASENetName'
-                    ComputerName         = 'BASEComputerName'
-                    InstanceName         = 'BASEInstanceName'
-                    DomainInstanceName   = 'BASEDomainInstanceName'
-                    InstallDataDirectory = 'BASEInstallDataDirectory'
-                    ErrorLogPath         = 'BASEErrorLog_{0}_{1}_{2}_Path' -f "'", '"', ']'
-                    ServiceName          = 'BASEServiceName'
-                    VersionMajor         = 9
-                    ConnectionContext    = New-Object PSObject
+            It "Should return fail if dest db exists" {
+                $BackupHistory = Import-Clixml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
+                $BackupHistory = $BackupHistory | Format-DbaBackupInformation
+                $BackupHistory[1].OriginalDatabase = 'Error'
+                Mock Connect-DbaInstance -MockWith {
+                    $obj = [PSCustomObject]@{
+                        Name                 = 'BASEName'
+                        NetName              = 'BASENetName'
+                        ComputerName         = 'BASEComputerName'
+                        InstanceName         = 'BASEInstanceName'
+                        DomainInstanceName   = 'BASEDomainInstanceName'
+                        InstallDataDirectory = 'BASEInstallDataDirectory'
+                        ErrorLogPath         = 'BASEErrorLog_{0}_{1}_{2}_Path' -f "'", '"', ']'
+                        ServiceName          = 'BASEServiceName'
+                        VersionMajor         = 9
+                        ConnectionContext    = New-Object PSObject
+                    }
+                    Add-Member -InputObject $obj.ConnectionContext -Name ConnectionString  -MemberType NoteProperty -Value 'put=an=equal=in=it'
+                    Add-Member -InputObject $obj -Name Query -MemberType ScriptMethod -Value {
+                        param($query)
+                        if ($query -eq "SELECT DB_NAME(database_id) AS Name, physical_name AS PhysicalName FROM sys.master_files") {
+                            return @(
+                                @{ "Name"          = "master"
+                                    "PhysicalName" = "C:\temp\master.mdf"
+                                }
+                            )
+                        }
+                    }
+                    $obj.PSObject.TypeNames.Clear()
+                    $obj.PSObject.TypeNames.Add("Microsoft.SqlServer.Management.Smo.Server")
+                    return $obj
                 }
-                Add-Member -InputObject $obj.ConnectionContext -Name ConnectionString  -MemberType NoteProperty -Value 'put=an=equal=in=it'
-                Add-Member -InputObject $obj -Name Query -MemberType ScriptMethod -Value {
-                    param($query)
-                    if ($query -eq "SELECT DB_NAME(database_id) AS Name, physical_name AS PhysicalName FROM sys.master_files") {
-                        return @(
-                            @{ "Name"          = "master"
-                                "PhysicalName" = "C:\temp\master.mdf"
-                            }
-                        )
+                Mock Get-DbaDatabase { '1' }
+                Mock New-DbaDirectory { $true }
+                Mock Test-DbaPath { [PSCustomObject]@{
+                        FilePath   = 'does\exists'
+                        FileExists = $true
                     }
                 }
-                $obj.PSObject.TypeNames.Clear()
-                $obj.PSObject.TypeNames.Add("Microsoft.SqlServer.Management.Smo.Server")
-                return $obj
-            }
-            Mock Get-DbaDatabase { '1' }
-            Mock New-DbaDirectory { $true }
-            Mock Test-DbaPath { [PSCustomObject]@{
-                    FilePath   = 'does\exists'
-                    FileExists = $true
-                }
-            }
-            Mock New-DbaDirectory { $True }
-            It "Should return fail if dest db exists" {
+                Mock New-DbaDirectory { $True }
                 $output = $BackupHistory | Test-DbaBackupInformation -SqlInstance NotExist -WarningVariable warnvar -WarningAction SilentlyContinue
                 ($output.Count) -gt 0 | Should -Be $true
                 $true -in ($Output.IsVerified) | Should -Be $False
@@ -219,46 +215,46 @@ Describe $CommandName -Tag IntegrationTests {
             }
         }
         Context "Pass if Destination db exists and WithReplace set" {
-            $BackupHistory = Import-Clixml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
-            $BackupHistory = $BackupHistory | Format-DbaBackupInformation
-            $BackupHistory[1].OriginalDatabase = 'Error'
-            Mock Connect-DbaInstance -MockWith {
-                $obj = [PSCustomObject]@{
-                    Name                 = 'BASEName'
-                    NetName              = 'BASENetName'
-                    ComputerName         = 'BASEComputerName'
-                    InstanceName         = 'BASEInstanceName'
-                    DomainInstanceName   = 'BASEDomainInstanceName'
-                    InstallDataDirectory = 'BASEInstallDataDirectory'
-                    ErrorLogPath         = 'BASEErrorLog_{0}_{1}_{2}_Path' -f "'", '"', ']'
-                    ServiceName          = 'BASEServiceName'
-                    VersionMajor         = 9
-                    ConnectionContext    = New-Object PSObject
+            It "Should pass if destdb exists and WithReplace specified" {
+                $BackupHistory = Import-Clixml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
+                $BackupHistory = $BackupHistory | Format-DbaBackupInformation
+                $BackupHistory[1].OriginalDatabase = 'Error'
+                Mock Connect-DbaInstance -MockWith {
+                    $obj = [PSCustomObject]@{
+                        Name                 = 'BASEName'
+                        NetName              = 'BASENetName'
+                        ComputerName         = 'BASEComputerName'
+                        InstanceName         = 'BASEInstanceName'
+                        DomainInstanceName   = 'BASEDomainInstanceName'
+                        InstallDataDirectory = 'BASEInstallDataDirectory'
+                        ErrorLogPath         = 'BASEErrorLog_{0}_{1}_{2}_Path' -f "'", '"', ']'
+                        ServiceName          = 'BASEServiceName'
+                        VersionMajor         = 9
+                        ConnectionContext    = New-Object PSObject
+                    }
+                    Add-Member -InputObject $obj.ConnectionContext -Name ConnectionString  -MemberType NoteProperty -Value 'put=an=equal=in=it'
+                    Add-Member -InputObject $obj -Name Query -MemberType ScriptMethod -Value {
+                        param($query)
+                        if ($query -eq "SELECT DB_NAME(database_id) AS Name, physical_name AS PhysicalName FROM sys.master_files") {
+                            return @(
+                                @{ "Name"          = "master"
+                                    "PhysicalName" = "C:\temp\master.mdf"
+                                }
+                            )
+                        }
+                    }
+                    $obj.PSObject.TypeNames.Clear()
+                    $obj.PSObject.TypeNames.Add("Microsoft.SqlServer.Management.Smo.Server")
+                    return $obj
                 }
-                Add-Member -InputObject $obj.ConnectionContext -Name ConnectionString  -MemberType NoteProperty -Value 'put=an=equal=in=it'
-                Add-Member -InputObject $obj -Name Query -MemberType ScriptMethod -Value {
-                    param($query)
-                    if ($query -eq "SELECT DB_NAME(database_id) AS Name, physical_name AS PhysicalName FROM sys.master_files") {
-                        return @(
-                            @{ "Name"          = "master"
-                                "PhysicalName" = "C:\temp\master.mdf"
-                            }
-                        )
+                Mock Get-DbaDatabase { '1' }
+                Mock New-DbaDirectory { $true }
+                Mock Test-DbaPath { [PSCustomObject]@{
+                        FilePath   = 'does\exists'
+                        FileExists = $true
                     }
                 }
-                $obj.PSObject.TypeNames.Clear()
-                $obj.PSObject.TypeNames.Add("Microsoft.SqlServer.Management.Smo.Server")
-                return $obj
-            }
-            Mock Get-DbaDatabase { '1' }
-            Mock New-DbaDirectory { $true }
-            Mock Test-DbaPath { [PSCustomObject]@{
-                    FilePath   = 'does\exists'
-                    FileExists = $true
-                }
-            }
-            Mock New-DbaDirectory { $True }
-            It "Should pass if destdb exists and WithReplace specified" {
+                Mock New-DbaDirectory { $True }
                 $output = $BackupHistory | Test-DbaBackupInformation -SqlInstance NotExist -WarningVariable warnvar -WarningAction SilentlyContinue -WithReplace
                 ($output.Count) -gt 0 | Should -Be $true
                 $true -in ($Output.IsVerified) | Should -Be $False

--- a/tests/Test-DbaBuild.Tests.ps1
+++ b/tests/Test-DbaBuild.Tests.ps1
@@ -1,21 +1,32 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Test-DbaBuild",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
-    BeforeAll {
-        $PSDefaultParameterValues["*:Confirm"] = $false
-        $PSDefaultParameterValues["*:WarningVariable"] = 'WarnVar'
-    }
-
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        It "Should only contain our specific parameters" {
-            $params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-            $knownParameters = 'Build', 'MinimumBuild', 'MaxBehind', 'Latest', 'SqlInstance', 'SqlCredential', 'Update', 'Quiet', 'EnableException'
-            $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "Build",
+                "MinimumBuild",
+                "MaxBehind",
+                "Latest",
+                "SqlInstance",
+                "SqlCredential",
+                "Update",
+                "Quiet",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
+}
+
+Describe $CommandName -Tag IntegrationTests {
     Context "Retired KBs" {
         It "Handles retired kbs" {
             $result = Test-DbaBuild -Build '13.0.5479' -Latest
@@ -44,11 +55,6 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     }
 }
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-    BeforeAll {
-        $PSDefaultParameterValues["*:Confirm"] = $false
-        $PSDefaultParameterValues["*:WarningVariable"] = 'WarnVar'
-    }
-
     Context "Command actually works" {
         It "Should return a result" {
             $results = Test-DbaBuild -Build "12.00.4502" -MinimumBuild "12.0.4511" -SqlInstance $TestConfig.instance2

--- a/tests/Test-DbaComputerCertificateExpiration.Tests.ps1
+++ b/tests/Test-DbaComputerCertificateExpiration.Tests.ps1
@@ -28,11 +28,6 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     Context "tests a certificate" {
-        BeforeAll {
-            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-        }
-
         AfterAll {
             Remove-DbaComputerCertificate -Thumbprint "29C469578D6C6211076A09CEE5C5797EEA0C2713" -Confirm:$false
         }

--- a/tests/Test-DbaComputerCertificateExpiration.Tests.ps1
+++ b/tests/Test-DbaComputerCertificateExpiration.Tests.ps1
@@ -30,7 +30,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "tests a certificate" {
         BeforeAll {
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-            $PSDefaultParameterValues.Remove('*-Dba*:EnableException')
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {

--- a/tests/Test-DbaDbCollation.Tests.ps1
+++ b/tests/Test-DbaDbCollation.Tests.ps1
@@ -40,6 +40,8 @@ Describe $CommandName -Tags IntegrationTests {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $null = Remove-DbaDatabase -SqlInstance $TestConfig.Instance1 -Name $dbName
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "confirms the db is the same collation as the server" {

--- a/tests/Test-DbaDbDataGeneratorConfig.Tests.ps1
+++ b/tests/Test-DbaDbDataGeneratorConfig.Tests.ps1
@@ -1,19 +1,25 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Test-DbaDbDataGeneratorConfig",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'FilePath', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should have the expected parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "FilePath",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         $dbname = "dbatools_datagentest"
         $query = "CREATE DATABASE [$dbname]"

--- a/tests/Test-DbaDbOwner.Tests.ps1
+++ b/tests/Test-DbaDbOwner.Tests.ps1
@@ -1,16 +1,30 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-$global:TestConfig = Get-TestConfig
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Test-DbaDbOwner",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'TargetLogin', 'InputObject', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Database",
+                "ExcludeDatabase",
+                "TargetLogin",
+                "InputObject",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
+}
+
+Describe $CommandName -Tag IntegrationTests {
     InModuleScope 'dbatools' {
         Context "Connects to SQL Server" {
             It -Skip "Should not throw" {

--- a/tests/Test-DbaDbQueryStore.Tests.ps1
+++ b/tests/Test-DbaDbQueryStore.Tests.ps1
@@ -45,6 +45,8 @@ Describe $CommandName -Tag IntegrationTests {
 
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $global:dbname -Confirm:$false
         $null = Disable-DbaTraceFlag -SqlInstance $TestConfig.instance2 -TraceFlag 7745
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Function works as expected" {

--- a/tests/Test-DbaMaxDop.Tests.ps1
+++ b/tests/Test-DbaMaxDop.Tests.ps1
@@ -41,6 +41,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $testDbName | Remove-DbaDatabase -Confirm:$false
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     # Just not messin with this in appveyor

--- a/tests/Test-DbaMigrationConstraint.Tests.ps1
+++ b/tests/Test-DbaMigrationConstraint.Tests.ps1
@@ -48,6 +48,8 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Remove-DbaDatabase -Confirm:$false -SqlInstance $TestConfig.instance1 -Database $global:db1, $global:db2 -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When setup is successful" {

--- a/tests/Watch-DbaDbLogin.Tests.ps1
+++ b/tests/Watch-DbaDbLogin.Tests.ps1
@@ -62,6 +62,8 @@ Describe $CommandName -Tag IntegrationTests {
         $null = $newDb | Remove-DbaDatabase -Confirm:$false
         Get-DbaRegServer -SqlInstance $TestConfig.instance1 | Where-Object Name -match dbatoolsci | Remove-DbaRegServer -Confirm:$false
         Remove-Item -Path $testFile -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     Context "Command actually works" {
 

--- a/tests/Watch-DbaXESession.Tests.ps1
+++ b/tests/Watch-DbaXESession.Tests.ps1
@@ -34,6 +34,7 @@ Describe $CommandName -Tag IntegrationTests {
         AfterAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
             Start-DbaXESession -SqlInstance $TestConfig.instance2 -Session system_health
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         # This command is special and runs infinitely so don't actually try to run it


### PR DESCRIPTION
A lot of changes, but now every test uses pester 5.

Still a lot of TODO comments in the tests - but we will take care of that later.