### PR TITLE
New-/Get-/Remove-DbaFirewallRule: New rule for database mirroring or Availability Groups

### DIFF
--- a/public/Remove-DbaFirewallRule.ps1
+++ b/public/Remove-DbaFirewallRule.ps1
@@ -21,7 +21,7 @@ function Remove-DbaFirewallRule {
     .PARAMETER Type
         Specifies which types of SQL Server firewall rules to remove from the target computer.
         Use this to control exactly which network access rules are cleaned up when decommissioning or reconfiguring SQL Server instances.
-        Engine removes rules for SQL Server database connections, Browser removes UDP port 1434 rules for SQL Server Browser service, DAC removes Dedicated Admin Connection rules, and AllInstance removes all SQL Server-related rules. Defaults to Engine and DAC since Browser rules are often shared between multiple instances.
+        Engine removes rules for SQL Server database connections, Browser removes UDP port 1434 rules for SQL Server Browser service, DAC removes Dedicated Admin Connection rules, DatabaseMirroring removes database mirroring or Availability Groups rules, and AllInstance removes all SQL Server-related rules. Defaults to Engine and DAC since Browser rules are often shared between multiple instances.
 
     .PARAMETER InputObject
         Accepts firewall rule objects from Get-DbaFirewallRule for pipeline-based removal operations.
@@ -77,7 +77,7 @@ function Remove-DbaFirewallRule {
         [Parameter(ParameterSetName = 'NonPipeline')]
         [PSCredential]$Credential,
         [Parameter(ParameterSetName = 'NonPipeline')]
-        [ValidateSet('Engine', 'Browser', 'DAC', 'AllInstance')]
+        [ValidateSet('Engine', 'Browser', 'DAC', 'DatabaseMirroring', 'AllInstance')]
         [string[]]$Type = @('Engine', 'DAC'),
         [parameter(ValueFromPipeline, ParameterSetName = 'Pipeline', Mandatory = $true)]
         [object[]]$InputObject,


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
I sometimes have labs or clients that use the windows firewall. So I want to be able to create the firewall rule before running New-DbaAvailabilityGroup. Maybe I add a switch to New-DbaAvailabilityGroup later to create the rule like we have -ConfigureXESession to enable the extended event session. But that would be a seperate PR.

### Approach
I mostly copied the code for the DAC to have the same wording. I used the term "DatabaseMirroring" because that is the name of the type of endpoint that is listening on that port.

### Commands to test
```
New-DbaFirewallRule -SqlInstance sql01 -Type DatabaseMirroring 
New-DbaFirewallRule -SqlInstance sql01 -Type DatabaseMirroring -Force -Configuration @{ LocalPort = '5023' }
Get-DbaFirewallRule -SqlInstance sql01 -Type DatabaseMirroring 
Remove-DbaFirewallRule -SqlInstance sql01 -Type DatabaseMirroring 
```
