### PR TITLE
Compare-DbaDbSchema: Fix Resolve-Path usage to return ProviderPath

### DIFF
--- a/public/Compare-DbaDbSchema.ps1
+++ b/public/Compare-DbaDbSchema.ps1
@@ -144,7 +144,7 @@ function Compare-DbaDbSchema {
             return
         }
 
-        $sourcePathFull = (Resolve-Path -Path $SourcePath).Path
+        $sourcePathFull = (Resolve-Path -Path $SourcePath).ProviderPath
         $timeStamp = (Get-Date).ToString("yyMMdd_HHmmss_f")
         $reportFile = Join-Path -Path $OutputPath -ChildPath "Compare-DbaDbSchema_$timeStamp.xml"
 
@@ -167,7 +167,7 @@ function Compare-DbaDbSchema {
             $sqlPackageArgs += " /tcs:""$connStringEscaped"""
             $targetDescription = "$($targetServer.DomainInstanceName)\$TargetDatabase"
         } else {
-            $targetPathFull = (Resolve-Path -Path $TargetPath).Path
+            $targetPathFull = (Resolve-Path -Path $TargetPath).ProviderPath
             $targetDbName = [System.IO.Path]::GetFileNameWithoutExtension($TargetPath)
             $sqlPackageArgs += " /tf:""$targetPathFull"" /tdn:""$targetDbName"""
             $targetDescription = $TargetPath

--- a/tests/Compare-DbaDbSchema.Tests.ps1
+++ b/tests/Compare-DbaDbSchema.Tests.ps1
@@ -91,7 +91,7 @@ Describe $CommandName -Tag UnitTests {
                 Mock Resolve-Path {
                     param($Path)
                     [PSCustomObject]@{
-                        Path = $Path
+                        ProviderPath = $Path
                     }
                 }
                 Mock Get-Content {
@@ -157,7 +157,7 @@ Describe $CommandName -Tag UnitTests {
                 Mock Resolve-Path {
                     param($Path)
                     [PSCustomObject]@{
-                        Path = $Path
+                        ProviderPath = $Path
                     }
                 }
                 Mock Connect-DbaInstance {
@@ -307,7 +307,7 @@ Describe $CommandName -Tag IntegrationTests {
             }
             $result = Compare-DbaDbSchema @splatCompare
             $result | Should -Not -BeNullOrEmpty
-            $result[0].SourcePath | Should -Be (Resolve-Path -Path $sourceDacpac).Path
+            $result[0].SourcePath | Should -Be (Resolve-Path -Path $sourceDacpac).ProviderPath
             $result[0].Target | Should -Be $emptyTargetDacpac
         }
 


### PR DESCRIPTION
Supports network paths.

Before:

<img width="1325" height="657" alt="image" src="https://github.com/user-attachments/assets/16abc5bb-23dd-4df2-9faf-d135e394c5b8" />


After:
<img width="875" height="410" alt="image" src="https://github.com/user-attachments/assets/d0343e4e-fce6-4e7d-bad1-64975c7ae88c" />
