### PR TITLE
Harden Claude and CI workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CI, release, and agent automation are part of the supply-chain boundary.
+/.github/workflows/ @potatoqualitee @niphlod @andreasjordan
+/.github/scripts/ @potatoqualitee @niphlod @andreasjordan
+/.github/prompts/ @potatoqualitee @niphlod @andreasjordan
+/.github/copilot-instructions.md @potatoqualitee @niphlod @andreasjordan
+/appveyor.yml @potatoqualitee @niphlod @andreasjordan

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,18 +10,15 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: contains(fromJSON('["potatoqualitee","niphlod","andreasjordan"]'), github.actor)
 
     runs-on: ubuntu-latest
+    env:
+      CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: 1
     permissions:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -29,12 +26,21 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Validate PR number
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+        run: |
+          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "PR number must be numeric"
+            exit 1
+          fi
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "*"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.inputs.pr_number }}
@@ -52,5 +58,6 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-
+          claude_args: >-
+            --max-turns 10
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,24 +5,24 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      contains(fromJSON('["potatoqualitee","niphlod","andreasjordan"]'), github.actor) && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      )
     runs-on: ubuntu-latest
+    env:
+      CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: 1
     permissions:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
@@ -40,6 +40,12 @@ jobs:
           additional_permissions: |
             actions: read
 
+          # Keep public-triggered Claude runs read-only. Use a maintainer-run
+          # local session or a separate protected workflow for code-writing tasks.
+          claude_args: >-
+            --max-turns 10
+            --allowedTools "Read,Glob,Grep,Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh run view:*)"
+
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
@@ -47,4 +53,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -56,6 +56,7 @@ jobs:
         shell: pwsh
         run: |
           Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           ./.github/scripts/install-dbatools-library.ps1
 
       - name: Install dbatools.library (preview versions)
@@ -63,6 +64,7 @@ jobs:
         shell: pwsh
         run: |
           Write-Output "Preview version detected, bypassing PSModuleCache and using install script"
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           ./.github/scripts/install-dbatools-library.ps1
 
       - name: Download dbatools from Gallery

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -22,6 +22,9 @@ on:
 defaults:
   run:
     shell: pwsh
+
+permissions:
+  contents: read
 jobs:
   linux-tests:
     env:
@@ -48,11 +51,12 @@ jobs:
           Write-Output "Using dbatools.library version: $version"
           Write-Output "Is preview version: $isPreview"
 
-      - name: Install and cache PowerShell modules (stable versions)
+      - name: Install dbatools.library (stable versions)
         if: steps.get-version.outputs.is_preview == 'False'
-        uses: potatoqualitee/psmodulecache@v6.2.1
-        with:
-          modules-to-cache: dbatools.library:${{ steps.get-version.outputs.version }}
+        shell: pwsh
+        run: |
+          Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
+          ./.github/scripts/install-dbatools-library.ps1
 
       - name: Install dbatools.library (preview versions)
         if: steps.get-version.outputs.is_preview == 'True'

--- a/.github/workflows/integration-tests-repl.yml
+++ b/.github/workflows/integration-tests-repl.yml
@@ -23,6 +23,9 @@ on:
 defaults:
   run:
     shell: pwsh
+
+permissions:
+  contents: read
 jobs:
   repl-tests-part1:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests-s3.yml
+++ b/.github/workflows/integration-tests-s3.yml
@@ -32,6 +32,9 @@ defaults:
   run:
     shell: pwsh
 
+permissions:
+  contents: read
+
 jobs:
   s3-backup-tests:
     env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-          ./.github/scripts/install-dbatools-library.ps1
+          ./.github/scripts/install-dbatools-library.ps1 -Scope AllUsers
 
       - name: Install dbatools.library for PowerShell 7 (stable versions)
         if: steps.get-version.outputs.is_preview == 'False'
@@ -148,7 +148,7 @@ jobs:
         run: |
           Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-          ./.github/scripts/install-dbatools-library.ps1
+          ./.github/scripts/install-dbatools-library.ps1 -Scope AllUsers
 
       - name: Install dbatools.library (preview versions)
         if: steps.get-version.outputs.is_preview == 'True'
@@ -156,7 +156,7 @@ jobs:
         run: |
           Write-Output "Preview version detected, bypassing PSModuleCache and using install script"
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-          ./.github/scripts/install-dbatools-library.ps1
+          ./.github/scripts/install-dbatools-library.ps1 -Scope AllUsers
 
       - name: Install SQL Server engine and localdb
         uses: potatoqualitee/mssqlsuite@v1.8

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,6 +24,9 @@ defaults:
   run:
     shell: pwsh
 
+permissions:
+  contents: read
+
 jobs:
   linux-tests:
     env:
@@ -50,11 +53,11 @@ jobs:
           Write-Output "Using dbatools.library version: $version"
           Write-Output "Is preview version: $isPreview"
 
-      - name: Install and cache PowerShell modules (stable versions)
+      - name: Install dbatools.library (stable versions)
         if: steps.get-version.outputs.is_preview == 'False'
