### PR TITLE
ci-azure - Split SINGLE into fifths for a 10-way matrix (do ci-azure)

### DIFF
--- a/.github/workflows/ci-azure.yml
+++ b/.github/workflows/ci-azure.yml
@@ -69,13 +69,19 @@ jobs:
       matrix:
         include:
           - scenario: SINGLE
-            part: 1/3
+            part: 1/5
             InstanceSingle: sql2022
           - scenario: SINGLE
-            part: 2/3
+            part: 2/5
             InstanceSingle: sql2022
           - scenario: SINGLE
-            part: 3/3
+            part: 3/5
+            InstanceSingle: sql2022
+          - scenario: SINGLE
+            part: 4/5
+            InstanceSingle: sql2022
+          - scenario: SINGLE
+            part: 5/5
             InstanceSingle: sql2022
           - scenario: MULTI
             InstanceMulti1: sql2022


### PR DESCRIPTION
## What

Re-shards the `SINGLE` scenario from thirds to fifths, expanding the ci-azure matrix from **8 to 10 parallel jobs**:

`5× SINGLE (1/5..5/5) + MULTI + COPY + HADR + RESTART + default = 10`

## Why it needs no harness change

`tests/appveyor.common.ps1` already reads `$env:PART` as `num/denom` and splits each scenario's command list into `denom` equal parts (`Split-ArrayInParts`). Changing `1/3` → `1/5` just asks it for five slices instead of three — fully dynamic, nothing was hardcoded to 3.

## Fleet impact

`MAX_RUNNERS` is already `10`, so the VMSS fleet can now run every matrix job concurrently instead of queuing two behind the 8-runner ceiling.

## Testing

This PR run exercises the change end-to-end — all 10 jobs should appear in the Actions tab and land on 10 ephemeral runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)