### PR TITLE
Harden Azure runner scaling and keep pools hot

### DIFF
--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -2,12 +2,12 @@
 
 Replaces AppVeyor with disposable Azure VMs: every job runs on a factory-fresh
 ephemeral VM booted from a golden image with SQL Server preinstalled, registered as a
-single-use GitHub runner, and deleted afterwards. Nights and weekends the fleet scales
-to zero; during Paris business hours a small standby pool keeps queue times low.
+single-use GitHub runner, and deleted afterwards. Five shared runners stay hot for
+community CI; maintainer pushes raise the hot pool to ten for two hours.
 
 ```
 GitHub (public repo)                          Azure (eastus)
-├─ ci-azure.yml           8-job matrix   ──►  VMSS dbatools-runners (Flexible, D4ds_v5)
+├─ ci-azure.yml          10-job matrix   ──►  VMSS dbatools-runners (Flexible, D4ds_v5)
 ├─ runner-scale-up.yml    on demand +1..N     ├─ ephemeral OS disk on local SSD ($0)
 ├─ runner-reconcile.yml   */30 min janitor    ├─ instance public IPs, NSG deny inbound
 └─ ps3-smoke.yml          nightly PS 3.0      └─ image: dbatoolsGallery/dbatools-modern-image
@@ -24,8 +24,8 @@ GitHub (public repo)                          Azure (eastus)
 | Runner execution | **interactive autologon session** as local admin `appveyor` (AppVeyor parity: BITS transfers, `$env:USERNAME`, `C:\Users\appveyor\Documents\DbatoolsExport`); bootstrap registers the ephemeral runner, arms autologon + a logon task, reboots |
 | Instance parity knobs | firewall off, `LocalAccountTokenFilterPolicy=1`, pagefile setting on D:, `@@SERVERNAME` repaired per job (all NSG-shielded) |
 | Harness | untouched `tests/appveyor.*.ps1` via `tests/gha.shim.ps1` (`APPVEYOR=True` drives Get-TestConfig) |
-| Scaling controls | repo variables `STANDBY_COUNT` / `STANDBY_HOURS` / `STANDBY_TZ` / `MAX_RUNNERS` |
-| Maintainer boost | repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS` / `BOOST_COMMITS` — once listed users have pushed `BOOST_COMMITS` commits (default 3) to branches other than development/master within the trailing `BOOST_HOURS` window, the floor rises to `BOOST_COUNT` until the window drains (any hour, any day); `runner-boost.yml` nudges reconcile on those pushes so it applies within ~1 minute |
+| Scaling controls | fixed five-runner community pool; repo variable `MAX_RUNNERS` remains the hard VMSS ceiling |
+| Maintainer boost | repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS` — every push by a listed user raises the pool to `BOOST_COUNT` until `BOOST_HOURS` after the latest push; `runner-boost.yml` passes the actor directly so the first scale-out does not depend on repository-event timing |
 | Azure auth | OIDC only — Entra app `dbatools-ci-github`, federated for the default branch, custom role `dbatools-ci-operator` scoped to RG `dbatools-ci` |
 | Runner registration | `CI_RUNNER_PAT` secret mints single-use tokens; tokens are never stored on VMs |
 
@@ -68,7 +68,7 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
 
 ## How a CI run flows
 
-1. Push/PR triggers `ci-azure.yml` → 8 matrix jobs queue on label `dbatools-modern`.
+1. Push/PR triggers `ci-azure.yml` → 10 matrix jobs queue on label `dbatools-modern`.
 2. `runner-scale-up.yml` (workflow_run: requested) counts queued jobs, raises VMSS
    capacity (cap `MAX_RUNNERS`), and registers an ephemeral runner on every new
    instance via `az vm run-command` + `bootstrap-runner.ps1` (which then reboots the
@@ -77,29 +77,30 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
    runs prep → instance setup (`appveyor.SQL*.ps1` set static ports, start services,
    EKM/HADR/master key) → `@@SERVERNAME` repair → Pester 6 → finalize → post.
 4. After the job the ephemeral runner unregisters; `runner-reconcile.yml` deletes the
-   spent instance and tops the fleet back up to the standby floor (or zero off-hours).
+   spent instance and tops the fleet back up to the active pool size (five shared,
+   or ten for two hours after the latest maintainer push).
 
 ## Cost guardrails
 
 - Budget `dbatools-ci-budget`: $600/month on RG `dbatools-ci`, email at 50/80/100%.
-- Zombie kill: reconcile deletes any non-busy instance older than 3h.
-- Scale-to-zero outside `STANDBY_HOURS` (`STANDBY_TZ`, Mon–Fri).
-- Maintainer boost holds `BOOST_COUNT` warm runners once `BOOST_COMMITS` commits
-  land in the window; it self-expires `BOOST_HOURS` after the last qualifying
-  push (worst case ~10 × D4ds_v5 for 3h ≈ $7).
+- Dead-runner cleanup: reconcile deletes never-registered and offline instances;
+  healthy online hot-pool runners are not evicted merely because of age.
+- Community CI keeps five shared runners hot so jobs do not wait for VM provisioning.
+- Every maintainer push holds `BOOST_COUNT` hot runners and refreshes the window; it
+  self-expires `BOOST_HOURS` after the last qualifying push.
 - Weekly month-to-date spend lands on the "CI cost tracker" issue (Mondays).
 - Ephemeral OS disks cost nothing; the only storage bill is the gallery replicas.
 - Dead man's switch (last ditch): Azure Automation account `dbatools-ci-janitor`
   runs the `Remove-RunawayRunner` runbook every 6 hours, entirely independent
-  of GitHub Actions (source: `janitor-runbook.ps1`). The kill rule is keyed to
-  maintainer activity: once no maintainer has pushed for 6 hours, every runner
-  VM older than 2h is deleted no matter what the GitHub-side machinery thinks;
-  within an active window only >14h zombies die (reconcile owns the rest); if
-  GitHub is unreachable, conservative age caps apply. ps3smoke VMs past 2h and
-  orphaned CI NICs/public IPs die in every mode. Its managed identity holds
+  of GitHub Actions (source: `janitor-runbook.ps1`, deployed manually). It always
+  preserves the five newest community-pool runners. After the two-hour maintainer
+  window, excess runners older than 2h are deleted; within the window only >14h
+  zombies die. If GitHub is unreachable, conservative age caps apply only above
+  the preserved baseline. ps3smoke VMs past 2h and orphaned CI NICs/public IPs
+  die in every mode. Its managed identity holds
   only the `dbatools-ci-operator` role on RG `dbatools-ci` -- no storage, no
-  other resource groups. Worst-case wedged-fleet spend is a few hours of VMs
-  (~$30), never an all-day burn.
+  other resource groups. The five-runner baseline is intentional all-day spend;
+  the switch caps runaway capacity above it.
 
 ## Phase 0 gate results (2026-07-10)
 

--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -9,7 +9,7 @@ community CI; maintainer pushes raise the hot pool to ten for two hours.
 GitHub (public repo)                          Azure (eastus)
 ├─ ci-azure.yml          10-job matrix   ──►  VMSS dbatools-runners (Flexible, D4ds_v5)
 ├─ runner-scale-up.yml    on demand +1..N     ├─ ephemeral OS disk on local SSD ($0)
-├─ runner-reconcile.yml   */30 min janitor    ├─ instance public IPs, NSG deny inbound
+├─ runner-reconcile.yml    hourly janitor     ├─ instance public IPs, NSG deny inbound
 └─ ps3-smoke.yml          nightly PS 3.0      └─ image: dbatoolsGallery/dbatools-modern-image
                                               RG dbatools-ci, budget $600/mo + alerts
 ```

