### PR TITLE
Find-DbaAgentJob - Add regex Pattern filtering

### DIFF
--- a/private/functions/Get-JobList.ps1
+++ b/private/functions/Get-JobList.ps1
@@ -84,7 +84,7 @@ function Get-JobList {
                     } else {
                         $stepFound = $job.JobSteps | Where-Object Name -Like $sFilter
                     }
-                    if ($stepFound.Count -gt 0) {
+                    if ($stepFound) {
                         $job
                     }
                 }

--- a/private/functions/Get-JobList.ps1
+++ b/private/functions/Get-JobList.ps1
@@ -72,45 +72,20 @@ function Get-JobList {
 
             foreach ($job in $jobs) {
                 foreach ($jFilter in $JobFilter) {
-                    if ($jFilter -match '`*') {
-                        if ($Not) {
-                            $job | Where-Object Name -NotLike $jFilter
-                        } else {
-                            $job | Where-Object Name -Like $jFilter
-                        }
+                    if ($Not) {
+                        $job | Where-Object Name -NotLike $jFilter
                     } else {
-                        if ($Not) {
-                            $job | Where-Object Name -NE $jFilter
-                        } else {
-                            $job | Where-Object Name -EQ $jFilter
-                        }
+                        $job | Where-Object Name -Like $jFilter
                     }
                 }
                 foreach ($sFilter in $StepFilter) {
-                    if ($sFilter -match '`*') {
-                        if ($Not) {
-                            $stepFound = $job.JobSteps | Where-Object Name -NotLike $sFilter
-                            if ($stepFound.Count -gt 0) {
-                                $job
-                            }
-                        } else {
-                            $stepFound = $job.JobSteps | Where-Object Name -Like $sFilter
-                            if ($stepFound.Count -gt 0) {
-                                $job
-                            }
-                        }
+                    if ($Not) {
+                        $stepFound = $job.JobSteps | Where-Object Name -NotLike $sFilter
                     } else {
-                        if ($Not) {
-                            $stepFound = $job.JobSteps | Where-Object Name -NE $sFilter
-                            if ($stepFound.Count -gt 0) {
-                                $job
-                            }
-                        } else {
-                            $stepFound = $job.JobSteps | Where-Object Name -EQ $sFilter
-                            if ($stepFound.Count -gt 0) {
-                                $job
-                            }
-                        }
+                        $stepFound = $job.JobSteps | Where-Object Name -Like $sFilter
+                    }
+                    if ($stepFound.Count -gt 0) {
+                        $job
                     }
                 }
             }

--- a/public/Find-DbaAgentJob.ps1
+++ b/public/Find-DbaAgentJob.ps1
@@ -30,6 +30,10 @@ function Find-DbaAgentJob {
         Supports wildcards to find jobs with steps like *backup*, *index*, or *cleanup*.
         Helpful when troubleshooting issues in multi-step jobs or finding jobs that perform specific operations.
 
+    .PARAMETER Pattern
+        Filters job names using one or more regular expressions. Multiple patterns use OR semantics.
+        Combine this with JobName or StepName to further narrow those results.
+
     .PARAMETER LastUsed
         Finds jobs that haven't executed successfully in the specified number of days.
         Use this to identify stale or potentially broken jobs that may need attention.
@@ -142,6 +146,11 @@ function Find-DbaAgentJob {
         Returns all agent job(s) that are named exactly Mybackup
 
     .EXAMPLE
+        PS C:\> Find-DbaAgentJob -SqlInstance Dev01 -Pattern "^(Backup|Restore)-\d{4}$"
+
+        Returns jobs whose names match the supplied regular expression.
+
+    .EXAMPLE
         PS C:\> Find-DbaAgentJob -SqlInstance Dev01 -LastUsed 10
 
         Returns all agent job(s) that have not ran in 10 days
@@ -189,9 +198,12 @@ function Find-DbaAgentJob {
         [PSCredential]
         $SqlCredential,
         [Alias("Name")]
+        [SupportsWildcards()]
         [string[]]$JobName,
         [string[]]$ExcludeJobName,
+        [SupportsWildcards()]
         [string[]]$StepName,
+        [string[]]$Pattern,
         [int]$LastUsed,
         [Alias("Disabled")]
         [switch]$IsDisabled,
@@ -207,7 +219,7 @@ function Find-DbaAgentJob {
         [switch]$EnableException
     )
     begin {
-        if ($IsFailed, [boolean]$JobName, [boolean]$StepName, [boolean]$LastUsed.ToString(), $IsDisabled, $IsNotScheduled, $IsNoEmailNotification, [boolean]$Category, [boolean]$Owner, [boolean]$ExcludeJobName -notcontains $true) {
+        if ($IsFailed, [boolean]$JobName, [boolean]$StepName, [boolean]$Pattern, [boolean]$LastUsed.ToString(), $IsDisabled, $IsNotScheduled, $IsNoEmailNotification, [boolean]$Category, [boolean]$Owner, [boolean]$ExcludeJobName -notcontains $true) {
             Stop-Function -Message "At least one search term must be specified"
         }
     }
@@ -240,6 +252,19 @@ function Find-DbaAgentJob {
             if ( -not ($JobName -or $StepName)) {
                 Write-Message -Level Verbose -Message "Retrieving all jobs"
                 $jobs = Get-JobList -SqlInstance $server
+                $output = $jobs
+            }
+
+            if ($Pattern) {
+                Write-Message -Level Verbose -Message "Filtering job names by regular expression pattern."
+                $jobs = foreach ($job in $jobs) {
+                    foreach ($regexPattern in $Pattern) {
+                        if ($job.Name -match $regexPattern) {
+                            $job
+                            break
+                        }
+                    }
+                }
                 $output = $jobs
             }
 

--- a/tests/Find-DbaAgentJob.Tests.ps1
+++ b/tests/Find-DbaAgentJob.Tests.ps1
@@ -16,6 +16,7 @@ Describe $CommandName -Tag UnitTests {
                 "JobName",
                 "ExcludeJobName",
                 "StepName",
+                "Pattern",
                 "LastUsed",
                 "IsDisabled",
                 "IsFailed",
@@ -27,6 +28,81 @@ Describe $CommandName -Tag UnitTests {
                 "EnableException"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Wildcard filtering" {
+        InModuleScope dbatools {
+            BeforeAll {
+                $script:agentJobs = @(
+                    [PSCustomObject]@{ Name = "Backup1Nightly"; JobSteps = @([PSCustomObject]@{ Name = "LoadData" }) }
+                    [PSCustomObject]@{ Name = "Backup2Nightly"; JobSteps = @([PSCustomObject]@{ Name = "LoadMeta" }) }
+                    [PSCustomObject]@{ Name = "ETL1"; JobSteps = @([PSCustomObject]@{ Name = "Extract" }) }
+                    [PSCustomObject]@{ Name = "ETL2"; JobSteps = @([PSCustomObject]@{ Name = "LoadData" }) }
+                    [PSCustomObject]@{ Name = "Literal*Job"; JobSteps = @([PSCustomObject]@{ Name = "Literal*Step" }) }
+                    [PSCustomObject]@{ Name = "LiteralXJob"; JobSteps = @([PSCustomObject]@{ Name = "LiteralXStep" }) }
+                )
+                $script:agentServer = [PSCustomObject]@{
+                    ComputerName       = "sql1"
+                    ServiceName        = "MSSQLSERVER"
+                    DomainInstanceName = "sql1"
+                    JobServer          = [PSCustomObject]@{ Jobs = $script:agentJobs }
+                }
+                Mock Connect-DbaInstance { $script:agentServer }
+            }
+
+            It "supports question-mark and character-class job wildcards" {
+                (Get-JobList -SqlInstance "sql1" -JobFilter "Backup?Nightly").Name | Should -Be @("Backup1Nightly", "Backup2Nightly")
+                (Get-JobList -SqlInstance "sql1" -JobFilter "ETL[12]").Name | Should -Be @("ETL1", "ETL2")
+            }
+
+            It "supports escaped literal asterisks and step wildcards" {
+                $escapedJobName = [System.Management.Automation.WildcardPattern]::Escape("Literal*Job")
+
+                (Get-JobList -SqlInstance "sql1" -JobFilter $escapedJobName).Name | Should -Be "Literal*Job"
+                (Get-JobList -SqlInstance "sql1" -StepFilter "Load?ata").Name | Should -Be @("Backup1Nightly", "ETL2")
+            }
+        }
+    }
+
+    Context "Public name filters" {
+        InModuleScope dbatools {
+            BeforeEach {
+                $script:publicAgentJobs = foreach ($publicAgentJobName in "Backup1Nightly", "Backup2Nightly", "ETL1", "ETL2", "Literal*Job", "LiteralXJob") {
+                    $publicAgentJob = New-Object Microsoft.SqlServer.Management.Smo.Agent.Job
+                    $publicAgentJob.Name = $publicAgentJobName
+                    $publicAgentJob
+                }
+                $script:publicAgentServer = [DbaInstanceParameter]"sql1"
+                $script:publicAgentServer | Add-Member -Force -MemberType NoteProperty -Name ComputerName -Value "sql1"
+                $script:publicAgentServer | Add-Member -Force -MemberType NoteProperty -Name ServiceName -Value "MSSQLSERVER"
+                $script:publicAgentServer | Add-Member -Force -MemberType NoteProperty -Name DomainInstanceName -Value "sql1"
+
+                Mock Connect-DbaInstance { $script:publicAgentServer }
+                Mock Get-JobList { $script:publicAgentJobs }
+                Mock Select-DefaultView { $InputObject }
+            }
+
+            It "marks JobName and StepName as wildcard-capable" {
+                $command = Get-Command Find-DbaAgentJob
+
+                @($command.Parameters["JobName"].Attributes | Where-Object { $PSItem -is [System.Management.Automation.SupportsWildcardsAttribute] }) | Should -HaveCount 1
+                @($command.Parameters["StepName"].Attributes | Where-Object { $PSItem -is [System.Management.Automation.SupportsWildcardsAttribute] }) | Should -HaveCount 1
+            }
+
+            It "matches job names with regex Pattern OR semantics" {
+                $results = Find-DbaAgentJob -SqlInstance "sql1" -Pattern "^Backup\dNightly$", "^ETL2$"
+
+                $results.Name | Should -Be @("Backup1Nightly", "Backup2Nightly", "ETL2")
+            }
+
+            It "narrows JobName results by Pattern and keeps ExcludeJobName exact" {
+                Mock Get-JobList { $script:publicAgentJobs | Where-Object Name -Like "Literal*" }
+
+                $results = Find-DbaAgentJob -SqlInstance "sql1" -JobName "Literal*" -Pattern "^Literal.*Job$" -ExcludeJobName "Literal*Job"
+
+                $results.Name | Should -Be "LiteralXJob"
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- remove unreachable equality branches while preserving `Get-JobList`'s effective wildcard behavior
- mark `JobName` and `StepName` as wildcard-capable
- add regex `Pattern` filtering with OR semantics, combinable with existing name/step filters
- keep `ExcludeJobName` as an exact match

## Root cause

The helper tested wildcard presence with a regex that matches every string, so it always used `-Like`/`-NotLike` and left misleading dead branches. The approved issue design also requested regex job-name matching.

## Validation

- `tests/Find-DbaAgentJob.Tests.ps1`: 6 unit tests passed, 0 failed (Pester 5.7.1)
- coverage includes `?`, character classes, escaped literal `*`, step wildcards, regex OR semantics, metadata, and exact exclusion
- PSScriptAnalyzer 1.18.2: no findings for both changed functions
- `git diff --check origin/development...HEAD`

## Review status

Claude Opus/high review completed after merge with `VERDICT: CLEAN`.

Closes #9600