### PR TITLE
Import-DbaCsv - Fix month/day swap when using -Culture with ambiguous dates

### DIFF
--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -604,8 +604,12 @@ function Import-DbaCsv {
         }
 
         # When Culture is specified but DateTimeFormats is not, derive unambiguous datetime format
-        # strings from the culture's DateTimeFormat patterns. This forces ParseExact (which respects
-        # field order) instead of Parse (which can swap day/month when both values are <= 12).
+        # strings from the culture's ShortDatePattern only (purely numeric patterns).
+        # This forces ParseExact (which respects field order) instead of Parse (which can swap
+        # day/month when both values are <= 12).
+        # NOTE: Only short patterns (no LongDatePattern with MMMM/dddd) are derived, because
+        # locale-specific month/day name tokens combined with InvariantCulture can cause the
+        # library's parser to throw and fall back to a broken Parse path.
         # See: https://github.com/dataplat/dbatools/issues/10338
         if ($PSBoundParameters.Culture -and -not $PSBoundParameters.DateTimeFormats) {
             $cultureObj = New-Object System.Globalization.CultureInfo($Culture)
@@ -613,9 +617,7 @@ function Import-DbaCsv {
             $effectiveDateTimeFormats = @(
                 "$($dtf.ShortDatePattern) $($dtf.LongTimePattern)",
                 "$($dtf.ShortDatePattern) $($dtf.ShortTimePattern)",
-                $dtf.ShortDatePattern,
-                "$($dtf.LongDatePattern) $($dtf.LongTimePattern)",
-                $dtf.LongDatePattern
+                $dtf.ShortDatePattern
             )
             Write-Message -Level Verbose -Message "Derived DateTimeFormats from Culture '$Culture': $($effectiveDateTimeFormats -join ', ')"
         } elseif ($PSBoundParameters.DateTimeFormats) {
@@ -1370,14 +1372,7 @@ WHERE c.object_id = OBJECT_ID(@tableName)
                         if ($effectiveDateTimeFormats) {
                             $csvOptions.DateTimeFormats = $effectiveDateTimeFormats
                         }
-                        # Only set Culture on csvOptions when the user explicitly provided DateTimeFormats
-                        # alongside Culture, OR when no DateTimeFormats derivation occurred.
-                        # When DateTimeFormats are auto-derived from Culture (issue #10338), do NOT set
-                        # Culture on csvOptions: the library bypasses DateTimeFormats when Culture is also
-                        # set, falling back to a broken DateTime.Parse path that ignores format order.
-                        # Omitting Culture here forces the library to use ParseExact with the derived
-                        # format strings, which correctly respects dd/MM vs MM/dd ordering.
-                        if ($PSBoundParameters.Culture -and $PSBoundParameters.DateTimeFormats) {
+                        if ($PSBoundParameters.Culture) {
                             $csvOptions.Culture = New-Object System.Globalization.CultureInfo($Culture)
                         }
                         if ($PSBoundParameters.StaticColumns) {

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -603,6 +603,25 @@ function Import-DbaCsv {
             Write-Message -Level Warning -Message "Both SampleRows and DetectColumnTypes specified. DetectColumnTypes (full scan) takes precedence for zero-risk type detection."
         }
 
+        # When Culture is specified but DateTimeFormats is not, derive unambiguous datetime format
+        # strings from the culture's DateTimeFormat patterns. This forces ParseExact (which respects
+        # field order) instead of Parse (which can swap day/month when both values are <= 12).
+        # See: https://github.com/dataplat/dbatools/issues/10338
+        if ($PSBoundParameters.Culture -and -not $PSBoundParameters.DateTimeFormats) {
+            $cultureObj = New-Object System.Globalization.CultureInfo($Culture)
+            $dtf = $cultureObj.DateTimeFormat
+            $effectiveDateTimeFormats = @(
+                "$($dtf.ShortDatePattern) $($dtf.LongTimePattern)",
+                "$($dtf.ShortDatePattern) $($dtf.ShortTimePattern)",
+                $dtf.ShortDatePattern,
+                "$($dtf.LongDatePattern) $($dtf.LongTimePattern)",
+                $dtf.LongDatePattern
+            )
+            Write-Message -Level Verbose -Message "Derived DateTimeFormats from Culture '$Culture': $($effectiveDateTimeFormats -join ', ')"
+        } elseif ($PSBoundParameters.DateTimeFormats) {
+            $effectiveDateTimeFormats = $DateTimeFormats
+        }
+
         function New-SqlTable {
             <#
                 .SYNOPSIS
@@ -1142,8 +1161,8 @@ WHERE c.object_id = OBJECT_ID(@tableName)
                         } else {
                             $inferOptions.AllowMultilineFields = $SupportsMultiline.IsPresent
                         }
-                        if ($PSBoundParameters.DateTimeFormats) {
-                            $inferOptions.DateTimeFormats = $DateTimeFormats
+                        if ($effectiveDateTimeFormats) {
+                            $inferOptions.DateTimeFormats = $effectiveDateTimeFormats
                         }
                         if ($PSBoundParameters.Culture) {
                             $inferOptions.Culture = New-Object System.Globalization.CultureInfo($Culture)
@@ -1348,8 +1367,8 @@ WHERE c.object_id = OBJECT_ID(@tableName)
                             $csvOptions.MaxQuotedFieldLength = $MaxQuotedFieldLength
                         }
                         $csvOptions.ParseErrorAction = [Dataplat.Dbatools.Csv.CsvParseErrorAction]::$ParseErrorAction
-                        if ($PSBoundParameters.DateTimeFormats) {
-                            $csvOptions.DateTimeFormats = $DateTimeFormats
+                        if ($effectiveDateTimeFormats) {
+                            $csvOptions.DateTimeFormats = $effectiveDateTimeFormats
                         }
                         if ($PSBoundParameters.Culture) {
                             $csvOptions.Culture = New-Object System.Globalization.CultureInfo($Culture)

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -1370,7 +1370,14 @@ WHERE c.object_id = OBJECT_ID(@tableName)
                         if ($effectiveDateTimeFormats) {
                             $csvOptions.DateTimeFormats = $effectiveDateTimeFormats
                         }
-                        if ($PSBoundParameters.Culture) {
+                        # Only set Culture on csvOptions when the user explicitly provided DateTimeFormats
+                        # alongside Culture, OR when no DateTimeFormats derivation occurred.
+                        # When DateTimeFormats are auto-derived from Culture (issue #10338), do NOT set
+                        # Culture on csvOptions: the library bypasses DateTimeFormats when Culture is also
+                        # set, falling back to a broken DateTime.Parse path that ignores format order.
+                        # Omitting Culture here forces the library to use ParseExact with the derived
+                        # format strings, which correctly respects dd/MM vs MM/dd ordering.
+                        if ($PSBoundParameters.Culture -and $PSBoundParameters.DateTimeFormats) {
                             $csvOptions.Culture = New-Object System.Globalization.CultureInfo($Culture)
                         }
                         if ($PSBoundParameters.StaticColumns) {

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -604,20 +604,40 @@ function Import-DbaCsv {
         }
 
         # When Culture is specified but DateTimeFormats is not, derive unambiguous datetime format
-        # strings from the culture's ShortDatePattern only (purely numeric patterns).
-        # This forces ParseExact (which respects field order) instead of Parse (which can swap
-        # day/month when both values are <= 12).
-        # NOTE: Only short patterns (no LongDatePattern with MMMM/dddd) are derived, because
-        # locale-specific month/day name tokens combined with InvariantCulture can cause the
-        # library's parser to throw and fall back to a broken Parse path.
+        # strings that force ParseExact (which respects day/month field order) instead of
+        # DateTime.Parse (which can swap day/month when both values are <= 12).
         # See: https://github.com/dataplat/dbatools/issues/10338
+        #
+        # Design notes:
+        # 1. We do NOT use $dtf.ShortDatePattern or $dtf.LongTimePattern directly because these
+        #    properties differ between Windows (NLS) and Linux (ICU), causing platform-specific
+        #    format mismatches in CI. Instead we derive the format from stable culture primitives.
+        # 2. Time colons are escaped as HH':'mm':'ss rather than HH:mm:ss. In DateTime.ParseExact,
+        #    an unescaped ':' is a placeholder for the culture's TimeSeparator property. For de-CH
+        #    on Linux/ICU the TimeSeparator is '.' not ':', so HH:mm:ss would expect "17.09.41"
+        #    and fail to match CSV data that uses the common "17:09:41" format. Escaping forces
+        #    a literal ':' match regardless of the culture's TimeSeparator.
         if ($PSBoundParameters.Culture -and -not $PSBoundParameters.DateTimeFormats) {
             $cultureObj = New-Object System.Globalization.CultureInfo($Culture)
             $dtf = $cultureObj.DateTimeFormat
+            $dateSep = $dtf.DateSeparator
+
+            # Determine date field order from the first character of ShortDatePattern
+            if ($dtf.ShortDatePattern -match '^y') {
+                # Year-first cultures (e.g. yyyy-MM-dd)
+                $datePattern = "yyyy${dateSep}MM${dateSep}dd"
+            } elseif ($dtf.ShortDatePattern -match '^M') {
+                # Month-first cultures (e.g. MM/dd/yyyy for en-US)
+                $datePattern = "MM${dateSep}dd${dateSep}yyyy"
+            } else {
+                # Day-first cultures (e.g. dd.MM.yyyy for de-CH, de-DE, en-GB)
+                $datePattern = "dd${dateSep}MM${dateSep}yyyy"
+            }
+
             $effectiveDateTimeFormats = @(
-                "$($dtf.ShortDatePattern) $($dtf.LongTimePattern)",
-                "$($dtf.ShortDatePattern) $($dtf.ShortTimePattern)",
-                $dtf.ShortDatePattern
+                "$datePattern HH':'mm':'ss",
+                "$datePattern HH':'mm",
+                $datePattern
             )
             Write-Message -Level Verbose -Message "Derived DateTimeFormats from Culture '$Culture': $($effectiveDateTimeFormats -join ', ')"
         } elseif ($PSBoundParameters.DateTimeFormats) {

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -616,6 +616,44 @@ Describe $CommandName -Tag IntegrationTests {
             Invoke-DbaQuery -SqlInstance $server -Query "DROP TABLE $tableName" -ErrorAction SilentlyContinue
             Remove-Item $filePath -ErrorAction SilentlyContinue
         }
+
+        It "correctly parses ambiguous dates (day and month both <= 12) using Culture datetime format (issue #10338)" {
+            $filePath = "$($TestConfig.Temp)\culture-datetime-$(Get-Random).csv"
+            $server = Connect-DbaInstance $TestConfig.InstanceMulti1 -Database tempdb
+            $tableName = "CultureDateTimeTest$(Get-Random)"
+
+            # Create CSV with de-CH style dates (dd.MM.yyyy HH:mm:ss, semicolon delimiter)
+            # Row 1: day=2, month=4 (both <= 12, ambiguous - previously parsed as Feb 4th)
+            # Row 2: day=11, month=6 (both <= 12, ambiguous - previously parsed as Nov 6th)
+            "Date1;Date2" | Out-File -FilePath $filePath -Encoding UTF8
+            "02.04.2026 17:09:41;14.04.2026 17:09:41" | Out-File -FilePath $filePath -Encoding UTF8 -Append
+            "11.06.2026 17:10:08;13.06.2026 06:22:23" | Out-File -FilePath $filePath -Encoding UTF8 -Append
+
+            # Create table with smalldatetime columns
+            Invoke-DbaQuery -SqlInstance $server -Query "CREATE TABLE $tableName (Date1 smalldatetime NULL, Date2 smalldatetime NULL)"
+
+            $result = Import-DbaCsv -Path $filePath -SqlInstance $server -Database tempdb -Table $tableName -Delimiter ";" -Culture "de-CH"
+
+            $result.RowsCopied | Should -Be 2
+
+            $data = Invoke-DbaQuery -SqlInstance $server -Query "SELECT * FROM $tableName ORDER BY Date1" -As PSObject
+
+            # Row 1: 02.04.2026 = April 2nd (not February 4th)
+            $data[0].Date1.Month | Should -Be 4
+            $data[0].Date1.Day | Should -Be 2
+            # Row 1 Date2: 14.04.2026 = April 14th (day > 12, was never ambiguous)
+            $data[0].Date2.Month | Should -Be 4
+            $data[0].Date2.Day | Should -Be 14
+            # Row 2: 11.06.2026 = June 11th (not November 6th)
+            $data[1].Date1.Month | Should -Be 6
+            $data[1].Date1.Day | Should -Be 11
+            # Row 2 Date2: 13.06.2026 = June 13th (day > 12, was never ambiguous)
+            $data[1].Date2.Month | Should -Be 6
+            $data[1].Date2.Day | Should -Be 13
+
+            Invoke-DbaQuery -SqlInstance $server -Query "DROP TABLE $tableName" -ErrorAction SilentlyContinue
+            Remove-Item $filePath -ErrorAction SilentlyContinue
+        }
     }
 
     Context "AutoCreateTable post-import optimization" {


### PR DESCRIPTION
Fixes dataplat/dbatools.library#48

## Root Cause

When `-Culture` is specified without `-DateTimeFormats`, the underlying CsvDataReader library doesn't apply the culture's date format order during DateTime parsing. It falls back to `DateTime.Parse` without an explicit format, which defaults to MM.dd order - swapping day and month when both values are ≤ 12.

## Fix

When `-Culture` is specified but `-DateTimeFormats` is not, automatically derive unambiguous datetime format strings from the culture's DateTimeFormat patterns. For de-CH this produces `"dd.MM.yyyy HH:mm:ss"`, `"dd.MM.yyyy HH:mm"`, `"dd.MM.yyyy"`, etc.

This forces ParseExact (which respects field order) instead of Parse (which guesses and defaults to month-first).

Generated with [Claude Code](https://claude.ai/code)