--- a/.github/runners/janitor-runbook.ps1
+++ b/.github/runners/janitor-runbook.ps1
@@ -7,20 +7,19 @@
     runbook: Remove-RunawayRunner), entirely independent of GitHub Actions.
     This is the LAST-DITCH kill switch: the GitHub-side janitor
     (runner-reconcile.yml) owns normal fleet lifecycle; this backstop exists so
-    the fleet can never idle all day on a wedged dispatch chain.
+    capacity above the intentional five-runner baseline cannot idle all day on
+    a wedged dispatch chain.
 
     The kill rule is keyed to maintainer activity, not the clock:
 
-      - STALE (no push by a maintainer in the last 6 hours, checked through the
-        anonymous GitHub events API): every dbatools-runners_* VM older than
-        2 hours is deleted. The 2-hour grace only spares an in-flight job from
-        a manual dispatch -- jobs time out at 90 minutes, so anything older is
-        by definition runaway.
-      - ACTIVE (maintainer push within 6 hours): reconcile owns the window, so
+      - STALE (no push by a maintainer in the last 2 hours, checked through the
+        anonymous GitHub events API): the five newest community-pool runners are
+        preserved and excess runners older than 2 hours are deleted.
+      - ACTIVE (maintainer push within 2 hours): reconcile owns the window, so
         only true zombies older than 14 hours are deleted here.
       - GITHUB UNREACHABLE: we cannot know activity, so conservative age caps
