### PR TITLE
New-DbaAgentSchedule: Add new parameter FrequencyText

### DIFF
--- a/tests/New-DbaAgentSchedule.Tests.ps1
+++ b/tests/New-DbaAgentSchedule.Tests.ps1
@@ -22,6 +22,7 @@ Describe $CommandName -Tag UnitTests {
                 "FrequencySubdayInterval",
                 "FrequencyRelativeInterval",
                 "FrequencyRecurrenceFactor",
+                "FrequencyText",
                 "StartDate",
                 "EndDate",
                 "StartTime",
@@ -265,6 +266,43 @@ Describe $CommandName -Tag IntegrationTests {
                 $results[$key].FrequencyRelativeIntervals | Should -BeIn $scheduleOptions
                 $results[$key].FrequencyRelativeIntervals | Should -Be $key
             }
+        }
+    }
+
+    Context "Should create schedules based on frequency texts" {
+        It "Should create a schedule for: Every minute" {
+            $results = New-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -FrequencyText 'Every minute'
+            $results.Name | Should -Be 'Every minute'
+            $results.Description | Should -BeLike 'Occurs every day every 1 minute(s) between 12:00:00 AM and 11:59:59 PM*'
+            $results | Remove-DbaAgentSchedule
+        }
+
+        It "Should create a schedule for: Every 10 minutes starting at 00:02:30" {
+            $results = New-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -FrequencyText 'Every 10 minutes starting at 00:02:30'
+            $results.Name | Should -Be 'Every 10 minutes starting at 00:02:30'
+            $results.Description | Should -BeLike 'Occurs every day every 10 minute(s) between 12:02:30 AM and 11:59:59 PM*'
+            $results | Remove-DbaAgentSchedule
+        }
+
+        It "Should create a schedule for: Every 2 hours" {
+            $results = New-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -FrequencyText 'Every 2 hours'
+            $results.Name | Should -Be 'Every 2 hours'
+            $results.Description | Should -BeLike 'Occurs every day every 2 hour(s) between 12:00:00 AM and 11:59:59 PM*'
+            $results | Remove-DbaAgentSchedule
+        }
+
+        It "Should create a schedule for: Every day at 05:00:00" {
+            $results = New-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -FrequencyText 'Every day at 05:00:00'
+            $results.Name | Should -Be 'Every day at 05:00:00'
+            $results.Description | Should -BeLike 'Occurs every day at 5:00:00 AM*'
+            $results | Remove-DbaAgentSchedule
+        }
+
+        It "Should create a schedule for: Every sunday at 02:00:00" {
+            $results = New-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -FrequencyText 'Every sunday at 02:00:00'
+            $results.Name | Should -Be 'Every sunday at 02:00:00'
+            $results.Description | Should -BeLike 'Occurs every week on Sunday at 2:00:00 AM*'
+            $results | Remove-DbaAgentSchedule
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Most of the schedules are very simple and it should be able to create them with a simple string as configuration. That is more readable in the code they are used in.

### Approach
I added a new parameter and some basic parsing logic. It sure can be enhanced, but I think that is a good starting point.

### Commands to test
```
$text = @(
        'Every minute'
        'Every 5 minutes'
        'Every 10 minutes starting at 00:02:30'
        'Every hour'
        'Every 2 hours'
        'Every 4 Hours starting at 02:00:00'
        'Every day at 05:00:00'
        'Every sunday at 02:00:00'
)
$schedule = foreach ($t in $text) {
    New-DbaAgentSchedule -SqlInstance sql01 -FrequencyText $t
}
$schedule | Format-Table Name, Description
```

### Screenshots
<img width="1319" height="203" alt="image" src="https://github.com/user-attachments/assets/f02ada87-a413-4e53-a22e-ee382f12202f" />
