### PR TITLE
Harden Azure runner scaling and transient CI setup

### DIFF
--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -25,7 +25,7 @@ GitHub (public repo)                          Azure (eastus)
 | Instance parity knobs | firewall off, `LocalAccountTokenFilterPolicy=1`, pagefile setting on D:, `@@SERVERNAME` repaired per job (all NSG-shielded) |
 | Harness | untouched `tests/appveyor.*.ps1` via `tests/gha.shim.ps1` (`APPVEYOR=True` drives Get-TestConfig) |
 | Scaling controls | fixed five-runner community pool; repo variable `MAX_RUNNERS` remains the hard VMSS ceiling |
-| Maintainer boost | repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS` — each listed user with a push in the trailing window contributes `BOOST_COUNT` runners, so two active maintainers get twenty total; `runner-boost.yml` passes the actor directly so the first scale-out does not depend on repository-event timing |
+| Maintainer boost | repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS` — each listed user with a push in the trailing window contributes `BOOST_COUNT` runners, so two active maintainers get twenty total; `runner-boost.yml` dispatches scale-up directly so it does not race reconcile for the fleet lock |
 | Azure auth | OIDC only — Entra app `dbatools-ci-github`, federated for the default branch, custom role `dbatools-ci-operator` scoped to RG `dbatools-ci` |
 | Runner registration | `CI_RUNNER_PAT` secret mints single-use tokens; tokens are never stored on VMs |
 

--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -3,7 +3,7 @@
 Replaces AppVeyor with disposable Azure VMs: every job runs on a factory-fresh
 ephemeral VM booted from a golden image with SQL Server preinstalled, registered as a
 single-use GitHub runner, and deleted afterwards. Five shared runners stay hot for
-community CI; maintainer pushes raise the hot pool to ten for two hours.
+community CI; each active maintainer gets ten runners for two hours (up to twenty).
 
 ```
 GitHub (public repo)                          Azure (eastus)
@@ -25,7 +25,7 @@ GitHub (public repo)                          Azure (eastus)
 | Instance parity knobs | firewall off, `LocalAccountTokenFilterPolicy=1`, pagefile setting on D:, `@@SERVERNAME` repaired per job (all NSG-shielded) |
 | Harness | untouched `tests/appveyor.*.ps1` via `tests/gha.shim.ps1` (`APPVEYOR=True` drives Get-TestConfig) |
 | Scaling controls | fixed five-runner community pool; repo variable `MAX_RUNNERS` remains the hard VMSS ceiling |
-| Maintainer boost | repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS` — every push by a listed user raises the pool to `BOOST_COUNT` until `BOOST_HOURS` after the latest push; `runner-boost.yml` passes the actor directly so the first scale-out does not depend on repository-event timing |
+| Maintainer boost | repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS` — each listed user with a push in the trailing window contributes `BOOST_COUNT` runners, so two active maintainers get twenty total; `runner-boost.yml` passes the actor directly so the first scale-out does not depend on repository-event timing |
 | Azure auth | OIDC only — Entra app `dbatools-ci-github`, federated for the default branch, custom role `dbatools-ci-operator` scoped to RG `dbatools-ci` |
 | Runner registration | `CI_RUNNER_PAT` secret mints single-use tokens; tokens are never stored on VMs |
 
@@ -78,7 +78,7 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
    EKM/HADR/master key) → `@@SERVERNAME` repair → Pester 6 → finalize → post.
 4. After the job the ephemeral runner unregisters; `runner-reconcile.yml` deletes the
    spent instance and tops the fleet back up to the active pool size (five shared,
-   or ten for two hours after the latest maintainer push).
+   ten for one active maintainer, or twenty while both are active).
 
 ## Cost guardrails
 
@@ -86,17 +86,16 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
 - Dead-runner cleanup: reconcile deletes never-registered and offline instances;
   healthy online hot-pool runners are not evicted merely because of age.
 - Community CI keeps five shared runners hot so jobs do not wait for VM provisioning.
-- Every maintainer push holds `BOOST_COUNT` hot runners and refreshes the window; it
-  self-expires `BOOST_HOURS` after the last qualifying push.
+- Every maintainer has an independent `BOOST_HOURS` window worth `BOOST_COUNT`
+  runners; the pool is ten with one active maintainer and twenty with both.
 - Weekly month-to-date spend lands on the "CI cost tracker" issue (Mondays).
 - Ephemeral OS disks cost nothing; the only storage bill is the gallery replicas.
 - Dead man's switch (last ditch): Azure Automation account `dbatools-ci-janitor`
   runs the `Remove-RunawayRunner` runbook every 6 hours, entirely independent
   of GitHub Actions (source: `janitor-runbook.ps1`, deployed manually). It always
-  preserves the five newest community-pool runners. After the two-hour maintainer
-  window, excess runners older than 2h are deleted; within the window only >14h
-  zombies die. If GitHub is unreachable, conservative age caps apply only above
-  the preserved baseline. ps3smoke VMs past 2h and orphaned CI NICs/public IPs
+  preserves the desired five/ten/twenty-runner pool. Excess runners older than 2h
+  are deleted; if GitHub is unreachable, conservative age caps apply only above
+  the five-runner baseline. ps3smoke VMs past 2h and orphaned CI NICs/public IPs
   die in every mode. Its managed identity holds
   only the `dbatools-ci-operator` role on RG `dbatools-ci` -- no storage, no
   other resource groups. The five-runner baseline is intentional all-day spend;

--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -8,8 +8,8 @@ community CI; each active maintainer gets ten runners for two hours (up to twent
 ```
 GitHub (public repo)                          Azure (eastus)
 ├─ ci-azure.yml          10-job matrix   ──►  VMSS dbatools-runners (Flexible, D4ds_v5)
-├─ runner-scale-up.yml    on demand +1..N     ├─ ephemeral OS disk on local SSD ($0)
-├─ runner-reconcile.yml    hourly janitor     ├─ instance public IPs, NSG deny inbound
+├─ runner-reconcile.yml  event + hourly       ├─ ephemeral OS disk on local SSD ($0)
+├─ runner-scale-up.yml    manual recovery     ├─ instance public IPs, NSG deny inbound
 └─ ps3-smoke.yml          nightly PS 3.0      └─ image: dbatoolsGallery/dbatools-modern-image
                                               RG dbatools-ci, budget $600/mo + alerts
 ```
@@ -25,7 +25,7 @@ GitHub (public repo)                          Azure (eastus)
 | Instance parity knobs | firewall off, `LocalAccountTokenFilterPolicy=1`, pagefile setting on D:, `@@SERVERNAME` repaired per job (all NSG-shielded) |
 | Harness | untouched `tests/appveyor.*.ps1` via `tests/gha.shim.ps1` (`APPVEYOR=True` drives Get-TestConfig) |
 | Scaling controls | fixed five-runner community pool; repo variable `MAX_RUNNERS` remains the hard VMSS ceiling |
-| Maintainer boost | repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS` — each listed user with a push in the trailing window contributes `BOOST_COUNT` runners, so two active maintainers get twenty total; `runner-boost.yml` dispatches scale-up directly so it does not race reconcile for the fleet lock |
+| Maintainer boost | repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS` — each listed user with a push in the trailing window contributes `BOOST_COUNT` runners, so two active maintainers get twenty total; `runner-boost.yml` nudges the single reconcile controller so fleet runs cannot cancel a separate scale-up controller |
 | Azure auth | OIDC only — Entra app `dbatools-ci-github`, federated for the default branch, custom role `dbatools-ci-operator` scoped to RG `dbatools-ci` |
 | Runner registration | `CI_RUNNER_PAT` secret mints single-use tokens; tokens are never stored on VMs |
 
@@ -69,10 +69,11 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
 ## How a CI run flows
 
 1. Push/PR triggers `ci-azure.yml` → 10 matrix jobs queue on label `dbatools-modern`.
-2. `runner-scale-up.yml` (workflow_run: requested) counts queued jobs, raises VMSS
-   capacity (cap `MAX_RUNNERS`), and registers an ephemeral runner on every new
-   instance via `az vm run-command` + `bootstrap-runner.ps1` (which then reboots the
-   VM into the appveyor autologon session where run.cmd picks up the job).
+2. `runner-reconcile.yml` reacts to the requested CI run, raises VMSS capacity (cap
+   `MAX_RUNNERS`), and registers an ephemeral runner on every new instance via
+   `az vm run-command` + `bootstrap-runner.ps1` (which then reboots the VM into the
+   appveyor autologon session where run.cmd picks up the job). `runner-scale-up.yml`
+   remains as a manual recovery tool.
 3. Each job: sync repo at `C:\github\dbatools` → CRLF tests → one PowerShell session
    runs prep → instance setup (`appveyor.SQL*.ps1` set static ports, start services,
    EKM/HADR/master key) → `@@SERVERNAME` repair → Pester 6 → finalize → post.

--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -2,14 +2,14 @@
 
 Replaces AppVeyor with disposable Azure VMs: every job runs on a factory-fresh
 ephemeral VM booted from a golden image with SQL Server preinstalled, registered as a
-single-use GitHub runner, and deleted afterwards. Nights and weekends the fleet scales
-to zero; during Paris business hours a small standby pool keeps queue times low.
+single-use GitHub runner, and deleted afterwards. Five shared runners stay hot for
+community CI; maintainer pushes raise the hot pool to ten for two hours.
 
 ```
 GitHub (public repo)                          Azure (eastus)
-├─ ci-azure.yml           8-job matrix   ──►  VMSS dbatools-runners (Flexible, D4ds_v5)
+├─ ci-azure.yml          10-job matrix   ──►  VMSS dbatools-runners (Flexible, D4ds_v5)
 ├─ runner-scale-up.yml    on demand +1..N     ├─ ephemeral OS disk on local SSD ($0)
