### PR TITLE
Test-DbaSpn - Fix no output when an instance has TCP/IP disabled

### DIFF
--- a/public/Test-DbaSpn.ps1
+++ b/public/Test-DbaSpn.ps1
@@ -177,6 +177,10 @@ function Test-DbaSpn {
                 foreach ($spn in $spns) {
                     $ports = @()
 
+                    if (-not $spn.TcpEnabled) {
+                        continue
+                    }
+
                     $ips = (($wmi.ServerInstances | Where-Object { $_.Name -eq $spn.InstanceName }).ServerProtocols | Where-Object { $_.DisplayName -eq "TCP/IP" -and $_.IsEnabled -eq "True" }).IpAddresses
                     $ipAllPort = $null
                     foreach ($ip in $ips) {


### PR DESCRIPTION
When one of multiple SQL Server instances has TCP/IP disabled, the remote scriptblock crashed with a NullReferenceException. `$ipAllPort` was `$null` and the check `$null -ne ""` evaluated to `$true`, setting `$ports = $null`. Then `$null.Split(',')` threw, silently killing the entire scriptblock and returning nothing for all instances.

Fix: skip port processing for instances where TCP is not enabled.

Fixes #9315

Generated with [Claude Code](https://claude.ai/code)