### PR TITLE
Test-DBALsnChain - Fix NullArray exception

### DIFF
--- a/private/functions/Test-DbaLsnChain.ps1
+++ b/private/functions/Test-DbaLsnChain.ps1
@@ -97,7 +97,7 @@ function Test-DbaLsnChain {
 
         #Check T-log LSNs form a chain.
         $TranLogBackups = $TestHistory | Where-Object {
-            $_.$TypeName -in ('Transaction Log', 'Log') -and (($_.DatabaseBackupLSN.ToString() -eq $FullDBAnchor.CheckPointLSN) -or (($_.DatabaseBackupLSN.ToString() -ne $FullDBAnchor.CheckPointLSN) -and ($TranLogBackups[$i].FirstLSN -gt $FullDBAnchor.CheckPointLSN)))
+            $_.$TypeName -in ('Transaction Log', 'Log') -and (($_.DatabaseBackupLSN.ToString() -eq $FullDBAnchor.CheckPointLSN) -or (($_.DatabaseBackupLSN.ToString() -ne $FullDBAnchor.CheckPointLSN) -and ($_.FirstLSN -gt $FullDBAnchor.CheckPointLSN)))
         } | Sort-Object -Property LastLSN, FirstLsn
 
     for ($i = 0; $i -lt ($TranLogBackups.count)) {

--- a/private/functions/Test-DbaLsnChain.ps1
+++ b/private/functions/Test-DbaLsnChain.ps1
@@ -27,6 +27,7 @@ function Test-DbaLsnChain {
 
     #>
     [CmdletBinding()]
+    [OutputType([Boolean])]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$FilteredRestoreFiles,
@@ -100,26 +101,26 @@ function Test-DbaLsnChain {
             $_.$TypeName -in ('Transaction Log', 'Log') -and (($_.DatabaseBackupLSN.ToString() -eq $FullDBAnchor.CheckPointLSN) -or (($_.DatabaseBackupLSN.ToString() -ne $FullDBAnchor.CheckPointLSN) -and ($_.FirstLSN -gt $FullDBAnchor.CheckPointLSN)))
         } | Sort-Object -Property LastLSN, FirstLsn
 
-    for ($i = 0; $i -lt ($TranLogBackups.count)) {
-        Write-Message -Level Debug -Message "looping t logs"
-        if ($i -eq 0) {
-            if ($TranLogBackups[$i].FirstLSN.ToString() -gt $TlogAnchor.LastLSN) {
-                Write-Message -Level Warning -Message "Break in LSN Chain between $($TlogAnchor.FullName) and $($TranLogBackups[($i)].FullName) "
-                Write-Message -Level Verbose -Message "Anchor $($TlogAnchor.LastLSN) - FirstLSN $($TranLogBackups[$i].FirstLSN)"
-                return $false
-                break
+        for ($i = 0; $i -lt ($TranLogBackups.count)) {
+            Write-Message -Level Debug -Message "looping t logs"
+            if ($i -eq 0) {
+                if ($TranLogBackups[$i].FirstLSN.ToString() -gt $TlogAnchor.LastLSN) {
+                    Write-Message -Level Warning -Message "Break in LSN Chain between $($TlogAnchor.FullName) and $($TranLogBackups[($i)].FullName) "
+                    Write-Message -Level Verbose -Message "Anchor $($TlogAnchor.LastLSN) - FirstLSN $($TranLogBackups[$i].FirstLSN)"
+                    return $false
+                    break
+                }
+            } else {
+                if ($TranLogBackups[($i - 1)].LastLsn -ne $TranLogBackups[($i)].FirstLSN -and ($TranLogBackups[($i)] -ne $TranLogBackups[($i - 1)])) {
+                    Write-Message -Level Warning -Message "Break in transaction log between $($TranLogBackups[($i-1)].FullName) and $($TranLogBackups[($i)].FullName) "
+                    return $false
+                    break
+                }
             }
-        } else {
-            if ($TranLogBackups[($i - 1)].LastLsn -ne $TranLogBackups[($i)].FirstLSN -and ($TranLogBackups[($i)] -ne $TranLogBackups[($i - 1)])) {
-                Write-Message -Level Warning -Message "Break in transaction log between $($TranLogBackups[($i-1)].FullName) and $($TranLogBackups[($i)].FullName) "
-                return $false
-                break
-            }
-        }
-        $i++
+            $i++
 
+        }
+        Write-Message -Level VeryVerbose -Message "Passed LSN Chain checks"
+        return $true
     }
-    Write-Message -Level VeryVerbose -Message "Passed LSN Chain checks"
-    return $true
-}
 }

--- a/private/functions/Test-DbaLsnChain.ps1
+++ b/private/functions/Test-DbaLsnChain.ps1
@@ -70,9 +70,12 @@ function Test-DbaLsnChain {
             break;
         }
 
+        #If same multiple Full DB backup exist with Same FirstLSN, just select one
+        $FullDBAnchor = ($FullDBAnchor | Select-Object -First 1)
+
         #Via LSN chain:
-        [BigInt]$CheckPointLSN = ($FullDBAnchor | Select-Object -First 1).CheckPointLSN.ToString()
-        [BigInt]$FullDBLastLSN = ($FullDBAnchor | Select-Object -First 1).LastLSN.ToString()
+        [BigInt]$CheckPointLSN = $FullDBAnchor.CheckPointLSN.ToString()
+        [BigInt]$FullDBLastLSN = $FullDBAnchor.LastLSN.ToString()
         $BackupWrongLSN = $FilteredRestoreFiles | Where-Object { $_.DatabaseBackupLSN -ne $CheckPointLSN }
         #Should be 0 in there, if not, lets check that they're from during the full backup
         if ($BackupWrongLSN.count -gt 0 ) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #9855)
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [x] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
Correct NullArray bug when restoring multiple files set including log backups

### Commands to test
```
$PathToBackup = "C:\Backup\" #All files inside this folder will be deleted
$SQLInstance = "."

# Create and clead backup folder if needed
$null=New-Item -ItemType Directory -Force -Path $PathToBackup
(gci "$PathToBackup*.*")| Remove-Item

Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true

$null =New-DbaDatabase -SqlInstance $SQLInstance -Name Bug

#Doing 1 full backup, 2 log, 1 diff and 2 more logs
$null =Backup-DbaDatabase -SqlInstance $SQLInstance -Database Bug -Type Full -Path $PathToBackup -TimeStampFormat yyyyMMddHHmmssfff
$null =Backup-DbaDatabase -SqlInstance $SQLInstance -Database Bug -Type Log -Path $PathToBackup -TimeStampFormat yyyyMMddHHmmssfff

$null =Backup-DbaDatabase -SqlInstance $SQLInstance -Database Bug -Type Log -Path $PathToBackup -TimeStampFormat yyyyMMddHHmmssfff


$null =Backup-DbaDatabase -SqlInstance $SQLInstance -Database Bug -Type Diff -Path $PathToBackup -TimeStampFormat yyyyMMddHHmmssfff
$null =Backup-DbaDatabase -SqlInstance $SQLInstance -Database Bug -Type Log -Path $PathToBackup -TimeStampFormat yyyyMMddHHmmssfff

$null =Backup-DbaDatabase -SqlInstance $SQLInstance -Database Bug -Type Log -Path $PathToBackup -TimeStampFormat yyyyMMddHHmmssfff

#drop Db
$null = Remove-DbaDatabase -SqlInstance $SQLInstance -Database Bug -Confirm:$false

Write-Host 'Test correct chaining'
$BackupHistory = Get-DbaBackupInformation -SqlInstance $SQLInstance -Path $PathToBackup
$BackupHistory  = $BackupHistory | Format-DbaBackupInformation
$null = $BackupHistory | Test-DbaBackupInformation -SqlInstance $SQLInstance
$BackupHistory | Sort-Object Start |Select-Object Database, Type, TotalSize, DeviceType, Start, End, FirstLSN, LastLSN,CheckPointLSN | Format-Table

Write-Host 'Remove one log backup to break LSN chaining & test'
(gci "$PathToBackup*.trn")[2] | Remove-Item
$BackupHistory = Get-DbaBackupInformation -SqlInstance $SQLInstance -Path $PathToBackup
$BackupHistory  = $BackupHistory | Format-DbaBackupInformation
$null = $BackupHistory | Test-DbaBackupInformation -SqlInstance $SQLInstance
$BackupHistory | Sort-Object Start |Select-Object Database, Type, TotalSize, DeviceType, Start, End, FirstLSN, LastLSN,CheckPointLSN | Format-Table

```

### Screenshots

<img width="1757" height="419" alt="2025-10-07_09h33_32" src="https://github.com/user-attachments/assets/51589cef-aa7a-4e5b-b918-e9c25ad4cdbc" />

<img width="1482" height="388" alt="2025-10-07_12h04_11" src="https://github.com/user-attachments/assets/bc25656d-3dd0-4446-9313-33706dc6e13d" />
