### PR TITLE
Huge performance improvement in query for duplicate/overlapping indexes

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -363,8 +363,8 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Test-DbaNetworkLatency',
         'Find-DbaDbDuplicateIndex',
         'Remove-DbaDatabaseSafely',
-        'Set-DbaTempdbConfig',
-        'Test-DbaTempdbConfig',
+        'Set-DbaTempDbConfig',
+        'Test-DbaTempDbConfig',
         'Repair-DbaDbOrphanUser',
         'Remove-DbaDbOrphanUser',
         'Find-DbaDbUnusedIndex',
@@ -408,7 +408,6 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'New-DbaDbAsymmetricKey',
         'Remove-DbaDbAsymmetricKey',
         'Invoke-DbaDbTransfer',
-        'Invoke-DbaDbAzSqlTips',
         'New-DbaDbTransfer',
         'Remove-DbaDbData',
         'Resolve-DbaNetworkName',
@@ -612,7 +611,6 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Get-DbaRegServerGroup',
         'New-DbaDbUser',
         'Measure-DbaDiskSpaceRequirement',
-        'Invoke-DbaXeReplay',
         'Find-DbaInstance',
         'Test-DbaDiskSpeed',
         'Get-DbaDbExtentDiff',
@@ -769,7 +767,7 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Add-DbaDbRoleMember',
         'Disable-DbaStartupProcedure',
         'Enable-DbaStartupProcedure',
-        'Get-DbaDbFilegroup',
+        'Get-DbaDbFileGroup',
         'Get-DbaDbObjectTrigger',
         'Get-DbaStartupProcedure',
         'Get-DbatoolsChangeLog',
@@ -860,6 +858,26 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Remove-DbaLinkedServerLogin',
         'Remove-DbaCredential',
         'Remove-DbaAgentProxy',
