### PR TITLE
Refactor Filestream related tests

### DIFF
--- a/tests/Disable-DbaFilestream.Tests.ps1
+++ b/tests/Disable-DbaFilestream.Tests.ps1
@@ -22,47 +22,23 @@ Describe $CommandName -Tag UnitTests {
     }
 }
 
-<#
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-        # Store the original FileStream level to restore after testing
-        $originalFileStream = Get-DbaFilestream -SqlInstance $TestConfig.instance1
+        $null = Enable-DbaFilestream -SqlInstance $TestConfig.instance1 -FileStreamLevel 1 -Force
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
-    AfterAll {
-        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-
-        # Restore the original FileStream level
-        Set-DbaFilestream -SqlInstance $TestConfig.instance1 -FileStreamLevel $originalFileStream.InstanceAccessLevel -Force
-
-        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-    }
-
     Context "When changing FileStream Level" {
-        BeforeAll {
-            # Move it on one, but keep it less than 4 with modulo division
-            $newLevel = ($originalFileStream.FileStreamStateId + 1) % 3
-            $splatFilestream = @{
-                SqlInstance     = $TestConfig.instance1
-                FileStreamLevel = $newLevel
-                Force           = $true
-                WarningAction   = "SilentlyContinue"
-                ErrorVariable   = "errvar"
-                ErrorAction     = "SilentlyContinue"
-            }
-            $results = Set-DbaFilestream @splatFilestream
-        }
-
         It "Should change the FileStream Level" {
-            $results.InstanceAccessLevel | Should -Be $newLevel
+            $results = Disable-DbaFilestream -SqlInstance $TestConfig.instance1 -Force
+
+            $results.InstanceAccessLevel | Should -Be 0
+            $results.ServiceAccessLevel | Should -Be 0
         }
     }
 }
-#>

--- a/tests/Enable-DbaFilestream.Tests.ps1
+++ b/tests/Enable-DbaFilestream.Tests.ps1
@@ -24,41 +24,37 @@ Describe $CommandName -Tag UnitTests {
     }
 }
 
-Describe $CommandName -Tag IntegrationTests -Skip:($PSVersionTable.PSVersion.Major -gt 5) {
-    # Skip IntegrationTests on pwsh because the command is currently not supported (because of FileStream configuration via WMI).
-
-    BeforeAll {
-        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-
-        # Store the original FileStream level so we can restore it after the test
-        # TODO: We should rely on a file stream setting in the test environment and work from there.
-        $originalFileStream = Get-DbaFilestream -SqlInstance $TestConfig.instance1
-
-        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-    }
-
+Describe $CommandName -Tag IntegrationTests {
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-        # Restore the original FileStream level
-        if ($originalFileStream.InstanceAccessLevel -eq 0) {
-            $null = Disable-DbaFilestream -SqlInstance $TestConfig.instance1 -WarningAction SilentlyContinue
-        } else {
-            $null = Enable-DbaFilestream -SqlInstance $TestConfig.instance1 -FileStreamLevel $originalFileStream.InstanceAccessLevel -WarningAction SilentlyContinue
-        }
+        $null = Disable-DbaFilestream -SqlInstance $TestConfig.instance1 -Force
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When changing FileStream Level" {
-        It "Should change the FileStream Level to the new value" {
-            $newLevel = ($originalFileStream.InstanceAccessLevel + 1) % 3 #Move it on one, but keep it less than 4 with modulo division
-            $results = Enable-DbaFilestream -SqlInstance $TestConfig.instance1 -FileStreamLevel $newLevel -WarningAction SilentlyContinue
+        It "Should change the FileStream Level to 1" {
+            $results = Enable-DbaFilestream -SqlInstance $TestConfig.instance1 -FileStreamLevel 1 -Force
 
-            $results.InstanceAccessLevel | Should -Be $newLevel
+            $results.InstanceAccessLevel | Should -Be 1
+            $results.ServiceAccessLevel | Should -Be 1
+        }
+
+        It "Should change the FileStream Level to 2" {
+            $results = Enable-DbaFilestream -SqlInstance $TestConfig.instance1 -FileStreamLevel 2 -ShareName TestShare -Force
+
+            $results.InstanceAccessLevel | Should -Be 2
+            $results.ServiceAccessLevel | Should -Be 2
+            $results.ServiceShareName | Should -Be TestShare
+        }
+
+        It "Should warn if using ShareName with FileStreamLevel 1" {
+            $results = Enable-DbaFilestream -SqlInstance $TestConfig.instance1 -FileStreamLevel 1 -ShareName Test -WarningAction SilentlyContinue
+
+            $WarnVar | Should -BeLike '*Filestream must be at least level 2 when using ShareName*'
+            $results | Should -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
After we fixed the code so that it work with powershell.exe and pwsh.exe, we can now refactor the tests to have a better test coverage.

We are again assuming a newly installed instance where Filestream is not yet active.