### PR TITLE
runner-boost: dispatch reconcile against development

### DIFF
--- a/.github/workflows/runner-boost.yml
+++ b/.github/workflows/runner-boost.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Dispatch runner-reconcile
         env:
           GH_TOKEN: ${{ github.token }}
-        # TEMP until PR #10414 merges (then flip back to development): reconcile
-        # does not exist on development right now, and the Azure OIDC federated
-        # credential only trusts specific branch subjects, so every nudge targets
-        # vmssredux -- the one feature branch with a matching credential
-        run: gh workflow run runner-reconcile.yml --ref vmssredux -R "${{ github.repository }}"
+        # PR #10414 has merged, reconcile now lives on development, and the
+        # vmssredux feature branch is deleted -- dispatching the deleted ref
+        # failed every nudge with HTTP 422 "No ref found for: vmssredux".
+        run: gh workflow run runner-reconcile.yml --ref development -R "${{ github.repository }}"


### PR DESCRIPTION
## Summary

The `nudge` job in runner-boost.yml still dispatched `runner-reconcile.yml --ref vmssredux` — the TEMP hack from before #10414 merged. That branch is deleted now, so every maintainer push to a feature branch fails the nudge with:

```
could not create workflow dispatch event: HTTP 422: No ref found for: vmssredux
```

(example: https://github.com/dataplat/dbatools/actions/runs/29199127511/job/86667301123, red X on #10415)

The workflow's own comment said to flip it back to development once #10414 merged. Reconcile lives on development now, and the ci-azure completion hooks already dispatch it with `--ref development` successfully.

## Validation

The push of this branch itself runs the fixed nudge (push events use the pushed branch's workflow file), so its own `nudge` check demonstrates the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)