### PR TITLE
Fix Get-DbaSchemaChangeHistory when no trace file exists

### DIFF
--- a/public/Get-DbaSchemaChangeHistory.ps1
+++ b/public/Get-DbaSchemaChangeHistory.ps1
@@ -94,6 +94,11 @@ function Get-DbaSchemaChangeHistory {
 
             $TraceFile = $server.Query($TraceFileQuery) | Select-Object Path
 
+            if (!$TraceFile -or !$TraceFile.Path) {
+                Write-Message -Level Warning -Message "No default trace file found on $instance. Schema change tracking requires the default trace to be enabled."
+                continue
+            }
+
             $Databases = $server.Databases
 
             if ($Database) { $Databases = $Databases | Where-Object Name -in $database }


### PR DESCRIPTION
Adds a check to handle cases where the default system trace is not enabled. Previously, the function would fail when querying fn_trace_gettable with a null path. Now displays a warning message and skips the instance gracefully.

## Type of Change
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
Fix a bug where `Get-DbaSchemaChangeHistory` would crash with an error when executed on a SQL Server instance that has no default system trace enabled. This is a valid configuration scenario that should be handled gracefully.

### Approach
Added a validation check after retrieving the trace file path (line 97-100). If no trace file is found (`!$TraceFile -or !$TraceFile.Path`), the function now:
1. Displays a warning message explaining that the default trace is required for schema change tracking
2. Uses `continue` to skip to the next instance instead of crashing