-        apply -- 3 hours on nights and weekends, 13 hours on weekday daytime
-        (06-17 UTC) so a healthy standby floor is not murdered blind.
+        apply to capacity above the preserved five-runner community pool -- 3
+        hours on nights and weekends, 13 hours on weekday daytime (06-17 UTC).
 
     Always, regardless of mode:
       - ps3smoke-* VMs older than 2 hours are deleted (nightly job caps at 55m).
@@ -43,7 +42,8 @@ $null = Connect-AzAccount -Identity
 $rg = "dbatools-ci"
 $repo = "dataplat/dbatools"
 $maintainers = @("potatoqualitee", "andreasjordan")
-$activityWindowHours = 6
+$activityWindowHours = 2
+$communityPoolSize = 5
 $utcNow = (Get-Date).ToUniversalTime()
 
 # ---- how long since the last maintainer push? (anonymous API, public repo) ----
@@ -84,7 +84,7 @@ switch ($mode) {
         if ($null -ne $lastPushAgeHours) {
             $ageText = "$([math]::Round($lastPushAgeHours, 1))h ago"
         }
-        Write-Output "mode=stale: last maintainer push $ageText -- every runner VM past ${runnerMaxHours}h dies"
+        Write-Output "mode=stale: last maintainer push $ageText -- excess runners past ${runnerMaxHours}h die; five newest are preserved"
     }
     default {
         $isWeekend = $utcNow.DayOfWeek -in @([DayOfWeek]::Saturday, [DayOfWeek]::Sunday)
@@ -100,10 +100,20 @@ switch ($mode) {
 
 $deleted = 0
 $vms = Get-AzVM -ResourceGroupName $rg
+$protectedRunners = @(
+    $vms |
+        Where-Object Name -Like "dbatools-runners_*" |
+        Sort-Object TimeCreated -Descending |
+        Select-Object -First $communityPoolSize -ExpandProperty Name
+)
 Write-Output "found $(@($vms).Count) VM(s) in $rg"
 foreach ($vm in $vms) {
     $cap = $null
     if ($vm.Name -like "dbatools-runners_*") {
+        if ($mode -ne "active" -and $vm.Name -in $protectedRunners) {
+            Write-Output "preserving community-pool runner $($vm.Name)"
+            continue
+        }
         $cap = $runnerMaxHours
     } elseif ($vm.Name -like "ps3smoke*") {
         $cap = 2

--- a/.github/workflows/runner-boost.yml
+++ b/.github/workflows/runner-boost.yml
@@ -1,7 +1,6 @@
-# When a maintainer listed in the BOOST_USERS repo variable pushes to a branch
-# other than development/master, immediately dispatch runner-reconcile so the
-# maintainer-boost floor (BOOST_COUNT runners once BOOST_COMMITS commits land
-# within BOOST_HOURS) kicks in without waiting for the best-effort cron.
+# When a maintainer listed in the BOOST_USERS repo variable pushes to any branch,
+# immediately dispatch runner-reconcile so the BOOST_COUNT runner pool kicks in
+# without waiting for the best-effort cron and remains hot for BOOST_HOURS.
 #
 # The boost decision itself lives in runner-reconcile.yml -- this workflow is
 # only a promptness nudge, and only fires from branches that carry this file.
@@ -10,9 +9,6 @@ name: runner-boost
 
 on:
   push:
-    branches-ignore:
-      - development
-      - master
 
 permissions:
   actions: write
@@ -28,4 +24,10 @@ jobs:
       - name: Dispatch runner-reconcile
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run runner-reconcile.yml --ref development -R "${{ github.repository }}"
+          BOOST_USER: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          if ! gh workflow run runner-reconcile.yml --ref development -f boost_user="$BOOST_USER" -R "${{ github.repository }}"; then
+            echo "boost_user input unavailable; retrying a plain reconcile dispatch"
+            gh workflow run runner-reconcile.yml --ref development -R "${{ github.repository }}"
+          fi

--- a/.github/workflows/runner-reconcile.yml
+++ b/.github/workflows/runner-reconcile.yml
@@ -1,16 +1,14 @@
 # The fleet janitor: every 30 minutes (and after each CI run) it deletes spent and
-# zombie runner instances, enforces the business-hours standby floor, self-heals
+# zombie runner instances, enforces the active pool size, self-heals
 # unregistered instances, and tops capacity up if the event-driven scale-up missed
 # anything (re-runs of failed jobs do not emit a "requested" event -- this catches them).
 #
-# Standby floor: STANDBY_COUNT instances during STANDBY_HOURS (STANDBY_TZ) Mon-Fri,
-# zero outside them. All three come from repo variables so tuning needs no code change.
+# Pool policy: five shared runners stay hot for community CI. A push by a user in
+# BOOST_USERS raises the pool to BOOST_COUNT for the trailing BOOST_HOURS window.
 #
-# Maintainer boost: once the users in BOOST_USERS have pushed BOOST_COMMITS
-# commits (default 3) to branches other than development/master within the
-# trailing BOOST_HOURS window, the floor is raised to BOOST_COUNT until the
-# window drains (any hour, any day). runner-boost.yml nudges this workflow on
-# those pushes so the boost kicks in without waiting for cron.
+# runner-boost.yml nudges this workflow on every qualifying push and supplies the
+# actor for immediate scale-out; repository events preserve the boost after that
+# dispatch until the window drains.
 #
 # Mondays at 07:00 UTC one extra scheduled tick posts month-to-date spend to the
 # "CI cost tracker" issue.
@@ -26,6 +24,11 @@ on:
   # not emit a scale-up "requested" event). A workflow_run:completed trigger would
   # duplicate the nudge one-for-one, so it is intentionally omitted.
   workflow_dispatch:
+    inputs:
+      boost_user:
+        description: "Maintainer whose push requested an immediate pool boost"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -51,14 +54,11 @@ jobs:
       REPO: ${{ github.repository }}
       RG: ${{ vars.CI_AZURE_RG }}
       VMSS: ${{ vars.CI_VMSS_NAME }}
-      MAX_RUNNERS: ${{ vars.MAX_RUNNERS }}
-      STANDBY_COUNT: ${{ vars.STANDBY_COUNT }}
-      STANDBY_HOURS: ${{ vars.STANDBY_HOURS }}
-      STANDBY_TZ: ${{ vars.STANDBY_TZ }}
+      COMMUNITY_COUNT: 5
       BOOST_USERS: ${{ vars.BOOST_USERS }}
       BOOST_COUNT: ${{ vars.BOOST_COUNT }}
       BOOST_HOURS: ${{ vars.BOOST_HOURS }}
-      BOOST_COMMITS: ${{ vars.BOOST_COMMITS }}
+      BOOST_TRIGGER: ${{ inputs.boost_user }}
       RUNNER_LABEL: dbatools-modern
       RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}
     steps:
@@ -74,31 +74,31 @@ jobs:
           set -euo pipefail
           NOW=$(date -u +%s)
 
-          # ---- desired floor from business hours -------------------------------
-          LOCAL_HOUR=$(TZ="$STANDBY_TZ" date +%H | sed 's/^0//')
-          LOCAL_DOW=$(TZ="$STANDBY_TZ" date +%u)
-          START_HOUR=$(echo "$STANDBY_HOURS" | cut -d- -f1 | sed 's/^0//')
-          END_HOUR=$(echo "$STANDBY_HOURS" | cut -d- -f2 | sed 's/^0//')
-          FLOOR=0
-          if [ "$LOCAL_DOW" -le 5 ] && [ "$LOCAL_HOUR" -ge "$START_HOUR" ] && [ "$LOCAL_HOUR" -lt "$END_HOUR" ]; then
-            FLOOR=$STANDBY_COUNT
+          # ---- fixed community pool + two-hour maintainer boost -----------------
+          FLOOR=${COMMUNITY_COUNT:-5}
+          BOOST_ACTIVE=false
+          if [ -n "${BOOST_TRIGGER:-}" ]; then
+            case " $BOOST_USERS " in
+              *" $BOOST_TRIGGER "*) BOOST_ACTIVE=true ;;
+            esac
           fi
 
-          # ---- maintainer boost: recent feature-branch pushes raise the floor ---
-          # (fork pushes do not appear in this repo's event stream, so only pushes
-          # to branches on dataplat/dbatools count)
-          if [ -n "${BOOST_USERS:-}" ] && [ "${BOOST_COUNT:-0}" -gt "$FLOOR" ]; then
+          # Repository events keep the boost active on later reconcile ticks. The
+          # explicit trigger above makes the initial tick immune to event-feed lag.
+          if [ "$BOOST_ACTIVE" != "true" ] && [ -n "${BOOST_USERS:-}" ]; then
             CUTOFF=$(date -u -d "${BOOST_HOURS:-3} hours ago" +%Y-%m-%dT%H:%M:%SZ)
             EVENTS=$(gh api --paginate "repos/$REPO/events?per_page=100" 2>/dev/null || echo "[]")
             RECENT=$(echo "$EVENTS" | jq -s --arg cutoff "$CUTOFF" --arg users "$BOOST_USERS" \
               '[.[][] | select(.type == "PushEvent" and .created_at > $cutoff
-                and (.actor.login | IN($users | split(" ")[]))
-                and ((.payload.ref // "") | test("^refs/heads/(development|master)$") | not))
-                | .payload.size // 1] | add // 0')
-            if [ "${RECENT:-0}" -ge "${BOOST_COMMITS:-3}" ]; then
-              echo "maintainer boost: $RECENT commit(s) to feature branches by [$BOOST_USERS] in the last ${BOOST_HOURS:-3}h (threshold ${BOOST_COMMITS:-3}) -- floor raised to $BOOST_COUNT"
-              FLOOR=$BOOST_COUNT
+                and (.actor.login | IN($users | split(" ")[])))
+                | .payload.size // 0] | add // 0')
+            if [ "${RECENT:-0}" -gt 0 ]; then
+              BOOST_ACTIVE=true
             fi
+          fi
+          if [ "$BOOST_ACTIVE" = "true" ]; then
+            FLOOR=${BOOST_COUNT:-10}
+            echo "maintainer boost active for [$BOOST_USERS] -- pool raised to $FLOOR for ${BOOST_HOURS:-2}h after the latest push"
           fi
 
           # ---- current state ---------------------------------------------------
@@ -120,7 +120,7 @@ jobs:
             QUEUED=$((QUEUED + N))
           done
 
-          echo "floor=$FLOOR queued_runs=$QUEUED"
+          echo "pool=$FLOOR queued_jobs=$QUEUED"
           echo "$VMS_JSON" | jq -r '.[] | "vm: \(.name) \(.power) created \(.created)"'
           echo "$RUNNERS_JSON" | jq -r '.[] | "runner: \(.name) \(.status) busy=\(.busy)"'
 
@@ -144,7 +144,8 @@ jobs:
                 echo "$OUT" | tail -3
                 if echo "$OUT" | grep -q "SPENT-VM"; then
                   echo "$vm already served a job -- deleting instead of reusing"
-                  az vm delete -g "$RG" -n "$vm" --yes --no-wait || true
+                  # Wait so VMSS capacity reflects the deletion before pass 3 tops up.
+                  az vm delete -g "$RG" -n "$vm" --yes || true
                 fi
               ) &
             done
@@ -181,24 +182,20 @@ jobs:
               # bootstrap reboots into the interactive session; fresh instances are
               # briefly offline between config and the post-reboot logon
               DELETE="runner offline (spent ephemeral or dead)"
-            elif [ "$AGE_MIN" -gt 180 ]; then
-              DELETE="zombie: age ${AGE_MIN}m"
             fi
 
             if [ -n "$DELETE" ]; then
               echo "deleting $VM -- $DELETE"
               [ -n "$R_ID" ] && gh api -X DELETE "repos/$REPO/actions/runners/$R_ID" || true
-              az vm delete -g "$RG" -n "$VM" --yes --no-wait || true
+              # Wait so the capacity check below can create the replacement now.
+              az vm delete -g "$RG" -n "$VM" --yes || true
             else
               KEEP=$((KEEP + 1))
             fi
           done
 
-          # ---- pass 3: top up to floor / demand ----------------------------------
-          BUSY=$(echo "$RUNNERS_JSON" | jq '[.[] | select(.busy == true)] | length')
-          DESIRED=$(( BUSY + QUEUED ))
-          [ "$DESIRED" -lt "$FLOOR" ] && DESIRED=$FLOOR
-          [ "$DESIRED" -gt "$MAX_RUNNERS" ] && DESIRED=$MAX_RUNNERS
+          # ---- pass 3: enforce the active fixed-size pool -------------------------
+          DESIRED=$FLOOR
           # az vmss scale is bidirectional: pushing a target BELOW the real capacity
           # scale-INS the newest instances -- which is exactly what happens when the
           # eventually-consistent vm listing hides fresh VMs from KEEP. Scale-out only

--- a/.github/workflows/runner-reconcile.yml
+++ b/.github/workflows/runner-reconcile.yml
@@ -1,4 +1,4 @@
-# The fleet janitor: every 30 minutes (and after each CI run) it deletes spent and
+# The fleet janitor: every hour (and after each CI run) it deletes spent and
 # zombie runner instances, enforces the active pool size, self-heals
 # unregistered instances, and tops capacity up if the event-driven scale-up missed
 # anything (re-runs of failed jobs do not emit a "requested" event -- this catches them).
@@ -16,10 +16,10 @@ name: runner-reconcile
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "0 * * * *"
     - cron: "0 7 * * 1"
   # ci-azure nudges this workflow via workflow_dispatch when its matrix finishes, so
-  # spent VMs are replaced promptly. That nudge is the fast path; the */30 cron is a
+  # spent VMs are replaced promptly. That nudge is the fast path; the hourly cron is a
   # best-effort backstop for events that never fire (e.g. re-runs of failed jobs do
   # not emit a scale-up "requested" event). A workflow_run:completed trigger would
   # duplicate the nudge one-for-one, so it is intentionally omitted.
@@ -46,7 +46,9 @@ jobs:
     # fail at Azure login. Cron and workflow_run always resolve to the default
     # branch, so this only skips stray dispatches on feature branches (which could
     # not do useful work anyway) -- they no-op green instead of failing red.
-    if: github.ref == 'refs/heads/development'
+    # The second schedule entry is spend-report-only; excluding it keeps fleet
+    # reconciliation to exactly once during Monday's 07:00 UTC hour.
+    if: github.ref == 'refs/heads/development' && github.event.schedule != '0 7 * * 1'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/runner-scale-up.yml
+++ b/.github/workflows/runner-scale-up.yml
@@ -124,5 +124,7 @@ jobs:
             done
             wait
             echo "registration sweep $sweep complete ($MISSED handled)"
-            [ "$sweep" = "1" ] && sleep 90
+            if [ "$sweep" = "1" ]; then
+              sleep 90
+            fi
           done

--- a/.github/workflows/runner-scale-up.yml
+++ b/.github/workflows/runner-scale-up.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       ensure:
-        description: "Minimum instance count to ensure (defaults to standby floor logic)"
+        description: "Minimum instance count to ensure (capped by the active pool policy)"
         required: false
         default: ""
 
@@ -37,6 +37,10 @@ jobs:
       RG: ${{ vars.CI_AZURE_RG }}
       VMSS: ${{ vars.CI_VMSS_NAME }}
       MAX_RUNNERS: ${{ vars.MAX_RUNNERS }}
+      COMMUNITY_COUNT: 5
+      BOOST_USERS: ${{ vars.BOOST_USERS }}
+      BOOST_COUNT: ${{ vars.BOOST_COUNT }}
+      TRIGGER_ACTOR: ${{ github.event.workflow_run.actor.login || github.actor }}
       RUNNER_LABEL: dbatools-modern
       RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}
     steps:
@@ -73,9 +77,14 @@ jobs:
           NEED=$(( QUEUED - IDLE ))
           [ "$NEED" -lt 0 ] && NEED=0
           TARGET=$(( CAPACITY + NEED ))
+          POOL_LIMIT=${COMMUNITY_COUNT:-5}
+          case " $BOOST_USERS " in
+            *" $TRIGGER_ACTOR "*) POOL_LIMIT=${BOOST_COUNT:-10} ;;
+          esac
           [ "$TARGET" -gt "$MAX_RUNNERS" ] && TARGET=$MAX_RUNNERS
+          [ "$TARGET" -gt "$POOL_LIMIT" ] && TARGET=$POOL_LIMIT
 
-          echo "queued=$QUEUED idle=$IDLE capacity=$CAPACITY target=$TARGET"
+          echo "actor=$TRIGGER_ACTOR queued=$QUEUED idle=$IDLE capacity=$CAPACITY pool_limit=$POOL_LIMIT target=$TARGET"
           if [ "$TARGET" -gt "$CAPACITY" ]; then
             az vmss scale -g "$RG" -n "$VMSS" --new-capacity "$TARGET" --no-wait
             echo "scaled=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- stop successful VMSS registration sweeps from ending as false-red failures
- keep a five-runner shared community pool hot at all times
- give pushes by `potatoqualitee` and `andreasjordan` a ten-runner pool immediately, retaining it for two hours after the latest push
- reconcile the fleet hourly instead of every 30 minutes, without duplicating the Monday spend-report run
- preserve the community baseline in the independent Azure janitor and replace spent/dead VMs before calculating new capacity

## Root cause

The three latest failed `runner-scale-up` runs successfully configured all ten runners, then returned exit code 1 because the second sweep ended with a false `[ "$sweep" = "1" ] && sleep 90` condition under strict shell handling.

The previous lifecycle policy also aged out healthy online runners and used asynchronous deletion, which could leave Azure reporting stale capacity and defer replacement until a later reconcile.

## Impact

Community CI receives a fixed five-runner shared pool. Maintainer pushes activate all ten VMSS runners for two hours. The existing VMSS remains a shared capacity pool; this PR does not introduce security-isolated per-user runner labels or separate scale sets.

The five-runner baseline is intentional continuous Azure spend. The updated `janitor-runbook.ps1` is versioned source and must be redeployed manually after merge.

## Validation

- `actionlint` 1.7.12 on all changed workflows
- YAML parsing for all changed workflows
- Bash syntax checks for embedded workflow scripts
- PowerShell parser validation for `janitor-runbook.ps1`
- simulated maintainer/community pool selection: 10 / 10 / 5
- simulated two-hour GitHub event window and dispatch fallback
- verified the original scale-up loop exits 1 and the corrected loop exits 0