+        'Invoke-DbaDbAzSqlTip',
+        'New-DbaAgentAlert',
+        'Set-DbatoolsInsecureConnection',
+        'Test-DbaAgSpn'
+    )
+    $script:noncoresmo = @(
+        # SMO issues
+        'Copy-DbaSsisCatalog',
+        'Get-DbaSsisEnvironmentVariable',
+        'New-DbaSsisCatalog',
+        'Copy-DbaPolicyManagement',
+        'Copy-DbaDataCollector',
+        'Get-DbaPbmCategory',
+        'Get-DbaPbmCategorySubscription',
+        'Get-DbaPbmCondition',
+        'Get-DbaPbmObjectSet',
+        'Get-DbaPbmPolicy',
+        'Get-DbaPbmStore',
+        'Test-DbaReplLatency',
+        'Export-DbaReplServerSetting',
         'Disable-DbaReplDistributor',
         'Enable-DbaReplDistributor',
         'Disable-DbaReplPublishing',
@@ -876,20 +894,8 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Get-DbaReplSubscription',
         'Get-DbaReplDistributor',
         'Get-DbaReplPublication',
-        'Get-DbaReplServer'
-    )
-    $script:noncoresmo = @(
-        # SMO issues
-        'Copy-DbaPolicyManagement',
-        'Copy-DbaDataCollector',
-        'Get-DbaPbmCategory',
-        'Get-DbaPbmCategorySubscription',
-        'Get-DbaPbmCondition',
-        'Get-DbaPbmObjectSet',
-        'Get-DbaPbmPolicy',
-        'Get-DbaPbmStore',
-        'Test-DbaReplLatency',
-        'Export-DbaReplServerSetting'
+        'Get-DbaReplServer',
+        'Get-DbaReplPublisher'
     )
     $script:windowsonly = @(
         # filesystem (\\ related),
@@ -984,7 +990,7 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Test-DbaComputerCertificateExpiration',
         'Get-DbaNetworkCertificate',
         'Set-DbaNetworkCertificate',
-        'Remove-DbaDbLogshipping',
+        'Remove-DbaDbLogShipping',
         'Invoke-DbaDbLogShipping',
         'New-DbaCmConnection',
         'Get-DbaCmConnection',

--- a/public/Find-DbaDbDuplicateIndex.ps1
+++ b/public/Find-DbaDbDuplicateIndex.ps1
@@ -81,12 +81,10 @@ function Find-DbaDbDuplicateIndex {
 
     begin {
         $exactDuplicateQuery2005 = "
-            WITH CTE_IndexCols
+        WITH CTE_IndexCols
             AS (
                 SELECT i.[object_id]
                     ,i.index_id
-                    ,OBJECT_SCHEMA_NAME(i.[object_id]) AS SchemaName
-                    ,OBJECT_NAME(i.[object_id]) AS TableName
                     ,NAME AS IndexName
                     ,ISNULL(STUFF((
                                 SELECT ', ' + col.NAME + ' ' + CASE
@@ -145,7 +143,7 @@ function Find-DbaDbDuplicateIndex {
                     ,s.index_id
                 )
             SELECT DB_NAME() AS DatabaseName
-                ,CI1.SchemaName + '.' + CI1.TableName AS 'TableName'
+                ,OBJECT_SCHEMA_NAME(CI1.[object_id]) + '.' + OBJECT_NAME(CI1.[object_id]) as 'TableName'
                 ,CI1.IndexName
                 ,CI1.KeyColumns
                 ,CI1.IncludedColumns
@@ -160,20 +158,17 @@ function Find-DbaDbDuplicateIndex {
             WHERE EXISTS (
                     SELECT 1
                     FROM CTE_IndexCols CI2
-                    WHERE CI1.SchemaName = CI2.SchemaName
-                        AND CI1.TableName = CI2.TableName
+                    WHERE CI1.[object_id] = CI2.[object_id]
                         AND CI1.KeyColumns = CI2.KeyColumns
                         AND CI1.IncludedColumns = CI2.IncludedColumns
                         AND CI1.IndexName <> CI2.IndexName
                     )"
 
         $overlappingQuery2005 = "
-            WITH CTE_IndexCols
+          WITH CTE_IndexCols
             AS (
                 SELECT i.[object_id]
                     ,i.index_id
-                    ,OBJECT_SCHEMA_NAME(i.[object_id]) AS SchemaName
-                    ,OBJECT_NAME(i.[object_id]) AS TableName
                     ,NAME AS IndexName
                     ,ISNULL(STUFF((
                                 SELECT ', ' + col.NAME + ' ' + CASE
@@ -232,7 +227,7 @@ function Find-DbaDbDuplicateIndex {
                     ,s.index_id
                 )
             SELECT DB_NAME() AS DatabaseName
-                ,CI1.SchemaName + '.' + CI1.TableName AS 'TableName'
+                ,OBJECT_SCHEMA_NAME(CI1.[object_id]) + '.' + OBJECT_NAME(CI1.[object_id]) AS 'TableName'
                 ,CI1.IndexName
                 ,CI1.KeyColumns
                 ,CI1.IncludedColumns
@@ -247,8 +242,7 @@ function Find-DbaDbDuplicateIndex {
             WHERE EXISTS (
                     SELECT 1
                     FROM CTE_IndexCols CI2
-                    WHERE CI1.SchemaName = CI2.SchemaName
-                        AND CI1.TableName = CI2.TableName
+                    WHERE CI1.[object_id] = CI2.[object_id]
                         AND (
                             (
                                 CI1.KeyColumns LIKE CI2.KeyColumns + '%'
@@ -268,8 +262,6 @@ function Find-DbaDbDuplicateIndex {
             AS (
                 SELECT i.[object_id]
                     ,i.index_id
-                    ,OBJECT_SCHEMA_NAME(i.[object_id]) AS SchemaName
-                    ,OBJECT_NAME(i.[object_id]) AS TableName
                     ,NAME AS IndexName
                     ,ISNULL(STUFF((
                                 SELECT ', ' + col.NAME + ' ' + CASE
@@ -331,7 +323,7 @@ function Find-DbaDbDuplicateIndex {
                     ,p.data_compression_desc
                 )
             SELECT DB_NAME() AS DatabaseName
-                ,CI1.SchemaName + '.' + CI1.TableName AS 'TableName'
+                ,OBJECT_SCHEMA_NAME(CI1.[object_id]) + '.' + OBJECT_NAME(CI1.[object_id]) AS 'TableName'
                 ,CI1.IndexName
                 ,CI1.KeyColumns
                 ,CI1.IncludedColumns
@@ -348,8 +340,7 @@ function Find-DbaDbDuplicateIndex {
             WHERE EXISTS (
                     SELECT 1
                     FROM CTE_IndexCols CI2
-                    WHERE CI1.SchemaName = CI2.SchemaName
-                        AND CI1.TableName = CI2.TableName
+                    WHERE CI1.[object_id] = CI2.[object_id]
                         AND CI1.KeyColumns = CI2.KeyColumns
                         AND CI1.IncludedColumns = CI2.IncludedColumns
                         AND CI1.IsFiltered = CI2.IsFiltered
@@ -362,8 +353,6 @@ function Find-DbaDbDuplicateIndex {
                 SELECT
                         i.[object_id]
                         ,i.index_id
-                        ,OBJECT_SCHEMA_NAME(i.[object_id]) AS SchemaName
-                        ,OBJECT_NAME(i.[object_id]) AS TableName
                         ,Name AS IndexName
                         ,ISNULL(STUFF((SELECT ', ' + col.NAME + ' ' + CASE
                                                                     WHEN idxCol.is_descending_key = 1 THEN 'DESC'
@@ -419,7 +408,7 @@ function Find-DbaDbDuplicateIndex {
             )
             SELECT
                     DB_NAME() AS DatabaseName
-                    ,CI1.SchemaName + '.' + CI1.TableName AS 'TableName'
+                    ,OBJECT_SCHEMA_NAME(CI1.[object_id]) + '.' + OBJECT_NAME(CI1.[object_id]) AS 'TableName'
                     ,CI1.IndexName
                     ,CI1.KeyColumns
                     ,CI1.IncludedColumns
@@ -436,8 +425,7 @@ function Find-DbaDbDuplicateIndex {
                 AND CI1.index_id = CSPC.index_id
             WHERE EXISTS (SELECT 1
                             FROM CTE_IndexCols CI2
-                        WHERE CI1.SchemaName = CI2.SchemaName
-                            AND CI1.TableName = CI2.TableName
+                        WHERE CI1.[object_id] = CI2.[object_id]
                             AND (
                                         (CI1.KeyColumns like CI2.KeyColumns + '%' and SUBSTRING(CI1.KeyColumns,LEN(CI2.KeyColumns)+1,1) = ' ')
                                     OR (CI2.KeyColumns like CI1.KeyColumns + '%' and SUBSTRING(CI2.KeyColumns,LEN(CI1.KeyColumns)+1,1) = ' ')

--- a/tests/Get-DbaTraceFlag.Tests.ps1
+++ b/tests/Get-DbaTraceFlag.Tests.ps1
@@ -28,7 +28,7 @@ Describe $CommandName -Tag IntegrationTests {
 
             $safeTraceFlag = 3226
             $server = Connect-DbaInstance -SqlInstance $TestConfig.instance2
-            $startingTfs = $server.Query("DBCC TRACESTATUS(-1)")
+            $startingTfs = @( $server.Query("DBCC TRACESTATUS(-1)") )
             $startingTfsCount = $startingTfs.Count
 
             if ($startingTfs.TraceFlag -notcontains $safeTraceFlag) {
@@ -61,11 +61,14 @@ Describe $CommandName -Tag IntegrationTests {
         It "Returns filtered results" {
             $results = Get-DbaTraceFlag -SqlInstance $TestConfig.instance2 -TraceFlag $safeTraceFlag
             $results.TraceFlag.Count | Should -Be 1
+            $results.TraceFlag | Should -Be $safeTraceFlag
+            $results.Status | Should -Be 1
         }
 
         It "Returns all TFs" {
             $results = Get-DbaTraceFlag -SqlInstance $TestConfig.instance2
-            $results.TraceFlag.Count | Should -Be $startingTfsCount
+            #$results.TraceFlag.Count | Should -Be $startingTfsCount
+            $results.TraceFlag | Should -Be $safeTraceFlag
         }
     }
 }

--- a/tests/New-DbaDatabase.Tests.ps1
+++ b/tests/New-DbaDatabase.Tests.ps1
@@ -41,45 +41,43 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
-
-    BeforeAll {
-        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-
-        $random = Get-Random
-        $instance2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
-        $instance3 = Connect-DbaInstance -SqlInstance $TestConfig.instance3
-        $null = Get-DbaProcess -SqlInstance $instance2, $instance3 | Where-Object Program -match dbatools | Stop-DbaProcess -WarningAction SilentlyContinue
-        $randomDb = New-DbaDatabase -SqlInstance $instance2
-        $newDbName = "dbatoolsci_newdb_$random"
-        $newDb1Name = "dbatoolsci_newdb1_$random"
-        $newDb2Name = "dbatoolsci_newdb2_$random"
-        $bug6780DbName = "dbatoolsci_6780_$random"
-        $collationDbName = "dbatoolsci_collation_$random"
-        $secondaryFileTestDbName = "dbatoolsci_secondaryfiletest_$random"
-        $secondaryFileCountTestDbName = "dbatoolsci_secondaryfilecounttest_$random"
-        $simpleRecoveryModelDbName = "dbatoolsci_simple_$random"
-        $fullRecoveryModelDbName = "dbatoolsci_full_$random"
-        $bulkLoggedRecoveryModelDbName = "dbatoolsci_bulklogged_$random"
-        $primaryFileGroupDbName = "dbatoolsci_primary_filegroup_$random"
-        $secondaryFileGroupDbName = "dbatoolsci_secondary_filegroup_$random"
-
-        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-    }
-
-    AfterAll {
-        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-
-        # Cleanup all created databases.
-        $null = Remove-DbaDatabase -SqlInstance $instance2 -Database $randomDb.Name, $newDbName, $newDb1Name, $newDb2Name, $bug6780DbName, $collationDbName, $simpleRecoveryModelDbName, $fullRecoveryModelDbName, $bulkLoggedRecoveryModelDbName -ErrorAction SilentlyContinue
-        $null = Remove-DbaDatabase -SqlInstance $instance3 -Database $newDbName, $newDb1Name, $newDb2Name, $secondaryFileTestDbName, $secondaryFileCountTestDbName, $primaryFileGroupDbName, $secondaryFileGroupDbName -ErrorAction SilentlyContinue
-
-        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-    }
-
     Context "When creating databases" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $random = Get-Random
+            $instance2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
+            $instance3 = Connect-DbaInstance -SqlInstance $TestConfig.instance3
+
+            $randomDb = New-DbaDatabase -SqlInstance $instance2
+
+            $newDbName = "dbatoolsci_newdb_$random"
+            $newDb1Name = "dbatoolsci_newdb1_$random"
+            $newDb2Name = "dbatoolsci_newdb2_$random"
+            $bug6780DbName = "dbatoolsci_6780_$random"
+            $collationDbName = "dbatoolsci_collation_$random"
+            $secondaryFileTestDbName = "dbatoolsci_secondaryfiletest_$random"
+            $secondaryFileCountTestDbName = "dbatoolsci_secondaryfilecounttest_$random"
+            $simpleRecoveryModelDbName = "dbatoolsci_simple_$random"
+            $fullRecoveryModelDbName = "dbatoolsci_full_$random"
+            $bulkLoggedRecoveryModelDbName = "dbatoolsci_bulklogged_$random"
+            $primaryFileGroupDbName = "dbatoolsci_primary_filegroup_$random"
+            $secondaryFileGroupDbName = "dbatoolsci_secondary_filegroup_$random"
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Cleanup all created databases.
+            Get-DbaDatabase -SqlInstance $instance2, $instance3 -ExcludeSystem | Remove-DbaDatabase
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
 
         It "creates one new randomly named database" {
             $randomDb.Name | Should -Match random

--- a/tests/Stop-DbaService.Tests.ps1
+++ b/tests/Stop-DbaService.Tests.ps1
@@ -52,7 +52,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "stops specific services based on instance name through pipeline" {
-            $services = Get-DbaService -ComputerName $TestConfig.instance2 -InstanceName $instanceName -Type Agent, Engine | Stop-DbaService
+            $services = Get-DbaService -ComputerName $TestConfig.instance2 -InstanceName $instanceName -Type Agent, Engine | Stop-DbaService -Force
             $services | Should -Not -BeNullOrEmpty
             foreach ($service in $services) {
                 $service.State | Should -Be 'Stopped'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9816 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
I am using the dbachecks framework to test my large set of servers, this framework uses dbatools for a lot of their checks. Running the duplicate index check takes a whole while my one server (15 minutes, for 50 databases with lots of objects), and use a lot of CPU. 
Since this should be a meta-data query, it should not take that long. 

### Approach
Looking at the query plan of the meta-data query for getting duplicate indexes, I see that most time gets spent on function calls "object_name" and "object_schema_name". Moving the function fall from the CTE to the query retrieving the data reduced the execution of the query from almost 2m to 1s on one of the 50 databases on my test server.

<img width="867" height="653" alt="image" src="https://github.com/user-attachments/assets/36eb296d-37eb-4137-8291-9df0e6c8100a" />

