### PR TITLE
Harden GitHub Actions pinning

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,7 @@
 /.github/workflows/ @potatoqualitee @niphlod @andreasjordan
 /.github/scripts/ @potatoqualitee @niphlod @andreasjordan
 /.github/prompts/ @potatoqualitee @niphlod @andreasjordan
+/.github/CODEOWNERS @potatoqualitee @niphlod @andreasjordan
 /.github/copilot-instructions.md @potatoqualitee @niphlod @andreasjordan
+/.github/dependabot.yml @potatoqualitee @niphlod @andreasjordan
 /appveyor.yml @potatoqualitee @niphlod @andreasjordan

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5

--- a/.github/scripts/Test-GitHubActionsPins.ps1
+++ b/.github/scripts/Test-GitHubActionsPins.ps1
@@ -1,0 +1,64 @@
+[CmdletBinding()]
+param(
+    [string]$WorkflowPath = ".github/workflows"
+)
+
+$ErrorActionPreference = "Stop"
+
+$resolvedWorkflowPath = Resolve-Path -LiteralPath $WorkflowPath
+$workflowFiles = Get-ChildItem -LiteralPath $resolvedWorkflowPath -Recurse -File |
+    Where-Object { $PSItem.Extension -in ".yml", ".yaml" }
+
+if (-not $workflowFiles) {
+    throw "No GitHub Actions workflow files found under $WorkflowPath"
+}
+
+$unpinnedActions = foreach ($file in $workflowFiles) {
+    $lineNumber = 0
+
+    foreach ($line in Get-Content -LiteralPath $file.FullName) {
+        $lineNumber++
+
+        if ($line -match '^\s*#') {
+            continue
+        }
+
+        if ($line -notmatch '^\s*(?:-\s*)?uses:\s*(?<Action>[^#\s]+)') {
+            continue
+        }
+
+        $action = $Matches.Action.Trim("'`"")
+
+        if ($action -match '^\./|^\.\\|^docker://') {
+            continue
+        }
+
+        $refSeparator = $action.LastIndexOf("@")
+        if ($refSeparator -lt 0) {
+            [pscustomobject]@{
+                File   = Resolve-Path -LiteralPath $file.FullName -Relative
+                Line   = $lineNumber
+                Uses   = $action
+                Reason = "missing @ref"
+            }
+            continue
+        }
+
+        $ref = $action.Substring($refSeparator + 1)
+        if ($ref -notmatch '^[0-9a-fA-F]{40}$') {
+            [pscustomobject]@{
+                File   = Resolve-Path -LiteralPath $file.FullName -Relative
+                Line   = $lineNumber
+                Uses   = $action
+                Reason = "ref is not a full 40-character commit SHA"
+            }
+        }
+    }
+}
+
+if ($unpinnedActions) {
+    $unpinnedActions | Format-Table -AutoSize | Out-String | Write-Error
+    throw "GitHub Actions must be pinned to full commit SHAs."
+}
+
+Write-Host "All GitHub Actions references are pinned to full commit SHAs."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@537ffff2eff706bd7e3e1c3daf2d4b39067a9f85 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@537ffff2eff706bd7e3e1c3daf2d4b39067a9f85 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -37,7 +37,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Read dbatools.library version
         id: get-version

--- a/.github/workflows/github-actions-security.yml
+++ b/.github/workflows/github-actions-security.yml
@@ -1,0 +1,33 @@
+name: GitHub Actions Security
+
+on:
+  pull_request:
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/scripts/Test-GitHubActionsPins.ps1"
+      - ".github/workflows/**"
+  push:
+    branches-ignore:
+      - master
+    tags-ignore:
+      - "**"
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/scripts/Test-GitHubActionsPins.ps1"
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  action-pinning:
+    name: Require pinned actions
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Verify action refs
+        shell: pwsh
+        run: ./.github/scripts/Test-GitHubActionsPins.ps1

--- a/.github/workflows/integration-tests-repl.yml
+++ b/.github/workflows/integration-tests-repl.yml
@@ -33,7 +33,7 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Read dbatools.library version
         id: get-version
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install and cache PowerShell modules (stable versions)
         if: steps.get-version.outputs.is_preview == 'False'
-        uses: potatoqualitee/psmodulecache@v6.2.1
+        uses: potatoqualitee/psmodulecache@ee5e9494714abf56f6efbfa51527b2aec5c761b8 # v6.2.1
         with:
           modules-to-cache: dbatools.library:${{ steps.get-version.outputs.version }}
 
@@ -103,7 +103,7 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Read dbatools.library version
         id: get-version
@@ -119,7 +119,7 @@ jobs:
 
       - name: Install and cache PowerShell modules (stable versions)
         if: steps.get-version.outputs.is_preview == 'False'
-        uses: potatoqualitee/psmodulecache@v6.2.1
+        uses: potatoqualitee/psmodulecache@ee5e9494714abf56f6efbfa51527b2aec5c761b8 # v6.2.1
         with:
           modules-to-cache: dbatools.library:${{ steps.get-version.outputs.version }}
 
@@ -173,7 +173,7 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Read dbatools.library version
         id: get-version
@@ -189,7 +189,7 @@ jobs:
 
       - name: Install and cache PowerShell modules (stable versions)
         if: steps.get-version.outputs.is_preview == 'False'
-        uses: potatoqualitee/psmodulecache@v6.2.1
+        uses: potatoqualitee/psmodulecache@ee5e9494714abf56f6efbfa51527b2aec5c761b8 # v6.2.1
         with:
           modules-to-cache: dbatools.library:${{ steps.get-version.outputs.version }}
 

--- a/.github/workflows/integration-tests-s3.yml
+++ b/.github/workflows/integration-tests-s3.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Read dbatools.library version
         id: get-version
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install and cache PowerShell modules (stable versions)
         if: steps.get-version.outputs.is_preview == 'False'
-        uses: potatoqualitee/psmodulecache@v6.2.1
+        uses: potatoqualitee/psmodulecache@ee5e9494714abf56f6efbfa51527b2aec5c761b8 # v6.2.1
         with:
           modules-to-cache: dbatools.library:${{ steps.get-version.outputs.version }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Read dbatools.library version
         id: get-version
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout dbatools repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Read dbatools.library version
         id: get-version
@@ -159,7 +159,7 @@ jobs:
           ./.github/scripts/install-dbatools-library.ps1 -Scope AllUsers
 
       - name: Install SQL Server engine and localdb
-        uses: potatoqualitee/mssqlsuite@v1.8
+        uses: potatoqualitee/mssqlsuite@605af2310e2e22978ebf2c74d5995ba102094b8a # v1.8
         with:
           install: localdb, sqlengine
 
@@ -219,7 +219,7 @@ jobs:
 
     steps:
       - name: Checkout dbatools repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Read dbatools.library version
         id: get-version

--- a/.github/workflows/reposize.yml
+++ b/.github/workflows/reposize.yml
@@ -12,8 +12,8 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: jwalton/gh-find-current-pr@v1
+      - uses: actions/checkout@544eadc6bf3d226fd7a7a9f0dc5b5bf7ca0675b9 # v1
+      - uses: jwalton/gh-find-current-pr@6a32a53e488fa17bcbc72582e7858deed736396e # v1
         id: findpr
         with:
           state: all

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v3.0.9
+    - uses: actions/stale@1e5e734da7bd7ea04daf52d9f1c6540e83867b73 # v3.0.9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: >

--- a/.github/workflows/validate_target_branch.yml
+++ b/.github/workflows/validate_target_branch.yml
@@ -13,7 +13,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Target branch should be development
         shell: pwsh
         run: |

--- a/.github/workflows/xplat-import.yml
+++ b/.github/workflows/xplat-import.yml
@@ -36,7 +36,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest, macOS-14]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Show pwsh version
       shell: pwsh
@@ -56,7 +56,7 @@ jobs:
 
     - name: Install and cache PowerShell modules (stable versions)
       if: steps.get-version.outputs.is_preview == 'False'
-      uses: potatoqualitee/psmodulecache@v6.2.1
+      uses: potatoqualitee/psmodulecache@ee5e9494714abf56f6efbfa51527b2aec5c761b8 # v6.2.1
       with:
           modules-to-cache: dbatools.library:${{ steps.get-version.outputs.version }}
 


### PR DESCRIPTION
## Summary
- Pin existing GitHub Actions references to full commit SHAs while preserving version comments for Dependabot.
- Add Dependabot config for weekly GitHub Actions updates.
- Add a CI guard that fails future unpinned workflow action refs.
- Add CODEOWNERS coverage for the supply-chain config files.

## Why
GitHub recommends full-length commit SHAs for immutable action references. This keeps current workflow behavior unchanged while reducing tag-move supply-chain risk.

## Validation
- PowerShell pinning check passed.
- Staged whitespace check passed.
- Scans found no remaining unpinned workflow action refs and no pull_request_target/workflow_run triggers.