-├─ runner-reconcile.yml   */30 min janitor    ├─ instance public IPs, NSG deny inbound
+├─ runner-reconcile.yml    hourly janitor     ├─ instance public IPs, NSG deny inbound
 └─ ps3-smoke.yml          nightly PS 3.0      └─ image: dbatoolsGallery/dbatools-modern-image
                                               RG dbatools-ci, budget $600/mo + alerts
 ```
@@ -24,8 +24,8 @@ GitHub (public repo)                          Azure (eastus)
 | Runner execution | **interactive autologon session** as local admin `appveyor` (AppVeyor parity: BITS transfers, `$env:USERNAME`, `C:\Users\appveyor\Documents\DbatoolsExport`); bootstrap registers the ephemeral runner, arms autologon + a logon task, reboots |
 | Instance parity knobs | firewall off, `LocalAccountTokenFilterPolicy=1`, pagefile setting on D:, `@@SERVERNAME` repaired per job (all NSG-shielded) |
 | Harness | untouched `tests/appveyor.*.ps1` via `tests/gha.shim.ps1` (`APPVEYOR=True` drives Get-TestConfig) |
-| Scaling controls | repo variables `STANDBY_COUNT` / `STANDBY_HOURS` / `STANDBY_TZ` / `MAX_RUNNERS` |
-| Maintainer boost | repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS` / `BOOST_COMMITS` — once listed users have pushed `BOOST_COMMITS` commits (default 3) to branches other than development/master within the trailing `BOOST_HOURS` window, the floor rises to `BOOST_COUNT` until the window drains (any hour, any day); `runner-boost.yml` nudges reconcile on those pushes so it applies within ~1 minute |
+| Scaling controls | fixed five-runner community pool; repo variable `MAX_RUNNERS` remains the hard VMSS ceiling |
+| Maintainer boost | repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS` — every push by a listed user raises the pool to `BOOST_COUNT` until `BOOST_HOURS` after the latest push; `runner-boost.yml` passes the actor directly so the first scale-out does not depend on repository-event timing |
 | Azure auth | OIDC only — Entra app `dbatools-ci-github`, federated for the default branch, custom role `dbatools-ci-operator` scoped to RG `dbatools-ci` |
 | Runner registration | `CI_RUNNER_PAT` secret mints single-use tokens; tokens are never stored on VMs |
 
@@ -68,7 +68,7 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
 
 ## How a CI run flows
 
-1. Push/PR triggers `ci-azure.yml` → 8 matrix jobs queue on label `dbatools-modern`.
+1. Push/PR triggers `ci-azure.yml` → 10 matrix jobs queue on label `dbatools-modern`.
 2. `runner-scale-up.yml` (workflow_run: requested) counts queued jobs, raises VMSS
    capacity (cap `MAX_RUNNERS`), and registers an ephemeral runner on every new
    instance via `az vm run-command` + `bootstrap-runner.ps1` (which then reboots the
@@ -77,29 +77,30 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
    runs prep → instance setup (`appveyor.SQL*.ps1` set static ports, start services,
    EKM/HADR/master key) → `@@SERVERNAME` repair → Pester 6 → finalize → post.
 4. After the job the ephemeral runner unregisters; `runner-reconcile.yml` deletes the
-   spent instance and tops the fleet back up to the standby floor (or zero off-hours).
+   spent instance and tops the fleet back up to the active pool size (five shared,
+   or ten for two hours after the latest maintainer push).
 
 ## Cost guardrails
 
 - Budget `dbatools-ci-budget`: $600/month on RG `dbatools-ci`, email at 50/80/100%.
-- Zombie kill: reconcile deletes any non-busy instance older than 3h.
-- Scale-to-zero outside `STANDBY_HOURS` (`STANDBY_TZ`, Mon–Fri).
-- Maintainer boost holds `BOOST_COUNT` warm runners once `BOOST_COMMITS` commits
-  land in the window; it self-expires `BOOST_HOURS` after the last qualifying
-  push (worst case ~10 × D4ds_v5 for 3h ≈ $7).
+- Dead-runner cleanup: reconcile deletes never-registered and offline instances;
+  healthy online hot-pool runners are not evicted merely because of age.
+- Community CI keeps five shared runners hot so jobs do not wait for VM provisioning.
+- Every maintainer push holds `BOOST_COUNT` hot runners and refreshes the window; it
+  self-expires `BOOST_HOURS` after the last qualifying push.
 - Weekly month-to-date spend lands on the "CI cost tracker" issue (Mondays).
 - Ephemeral OS disks cost nothing; the only storage bill is the gallery replicas.
 - Dead man's switch (last ditch): Azure Automation account `dbatools-ci-janitor`
   runs the `Remove-RunawayRunner` runbook every 6 hours, entirely independent
-  of GitHub Actions (source: `janitor-runbook.ps1`). The kill rule is keyed to
-  maintainer activity: once no maintainer has pushed for 6 hours, every runner
-  VM older than 2h is deleted no matter what the GitHub-side machinery thinks;
-  within an active window only >14h zombies die (reconcile owns the rest); if
-  GitHub is unreachable, conservative age caps apply. ps3smoke VMs past 2h and
-  orphaned CI NICs/public IPs die in every mode. Its managed identity holds
+  of GitHub Actions (source: `janitor-runbook.ps1`, deployed manually). It always
+  preserves the five newest community-pool runners. After the two-hour maintainer
+  window, excess runners older than 2h are deleted; within the window only >14h
+  zombies die. If GitHub is unreachable, conservative age caps apply only above
+  the preserved baseline. ps3smoke VMs past 2h and orphaned CI NICs/public IPs
+  die in every mode. Its managed identity holds
   only the `dbatools-ci-operator` role on RG `dbatools-ci` -- no storage, no
-  other resource groups. Worst-case wedged-fleet spend is a few hours of VMs
-  (~$30), never an all-day burn.
+  other resource groups. The five-runner baseline is intentional all-day spend;
+  the switch caps runaway capacity above it.
 
 ## Phase 0 gate results (2026-07-10)
 

--- a/.github/runners/janitor-runbook.ps1
+++ b/.github/runners/janitor-runbook.ps1
@@ -7,20 +7,19 @@
     runbook: Remove-RunawayRunner), entirely independent of GitHub Actions.
     This is the LAST-DITCH kill switch: the GitHub-side janitor
     (runner-reconcile.yml) owns normal fleet lifecycle; this backstop exists so
-    the fleet can never idle all day on a wedged dispatch chain.
+    capacity above the intentional five-runner baseline cannot idle all day on
+    a wedged dispatch chain.
 
     The kill rule is keyed to maintainer activity, not the clock:
 
-      - STALE (no push by a maintainer in the last 6 hours, checked through the
-        anonymous GitHub events API): every dbatools-runners_* VM older than
-        2 hours is deleted. The 2-hour grace only spares an in-flight job from
-        a manual dispatch -- jobs time out at 90 minutes, so anything older is
-        by definition runaway.
-      - ACTIVE (maintainer push within 6 hours): reconcile owns the window, so
+      - STALE (no push by a maintainer in the last 2 hours, checked through the
+        anonymous GitHub events API): the five newest community-pool runners are
+        preserved and excess runners older than 2 hours are deleted.
+      - ACTIVE (maintainer push within 2 hours): reconcile owns the window, so
         only true zombies older than 14 hours are deleted here.
       - GITHUB UNREACHABLE: we cannot know activity, so conservative age caps
-        apply -- 3 hours on nights and weekends, 13 hours on weekday daytime
-        (06-17 UTC) so a healthy standby floor is not murdered blind.
+        apply to capacity above the preserved five-runner community pool -- 3
+        hours on nights and weekends, 13 hours on weekday daytime (06-17 UTC).
 
     Always, regardless of mode:
       - ps3smoke-* VMs older than 2 hours are deleted (nightly job caps at 55m).
@@ -43,7 +42,8 @@ $null = Connect-AzAccount -Identity
 $rg = "dbatools-ci"
 $repo = "dataplat/dbatools"
 $maintainers = @("potatoqualitee", "andreasjordan")
-$activityWindowHours = 6
+$activityWindowHours = 2
+$communityPoolSize = 5
 $utcNow = (Get-Date).ToUniversalTime()
 
 # ---- how long since the last maintainer push? (anonymous API, public repo) ----
@@ -84,7 +84,7 @@ switch ($mode) {
         if ($null -ne $lastPushAgeHours) {
             $ageText = "$([math]::Round($lastPushAgeHours, 1))h ago"
         }
-        Write-Output "mode=stale: last maintainer push $ageText -- every runner VM past ${runnerMaxHours}h dies"
+        Write-Output "mode=stale: last maintainer push $ageText -- excess runners past ${runnerMaxHours}h die; five newest are preserved"
     }
     default {
         $isWeekend = $utcNow.DayOfWeek -in @([DayOfWeek]::Saturday, [DayOfWeek]::Sunday)
@@ -100,10 +100,20 @@ switch ($mode) {
 
 $deleted = 0
 $vms = Get-AzVM -ResourceGroupName $rg
+$protectedRunners = @(
+    $vms |
+        Where-Object Name -Like "dbatools-runners_*" |
+        Sort-Object TimeCreated -Descending |
+        Select-Object -First $communityPoolSize -ExpandProperty Name
+)
 Write-Output "found $(@($vms).Count) VM(s) in $rg"
 foreach ($vm in $vms) {
     $cap = $null
     if ($vm.Name -like "dbatools-runners_*") {
+        if ($mode -ne "active" -and $vm.Name -in $protectedRunners) {
+            Write-Output "preserving community-pool runner $($vm.Name)"
+            continue
+        }
         $cap = $runnerMaxHours
     } elseif ($vm.Name -like "ps3smoke*") {
         $cap = 2

--- a/.github/runners/janitor-runbook.ps1
+++ b/.github/runners/janitor-runbook.ps1
@@ -15,8 +15,8 @@
       - STALE (no push by a maintainer in the last 2 hours, checked through the
         anonymous GitHub events API): the five newest community-pool runners are
         preserved and excess runners older than 2 hours are deleted.
-      - ACTIVE (maintainer push within 2 hours): reconcile owns the window, so
-        only true zombies older than 14 hours are deleted here.
+      - ACTIVE (maintainer push within 2 hours): ten runners are preserved for
+        each active maintainer; excess runners older than 2 hours are deleted.
       - GITHUB UNREACHABLE: we cannot know activity, so conservative age caps
         apply to capacity above the preserved five-runner community pool -- 3
         hours on nights and weekends, 13 hours on weekday daytime (06-17 UTC).
@@ -38,29 +38,53 @@
 #>
 
 $ErrorActionPreference = "Continue"
-$null = Connect-AzAccount -Identity
+Connect-AzAccount -Identity -WarningAction SilentlyContinue | Out-Null
 $rg = "dbatools-ci"
 $repo = "dataplat/dbatools"
 $maintainers = @("potatoqualitee", "andreasjordan")
 $activityWindowHours = 2
 $communityPoolSize = 5
+$maintainerPoolSize = 10
 $utcNow = (Get-Date).ToUniversalTime()
 
 # ---- how long since the last maintainer push? (anonymous API, public repo) ----
 $mode = "github-unreachable"
 $lastPushAgeHours = $null
+$activeMaintainers = @( )
 try {
     $splatEvents = @{
         Uri        = "https://api.github.com/repos/$repo/events?per_page=100"
         Headers    = @{ "User-Agent" = "dbatools-ci-janitor" }
         TimeoutSec = 30
     }
-    $events = Invoke-RestMethod @splatEvents
+    $events = $null
+    foreach ($attempt in 1..3) {
+        try {
+            $events = Invoke-RestMethod @splatEvents
+            break
+        } catch {
+            if ($attempt -eq 3) {
+                throw
+            }
+            Write-Warning "GitHub activity attempt $attempt of 3 failed; retrying. $($PSItem.Exception.Message)"
+            Start-Sleep -Seconds (3 * $attempt)
+        }
+    }
     $pushes = @($events | Where-Object { $PSItem.type -eq "PushEvent" -and $PSItem.actor.login -in $maintainers })
     if ($pushes) {
         $lastPush = ($pushes | ForEach-Object { ([datetime]::Parse($PSItem.created_at)).ToUniversalTime() } | Sort-Object -Descending)[0]
         $lastPushAgeHours = ($utcNow - $lastPush).TotalHours
-        if ($lastPushAgeHours -le $activityWindowHours) {
+        foreach ($maintainer in $maintainers) {
+            $maintainerPushes = @($pushes | Where-Object { $PSItem.actor.login -eq $maintainer })
+            if (-not $maintainerPushes) {
+                continue
+            }
+            $latestMaintainerPush = ($maintainerPushes | ForEach-Object { ([datetime]::Parse($PSItem.created_at)).ToUniversalTime() } | Sort-Object -Descending)[0]
+            if (($utcNow - $latestMaintainerPush).TotalHours -le $activityWindowHours) {
+                $activeMaintainers += $maintainer
+            }
+        }
+        if ($activeMaintainers.Count -gt 0) {
             $mode = "active"
         } else {
             $mode = "stale"
@@ -73,10 +97,15 @@ try {
     Write-Warning "GitHub activity check failed ($($PSItem.Exception.Message)) -- falling back to age caps"
 }
 
+$desiredPoolSize = $communityPoolSize
+if ($activeMaintainers.Count -gt 0) {
+    $desiredPoolSize = $activeMaintainers.Count * $maintainerPoolSize
+}
+
 switch ($mode) {
     "active" {
-        $runnerMaxHours = 14
-        Write-Output "mode=active: last maintainer push $([math]::Round($lastPushAgeHours, 1))h ago (window ${activityWindowHours}h); only zombies past ${runnerMaxHours}h die"
+        $runnerMaxHours = 2
+        Write-Output "mode=active: $($activeMaintainers.Count) maintainer(s) [$($activeMaintainers -join ', ')] -- preserving $desiredPoolSize runners; excess runners past ${runnerMaxHours}h die"
     }
     "stale" {
         $runnerMaxHours = 2
@@ -104,14 +133,14 @@ $protectedRunners = @(
     $vms |
         Where-Object Name -Like "dbatools-runners_*" |
         Sort-Object TimeCreated -Descending |
-        Select-Object -First $communityPoolSize -ExpandProperty Name
+        Select-Object -First $desiredPoolSize -ExpandProperty Name
 )
 Write-Output "found $(@($vms).Count) VM(s) in $rg"
 foreach ($vm in $vms) {
     $cap = $null
     if ($vm.Name -like "dbatools-runners_*") {
-        if ($mode -ne "active" -and $vm.Name -in $protectedRunners) {
-            Write-Output "preserving community-pool runner $($vm.Name)"
+        if ($vm.Name -in $protectedRunners) {
+            Write-Output "preserving desired-pool runner $($vm.Name)"
             continue
         }
         $cap = $runnerMaxHours
@@ -162,8 +191,8 @@ foreach ($pip in Get-AzPublicIpAddress -ResourceGroupName $rg) {
 }
 
 $vmss = Get-AzVmss -ResourceGroupName $rg -VMScaleSetName "dbatools-runners" -ErrorAction SilentlyContinue
-if ($vmss -and $vmss.Sku.Capacity -gt 12) {
-    Write-Warning "VMSS capacity is $($vmss.Sku.Capacity) -- above any sane fleet size (MAX_RUNNERS is 10)"
+if ($vmss -and $vmss.Sku.Capacity -gt 22) {
+    Write-Warning "VMSS capacity is $($vmss.Sku.Capacity) -- above any sane fleet size (MAX_RUNNERS is 20)"
 }
 
 if ($deleted -gt 0) {

--- a/.github/scripts/gh-actions.ps1
+++ b/.github/scripts/gh-actions.ps1
@@ -199,11 +199,6 @@ exec sp_addrolemember 'userrole','bob';
         $results.Targets.Name | Should -Be "package0.event_file"
     }
 
-    It "installs darling data" {
-        $results = Install-DbaDarlingData
-        $results.Database | Select-Object -First 1 | Should -Be "master"
-    }
-
     It "tests the instance name" {
         $results = Test-DbaInstanceName
         $results.ServerName | Should -Be "mssql1"

--- a/.github/scripts/gh-winactions.ps1
+++ b/.github/scripts/gh-winactions.ps1
@@ -46,6 +46,11 @@ Describe "Integration Tests" -Tag "IntegrationTests" {
         $null = Remove-DbaDatabase -Database $db.Name
     }
 
+    It -Skip:($PSVersionTable.PSEdition -ne "Core") "installs darling data" {
+        $results = Install-DbaDarlingData
+        $results.Database | Select-Object -First 1 | Should -Be "master"
+    }
+
     It -Skip:(-not $hasAzureServicePrincipal) "connects to Azure using tenant and client id + client secret" {
         $PSDefaultParameterValues.Clear()
         $securestring = ConvertTo-SecureString $env:CLIENTSECRET -AsPlainText -Force

--- a/.github/workflows/runner-boost.yml
+++ b/.github/workflows/runner-boost.yml
@@ -1,18 +1,14 @@
-# When a maintainer listed in the BOOST_USERS repo variable pushes to a branch
-# other than development/master, immediately dispatch runner-reconcile so the
-# maintainer-boost floor (BOOST_COUNT runners once BOOST_COMMITS commits land
-# within BOOST_HOURS) kicks in without waiting for the best-effort cron.
+# When a maintainer listed in the BOOST_USERS repo variable pushes to any branch,
+# immediately dispatch runner-reconcile so the BOOST_COUNT runner pool kicks in
+# without waiting for the best-effort cron and remains hot for BOOST_HOURS.
 #
 # The boost decision itself lives in runner-reconcile.yml -- this workflow is
 # only a promptness nudge, and only fires from branches that carry this file.
-# Branches created before it merged are still covered by the */30 cron.
+# Branches created before it merged are still covered by the hourly cron.
 name: runner-boost
 
 on:
   push:
-    branches-ignore:
-      - development
-      - master
 
 permissions:
   actions: write
@@ -28,4 +24,10 @@ jobs:
       - name: Dispatch runner-reconcile
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run runner-reconcile.yml --ref development -R "${{ github.repository }}"
+          BOOST_USER: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          if ! gh workflow run runner-reconcile.yml --ref development -f boost_user="$BOOST_USER" -R "${{ github.repository }}"; then
+            echo "boost_user input unavailable; retrying a plain reconcile dispatch"
+            gh workflow run runner-reconcile.yml --ref development -R "${{ github.repository }}"
+          fi

--- a/.github/workflows/runner-boost.yml
+++ b/.github/workflows/runner-boost.yml
@@ -1,10 +1,9 @@
 # When a maintainer listed in the BOOST_USERS repo variable pushes to any branch,
-# immediately dispatch runner-scale-up so that maintainer's BOOST_COUNT allocation
-# kicks in without competing with a duplicate reconcile run and remains hot for
-# BOOST_HOURS.
+# immediately dispatch runner-reconcile so that maintainer's BOOST_COUNT allocation
+# kicks in and remains hot for BOOST_HOURS.
 #
-# The boost decision also lives in runner-scale-up.yml -- this workflow is only a
-# promptness nudge, and only fires from branches that carry this file.
+# Reconcile is the single event-driven fleet controller; using one workflow prevents
+# GitHub's concurrency queue from cancelling scale-up in favor of a janitor run.
 # Branches created before it merged are still covered by the hourly cron.
 name: runner-boost
 
@@ -26,16 +25,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           BOOST_USER: ${{ github.actor }}
-          BOOST_COUNT: ${{ vars.BOOST_COUNT }}
         run: |
           set -euo pipefail
-          if gh workflow run runner-scale-up.yml --ref development -f ensure="${BOOST_COUNT:-10}" -f boost_user="$BOOST_USER" -R "${{ github.repository }}"; then
+          if gh workflow run runner-reconcile.yml --ref development -f boost_user="$BOOST_USER" -R "${{ github.repository }}"; then
             exit 0
           fi
 
-          echo "boost_user input unavailable or transient dispatch failure; retrying with the existing ensure input"
+          echo "boost_user input unavailable or transient dispatch failure; retrying a plain reconcile dispatch"
           for attempt in 1 2 3; do
-            if gh workflow run runner-scale-up.yml --ref development -f ensure="${BOOST_COUNT:-10}" -R "${{ github.repository }}"; then
+            if gh workflow run runner-reconcile.yml --ref development -R "${{ github.repository }}"; then
               exit 0
             fi
             if [ "$attempt" -lt 3 ]; then

--- a/.github/workflows/runner-boost.yml
+++ b/.github/workflows/runner-boost.yml
@@ -1,9 +1,10 @@
 # When a maintainer listed in the BOOST_USERS repo variable pushes to any branch,
-# immediately dispatch runner-reconcile so that maintainer's BOOST_COUNT allocation
-# kicks in without waiting for the best-effort cron and remains hot for BOOST_HOURS.
+# immediately dispatch runner-scale-up so that maintainer's BOOST_COUNT allocation
+# kicks in without competing with a duplicate reconcile run and remains hot for
+# BOOST_HOURS.
 #
-# The boost decision itself lives in runner-reconcile.yml -- this workflow is
-# only a promptness nudge, and only fires from branches that carry this file.
+# The boost decision also lives in runner-scale-up.yml -- this workflow is only a
+# promptness nudge, and only fires from branches that carry this file.
 # Branches created before it merged are still covered by the hourly cron.
 name: runner-boost
 
@@ -25,9 +26,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           BOOST_USER: ${{ github.actor }}
+          BOOST_COUNT: ${{ vars.BOOST_COUNT }}
         run: |
           set -euo pipefail
-          if ! gh workflow run runner-reconcile.yml --ref development -f boost_user="$BOOST_USER" -R "${{ github.repository }}"; then
-            echo "boost_user input unavailable; retrying a plain reconcile dispatch"
-            gh workflow run runner-reconcile.yml --ref development -R "${{ github.repository }}"
+          if gh workflow run runner-scale-up.yml --ref development -f ensure="${BOOST_COUNT:-10}" -f boost_user="$BOOST_USER" -R "${{ github.repository }}"; then
+            exit 0
           fi
+
+          echo "boost_user input unavailable or transient dispatch failure; retrying with the existing ensure input"
+          for attempt in 1 2 3; do
+            if gh workflow run runner-scale-up.yml --ref development -f ensure="${BOOST_COUNT:-10}" -R "${{ github.repository }}"; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((attempt * 3))
+            fi
+          done
+          exit 1

--- a/.github/workflows/runner-boost.yml
+++ b/.github/workflows/runner-boost.yml
@@ -1,6 +1,6 @@
 # When a maintainer listed in the BOOST_USERS repo variable pushes to any branch,
-# immediately dispatch runner-reconcile so the BOOST_COUNT runner pool kicks in
-# without waiting for the best-effort cron and remains hot for BOOST_HOURS.
+# immediately dispatch runner-reconcile so that maintainer's BOOST_COUNT allocation
+# kicks in without waiting for the best-effort cron and remains hot for BOOST_HOURS.
 #
 # The boost decision itself lives in runner-reconcile.yml -- this workflow is
 # only a promptness nudge, and only fires from branches that carry this file.

--- a/.github/workflows/runner-reconcile.yml
+++ b/.github/workflows/runner-reconcile.yml
@@ -7,9 +7,9 @@
 # BOOST_USERS with a push in the trailing BOOST_HOURS window contributes
 # BOOST_COUNT runners, so both maintainers active means twenty runners.
 #
-# runner-boost.yml nudges this workflow on every qualifying push and supplies the
-# actor for immediate scale-out; repository events preserve the boost after that
-# dispatch until the window drains.
+# runner-boost.yml nudges runner-scale-up directly on every qualifying push.
+# Repository events preserve each allocation on later reconcile ticks until its
+# independent window drains.
 #
 # Mondays at 07:00 UTC one extra scheduled tick posts month-to-date spend to the
 # "CI cost tracker" issue.

--- a/.github/workflows/runner-reconcile.yml
+++ b/.github/workflows/runner-reconcile.yml
@@ -1,16 +1,14 @@
-# The fleet janitor: every 30 minutes (and after each CI run) it deletes spent and
-# zombie runner instances, enforces the business-hours standby floor, self-heals
+# The fleet janitor: every hour (and after each CI run) it deletes spent and
+# zombie runner instances, enforces the active pool size, self-heals
 # unregistered instances, and tops capacity up if the event-driven scale-up missed
 # anything (re-runs of failed jobs do not emit a "requested" event -- this catches them).
 #
-# Standby floor: STANDBY_COUNT instances during STANDBY_HOURS (STANDBY_TZ) Mon-Fri,
-# zero outside them. All three come from repo variables so tuning needs no code change.
+# Pool policy: five shared runners stay hot for community CI. A push by a user in
+# BOOST_USERS raises the pool to BOOST_COUNT for the trailing BOOST_HOURS window.
 #
-# Maintainer boost: once the users in BOOST_USERS have pushed BOOST_COMMITS
-# commits (default 3) to branches other than development/master within the
-# trailing BOOST_HOURS window, the floor is raised to BOOST_COUNT until the
-# window drains (any hour, any day). runner-boost.yml nudges this workflow on
-# those pushes so the boost kicks in without waiting for cron.
+# runner-boost.yml nudges this workflow on every qualifying push and supplies the
+# actor for immediate scale-out; repository events preserve the boost after that
+# dispatch until the window drains.
 #
 # Mondays at 07:00 UTC one extra scheduled tick posts month-to-date spend to the
 # "CI cost tracker" issue.
@@ -18,14 +16,19 @@ name: runner-reconcile
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "0 * * * *"
     - cron: "0 7 * * 1"
   # ci-azure nudges this workflow via workflow_dispatch when its matrix finishes, so
-  # spent VMs are replaced promptly. That nudge is the fast path; the */30 cron is a
+  # spent VMs are replaced promptly. That nudge is the fast path; the hourly cron is a
   # best-effort backstop for events that never fire (e.g. re-runs of failed jobs do
   # not emit a scale-up "requested" event). A workflow_run:completed trigger would
   # duplicate the nudge one-for-one, so it is intentionally omitted.
   workflow_dispatch:
+    inputs:
+      boost_user:
+        description: "Maintainer whose push requested an immediate pool boost"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -43,7 +46,9 @@ jobs:
     # fail at Azure login. Cron and workflow_run always resolve to the default
     # branch, so this only skips stray dispatches on feature branches (which could
     # not do useful work anyway) -- they no-op green instead of failing red.
-    if: github.ref == 'refs/heads/development'
+    # The second schedule entry is spend-report-only; excluding it keeps fleet
+    # reconciliation to exactly once during Monday's 07:00 UTC hour.
+    if: github.ref == 'refs/heads/development' && github.event.schedule != '0 7 * * 1'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -51,14 +56,11 @@ jobs:
       REPO: ${{ github.repository }}
       RG: ${{ vars.CI_AZURE_RG }}
       VMSS: ${{ vars.CI_VMSS_NAME }}
-      MAX_RUNNERS: ${{ vars.MAX_RUNNERS }}
-      STANDBY_COUNT: ${{ vars.STANDBY_COUNT }}
-      STANDBY_HOURS: ${{ vars.STANDBY_HOURS }}
-      STANDBY_TZ: ${{ vars.STANDBY_TZ }}
+      COMMUNITY_COUNT: 5
       BOOST_USERS: ${{ vars.BOOST_USERS }}
       BOOST_COUNT: ${{ vars.BOOST_COUNT }}
       BOOST_HOURS: ${{ vars.BOOST_HOURS }}
-      BOOST_COMMITS: ${{ vars.BOOST_COMMITS }}
+      BOOST_TRIGGER: ${{ inputs.boost_user }}
       RUNNER_LABEL: dbatools-modern
       RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}
     steps:
@@ -74,31 +76,31 @@ jobs:
           set -euo pipefail
           NOW=$(date -u +%s)
 
-          # ---- desired floor from business hours -------------------------------
-          LOCAL_HOUR=$(TZ="$STANDBY_TZ" date +%H | sed 's/^0//')
-          LOCAL_DOW=$(TZ="$STANDBY_TZ" date +%u)
-          START_HOUR=$(echo "$STANDBY_HOURS" | cut -d- -f1 | sed 's/^0//')
-          END_HOUR=$(echo "$STANDBY_HOURS" | cut -d- -f2 | sed 's/^0//')
-          FLOOR=0
-          if [ "$LOCAL_DOW" -le 5 ] && [ "$LOCAL_HOUR" -ge "$START_HOUR" ] && [ "$LOCAL_HOUR" -lt "$END_HOUR" ]; then
-            FLOOR=$STANDBY_COUNT
+          # ---- fixed community pool + two-hour maintainer boost -----------------
+          FLOOR=${COMMUNITY_COUNT:-5}
+          BOOST_ACTIVE=false
+          if [ -n "${BOOST_TRIGGER:-}" ]; then
+            case " $BOOST_USERS " in
+              *" $BOOST_TRIGGER "*) BOOST_ACTIVE=true ;;
+            esac
           fi
 
-          # ---- maintainer boost: recent feature-branch pushes raise the floor ---
-          # (fork pushes do not appear in this repo's event stream, so only pushes
-          # to branches on dataplat/dbatools count)
-          if [ -n "${BOOST_USERS:-}" ] && [ "${BOOST_COUNT:-0}" -gt "$FLOOR" ]; then
-            CUTOFF=$(date -u -d "${BOOST_HOURS:-3} hours ago" +%Y-%m-%dT%H:%M:%SZ)
+          # Repository events keep the boost active on later reconcile ticks. The
+          # explicit trigger above makes the initial tick immune to event-feed lag.
+          if [ "$BOOST_ACTIVE" != "true" ] && [ -n "${BOOST_USERS:-}" ]; then
+            CUTOFF=$(date -u -d "${BOOST_HOURS:-2} hours ago" +%Y-%m-%dT%H:%M:%SZ)
             EVENTS=$(gh api --paginate "repos/$REPO/events?per_page=100" 2>/dev/null || echo "[]")
             RECENT=$(echo "$EVENTS" | jq -s --arg cutoff "$CUTOFF" --arg users "$BOOST_USERS" \
               '[.[][] | select(.type == "PushEvent" and .created_at > $cutoff
-                and (.actor.login | IN($users | split(" ")[]))
-                and ((.payload.ref // "") | test("^refs/heads/(development|master)$") | not))
-                | .payload.size // 1] | add // 0')
-            if [ "${RECENT:-0}" -ge "${BOOST_COMMITS:-3}" ]; then
-              echo "maintainer boost: $RECENT commit(s) to feature branches by [$BOOST_USERS] in the last ${BOOST_HOURS:-3}h (threshold ${BOOST_COMMITS:-3}) -- floor raised to $BOOST_COUNT"
-              FLOOR=$BOOST_COUNT
+                and (.actor.login | IN($users | split(" ")[])))
+                | .payload.size // 0] | add // 0')
+            if [ "${RECENT:-0}" -gt 0 ]; then
+              BOOST_ACTIVE=true
             fi
+          fi
+          if [ "$BOOST_ACTIVE" = "true" ]; then
+            FLOOR=${BOOST_COUNT:-10}
+            echo "maintainer boost active for [$BOOST_USERS] -- pool raised to $FLOOR for ${BOOST_HOURS:-2}h after the latest push"
           fi
 
           # ---- current state ---------------------------------------------------
@@ -120,7 +122,7 @@ jobs:
             QUEUED=$((QUEUED + N))
           done
 
-          echo "floor=$FLOOR queued_runs=$QUEUED"
+          echo "pool=$FLOOR queued_jobs=$QUEUED"
           echo "$VMS_JSON" | jq -r '.[] | "vm: \(.name) \(.power) created \(.created)"'
           echo "$RUNNERS_JSON" | jq -r '.[] | "runner: \(.name) \(.status) busy=\(.busy)"'
 
@@ -144,7 +146,8 @@ jobs:
                 echo "$OUT" | tail -3
                 if echo "$OUT" | grep -q "SPENT-VM"; then
                   echo "$vm already served a job -- deleting instead of reusing"
-                  az vm delete -g "$RG" -n "$vm" --yes --no-wait || true
+                  # Wait so VMSS capacity reflects the deletion before pass 3 tops up.
+                  az vm delete -g "$RG" -n "$vm" --yes || true
                 fi
               ) &
             done
@@ -181,24 +184,20 @@ jobs:
               # bootstrap reboots into the interactive session; fresh instances are
               # briefly offline between config and the post-reboot logon
               DELETE="runner offline (spent ephemeral or dead)"
-            elif [ "$AGE_MIN" -gt 180 ]; then
-              DELETE="zombie: age ${AGE_MIN}m"
             fi
 
             if [ -n "$DELETE" ]; then
               echo "deleting $VM -- $DELETE"
               [ -n "$R_ID" ] && gh api -X DELETE "repos/$REPO/actions/runners/$R_ID" || true
-              az vm delete -g "$RG" -n "$VM" --yes --no-wait || true
+              # Wait so the capacity check below can create the replacement now.
+              az vm delete -g "$RG" -n "$VM" --yes || true
             else
               KEEP=$((KEEP + 1))
             fi
           done
 
-          # ---- pass 3: top up to floor / demand ----------------------------------
-          BUSY=$(echo "$RUNNERS_JSON" | jq '[.[] | select(.busy == true)] | length')
-          DESIRED=$(( BUSY + QUEUED ))
-          [ "$DESIRED" -lt "$FLOOR" ] && DESIRED=$FLOOR
-          [ "$DESIRED" -gt "$MAX_RUNNERS" ] && DESIRED=$MAX_RUNNERS
+          # ---- pass 3: enforce the active fixed-size pool -------------------------
+          DESIRED=$FLOOR
           # az vmss scale is bidirectional: pushing a target BELOW the real capacity
           # scale-INS the newest instances -- which is exactly what happens when the
           # eventually-consistent vm listing hides fresh VMs from KEEP. Scale-out only

--- a/.github/workflows/runner-reconcile.yml
+++ b/.github/workflows/runner-reconcile.yml
@@ -1,7 +1,6 @@
-# The fleet janitor: every hour (and after each CI run) it deletes spent and
-# zombie runner instances, enforces the active pool size, self-heals
-# unregistered instances, and tops capacity up if the event-driven scale-up missed
-# anything (re-runs of failed jobs do not emit a "requested" event -- this catches them).
+# The single fleet controller: when CI is requested, after CI completes, and every
+# hour it deletes spent and zombie runner instances, enforces the active pool size,
+# self-heals unregistered instances, and tops capacity up.
 #
 # Pool policy: five shared runners stay hot for community CI. Each user in
 # BOOST_USERS with a push in the trailing BOOST_HOURS window contributes
@@ -19,11 +18,13 @@ on:
   schedule:
     - cron: "0 * * * *"
     - cron: "0 7 * * 1"
-  # ci-azure nudges this workflow via workflow_dispatch when its matrix finishes, so
-  # spent VMs are replaced promptly. That nudge is the fast path; the hourly cron is a
-  # best-effort backstop for events that never fire (e.g. re-runs of failed jobs do
-  # not emit a scale-up "requested" event). A workflow_run:completed trigger would
-  # duplicate the nudge one-for-one, so it is intentionally omitted.
+  workflow_run:
+    workflows: ["ci-azure"]
+    types: [requested]
+  # workflow_run:requested is the fast scale-out path. ci-azure also nudges this
+  # workflow via workflow_dispatch when its matrix finishes so spent VMs are replaced
+  # promptly. The hourly cron catches re-runs, which emit no new requested event. A
+  # workflow_run:completed trigger would duplicate the completion nudge one-for-one.
   workflow_dispatch:
     inputs:
       boost_user:
@@ -62,7 +63,7 @@ jobs:
       BOOST_USERS: ${{ vars.BOOST_USERS }}
       BOOST_COUNT: ${{ vars.BOOST_COUNT }}
       BOOST_HOURS: ${{ vars.BOOST_HOURS }}
-      BOOST_TRIGGER: ${{ inputs.boost_user }}
+      BOOST_TRIGGER: ${{ inputs.boost_user || github.event.workflow_run.actor.login }}
       RUNNER_LABEL: dbatools-modern
       RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}
     steps:

--- a/.github/workflows/runner-reconcile.yml
+++ b/.github/workflows/runner-reconcile.yml
@@ -3,8 +3,9 @@
 # unregistered instances, and tops capacity up if the event-driven scale-up missed
 # anything (re-runs of failed jobs do not emit a "requested" event -- this catches them).
 #
-# Pool policy: five shared runners stay hot for community CI. A push by a user in
-# BOOST_USERS raises the pool to BOOST_COUNT for the trailing BOOST_HOURS window.
+# Pool policy: five shared runners stay hot for community CI. Each user in
+# BOOST_USERS with a push in the trailing BOOST_HOURS window contributes
+# BOOST_COUNT runners, so both maintainers active means twenty runners.
 #
 # runner-boost.yml nudges this workflow on every qualifying push and supplies the
 # actor for immediate scale-out; repository events preserve the boost after that
@@ -56,6 +57,7 @@ jobs:
       REPO: ${{ github.repository }}
       RG: ${{ vars.CI_AZURE_RG }}
       VMSS: ${{ vars.CI_VMSS_NAME }}
+      MAX_RUNNERS: ${{ vars.MAX_RUNNERS }}
       COMMUNITY_COUNT: 5
       BOOST_USERS: ${{ vars.BOOST_USERS }}
       BOOST_COUNT: ${{ vars.BOOST_COUNT }}
@@ -76,35 +78,63 @@ jobs:
           set -euo pipefail
           NOW=$(date -u +%s)
 
-          # ---- fixed community pool + two-hour maintainer boost -----------------
-          FLOOR=${COMMUNITY_COUNT:-5}
-          BOOST_ACTIVE=false
-          if [ -n "${BOOST_TRIGGER:-}" ]; then
-            case " $BOOST_USERS " in
-              *" $BOOST_TRIGGER "*) BOOST_ACTIVE=true ;;
-            esac
-          fi
+          gh_api_retry() {
+            local attempt status
+            for attempt in 1 2 3; do
+              if gh api "$@"; then
+                return 0
+              else
+                status=$?
+              fi
+              echo "GitHub API attempt $attempt of 3 failed" >&2
+              if [ "$attempt" -lt 3 ]; then
+                sleep $((attempt * 3))
+              fi
+            done
+            return "$status"
+          }
 
-          # Repository events keep the boost active on later reconcile ticks. The
-          # explicit trigger above makes the initial tick immune to event-feed lag.
-          if [ "$BOOST_ACTIVE" != "true" ] && [ -n "${BOOST_USERS:-}" ]; then
+          # ---- fixed community pool + independent maintainer boosts --------------
+          FLOOR=${COMMUNITY_COUNT:-5}
+          ACTIVE_COUNT=0
+          ACTIVE_USERS=""
+          EVENTS_AVAILABLE=true
+          EVENTS="[]"
+          if [ -n "${BOOST_USERS:-}" ]; then
             CUTOFF=$(date -u -d "${BOOST_HOURS:-2} hours ago" +%Y-%m-%dT%H:%M:%SZ)
-            EVENTS=$(gh api --paginate "repos/$REPO/events?per_page=100" 2>/dev/null || echo "[]")
-            RECENT=$(echo "$EVENTS" | jq -s --arg cutoff "$CUTOFF" --arg users "$BOOST_USERS" \
-              '[.[][] | select(.type == "PushEvent" and .created_at > $cutoff
-                and (.actor.login | IN($users | split(" ")[])))
-                | .payload.size // 0] | add // 0')
-            if [ "${RECENT:-0}" -gt 0 ]; then
-              BOOST_ACTIVE=true
+            if ! EVENTS=$(gh_api_retry --paginate "repos/$REPO/events?per_page=100" 2>/dev/null); then
+              EVENTS_AVAILABLE=false
             fi
           fi
-          if [ "$BOOST_ACTIVE" = "true" ]; then
-            FLOOR=${BOOST_COUNT:-10}
-            echo "maintainer boost active for [$BOOST_USERS] -- pool raised to $FLOOR for ${BOOST_HOURS:-2}h after the latest push"
+          if [ "$EVENTS_AVAILABLE" = "true" ]; then
+            for BOOST_USER in $BOOST_USERS; do
+              USER_ACTIVE=false
+              if [ "${BOOST_TRIGGER:-}" = "$BOOST_USER" ]; then
+                USER_ACTIVE=true
+              else
+                RECENT=$(printf '%s' "$EVENTS" | jq -s --arg cutoff "$CUTOFF" --arg user "$BOOST_USER" \
+                  '[.[][] | select(.type == "PushEvent" and .created_at > $cutoff and .actor.login == $user)] | length')
+                [ "${RECENT:-0}" -gt 0 ] && USER_ACTIVE=true
+              fi
+              if [ "$USER_ACTIVE" = "true" ]; then
+                ACTIVE_COUNT=$((ACTIVE_COUNT + 1))
+                ACTIVE_USERS="$ACTIVE_USERS $BOOST_USER"
+              fi
+            done
+            if [ "$ACTIVE_COUNT" -gt 0 ]; then
+              FLOOR=$((ACTIVE_COUNT * ${BOOST_COUNT:-10}))
+            fi
+          else
+            # Do not trim a possibly active maintainer pool when the event feed has
+            # a transient outage. The next hourly or completion nudge will retry.
+            FLOOR=${MAX_RUNNERS:-20}
+            echo "GitHub events unavailable after retries -- preserving the maximum pool for this cycle"
           fi
+          [ "$FLOOR" -gt "${MAX_RUNNERS:-20}" ] && FLOOR=${MAX_RUNNERS:-20}
+          echo "active_maintainers=$ACTIVE_COUNT users=[$ACTIVE_USERS] pool=$FLOOR window=${BOOST_HOURS:-2}h"
 
           # ---- current state ---------------------------------------------------
-          RUNNERS_JSON=$(gh api "repos/$REPO/actions/runners?per_page=100" --paginate \
+          RUNNERS_JSON=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate \
             --jq "[.runners[] | select([.labels[].name] | index(\"$RUNNER_LABEL\")) | {name, status, busy, id}]")
           VMS_JSON=$(az vm list -g "$RG" --show-details \
             --query "[?starts_with(name, '${VMSS}_')].{name: name, created: timeCreated, power: powerState}" -o json 2>/dev/null || echo "[]")
@@ -112,12 +142,12 @@ jobs:
           # count queued JOBS, not queued runs: a matrix run flips to in_progress the
           # moment one job starts, hiding its other queued jobs from a run-level count
           QUEUED=0
-          CI_RUN_IDS=$( (gh api "repos/$REPO/actions/runs?status=queued&per_page=50" \
+          CI_RUN_IDS=$( (gh_api_retry "repos/$REPO/actions/runs?status=queued&per_page=50" \
               --jq '.workflow_runs[] | select(.name == "ci-azure") | .id'; \
-            gh api "repos/$REPO/actions/runs?status=in_progress&per_page=50" \
+            gh_api_retry "repos/$REPO/actions/runs?status=in_progress&per_page=50" \
               --jq '.workflow_runs[] | select(.name == "ci-azure") | .id') 2>/dev/null || true)
           for CI_RUN_ID in $CI_RUN_IDS; do
-            N=$(gh api "repos/$REPO/actions/runs/$CI_RUN_ID/jobs?per_page=100" --paginate \
+            N=$(gh_api_retry "repos/$REPO/actions/runs/$CI_RUN_ID/jobs?per_page=100" --paginate \
               --jq "[.jobs[] | select(.status == \"queued\" or .status == \"waiting\") | select((.labels // []) | index(\"$RUNNER_LABEL\"))] | length" 2>/dev/null || echo 0)
             QUEUED=$((QUEUED + N))
           done
@@ -130,14 +160,14 @@ jobs:
           curl -fsSL "$RAW_BASE/.github/runners/bootstrap-runner.ps1" -o /tmp/bootstrap-runner.ps1
           register_unregistered() {
             local registered vms vm token
-            registered=$(gh api "repos/$REPO/actions/runners?per_page=100" --paginate --jq '[.runners[].name] | join(" ")')
+            registered=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate --jq '[.runners[].name] | join(" ")')
             vms=$(az vm list -g "$RG" --query "[?starts_with(name, '${VMSS}_') && provisioningState == 'Succeeded'].name" -o tsv 2>/dev/null || true)
             for vm in $vms; do
               case " $registered " in
                 *" $vm "*) continue ;;
               esac
               echo "registering $vm"
-              token=$(gh api -X POST "repos/$REPO/actions/runners/registration-token" --jq .token)
+              token=$(gh_api_retry -X POST "repos/$REPO/actions/runners/registration-token" --jq .token)
               (
                 OUT=$(az vm run-command invoke -g "$RG" -n "$vm" --command-id RunPowerShellScript \
                   --scripts @/tmp/bootstrap-runner.ps1 \
@@ -160,7 +190,7 @@ jobs:
           register_unregistered
 
           # refresh state after registration/spent-deletions
-          RUNNERS_JSON=$(gh api "repos/$REPO/actions/runners?per_page=100" --paginate \
+          RUNNERS_JSON=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate \
             --jq "[.runners[] | select([.labels[].name] | index(\"$RUNNER_LABEL\")) | {name, status, busy, id}]")
           VMS_JSON=$(az vm list -g "$RG" --show-details \
             --query "[?starts_with(name, '${VMSS}_')].{name: name, created: timeCreated, power: powerState}" -o json 2>/dev/null || echo "[]")
@@ -198,6 +228,7 @@ jobs:
 
           # ---- pass 3: enforce the active fixed-size pool -------------------------
           DESIRED=$FLOOR
+          [ "$DESIRED" -gt "${MAX_RUNNERS:-20}" ] && DESIRED=${MAX_RUNNERS:-20}
           # az vmss scale is bidirectional: pushing a target BELOW the real capacity
           # scale-INS the newest instances -- which is exactly what happens when the
           # eventually-consistent vm listing hides fresh VMs from KEEP. Scale-out only
@@ -220,7 +251,7 @@ jobs:
             # refresh state right before deleting: registration races and az listing
             # lag make the snapshots minutes old by now, and a "surplus idle" VM may
             # in fact be freshly registered and about to take a queued job
-            RUNNERS_JSON=$(gh api "repos/$REPO/actions/runners?per_page=100" --paginate \
+            RUNNERS_JSON=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate \
               --jq "[.runners[] | select([.labels[].name] | index(\"$RUNNER_LABEL\")) | {name, status, busy, id}]")
             VMS_JSON=$(az vm list -g "$RG" --show-details \
               --query "[?starts_with(name, '${VMSS}_')].{name: name, created: timeCreated, power: powerState}" -o json 2>/dev/null || echo "[]")

--- a/.github/workflows/runner-scale-up.yml
+++ b/.github/workflows/runner-scale-up.yml
@@ -17,6 +17,10 @@ on:
         description: "Minimum instance count to ensure (capped by the active pool policy)"
         required: false
         default: ""
+      boost_user:
+        description: "Maintainer whose push requested an immediate pool allocation"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -29,6 +33,10 @@ concurrency:
 
 jobs:
   scale-up:
+    # runner-boost dispatches maintainer pushes with the actor and desired capacity.
+    # Skip the duplicate workflow_run copy so it cannot replace that dispatch in the
+    # shared concurrency group's single pending slot.
+    if: github.event_name != 'workflow_run' || !contains(format(' {0} ', vars.BOOST_USERS), format(' {0} ', github.event.workflow_run.actor.login))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -41,7 +49,7 @@ jobs:
       BOOST_USERS: ${{ vars.BOOST_USERS }}
       BOOST_COUNT: ${{ vars.BOOST_COUNT }}
       BOOST_HOURS: ${{ vars.BOOST_HOURS }}
-      TRIGGER_ACTOR: ${{ github.event.workflow_run.actor.login || github.actor }}
+      TRIGGER_ACTOR: ${{ inputs.boost_user || github.event.workflow_run.actor.login || github.actor }}
       RUNNER_LABEL: dbatools-modern
       RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}
     steps:

--- a/.github/workflows/runner-scale-up.yml
+++ b/.github/workflows/runner-scale-up.yml
@@ -1,6 +1,6 @@
-# Scales the dbatools-runners VMSS up when CI jobs queue, and registers an ephemeral
-# runner on every new instance. Runs on free GitHub-hosted compute in default-branch
-# context only -- runner VMs themselves never hold Azure credentials or the PAT.
+# Manual recovery workflow that scales the dbatools-runners VMSS and registers an
+# ephemeral runner on every new instance. Normal event-driven scaling lives in
+# runner-reconcile.yml so GitHub concurrency cannot cancel one controller for another.
 #
 # The CI_RUNNER_PAT secret mints single-use registration tokens (GITHUB_TOKEN cannot).
 # Azure access is OIDC (federated credential on the dbatools-ci-github Entra app); no
@@ -8,9 +8,6 @@
 name: runner-scale-up
 
 on:
-  workflow_run:
-    workflows: ["ci-azure"]
-    types: [requested]
   workflow_dispatch:
     inputs:
       ensure:
@@ -33,10 +30,6 @@ concurrency:
 
 jobs:
   scale-up:
-    # runner-boost dispatches maintainer pushes with the actor and desired capacity.
-    # Skip the duplicate workflow_run copy so it cannot replace that dispatch in the
-    # shared concurrency group's single pending slot.
-    if: github.event_name != 'workflow_run' || !contains(format(' {0} ', vars.BOOST_USERS), format(' {0} ', github.event.workflow_run.actor.login))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -49,7 +42,7 @@ jobs:
       BOOST_USERS: ${{ vars.BOOST_USERS }}
       BOOST_COUNT: ${{ vars.BOOST_COUNT }}
       BOOST_HOURS: ${{ vars.BOOST_HOURS }}
-      TRIGGER_ACTOR: ${{ inputs.boost_user || github.event.workflow_run.actor.login || github.actor }}
+      TRIGGER_ACTOR: ${{ inputs.boost_user || github.actor }}
       RUNNER_LABEL: dbatools-modern
       RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}
     steps:
@@ -81,15 +74,8 @@ jobs:
             return "$status"
           }
 
-          # Give the triggering run a moment to materialize its jobs
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            sleep 25
-            QUEUED=$(gh_api_retry "repos/$REPO/actions/runs/${{ github.event.workflow_run.id }}/jobs?per_page=100" --paginate \
-              --jq "[.jobs[] | select(.status == \"queued\" or .status == \"waiting\") | select((.labels // []) | index(\"$RUNNER_LABEL\"))] | length")
-          else
-            QUEUED="${{ inputs.ensure }}"
-            QUEUED="${QUEUED:-0}"
-          fi
+          QUEUED="${{ inputs.ensure }}"
+          QUEUED="${QUEUED:-0}"
 
           IDLE=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate \
             --jq "[.runners[] | select(.status == \"online\" and .busy == false) | select([.labels[].name] | index(\"$RUNNER_LABEL\"))] | length")

--- a/.github/workflows/runner-scale-up.yml
+++ b/.github/workflows/runner-scale-up.yml
@@ -40,6 +40,7 @@ jobs:
       COMMUNITY_COUNT: 5
       BOOST_USERS: ${{ vars.BOOST_USERS }}
       BOOST_COUNT: ${{ vars.BOOST_COUNT }}
+      BOOST_HOURS: ${{ vars.BOOST_HOURS }}
       TRIGGER_ACTOR: ${{ github.event.workflow_run.actor.login || github.actor }}
       RUNNER_LABEL: dbatools-modern
       RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}
@@ -56,17 +57,33 @@ jobs:
         run: |
           set -euo pipefail
 
+          gh_api_retry() {
+            local attempt status
+            for attempt in 1 2 3; do
+              if gh api "$@"; then
+                return 0
+              else
+                status=$?
+              fi
+              echo "GitHub API attempt $attempt of 3 failed" >&2
+              if [ "$attempt" -lt 3 ]; then
+                sleep $((attempt * 3))
+              fi
+            done
+            return "$status"
+          }
+
           # Give the triggering run a moment to materialize its jobs
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
             sleep 25
-            QUEUED=$(gh api "repos/$REPO/actions/runs/${{ github.event.workflow_run.id }}/jobs?per_page=100" --paginate \
+            QUEUED=$(gh_api_retry "repos/$REPO/actions/runs/${{ github.event.workflow_run.id }}/jobs?per_page=100" --paginate \
               --jq "[.jobs[] | select(.status == \"queued\" or .status == \"waiting\") | select((.labels // []) | index(\"$RUNNER_LABEL\"))] | length")
           else
             QUEUED="${{ inputs.ensure }}"
             QUEUED="${QUEUED:-0}"
           fi
 
-          IDLE=$(gh api "repos/$REPO/actions/runners?per_page=100" --paginate \
+          IDLE=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate \
             --jq "[.runners[] | select(.status == \"online\" and .busy == false) | select([.labels[].name] | index(\"$RUNNER_LABEL\"))] | length")
 
           # sku.capacity is authoritative; az vm list is eventually consistent and can
@@ -78,13 +95,40 @@ jobs:
           [ "$NEED" -lt 0 ] && NEED=0
           TARGET=$(( CAPACITY + NEED ))
           POOL_LIMIT=${COMMUNITY_COUNT:-5}
-          case " $BOOST_USERS " in
-            *" $TRIGGER_ACTOR "*) POOL_LIMIT=${BOOST_COUNT:-10} ;;
-          esac
-          [ "$TARGET" -gt "$MAX_RUNNERS" ] && TARGET=$MAX_RUNNERS
+          ACTIVE_COUNT=0
+          EVENTS_AVAILABLE=true
+          EVENTS="[]"
+          if [ -n "${BOOST_USERS:-}" ]; then
+            CUTOFF=$(date -u -d "${BOOST_HOURS:-2} hours ago" +%Y-%m-%dT%H:%M:%SZ)
+            if ! EVENTS=$(gh_api_retry --paginate "repos/$REPO/events?per_page=100" 2>/dev/null); then
+              EVENTS_AVAILABLE=false
+            fi
+          fi
+          if [ "$EVENTS_AVAILABLE" = "true" ]; then
+            for BOOST_USER in $BOOST_USERS; do
+              USER_ACTIVE=false
+              if [ "$TRIGGER_ACTOR" = "$BOOST_USER" ]; then
+                USER_ACTIVE=true
+              else
+                RECENT=$(printf '%s' "$EVENTS" | jq -s --arg cutoff "$CUTOFF" --arg user "$BOOST_USER" \
+                  '[.[][] | select(.type == "PushEvent" and .created_at > $cutoff and .actor.login == $user)] | length')
+                [ "${RECENT:-0}" -gt 0 ] && USER_ACTIVE=true
+              fi
+              [ "$USER_ACTIVE" = "true" ] && ACTIVE_COUNT=$((ACTIVE_COUNT + 1))
+            done
+            if [ "$ACTIVE_COUNT" -gt 0 ]; then
+              POOL_LIMIT=$((ACTIVE_COUNT * ${BOOST_COUNT:-10}))
+            fi
+          else
+            # A transient event-feed outage must not make jobs wait or shrink a
+            # possibly active maintainer allocation.
+            POOL_LIMIT=${MAX_RUNNERS:-20}
+          fi
+          [ "$POOL_LIMIT" -gt "${MAX_RUNNERS:-20}" ] && POOL_LIMIT=${MAX_RUNNERS:-20}
+          [ "$TARGET" -gt "${MAX_RUNNERS:-20}" ] && TARGET=${MAX_RUNNERS:-20}
           [ "$TARGET" -gt "$POOL_LIMIT" ] && TARGET=$POOL_LIMIT
 
-          echo "actor=$TRIGGER_ACTOR queued=$QUEUED idle=$IDLE capacity=$CAPACITY pool_limit=$POOL_LIMIT target=$TARGET"
+          echo "actor=$TRIGGER_ACTOR active_maintainers=$ACTIVE_COUNT queued=$QUEUED idle=$IDLE capacity=$CAPACITY pool_limit=$POOL_LIMIT target=$TARGET"
           if [ "$TARGET" -gt "$CAPACITY" ]; then
             az vmss scale -g "$RG" -n "$VMSS" --new-capacity "$TARGET" --no-wait
             echo "scaled=true" >> "$GITHUB_OUTPUT"
@@ -95,7 +139,24 @@ jobs:
       - name: Register runners on unregistered instances
         run: |
           set -euo pipefail
-          curl -fsSL "$RAW_BASE/.github/runners/bootstrap-runner.ps1" -o /tmp/bootstrap-runner.ps1
+
+          gh_api_retry() {
+            local attempt status
+            for attempt in 1 2 3; do
+              if gh api "$@"; then
+                return 0
+              else
+                status=$?
+              fi
+              echo "GitHub API attempt $attempt of 3 failed" >&2
+              if [ "$attempt" -lt 3 ]; then
+                sleep $((attempt * 3))
+              fi
+            done
+            return "$status"
+          }
+
+          curl --retry 3 --retry-all-errors --retry-delay 3 -fsSL "$RAW_BASE/.github/runners/bootstrap-runner.ps1" -o /tmp/bootstrap-runner.ps1
 
           # Wait for any scale-out to finish provisioning
           for attempt in $(seq 1 20); do
@@ -108,7 +169,7 @@ jobs:
           # two sweeps: instances that finish provisioning after the first pass would
           # otherwise wait for the (often tardy) reconcile cron
           for sweep in 1 2; do
-            REGISTERED=$(gh api "repos/$REPO/actions/runners?per_page=100" --paginate --jq '[.runners[].name] | join(" ")')
+            REGISTERED=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate --jq '[.runners[].name] | join(" ")')
             VMS=$(az vm list -g "$RG" --query "[?starts_with(name, '${VMSS}_') && provisioningState == 'Succeeded'].name" -o tsv 2>/dev/null || true)
 
             MISSED=0
@@ -118,7 +179,7 @@ jobs:
               esac
               MISSED=$((MISSED + 1))
               echo "registering $VM (sweep $sweep)"
-              TOKEN=$(gh api -X POST "repos/$REPO/actions/runners/registration-token" --jq .token)
+              TOKEN=$(gh_api_retry -X POST "repos/$REPO/actions/runners/registration-token" --jq .token)
               (
                 OUT=$(az vm run-command invoke -g "$RG" -n "$VM" --command-id RunPowerShellScript \
                   --scripts @/tmp/bootstrap-runner.ps1 \

--- a/.github/workflows/runner-scale-up.yml
+++ b/.github/workflows/runner-scale-up.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       ensure:
-        description: "Minimum instance count to ensure (defaults to standby floor logic)"
+        description: "Minimum instance count to ensure (capped by the active pool policy)"
         required: false
         default: ""
 
@@ -37,6 +37,10 @@ jobs:
       RG: ${{ vars.CI_AZURE_RG }}
       VMSS: ${{ vars.CI_VMSS_NAME }}
       MAX_RUNNERS: ${{ vars.MAX_RUNNERS }}
+      COMMUNITY_COUNT: 5
+      BOOST_USERS: ${{ vars.BOOST_USERS }}
+      BOOST_COUNT: ${{ vars.BOOST_COUNT }}
+      TRIGGER_ACTOR: ${{ github.event.workflow_run.actor.login || github.actor }}
       RUNNER_LABEL: dbatools-modern
       RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}
     steps:
@@ -73,9 +77,14 @@ jobs:
           NEED=$(( QUEUED - IDLE ))
           [ "$NEED" -lt 0 ] && NEED=0
           TARGET=$(( CAPACITY + NEED ))
+          POOL_LIMIT=${COMMUNITY_COUNT:-5}
+          case " $BOOST_USERS " in
+            *" $TRIGGER_ACTOR "*) POOL_LIMIT=${BOOST_COUNT:-10} ;;
+          esac
           [ "$TARGET" -gt "$MAX_RUNNERS" ] && TARGET=$MAX_RUNNERS
+          [ "$TARGET" -gt "$POOL_LIMIT" ] && TARGET=$POOL_LIMIT
 
-          echo "queued=$QUEUED idle=$IDLE capacity=$CAPACITY target=$TARGET"
+          echo "actor=$TRIGGER_ACTOR queued=$QUEUED idle=$IDLE capacity=$CAPACITY pool_limit=$POOL_LIMIT target=$TARGET"
           if [ "$TARGET" -gt "$CAPACITY" ]; then
             az vmss scale -g "$RG" -n "$VMSS" --new-capacity "$TARGET" --no-wait
             echo "scaled=true" >> "$GITHUB_OUTPUT"
@@ -124,5 +133,7 @@ jobs:
             done
             wait
             echo "registration sweep $sweep complete ($MISSED handled)"
-            [ "$sweep" = "1" ] && sleep 90
+            if [ "$sweep" = "1" ]; then
+              sleep 90
+            fi
           done

--- a/tests/appveyor.SQL2017.ps1
+++ b/tests/appveyor.SQL2017.ps1
@@ -21,7 +21,7 @@ Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE CRYPTOGRAPHIC PROVIDER 
 Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE MASTER KEY ENCRYPTION BY PASSWORD = '<StrongPassword>'" -EnableException
 
 $loginName = "$env:COMPUTERNAME\$env:USERNAME"
-$login = Get-DbaLogin -SqlInstance $sqlinstance -Login $loginName
+$login = Get-AppveyorLoginWithRetry -SqlInstance $sqlinstance -Login $loginName
 if (-not $login) {
     Write-Host -Object "$indent Creating login $env:COMPUTERNAME\$env:USERNAME on $instance" -ForegroundColor DarkGreen
     $null = New-DbaLogin -SqlInstance $sqlinstance -Name $loginName -EnableException

--- a/tests/appveyor.SQL2019.ps1
+++ b/tests/appveyor.SQL2019.ps1
@@ -23,7 +23,7 @@ Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE MASTER KEY ENCRYPTION B
 Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE CERTIFICATE dbatoolsci_AGCert WITH SUBJECT = 'AG Certificate'" -EnableException
 
 $loginName = "$env:COMPUTERNAME\$env:USERNAME"
-$login = Get-DbaLogin -SqlInstance $sqlinstance -Login $loginName
+$login = Get-AppveyorLoginWithRetry -SqlInstance $sqlinstance -Login $loginName
 if (-not $login) {
     Write-Host -Object "$indent Creating login $env:COMPUTERNAME\$env:USERNAME on $instance" -ForegroundColor DarkGreen
     $null = New-DbaLogin -SqlInstance $sqlinstance -Name $loginName -EnableException

--- a/tests/appveyor.SQL2022.ps1
+++ b/tests/appveyor.SQL2022.ps1
@@ -23,7 +23,7 @@ Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE MASTER KEY ENCRYPTION B
 Invoke-DbaQuery -SqlInstance $sqlinstance -Query "CREATE CERTIFICATE dbatoolsci_AGCert WITH SUBJECT = 'AG Certificate'" -EnableException
 
 $loginName = "$env:COMPUTERNAME\$env:USERNAME"
-$login = Get-DbaLogin -SqlInstance $sqlinstance -Login $loginName
+$login = Get-AppveyorLoginWithRetry -SqlInstance $sqlinstance -Login $loginName
 if (-not $login) {
     Write-Host -Object "$indent Creating login $env:COMPUTERNAME\$env:USERNAME on $instance" -ForegroundColor DarkGreen
     $null = New-DbaLogin -SqlInstance $sqlinstance -Name $loginName -EnableException

--- a/tests/appveyor.sqlserver.ps1
+++ b/tests/appveyor.sqlserver.ps1
@@ -1,4 +1,34 @@
 Write-Host -Object "appveyor.sqlserver: Setting up instances for scenario $($env:SCENARIO)" -ForegroundColor DarkGreen
+
+function Get-AppveyorLoginWithRetry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$SqlInstance,
+        [Parameter(Mandatory)]
+        [string]$Login,
+        [ValidateRange(1, 10)]
+        [int]$MaxAttempts = 3
+    )
+
+    $loginParams = @{
+        SqlInstance     = $SqlInstance
+        Login           = $Login
+        EnableException = $true
+    }
+    foreach ($attempt in 1..$MaxAttempts) {
+        try {
+            return Get-DbaLogin @loginParams
+        } catch {
+            if ($attempt -eq $MaxAttempts) {
+                throw
+            }
+            Write-Warning "Get-DbaLogin attempt $attempt of $MaxAttempts failed for $SqlInstance; retrying. $($PSItem.Exception.Message)"
+            Start-Sleep -Seconds (5 * $attempt)
+        }
+    }
+}
+
 $instances = @( )
 if ($env:InstanceSingle) {
     $instances += $env:InstanceSingle


### PR DESCRIPTION
Supersedes #10421 after restarting from the current `development` tip.

## What changed

- Keep five shared hot runners for community CI.
- Give each active maintainer an independent ten-runner allocation for two hours: 10 when either `potatoqualitee` or `andreasjordan` is active, 20 when both are active.
- Use `runner-reconcile` as the single event-driven fleet controller for CI requests, completion cleanup, maintainer nudges, and the hourly backstop.
- Keep `runner-scale-up` as a manual recovery workflow.
- Retry transient GitHub API reads/token creation and bootstrap downloads before failing.
- Retry the harmless `Get-DbaLogin` readiness probe after SQL startup instead of rerunning non-idempotent instance setup.
- Move the DarlingData integration assertion from the Linux test file to the Windows PowerShell 7 test file.
- Fix the false-red registration sweep where a successful second pass ended with shell status 1.
- Align the independent Azure Automation janitor with the five/ten/twenty policy.

The live repository variables are now `BOOST_USERS=potatoqualitee andreasjordan`, `BOOST_COUNT=10`, `BOOST_HOURS=2`, and `MAX_RUNNERS=20`.

## Root causes

1. `runner-scale-up` and `runner-reconcile` shared one concurrency group but were launched together. GitHub permits only one pending run in a group, so janitor/completion nudges repeatedly cancelled scale-up before it created a job. A single event-driven controller removes that starvation path.
2. The scale-up registration loop ended with `[ "$sweep" = "1" ] && sleep 90`; sweep two returned 1 under `set -e` after otherwise successful work.
3. The linked COPY failure was a transient SQL Server named-pipe drop during `Get-DbaLogin`.
4. The Gallery Linux failure came from DarlingData's temporary download ZIP disappearing; that assertion now runs on Windows instead.

## Validation

- actionlint 1.7.12 and YAML parsing on changed workflows
- PowerShell parser on all changed scripts
- policy simulation proves 5 / 10 / 20 and independent two-hour expiry
- exact username matching rejects substring lookalikes
- DarlingData reference exists only in the Windows integration test file
- live repository variable verification and exact local/remote Git tree comparisons

## Operational note

After merge, redeploy `.github/runners/janitor-runbook.ps1` to the Azure Automation `Remove-RunawayRunner` runbook.