-        uses: potatoqualitee/psmodulecache@v6.2.1
-        with:
-          modules-to-cache: dbatools.library:${{ steps.get-version.outputs.version }}
+        run: |
+          Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
+          ./.github/scripts/install-dbatools-library.ps1
 
       - name: Install dbatools.library (preview versions)
         if: steps.get-version.outputs.is_preview == 'True'
@@ -129,12 +132,19 @@ jobs:
           Write-Output "Using dbatools.library version: $version"
           Write-Output "Is preview version: $isPreview"
 
-      - name: Install and cache PowerShell modules (stable versions)
+      - name: Install dbatools.library for Windows PowerShell (stable versions)
         if: steps.get-version.outputs.is_preview == 'False'
-        uses: potatoqualitee/psmodulecache@v6.2.1
-        with:
-          shell: powershell, pwsh
-          modules-to-cache: dbatools.library:${{ steps.get-version.outputs.version }}
+        shell: powershell
+        run: |
+          Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
+          ./.github/scripts/install-dbatools-library.ps1
+
+      - name: Install dbatools.library for PowerShell 7 (stable versions)
+        if: steps.get-version.outputs.is_preview == 'False'
+        shell: pwsh
+        run: |
+          Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
+          ./.github/scripts/install-dbatools-library.ps1
 
       - name: Install dbatools.library (preview versions)
         if: steps.get-version.outputs.is_preview == 'True'
@@ -218,11 +228,11 @@ jobs:
           Write-Output "Using dbatools.library version: $version"
           Write-Output "Is preview version: $isPreview"
 
-      - name: Install and cache PowerShell modules (stable versions)
+      - name: Install dbatools.library (stable versions)
         if: steps.get-version.outputs.is_preview == 'False'
-        uses: potatoqualitee/psmodulecache@v6.2.1
-        with:
-          modules-to-cache: dbatools.library:${{ steps.get-version.outputs.version }}
+        run: |
+          Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
+          ./.github/scripts/install-dbatools-library.ps1
 
       - name: Install dbatools.library (preview versions)
         if: steps.get-version.outputs.is_preview == 'True'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,6 +57,7 @@ jobs:
         if: steps.get-version.outputs.is_preview == 'False'
         run: |
           Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           ./.github/scripts/install-dbatools-library.ps1
 
       - name: Install dbatools.library (preview versions)
@@ -64,6 +65,7 @@ jobs:
         shell: pwsh
         run: |
           Write-Output "Preview version detected, bypassing PSModuleCache and using install script"
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           ./.github/scripts/install-dbatools-library.ps1
 
       - name: Set encryption values
@@ -137,6 +139,7 @@ jobs:
         shell: powershell
         run: |
           Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           ./.github/scripts/install-dbatools-library.ps1
 
       - name: Install dbatools.library for PowerShell 7 (stable versions)
@@ -144,6 +147,7 @@ jobs:
         shell: pwsh
         run: |
           Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           ./.github/scripts/install-dbatools-library.ps1
 
       - name: Install dbatools.library (preview versions)
@@ -151,6 +155,7 @@ jobs:
         shell: pwsh
         run: |
           Write-Output "Preview version detected, bypassing PSModuleCache and using install script"
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           ./.github/scripts/install-dbatools-library.ps1
 
       - name: Install SQL Server engine and localdb
@@ -232,6 +237,7 @@ jobs:
         if: steps.get-version.outputs.is_preview == 'False'
         run: |
           Write-Output "Stable version detected, bypassing PSModuleCache in this secret-bearing job"
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           ./.github/scripts/install-dbatools-library.ps1
 
       - name: Install dbatools.library (preview versions)
@@ -239,6 +245,7 @@ jobs:
         shell: pwsh
         run: |
           Write-Output "Preview version detected, bypassing PSModuleCache and using install script"
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           ./.github/scripts/install-dbatools-library.ps1
 
       - name: 👥 Clone appveyor repo

--- a/.github/workflows/reposize.yml
+++ b/.github/workflows/reposize.yml
@@ -1,6 +1,10 @@
 name: Check repo size
 on: [pull_request]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   clone:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,10 @@ name: Mark stale issues
 
 on:
   workflow_dispatch:
-  
+
+permissions:
+  issues: write
+
 jobs:
   stale:
 

--- a/.github/workflows/validate_target_branch.yml
+++ b/.github/workflows/validate_target_branch.yml
@@ -1,6 +1,9 @@
 name: Validate Target Branch
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   # This workflow contains a single job called "build"
   build:

--- a/.github/workflows/xplat-import.yml
+++ b/.github/workflows/xplat-import.yml
@@ -21,6 +21,9 @@ on:
       - '!bin/dbatools-buildref-index.json'
       - '!bin/dbatools-sqlinstallationcomponents.json'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     env:


### PR DESCRIPTION
## Summary
- restrict Claude workflow triggers to the maintainer allowlist
- remove issue-title/assignment agent triggers and broad bot access
- reduce workflow token permissions and remove cache use from secret-bearing jobs
- add CODEOWNERS coverage for CI, agent, prompt, and automation files

## Why
This reduces the risk of prompt-injection-driven CI abuse and GitHub Actions cache poisoning paths similar to the Cline incident.

## Validation
- git diff --check