### PR TITLE
Set-FileSystemSetting - Move from WMI to CIM to support pwsh

### DIFF
--- a/private/functions/Set-FileSystemSetting.ps1
+++ b/private/functions/Set-FileSystemSetting.ps1
@@ -63,9 +63,7 @@ function Set-FileSystemSetting {
 
             Write-Message -Level Verbose -Message "Attempting to connect to $computer's WMI"
             $ognamespace = Get-DbaCmObject -EnableException -ComputerName $computerName -Namespace root\Microsoft\SQLServer -Query "SELECT NAME FROM __NAMESPACE WHERE NAME LIKE 'ComputerManagement%'"
-            $namespace = $ognamespace | Where-Object {
-                (Get-DbaCmObject -EnableException -ComputerName $computerName -Namespace $("root\Microsoft\SQLServer\" + $_.Name) -ClassName FilestreamSettings).Count -gt 0
-            } | Sort-Object Name -Descending | Select-Object -First 1
+            $namespace = $ognamespace | Where-Object { (Get-DbaCmObject -EnableException -ComputerName $computerName -Namespace $("root\Microsoft\SQLServer\" + $_.Name) -ClassName FilestreamSettings).Count -gt 0 } | Sort-Object Name -Descending | Select-Object -First 1
 
             if (-not $namespace) {
                 $namespace = $ognamespace


### PR DESCRIPTION
I found this running the test for New-DbaDbFileGroup, where a filestream filegroup is created. This uses WMI calls that are not available on pwsh - or better say: They are serialized objects because an internal winrm connection is used. So they don't have the original methods.

I completly refactored the command using our own internal command for cim calls: Get-DbaCmObject