### PR TITLE
Remove duplicate 'PSAvoidUsingWriteHost' rule from analyzer

### DIFF
--- a/bin/PSScriptAnalyzerRules.psd1
+++ b/bin/PSScriptAnalyzerRules.psd1
@@ -3,7 +3,6 @@
     IncludeRules = @(
         'PSUseCompatibleSyntax',
         'PSAvoidUsingCmdletAliases',
-        'PSAvoidUsingWriteHost',
         'PSAvoidDefaultValueSwitchParameter',
         'PSReservedCmdletChar',
         'PSReservedParams',


### PR DESCRIPTION
Just spotted this in my travels, presumably not causing any problems, but just thought I'd clean it up 🙂