### PR TITLE
Fix Get-DecryptedObject

### DIFF
--- a/private/functions/Get-DecryptedObject.ps1
+++ b/private/functions/Get-DecryptedObject.ps1
@@ -52,10 +52,10 @@ function Get-DecryptedObject {
     # key_id 102 eq service master key, thumbprint 3 means encrypted with machinekey
     Write-Message -Level Verbose -Message "Querying service master key"
     try {
-        $sql = "SELECT SUBSTRING(crypt_property, 9, LEN(crypt_property) - 8) AS smk FROM sys.key_encryptions WHERE key_id = 102 AND thumbprint = 0x0300000001"
+        $sql = "SELECT SUBSTRING(crypt_property, 9, DATALENGTH(crypt_property) - 8) AS smk FROM sys.key_encryptions WHERE key_id = 102 AND thumbprint = 0x0300000001"
         $smkBytes = $server.Query($sql).smk
         if (-not $smkBytes) {
-            $sql = "SELECT SUBSTRING(crypt_property, 9, LEN(crypt_property) - 8) AS smk FROM sys.key_encryptions WHERE key_id = 102 AND thumbprint = 0x03"
+            $sql = "SELECT SUBSTRING(crypt_property, 9, DATALENGTH(crypt_property) - 8) AS smk FROM sys.key_encryptions WHERE key_id = 102 AND thumbprint = 0x03"
             $smkBytes = $server.Query($sql).smk
         }
     } catch {
@@ -106,7 +106,7 @@ function Get-DecryptedObject {
                 NULL AS Quotename,
                 syslnklgns.name AS [Identity],
                 SUBSTRING(syslnklgns.pwdhash, 5, $ivlen) AS iv,
-                SUBSTRING(syslnklgns.pwdhash, $($ivlen + 5), LEN(syslnklgns.pwdhash) - $($ivlen + 4)) AS pass,
+                SUBSTRING(syslnklgns.pwdhash, $($ivlen + 5), DATALENGTH(syslnklgns.pwdhash) - $($ivlen + 4)) AS pass,
                 NULL AS MappedClassType,
                 NULL AS ProviderName
             FROM master.sys.syslnklgns
@@ -119,7 +119,7 @@ function Get-DecryptedObject {
                 QUOTENAME(cred.name) AS Quotename,
                 cred.credential_identity AS [Identity],
                 SUBSTRING(obj.imageval, 5, $ivlen) AS iv,
-                SUBSTRING(obj.imageval, $($ivlen + 5), LEN(obj.imageval) - $($ivlen + 4)) AS pass,
+                SUBSTRING(obj.imageval, $($ivlen + 5), DATALENGTH(obj.imageval) - $($ivlen + 4)) AS pass,
                 cred.target_type AS MappedClassType,
                 cp.name AS ProviderName
             FROM sys.credentials cred


### PR DESCRIPTION
Change LEN by DATALENGTH to avoid incorrect decryption when binary password or service master key values end with 0x20

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #10401)
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Correct a bug that almost never happen.
To make the bug happen, one of the folowing binary value must end with 0x20 :
``` tsql
pwdhash FROM master.sys.syslnklgns
imageval FROM sys.sysobjvalues WHERE valclass = 28 AND valnum = 2
crypt_property FROM sys.key_encryptions WHERE key_id = 102 AND thumbprint = 0x0300000001
```
These tables are only accessible with DAC connection