### PR TITLE
Implement AppVeyor-style Azure runner pools

### DIFF
--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -2,8 +2,9 @@
 
 Replaces AppVeyor with disposable Azure VMs: every job runs on a factory-fresh
 ephemeral VM booted from a golden image with SQL Server preinstalled, registered as a
-single-use GitHub runner, and deleted afterwards. Five shared runners stay hot for
-community CI; each active maintainer gets ten runners for two hours (up to twenty).
+single-use GitHub runner, and deleted afterwards. Activity heats three independent
+AppVeyor-style lanes for two hours: ten runners each for `potatoqualitee` and
+`andreasjordan`, plus five shared community runners. With no activity, capacity is zero.
 
 ```
 GitHub (public repo)                          Azure (eastus)
@@ -18,14 +19,15 @@ GitHub (public repo)                          Azure (eastus)
 
 | Thing | Value |
 |---|---|
-| Runner label | `dbatools-modern` (`runs-on: [self-hosted, dbatools-modern]`) |
+| Runner labels | Base `dbatools-modern` plus exactly one pool label: `dbatools-pool-potatoqualitee`, `dbatools-pool-andreasjordan`, or `dbatools-pool-community` |
 | Golden image | `dbatoolsGallery/dbatools-modern-image` — Server 2022, SQL 2017/2019/2022 Developer (instances `SQL2017/SQL2019/SQL2022`, ports 14334/14335/14336, Manual start, mixed auth sa=AppVeyor convention) |
 | Legacy image | `dbatoolsGallery/dbatools-golden-image` v1.0.0 — Server 2012, PS 3.0, SQL 2008R2/2012/2014/2016/2017 (used by nightly `ps3-smoke.yml`, runnerless); v2.0.0 adds WMF 5.1 (PS 5.1) for a future legacy runner pool |
 | Runner execution | **interactive autologon session** as local admin `appveyor` (AppVeyor parity: BITS transfers, `$env:USERNAME`, `C:\Users\appveyor\Documents\DbatoolsExport`); bootstrap registers the ephemeral runner, arms autologon + a logon task, reboots |
 | Instance parity knobs | firewall off, `LocalAccountTokenFilterPolicy=1`, pagefile setting on D:, `@@SERVERNAME` repaired per job (all NSG-shielded) |
 | Harness | untouched `tests/appveyor.*.ps1` via `tests/gha.shim.ps1` (`APPVEYOR=True` drives Get-TestConfig) |
-| Scaling controls | fixed five-runner community pool; repo variable `MAX_RUNNERS` remains the hard VMSS ceiling |
-| Maintainer boost | repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS` — each listed user with a push in the trailing window contributes `BOOST_COUNT` runners, so two active maintainers get twenty total; `runner-boost.yml` nudges the single reconcile controller so fleet runs cannot cancel a separate scale-up controller |
+| Scaling controls | Each lane heats on a commit or queued build and cools to zero after `BOOST_HOURS`; repo variable `MAX_RUNNERS=25` is the hard VMSS ceiling |
+| Build queue | Workflow concurrency uses `queue: max`: one matrix build per lane consumes that lane's workers while later builds wait FIFO, matching AppVeyor account concurrency |
+| Pool sizes | Repo variables `BOOST_USERS` / `BOOST_COUNT` / `BOOST_HOURS`; maintainers receive ten dedicated workers each and non-maintainers share five |
 | Azure auth | OIDC only — Entra app `dbatools-ci-github`, federated for the default branch, custom role `dbatools-ci-operator` scoped to RG `dbatools-ci` |
 | Runner registration | `CI_RUNNER_PAT` secret mints single-use tokens; tokens are never stored on VMs |
 
@@ -54,8 +56,8 @@ pwsh .github/runners/debug.ps1 -Action tail-runner -InstanceName dbatools-runner
 pwsh .github/runners/debug.ps1 -Action tail-sql    -InstanceName dbatools-runners_xxxxxx
 pwsh .github/runners/debug.ps1 -Action run -InstanceName dbatools-runners_xxxxxx -Script "Get-Service MSSQL*"
 
-# force capacity now (reconcile enforces the floor within 10 minutes anyway)
-gh workflow run runner-scale-up.yml -f ensure=3
+# manually reconcile now, optionally heating one maintainer lane immediately
+gh workflow run runner-scale-up.yml -f boost_user=potatoqualitee
 
 # rebuild the modern golden image (new SQL CU, new tooling, or adding sql2025)
 pwsh .github/runners/build-modern-image.ps1 -ImageVersion 1.0.1 -Branch development
@@ -68,39 +70,41 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
 
 ## How a CI run flows
 
-1. Push/PR triggers `ci-azure.yml` → 10 matrix jobs queue on label `dbatools-modern`.
-2. `runner-reconcile.yml` reacts to the requested CI run, raises VMSS capacity (cap
-   `MAX_RUNNERS`), and registers an ephemeral runner on every new instance via
+1. Push/PR triggers `ci-azure.yml`; its build waits in the actor's FIFO concurrency
+   lane, then its matrix queues on that lane's pool-specific runner label.
+2. `runner-reconcile.yml` reacts to the requested CI run, raises that logical pool to
+   five or ten workers (total cap `MAX_RUNNERS=25`), tags each Flexible VMSS instance
+   with its pool, and registers an ephemeral runner on every new instance via
    `az vm run-command` + `bootstrap-runner.ps1` (which then reboots the VM into the
    appveyor autologon session where run.cmd picks up the job). `runner-scale-up.yml`
    remains as a manual recovery tool.
 3. Each job: sync repo at `C:\github\dbatools` → CRLF tests → one PowerShell session
    runs prep → instance setup (`appveyor.SQL*.ps1` set static ports, start services,
    EKM/HADR/master key) → `@@SERVERNAME` repair → Pester 6 → finalize → post.
-4. After the job the ephemeral runner unregisters; `runner-reconcile.yml` deletes the
-   spent instance and tops the fleet back up to the active pool size (five shared,
-   ten for one active maintainer, or twenty while both are active).
+4. Every matrix job nudges reconcile as it finishes. The ephemeral runner unregisters,
+   its spent VM is deleted, and a pristine replacement restores that lane's hot size.
+   A lane cools to zero two hours after its last commit once no build remains queued.
 
 ## Cost guardrails
 
 - Budget `dbatools-ci-budget`: $600/month on RG `dbatools-ci`, email at 50/80/100%.
 - Dead-runner cleanup: reconcile deletes never-registered and offline instances;
   healthy online hot-pool runners are not evicted merely because of age.
-- Community CI keeps five shared runners hot so jobs do not wait for VM provisioning.
-- Every maintainer has an independent `BOOST_HOURS` window worth `BOOST_COUNT`
-  runners; the pool is ten with one active maintainer and twenty with both.
+- Community activity heats a five-runner shared lane for `BOOST_HOURS`; it is zero
+  during inactive weeks. Each maintainer independently heats ten dedicated runners.
+- Maximum capacity is 25 only when both maintainers and community are active together;
+  otherwise the VMSS scales to the sum of the active lanes, including zero.
 - Weekly month-to-date spend lands on the "CI cost tracker" issue (Mondays).
 - Ephemeral OS disks cost nothing; the only storage bill is the gallery replicas.
 - Dead man's switch (last ditch): Azure Automation account `dbatools-ci-janitor`
   runs the `Remove-RunawayRunner` runbook every 6 hours, entirely independent
   of GitHub Actions (source: `janitor-runbook.ps1`, deployed manually). It always
-  preserves the desired five/ten/twenty-runner pool. Excess runners older than 2h
-  are deleted; if GitHub is unreachable, conservative age caps apply only above
-  the five-runner baseline. ps3smoke VMs past 2h and orphaned CI NICs/public IPs
+  preserves the desired 0/5/10/15/20/25-runner total. Excess runners older than 2h
+  are deleted; if GitHub is unreachable, conservative age caps apply to all capacity.
+  ps3smoke VMs past 2h and orphaned CI NICs/public IPs
   die in every mode. Its managed identity holds
   only the `dbatools-ci-operator` role on RG `dbatools-ci` -- no storage, no
-  other resource groups. The five-runner baseline is intentional all-day spend;
-  the switch caps runaway capacity above it.
+  other resource groups. There is no all-day baseline; the switch caps runaway cost.
 
 ## Phase 0 gate results (2026-07-10)
 

--- a/.github/runners/janitor-runbook.ps1
+++ b/.github/runners/janitor-runbook.ps1
@@ -7,19 +7,18 @@
     runbook: Remove-RunawayRunner), entirely independent of GitHub Actions.
     This is the LAST-DITCH kill switch: the GitHub-side janitor
     (runner-reconcile.yml) owns normal fleet lifecycle; this backstop exists so
-    capacity above the intentional five-runner baseline cannot idle all day on
-    a wedged dispatch chain.
+    hot capacity cannot idle all day on a wedged dispatch chain.
 
     The kill rule is keyed to maintainer activity, not the clock:
 
-      - STALE (no push by a maintainer in the last 2 hours, checked through the
-        anonymous GitHub events API): the five newest community-pool runners are
-        preserved and excess runners older than 2 hours are deleted.
-      - ACTIVE (maintainer push within 2 hours): ten runners are preserved for
-        each active maintainer; excess runners older than 2 hours are deleted.
+      - STALE (no push in the last 2 hours, checked through the anonymous GitHub
+        events API): no runner capacity is preserved; runners older than 2 hours
+        are deleted.
+      - ACTIVE: ten runners are preserved for each active maintainer and five
+        for recent non-maintainer activity; excess runners older than 2 hours die.
       - GITHUB UNREACHABLE: we cannot know activity, so conservative age caps
-        apply to capacity above the preserved five-runner community pool -- 3
-        hours on nights and weekends, 13 hours on weekday daytime (06-17 UTC).
+        apply to all capacity -- 3 hours on nights and weekends, 13 hours on
+        weekday daytime (06-17 UTC).
 
     Always, regardless of mode:
       - ps3smoke-* VMs older than 2 hours are deleted (nightly job caps at 55m).
@@ -47,10 +46,11 @@ $communityPoolSize = 5
 $maintainerPoolSize = 10
 $utcNow = (Get-Date).ToUniversalTime()
 
-# ---- how long since the last maintainer push? (anonymous API, public repo) ----
+# ---- recent pool activity (anonymous API, public repo) -------------------------
 $mode = "github-unreachable"
 $lastPushAgeHours = $null
 $activeMaintainers = @( )
+$communityActive = $false
 try {
     $splatEvents = @{
         Uri        = "https://api.github.com/repos/$repo/events?per_page=100"
@@ -70,7 +70,10 @@ try {
             Start-Sleep -Seconds (3 * $attempt)
         }
     }
-    $pushes = @($events | Where-Object { $PSItem.type -eq "PushEvent" -and $PSItem.actor.login -in $maintainers })
+    $pushes = @($events | Where-Object {
+            $PSItem.type -eq "PushEvent" -or
+            ($PSItem.type -eq "PullRequestEvent" -and $PSItem.payload.action -in @("opened", "reopened", "synchronize"))
+        })
     if ($pushes) {
         $lastPush = ($pushes | ForEach-Object { ([datetime]::Parse($PSItem.created_at)).ToUniversalTime() } | Sort-Object -Descending)[0]
         $lastPushAgeHours = ($utcNow - $lastPush).TotalHours
@@ -84,28 +87,33 @@ try {
                 $activeMaintainers += $maintainer
             }
         }
-        if ($activeMaintainers.Count -gt 0) {
+        $communityPushes = @($pushes | Where-Object { $PSItem.actor.login -notin $maintainers })
+        if ($communityPushes) {
+            $latestCommunityPush = ($communityPushes | ForEach-Object { ([datetime]::Parse($PSItem.created_at)).ToUniversalTime() } | Sort-Object -Descending)[0]
+            $communityActive = ($utcNow - $latestCommunityPush).TotalHours -le $activityWindowHours
+        }
+        if ($activeMaintainers.Count -gt 0 -or $communityActive) {
             $mode = "active"
         } else {
             $mode = "stale"
         }
     } else {
-        # no maintainer push within the last ~100 repo events: definitely stale
+        # no push within the last ~100 repo events: definitely stale
         $mode = "stale"
     }
 } catch {
     Write-Warning "GitHub activity check failed ($($PSItem.Exception.Message)) -- falling back to age caps"
 }
 
-$desiredPoolSize = $communityPoolSize
-if ($activeMaintainers.Count -gt 0) {
-    $desiredPoolSize = $activeMaintainers.Count * $maintainerPoolSize
+$desiredPoolSize = ($activeMaintainers.Count * $maintainerPoolSize)
+if ($communityActive) {
+    $desiredPoolSize += $communityPoolSize
 }
 
 switch ($mode) {
     "active" {
         $runnerMaxHours = 2
-        Write-Output "mode=active: $($activeMaintainers.Count) maintainer(s) [$($activeMaintainers -join ', ')] -- preserving $desiredPoolSize runners; excess runners past ${runnerMaxHours}h die"
+        Write-Output "mode=active: maintainers=[$($activeMaintainers -join ', ')] community=$communityActive -- preserving $desiredPoolSize runners; excess runners past ${runnerMaxHours}h die"
     }
     "stale" {
         $runnerMaxHours = 2
@@ -113,7 +121,7 @@ switch ($mode) {
         if ($null -ne $lastPushAgeHours) {
             $ageText = "$([math]::Round($lastPushAgeHours, 1))h ago"
         }
-        Write-Output "mode=stale: last maintainer push $ageText -- excess runners past ${runnerMaxHours}h die; five newest are preserved"
+        Write-Output "mode=stale: last push $ageText -- no capacity preserved; runners past ${runnerMaxHours}h die"
     }
     default {
         $isWeekend = $utcNow.DayOfWeek -in @([DayOfWeek]::Saturday, [DayOfWeek]::Sunday)
@@ -191,8 +199,8 @@ foreach ($pip in Get-AzPublicIpAddress -ResourceGroupName $rg) {
 }
 
 $vmss = Get-AzVmss -ResourceGroupName $rg -VMScaleSetName "dbatools-runners" -ErrorAction SilentlyContinue
-if ($vmss -and $vmss.Sku.Capacity -gt 22) {
-    Write-Warning "VMSS capacity is $($vmss.Sku.Capacity) -- above any sane fleet size (MAX_RUNNERS is 20)"
+if ($vmss -and $vmss.Sku.Capacity -gt 27) {
+    Write-Warning "VMSS capacity is $($vmss.Sku.Capacity) -- above any sane fleet size (MAX_RUNNERS is 25)"
 }
 
 if ($deleted -gt 0) {

--- a/.github/runners/reconcile-runner-fleet.ps1
+++ b/.github/runners/reconcile-runner-fleet.ps1
@@ -1,0 +1,414 @@
+<#
+.SYNOPSIS
+    Reconciles the AppVeyor-style GitHub Actions worker pools on the Azure VMSS.
+
+.DESCRIPTION
+    Maintains three logical pools on one Flexible VMSS. Individual VMs retain their
+    pool assignment in the runnerPool tag and register with a matching GitHub runner
+    label. Runner agents are ephemeral; a VM is deleted after its single job and its
+    pool slot is replaced from the golden image.
+
+    External control-plane calls are retried three times. Exhausted control-plane
+    failures throw TransientFleetException so the workflow can bail out green without
+    making scaling decisions from incomplete state. Logic errors still fail normally.
+#>
+
+class TransientFleetException : System.Exception {
+    TransientFleetException([string]$message) : base($message) { }
+}
+
+$ErrorActionPreference = "Stop"
+$repo = $env:REPO
+$resourceGroup = $env:RG
+$vmss = $env:VMSS
+$runnerLabel = $env:RUNNER_LABEL
+$poolLabelPrefix = "dbatools-pool-"
+$communityCount = if ($env:COMMUNITY_COUNT) { [int]$env:COMMUNITY_COUNT } else { 5 }
+$maintainerCount = if ($env:BOOST_COUNT) { [int]$env:BOOST_COUNT } else { 10 }
+$boostHours = if ($env:BOOST_HOURS) { [int]$env:BOOST_HOURS } else { 2 }
+$maxRunners = if ($env:MAX_RUNNERS) { [int]$env:MAX_RUNNERS } else { 25 }
+$maintainers = @($env:BOOST_USERS -split "\s+" | Where-Object { $PSItem })
+$bootstrapPath = $env:BOOTSTRAP_PATH
+$deletedVms = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+$missingSettings = @(
+    @{ Name = "REPO"; Value = $repo }, @{ Name = "RG"; Value = $resourceGroup },
+    @{ Name = "VMSS"; Value = $vmss }, @{ Name = "RUNNER_LABEL"; Value = $runnerLabel },
+    @{ Name = "BOOTSTRAP_PATH"; Value = $bootstrapPath }
+    | Where-Object { -not $PSItem.Value } | ForEach-Object Name
+)
+if ($missingSettings) {
+    throw "Missing required fleet settings: $($missingSettings -join ', ')"
+}
+
+function Invoke-WithRetry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Operation,
+        [Parameter(Mandatory)]
+        [scriptblock]$Action
+    )
+
+    foreach ($attempt in 1..3) {
+        try {
+            return & $Action
+        } catch {
+            if ($attempt -eq 3) {
+                throw [TransientFleetException]::new("$Operation failed after 3 attempts. $($PSItem.Exception.Message)")
+            }
+            Write-Warning "$Operation attempt $attempt of 3 failed; retrying. $($PSItem.Exception.Message)"
+            Start-Sleep -Seconds (3 * $attempt)
+        }
+    }
+}
+
+function Invoke-NativeText {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Tool,
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory)]
+        [string]$Operation
+    )
+
+    Invoke-WithRetry -Operation $Operation -Action {
+        $output = @(& $Tool @Arguments 2>&1)
+        if ($LASTEXITCODE -ne 0) {
+            throw ($output -join [Environment]::NewLine)
+        }
+        $output -join [Environment]::NewLine
+    }
+}
+
+function Invoke-NativeJson {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Tool,
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory)]
+        [string]$Operation
+    )
+
+    $text = Invoke-NativeText -Tool $Tool -Arguments $Arguments -Operation $Operation
+    if (-not $text) {
+        return $null
+    }
+    $text | ConvertFrom-Json -Depth 20
+}
+
+function Invoke-GhJson {
+    param([string[]]$Arguments, [string]$Operation)
+    Invoke-NativeJson -Tool "gh" -Arguments (@("api") + $Arguments) -Operation $Operation
+}
+
+function Invoke-AzJson {
+    param([string[]]$Arguments, [string]$Operation)
+    Invoke-NativeJson -Tool "az" -Arguments ($Arguments + @("--only-show-errors", "--output", "json")) -Operation $Operation
+}
+
+function Get-RunnerPool {
+    param($Runner)
+    if (-not $Runner) {
+        return $null
+    }
+    $label = @($Runner.labels.name | Where-Object { $PSItem -like "$poolLabelPrefix*" } | Select-Object -First 1)
+    if (-not $label) {
+        return $null
+    }
+    $label[0].Substring($poolLabelPrefix.Length)
+}
+
+function Get-VmPool {
+    param($Vm)
+    if ($Vm.tags -and $Vm.tags.runnerPool) {
+        return [string]$Vm.tags.runnerPool
+    }
+    return $null
+}
+
+function Get-VmAgeMinutes {
+    param($Vm)
+    if (-not $Vm.created) {
+        return 0
+    }
+    [int](([DateTimeOffset]::UtcNow - [DateTimeOffset]::Parse($Vm.created)).TotalMinutes)
+}
+
+function Test-CiActivityEvent {
+    param($Event)
+    $Event.type -eq "PushEvent" -or
+    ($Event.type -eq "PullRequestEvent" -and $Event.payload.action -in @("opened", "reopened", "synchronize"))
+}
+
+function Get-FleetState {
+    $runnerResponse = Invoke-GhJson -Arguments @("repos/$repo/actions/runners?per_page=100") -Operation "list GitHub runners"
+    $runners = @($runnerResponse.runners | Where-Object { $PSItem.labels.name -contains $runnerLabel })
+    $vmQuery = "[?starts_with(name, '${vmss}_')].{name:name,created:timeCreated,power:powerState,provisioning:provisioningState,tags:tags}"
+    $vms = @(Invoke-AzJson -Arguments @("vm", "list", "--resource-group", $resourceGroup, "--show-details", "--query", $vmQuery) -Operation "list Azure runner VMs")
+    [pscustomobject]@{ Runners = $runners; Vms = $vms }
+}
+
+function Get-RunnerForVm {
+    param($State, [string]$VmName)
+    @($State.Runners | Where-Object name -EQ $VmName | Select-Object -First 1)[0]
+}
+
+function Set-VmPool {
+    param([string]$VmName, [string]$Pool)
+    $null = Invoke-NativeText -Tool "az" -Arguments @(
+        "vm", "update", "--resource-group", $resourceGroup, "--name", $VmName,
+        "--set", "tags.runnerPool=$Pool", "--only-show-errors", "--output", "none"
+    ) -Operation "tag $VmName for pool $Pool"
+    Write-Host "assigned $VmName to pool $Pool"
+}
+
+function Remove-FleetVm {
+    param($State, $Vm, [string]$Reason)
+    if (-not $deletedVms.Add($Vm.name)) {
+        return
+    }
+    $runner = Get-RunnerForVm -State $State -VmName $Vm.name
+    if ($runner -and $runner.busy) {
+        $null = $deletedVms.Remove($Vm.name)
+        Write-Host "preserving busy $($Vm.name) despite: $Reason"
+        return
+    }
+    Write-Host "deleting $($Vm.name) -- $Reason"
+    if ($runner) {
+        try {
+            $null = Invoke-NativeText -Tool "gh" -Arguments @(
+                "api", "--method", "DELETE", "repos/$repo/actions/runners/$($runner.id)"
+            ) -Operation "remove runner record $($runner.name)"
+        } catch [TransientFleetException] {
+            if ($PSItem.Exception.Message -notmatch "currently running a job") {
+                throw
+            }
+            $null = $deletedVms.Remove($Vm.name)
+            Write-Host "preserving $($Vm.name); it accepted a job during the deletion check"
+            return
+        }
+    }
+    $null = Invoke-NativeText -Tool "az" -Arguments @(
+        "vm", "delete", "--resource-group", $resourceGroup, "--name", $Vm.name,
+        "--yes", "--only-show-errors", "--output", "none"
+    ) -Operation "delete VM $($Vm.name)"
+}
+
+function Get-DesiredPools {
+    $events = @(Invoke-GhJson -Arguments @("repos/$repo/events?per_page=100") -Operation "read repository activity")
+    $runResponse = Invoke-GhJson -Arguments @(
+        "repos/$repo/actions/workflows/ci-azure.yml/runs?per_page=100"
+    ) -Operation "read CI build queue"
+    $liveRuns = @($runResponse.workflow_runs | Where-Object { $PSItem.status -ne "completed" })
+    $cutoff = [DateTimeOffset]::UtcNow.AddHours(-$boostHours)
+    $desired = [ordered]@{}
+
+    foreach ($maintainer in $maintainers) {
+        $recentPush = @($events | Where-Object {
+                (Test-CiActivityEvent -Event $PSItem) -and
+                $PSItem.actor.login -eq $maintainer -and
+                [DateTimeOffset]::Parse($PSItem.created_at) -ge $cutoff
+            }).Count -gt 0
+        $queuedBuild = @($liveRuns | Where-Object { $PSItem.actor.login -eq $maintainer }).Count -gt 0
+        $directTrigger = $env:BOOST_TRIGGER -eq $maintainer
+        $desired[$maintainer] = if ($recentPush -or $queuedBuild -or $directTrigger) { $maintainerCount } else { 0 }
+    }
+    $recentCommunityPush = @($events | Where-Object {
+            (Test-CiActivityEvent -Event $PSItem) -and
+            $PSItem.actor.login -notin $maintainers -and
+            [DateTimeOffset]::Parse($PSItem.created_at) -ge $cutoff
+        }).Count -gt 0
+    $queuedCommunityBuild = @($liveRuns | Where-Object { $PSItem.actor.login -notin $maintainers }).Count -gt 0
+    $directCommunityTrigger = $env:BOOST_TRIGGER -and $env:BOOST_TRIGGER -notin $maintainers
+    $desired["community"] = if ($recentCommunityPush -or $queuedCommunityBuild -or $directCommunityTrigger) { $communityCount } else { 0 }
+
+    $total = ($desired.Values | Measure-Object -Sum).Sum
+    if ($total -gt $maxRunners) {
+        throw "Pool policy requests $total runners but MAX_RUNNERS is $maxRunners"
+    }
+    Write-Host "desired pools: $(($desired.GetEnumerator() | ForEach-Object { "$($PSItem.Key)=$($PSItem.Value)" }) -join ', ') total=$total"
+    $desired
+}
+
+function Assign-UnallocatedVms {
+    param($State, $Desired)
+    $available = [System.Collections.Generic.Queue[object]]::new()
+    foreach ($vm in $State.Vms | Sort-Object created) {
+        $runner = Get-RunnerForVm -State $State -VmName $vm.name
+        if (-not (Get-VmPool -Vm $vm) -and -not $runner) {
+            $available.Enqueue($vm)
+        }
+    }
+
+    foreach ($pool in $Desired.Keys) {
+        $current = @($State.Vms | Where-Object { (Get-VmPool -Vm $PSItem) -eq $pool }).Count
+        $deficit = $Desired[$pool] - $current
+        while ($deficit -gt 0 -and $available.Count -gt 0) {
+            $vm = $available.Dequeue()
+            Set-VmPool -VmName $vm.name -Pool $pool
+            $deficit--
+        }
+    }
+}
+
+function Register-PoolVms {
+    param($State, $Desired)
+    $tasks = @()
+    foreach ($vm in $State.Vms) {
+        $pool = Get-VmPool -Vm $vm
+        if (-not $pool -or $Desired[$pool] -le 0 -or (Get-RunnerForVm -State $State -VmName $vm.name)) {
+            continue
+        }
+        $tokenResponse = Invoke-GhJson -Arguments @(
+            "--method", "POST", "repos/$repo/actions/runners/registration-token"
+        ) -Operation "mint registration token for $($vm.name)"
+        $tasks += [pscustomobject]@{
+            VmName = $vm.name
+            Token = $tokenResponse.token
+            Labels = "$runnerLabel,$poolLabelPrefix$pool"
+        }
+    }
+    if (-not $tasks) {
+        return
+    }
+
+    Write-Host "registering $($tasks.Count) pool runner(s)"
+    $results = $tasks | ForEach-Object -Parallel {
+        $result = $null
+        foreach ($attempt in 1..3) {
+            $output = @(& az vm run-command invoke --resource-group $using:resourceGroup --name $PSItem.VmName `
+                    --command-id RunPowerShellScript --scripts "@$using:bootstrapPath" `
+                    --parameters "Token=$($PSItem.Token)" "RunnerName=$($PSItem.VmName)" "Labels=$($PSItem.Labels)" `
+                    --query "value[0].message" --output tsv --only-show-errors 2>&1)
+            $code = $LASTEXITCODE
+            if ($code -eq 0) {
+                $result = [pscustomobject]@{ VmName = $PSItem.VmName; Succeeded = $true; Output = ($output -join [Environment]::NewLine) }
+                break
+            }
+            if ($attempt -lt 3) {
+                Start-Sleep -Seconds (3 * $attempt)
+            } else {
+                $result = [pscustomobject]@{ VmName = $PSItem.VmName; Succeeded = $false; Output = ($output -join [Environment]::NewLine) }
+            }
+        }
+        $result
+    } -ThrottleLimit 25
+
+    foreach ($result in $results) {
+        if (-not $result.Succeeded) {
+            Write-Warning "Registration for $($result.VmName) exhausted retries; leaving it for the next reconcile. $($result.Output)"
+            continue
+        }
+        Write-Host (($result.Output -split "`r?`n" | Select-Object -Last 3) -join [Environment]::NewLine)
+        if ($result.Output -match "SPENT-VM") {
+            $vm = @($State.Vms | Where-Object name -EQ $result.VmName | Select-Object -First 1)[0]
+            Remove-FleetVm -State $State -Vm $vm -Reason "ephemeral runner already served a job"
+        }
+    }
+}
+
+try {
+    $desired = Get-DesiredPools
+    $desiredTotal = ($desired.Values | Measure-Object -Sum).Sum
+    $state = Get-FleetState
+
+    # Migrate or remove generic pre-pool runners without interrupting active jobs.
+    foreach ($vm in $state.Vms) {
+        $runner = Get-RunnerForVm -State $state -VmName $vm.name
+        $vmPool = Get-VmPool -Vm $vm
+        $runnerPool = Get-RunnerPool -Runner $runner
+        if (-not $vmPool -and $runnerPool) {
+            Set-VmPool -VmName $vm.name -Pool $runnerPool
+        } elseif ($runner -and -not $runnerPool -and -not $runner.busy) {
+            Remove-FleetVm -State $state -Vm $vm -Reason "legacy runner lacks a pool label"
+        }
+    }
+
+    $state = Get-FleetState
+    Assign-UnallocatedVms -State $state -Desired $desired
+    $state = Get-FleetState
+    Register-PoolVms -State $state -Desired $desired
+    $state = Get-FleetState
+
+    # Remove dead runners and trim pools whose hot window has ended.
+    foreach ($vm in $state.Vms) {
+        $pool = Get-VmPool -Vm $vm
+        $runner = Get-RunnerForVm -State $state -VmName $vm.name
+        $ageMinutes = Get-VmAgeMinutes -Vm $vm
+        if (-not $pool -and -not $runner) {
+            Remove-FleetVm -State $state -Vm $vm -Reason "unallocated capacity exceeds all active pool targets"
+        } elseif ($runner -and $runner.status -eq "offline" -and $ageMinutes -gt 15) {
+            Remove-FleetVm -State $state -Vm $vm -Reason "runner offline after bootstrap grace period"
+        } elseif (-not $runner -and $pool -and $ageMinutes -gt 45) {
+            Remove-FleetVm -State $state -Vm $vm -Reason "never registered after 45 minutes"
+        }
+    }
+
+    $state = Get-FleetState
+    foreach ($pool in $desired.Keys) {
+        $poolVms = @($state.Vms | Where-Object { (Get-VmPool -Vm $PSItem) -eq $pool } | Sort-Object created)
+        $excess = $poolVms.Count - $desired[$pool]
+        foreach ($vm in $poolVms) {
+            if ($excess -le 0) {
+                break
+            }
+            $runner = Get-RunnerForVm -State $state -VmName $vm.name
+            if ($runner -and $runner.busy) {
+                continue
+            }
+            Remove-FleetVm -State $state -Vm $vm -Reason "pool $pool is $excess above desired capacity"
+            $excess--
+        }
+    }
+
+    $state = Get-FleetState
+    $transitionBusy = @($state.Vms | Where-Object {
+            $runner = Get-RunnerForVm -State $state -VmName $PSItem.name
+            $pool = Get-VmPool -Vm $PSItem
+            $outsideDesiredPool = -not $pool -or -not $desired.Contains($pool) -or $desired[$pool] -eq 0
+            $outsideDesiredPool -and $runner -and $runner.busy
+        }).Count
+    $target = [math]::Min($maxRunners, $desiredTotal + $transitionBusy)
+    $capacityResponse = Invoke-AzJson -Arguments @(
+        "vmss", "show", "--resource-group", $resourceGroup, "--name", $vmss,
+        "--query", "{capacity:sku.capacity}"
+    ) -Operation "read VMSS capacity"
+    $capacity = [int]$capacityResponse.capacity
+    Write-Host "capacity=$capacity target=$target transition_busy=$transitionBusy"
+    if ($capacity -lt $target) {
+        $null = Invoke-NativeText -Tool "az" -Arguments @(
+            "vmss", "scale", "--resource-group", $resourceGroup, "--name", $vmss,
+            "--new-capacity", "$target", "--no-wait", "--only-show-errors", "--output", "none"
+        ) -Operation "scale VMSS to $target"
+        foreach ($attempt in 1..15) {
+            Start-Sleep -Seconds 20
+            $state = Get-FleetState
+            $notReady = @($state.Vms | Where-Object provisioning -NE "Succeeded").Count
+            if ($state.Vms.Count -ge $target -and $notReady -eq 0) {
+                break
+            }
+            Write-Host "provisioning check $attempt of 15: vms=$($state.Vms.Count)/$target not_ready=$notReady"
+        }
+    }
+
+    $state = Get-FleetState
+    Assign-UnallocatedVms -State $state -Desired $desired
+    $state = Get-FleetState
+    Register-PoolVms -State $state -Desired $desired
+    $state = Get-FleetState
+    foreach ($pool in $desired.Keys) {
+        $poolVms = @($state.Vms | Where-Object { (Get-VmPool -Vm $PSItem) -eq $pool })
+        $poolRunners = @($state.Runners | Where-Object { (Get-RunnerPool -Runner $PSItem) -eq $pool })
+        $online = @($poolRunners | Where-Object status -EQ "online").Count
+        $busy = @($poolRunners | Where-Object busy).Count
+        Write-Host "pool=$pool desired=$($desired[$pool]) vms=$($poolVms.Count) online=$online busy=$busy"
+    }
+} catch [TransientFleetException] {
+    Write-Warning "$($PSItem.Exception.Message) No further fleet changes will be attempted; a job-completion nudge or the hourly reconcile will retry."
+    exit 0
+}

--- a/.github/workflows/ci-azure.yml
+++ b/.github/workflows/ci-azure.yml
@@ -46,9 +46,12 @@ permissions:
   contents: read
   actions: write
 
+# AppVeyor-style build lanes: one matrix build consumes its lane's worker limit
+# while later builds wait in FIFO order. Pool-specific runner labels below prevent
+# an active maintainer or community lane from stealing another lane's workers.
 concurrency:
-  group: ci-azure-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-azure-${{ github.actor == 'potatoqualitee' && 'potatoqualitee' || (github.actor == 'andreasjordan' && 'andreasjordan' || 'community') }}
+  queue: max
 
 env:
   APPVEYOR: "True"
@@ -62,7 +65,10 @@ env:
 
 jobs:
   test:
-    runs-on: [self-hosted, dbatools-modern]
+    runs-on:
+      - self-hosted
+      - dbatools-modern
+      - dbatools-pool-${{ github.actor == 'potatoqualitee' && 'potatoqualitee' || (github.actor == 'andreasjordan' && 'andreasjordan' || 'community') }}
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -159,30 +165,30 @@ jobs:
             }
           }
 
-  # A single nudge after the whole matrix finishes (not once per job) prompts
-  # runner-reconcile to replace spent VMs promptly. Runs on GitHub-hosted compute
-  # so it never burns a spent self-hosted VM. Always dispatches against development:
-  # reconcile's Azure OIDC federated credential trusts only refs/heads/development,
-  # so a nudge on any other ref (e.g. a PR head branch) would fail at Azure login.
-  # Dispatching development also runs development's canonical reconcile + bootstrap
-  # script (RAW_BASE tracks the dispatched ref), matching how runner-boost nudges.
-  nudge-reconcile:
-    needs: test
-    if: always()
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      actions: write
-    steps:
-      - name: Nudge fleet reconcile (prompt spent-VM replacement)
+      # AppVeyor replenishes a worker slot as soon as one matrix job ends. Nudging
+      # per job avoids waiting for the longest matrix row before replacing every VM.
+      - name: Nudge replacement for this worker
+        if: always()
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           $splatNudge = @{
-            Method  = "Post"
-            Uri     = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/workflows/runner-reconcile.yml/dispatches"
-            Headers = @{ Authorization = "Bearer $env:GH_TOKEN"; Accept = "application/vnd.github+json" }
-            Body    = (ConvertTo-Json -InputObject @{ ref = "development" })
+              Method      = "Post"
+              Uri         = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/workflows/runner-reconcile.yml/dispatches"
+              Headers     = @{ Authorization = "Bearer $env:GH_TOKEN"; Accept = "application/vnd.github+json" }
+              Body        = (ConvertTo-Json -InputObject @{ ref = "development" })
+              TimeoutSec  = 30
           }
-          try { Invoke-RestMethod @splatNudge } catch { Write-Host "nudge skipped: $($_.Exception.Message)" }
+          foreach ($attempt in 1..3) {
+              try {
+                  $null = Invoke-RestMethod @splatNudge
+                  return
+              } catch {
+                  Write-Warning "Reconcile nudge attempt $attempt of 3 failed. $($PSItem.Exception.Message)"
+                  if ($attempt -lt 3) {
+                      Start-Sleep -Seconds (3 * $attempt)
+                  }
+              }
+          }
+          Write-Warning "Reconcile nudge skipped after bounded retries; the next job completion or hourly reconcile will recover it."

--- a/.github/workflows/ci-azure.yml
+++ b/.github/workflows/ci-azure.yml
@@ -60,6 +60,9 @@ env:
   APPVEYOR_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
   APPVEYOR_BUILD_VERSION: 2.1.${{ github.run_number }}
   DBATOOLS_COMMIT_MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title || inputs.message }}
+  DBATOOLS_BUILD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  DBATOOLS_HEAD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+  DBATOOLS_HEAD_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
   environment: development
   version: 2.1.${{ github.run_number }}
 
@@ -117,16 +120,16 @@ jobs:
       - name: Sync repo to build commit
         shell: cmd
         run: |
-          git config --global --add safe.directory C:/github/dbatools
-          git fetch --force origin development
+          git config --global --add safe.directory C:/github/dbatools || exit /b 1
+          git fetch --force origin development || exit /b 1
           if "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (
-            git fetch --force origin %GITHUB_REF_NAME%
+            git fetch --force origin "%DBATOOLS_HEAD_REF%" || exit /b 1
           ) else (
-            git fetch --force origin pull/%APPVEYOR_PULL_REQUEST_NUMBER%/merge
+            git fetch --force "%DBATOOLS_HEAD_REPO%" "%DBATOOLS_HEAD_REF%" || exit /b 1
           )
-          git checkout --force %GITHUB_SHA%
-          git clean -xdff
-          git log -1 --oneline
+          git checkout --force "%DBATOOLS_BUILD_SHA%" || exit /b 1
+          git clean -xdff || exit /b 1
+          git log -1 --oneline || exit /b 1
 
       - name: Convert tests to CRLF (unix2dos equivalent)
         shell: powershell
@@ -169,7 +172,7 @@ jobs:
       # per job avoids waiting for the longest matrix row before replacing every VM.
       - name: Nudge replacement for this worker
         if: always()
-        shell: pwsh
+        shell: powershell
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/runner-boost.yml
+++ b/.github/workflows/runner-boost.yml
@@ -27,11 +27,16 @@ jobs:
           BOOST_USER: ${{ github.actor }}
         run: |
           set -euo pipefail
-          if gh workflow run runner-reconcile.yml --ref development -f boost_user="$BOOST_USER" -R "${{ github.repository }}"; then
-            exit 0
-          fi
+          for attempt in 1 2 3; do
+            if gh workflow run runner-reconcile.yml --ref development -f boost_user="$BOOST_USER" -R "${{ github.repository }}"; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((attempt * 3))
+            fi
+          done
 
-          echo "boost_user input unavailable or transient dispatch failure; retrying a plain reconcile dispatch"
+          echo "boost_user dispatch exhausted retries; trying the backward-compatible plain dispatch"
           for attempt in 1 2 3; do
             if gh workflow run runner-reconcile.yml --ref development -R "${{ github.repository }}"; then
               exit 0
@@ -40,4 +45,4 @@ jobs:
               sleep $((attempt * 3))
             fi
           done
-          exit 1
+          echo "::warning::Reconcile dispatch exhausted retries; workflow_run or the hourly reconcile will recover without a false failure."

--- a/.github/workflows/runner-reconcile.yml
+++ b/.github/workflows/runner-reconcile.yml
@@ -1,17 +1,15 @@
-# The single fleet controller: when CI is requested, after CI completes, and every
-# hour it deletes spent and zombie runner instances, enforces the active pool size,
-# self-heals unregistered instances, and tops capacity up.
+# The single VMSS fleet controller. CI requests, per-job completion nudges, maintainer
+# pushes, and the hourly safety tick all reconcile the same desired state.
 #
-# Pool policy: five shared runners stay hot for community CI. Each user in
-# BOOST_USERS with a push in the trailing BOOST_HOURS window contributes
-# BOOST_COUNT runners, so both maintainers active means twenty runners.
+# AppVeyor-style pool policy:
+#   - potatoqualitee: 10 dedicated workers for two hours after activity
+#   - andreasjordan:  10 dedicated workers for two hours after activity
+#   - community:       5 shared workers for two hours after activity
+#   - no activity or queued work: zero workers
 #
-# runner-boost.yml nudges runner-scale-up directly on every qualifying push.
-# Repository events preserve each allocation on later reconcile ticks until its
-# independent window drains.
-#
-# Mondays at 07:00 UTC one extra scheduled tick posts month-to-date spend to the
-# "CI cost tracker" issue.
+# Each Flexible VMSS instance stores its pool in the runnerPool Azure tag and the
+# matching GitHub runner label. Ephemeral agents take one job, unregister, and the
+# controller replaces their VM without letting another pool steal the slot.
 name: runner-reconcile
 
 on:
@@ -21,14 +19,10 @@ on:
   workflow_run:
     workflows: ["ci-azure"]
     types: [requested]
-  # workflow_run:requested is the fast scale-out path. ci-azure also nudges this
-  # workflow via workflow_dispatch when its matrix finishes so spent VMs are replaced
-  # promptly. The hourly cron catches re-runs, which emit no new requested event. A
-  # workflow_run:completed trigger would duplicate the completion nudge one-for-one.
   workflow_dispatch:
     inputs:
       boost_user:
-        description: "Maintainer whose push requested an immediate pool boost"
+        description: "Actor whose activity should heat their pool immediately"
         required: false
         default: ""
 
@@ -38,18 +32,14 @@ permissions:
   issues: write
   id-token: write
 
+# Reconcile is idempotent. Coalescing redundant pending nudges is intentional; the
+# running pass reads the complete GitHub queue rather than relying on one event body.
 concurrency:
   group: runner-fleet
   cancel-in-progress: false
 
 jobs:
   reconcile:
-    # Azure OIDC trusts only refs/heads/development; a run on any other ref would
-    # fail at Azure login. Cron and workflow_run always resolve to the default
-    # branch, so this only skips stray dispatches on feature branches (which could
-    # not do useful work anyway) -- they no-op green instead of failing red.
-    # The second schedule entry is spend-report-only; excluding it keeps fleet
-    # reconciliation to exactly once during Monday's 07:00 UTC hour.
     if: github.ref == 'refs/heads/development' && github.event.schedule != '0 7 * * 1'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -66,6 +56,7 @@ jobs:
       BOOST_TRIGGER: ${{ inputs.boost_user || github.event.workflow_run.actor.login }}
       RUNNER_LABEL: dbatools-modern
       RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}
+      BOOTSTRAP_PATH: /tmp/bootstrap-runner.ps1
     steps:
       - name: Azure login (OIDC)
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
@@ -74,217 +65,29 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Reconcile fleet
+      - name: Download fleet controller
+        id: controller
         run: |
           set -euo pipefail
-          NOW=$(date -u +%s)
-
-          gh_api_retry() {
-            local attempt status
-            for attempt in 1 2 3; do
-              if gh api "$@"; then
-                return 0
-              else
-                status=$?
-              fi
-              echo "GitHub API attempt $attempt of 3 failed" >&2
-              if [ "$attempt" -lt 3 ]; then
-                sleep $((attempt * 3))
-              fi
-            done
-            return "$status"
-          }
-
-          # ---- fixed community pool + independent maintainer boosts --------------
-          FLOOR=${COMMUNITY_COUNT:-5}
-          ACTIVE_COUNT=0
-          ACTIVE_USERS=""
-          EVENTS_AVAILABLE=true
-          EVENTS="[]"
-          if [ -n "${BOOST_USERS:-}" ]; then
-            CUTOFF=$(date -u -d "${BOOST_HOURS:-2} hours ago" +%Y-%m-%dT%H:%M:%SZ)
-            if ! EVENTS=$(gh_api_retry --paginate "repos/$REPO/events?per_page=100" 2>/dev/null); then
-              EVENTS_AVAILABLE=false
-            fi
+          echo "ready=false" >> "$GITHUB_OUTPUT"
+          if ! curl --retry 3 --retry-all-errors --retry-delay 3 -fsSL \
+              "$RAW_BASE/.github/runners/reconcile-runner-fleet.ps1" \
+              -o /tmp/reconcile-runner-fleet.ps1; then
+            echo "::warning::Fleet controller download exhausted retries; the next nudge or hourly tick will retry."
+            exit 0
           fi
-          if [ "$EVENTS_AVAILABLE" = "true" ]; then
-            for BOOST_USER in $BOOST_USERS; do
-              USER_ACTIVE=false
-              if [ "${BOOST_TRIGGER:-}" = "$BOOST_USER" ]; then
-                USER_ACTIVE=true
-              else
-                RECENT=$(printf '%s' "$EVENTS" | jq -s --arg cutoff "$CUTOFF" --arg user "$BOOST_USER" \
-                  '[.[][] | select(.type == "PushEvent" and .created_at > $cutoff and .actor.login == $user)] | length')
-                [ "${RECENT:-0}" -gt 0 ] && USER_ACTIVE=true
-              fi
-              if [ "$USER_ACTIVE" = "true" ]; then
-                ACTIVE_COUNT=$((ACTIVE_COUNT + 1))
-                ACTIVE_USERS="$ACTIVE_USERS $BOOST_USER"
-              fi
-            done
-            if [ "$ACTIVE_COUNT" -gt 0 ]; then
-              FLOOR=$((ACTIVE_COUNT * ${BOOST_COUNT:-10}))
-            fi
-          else
-            # Do not trim a possibly active maintainer pool when the event feed has
-            # a transient outage. The next hourly or completion nudge will retry.
-            FLOOR=${MAX_RUNNERS:-20}
-            echo "GitHub events unavailable after retries -- preserving the maximum pool for this cycle"
+          if ! curl --retry 3 --retry-all-errors --retry-delay 3 -fsSL \
+              "$RAW_BASE/.github/runners/bootstrap-runner.ps1" \
+              -o "$BOOTSTRAP_PATH"; then
+            echo "::warning::Runner bootstrap download exhausted retries; the next nudge or hourly tick will retry."
+            exit 0
           fi
-          [ "$FLOOR" -gt "${MAX_RUNNERS:-20}" ] && FLOOR=${MAX_RUNNERS:-20}
-          echo "active_maintainers=$ACTIVE_COUNT users=[$ACTIVE_USERS] pool=$FLOOR window=${BOOST_HOURS:-2}h"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
 
-          # ---- current state ---------------------------------------------------
-          RUNNERS_JSON=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate \
-            --jq "[.runners[] | select([.labels[].name] | index(\"$RUNNER_LABEL\")) | {name, status, busy, id}]")
-          VMS_JSON=$(az vm list -g "$RG" --show-details \
-            --query "[?starts_with(name, '${VMSS}_')].{name: name, created: timeCreated, power: powerState}" -o json 2>/dev/null || echo "[]")
-
-          # count queued JOBS, not queued runs: a matrix run flips to in_progress the
-          # moment one job starts, hiding its other queued jobs from a run-level count
-          QUEUED=0
-          CI_RUN_IDS=$( (gh_api_retry "repos/$REPO/actions/runs?status=queued&per_page=50" \
-              --jq '.workflow_runs[] | select(.name == "ci-azure") | .id'; \
-            gh_api_retry "repos/$REPO/actions/runs?status=in_progress&per_page=50" \
-              --jq '.workflow_runs[] | select(.name == "ci-azure") | .id') 2>/dev/null || true)
-          for CI_RUN_ID in $CI_RUN_IDS; do
-            N=$(gh_api_retry "repos/$REPO/actions/runs/$CI_RUN_ID/jobs?per_page=100" --paginate \
-              --jq "[.jobs[] | select(.status == \"queued\" or .status == \"waiting\") | select((.labels // []) | index(\"$RUNNER_LABEL\"))] | length" 2>/dev/null || echo 0)
-            QUEUED=$((QUEUED + N))
-          done
-
-          echo "pool=$FLOOR queued_jobs=$QUEUED"
-          echo "$VMS_JSON" | jq -r '.[] | "vm: \(.name) \(.power) created \(.created)"'
-          echo "$RUNNERS_JSON" | jq -r '.[] | "runner: \(.name) \(.status) busy=\(.busy)"'
-
-          # ---- registration helper (also detects and deletes spent VMs) ---------
-          curl -fsSL "$RAW_BASE/.github/runners/bootstrap-runner.ps1" -o /tmp/bootstrap-runner.ps1
-          register_unregistered() {
-            local registered vms vm token
-            registered=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate --jq '[.runners[].name] | join(" ")')
-            vms=$(az vm list -g "$RG" --query "[?starts_with(name, '${VMSS}_') && provisioningState == 'Succeeded'].name" -o tsv 2>/dev/null || true)
-            for vm in $vms; do
-              case " $registered " in
-                *" $vm "*) continue ;;
-              esac
-              echo "registering $vm"
-              token=$(gh_api_retry -X POST "repos/$REPO/actions/runners/registration-token" --jq .token)
-              (
-                OUT=$(az vm run-command invoke -g "$RG" -n "$vm" --command-id RunPowerShellScript \
-                  --scripts @/tmp/bootstrap-runner.ps1 \
-                  --parameters "Token=$token" "RunnerName=$vm" "Labels=$RUNNER_LABEL" \
-                  --query "value[0].message" -o tsv || true)
-                echo "$OUT" | tail -3
-                if echo "$OUT" | grep -q "SPENT-VM"; then
-                  echo "$vm already served a job -- deleting instead of reusing"
-                  # Wait so VMSS capacity reflects the deletion before pass 3 tops up.
-                  az vm delete -g "$RG" -n "$vm" --yes || true
-                fi
-              ) &
-            done
-            wait
-          }
-
-          # ---- pass 1: try to register BEFORE any deletion decisions ------------
-          # (cron delivery is unreliable; a slow-provisioning instance must get its
-          # registration attempt before the never-registered rule can reap it)
-          register_unregistered
-
-          # refresh state after registration/spent-deletions
-          RUNNERS_JSON=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate \
-            --jq "[.runners[] | select([.labels[].name] | index(\"$RUNNER_LABEL\")) | {name, status, busy, id}]")
-          VMS_JSON=$(az vm list -g "$RG" --show-details \
-            --query "[?starts_with(name, '${VMSS}_')].{name: name, created: timeCreated, power: powerState}" -o json 2>/dev/null || echo "[]")
-
-          # ---- pass 2: delete spent/zombie instances ----------------------------
-          KEEP=0
-          for VM in $(echo "$VMS_JSON" | jq -r '.[].name'); do
-            CREATED=$(echo "$VMS_JSON" | jq -r ".[] | select(.name == \"$VM\") | .created")
-            AGE_MIN=$(( (NOW - $(date -u -d "$CREATED" +%s)) / 60 ))
-            R_STATUS=$(echo "$RUNNERS_JSON" | jq -r ".[] | select(.name == \"$VM\") | .status")
-            R_BUSY=$(echo "$RUNNERS_JSON" | jq -r ".[] | select(.name == \"$VM\") | .busy")
-            R_ID=$(echo "$RUNNERS_JSON" | jq -r ".[] | select(.name == \"$VM\") | .id")
-
-            DELETE=""
-            if [ "$R_BUSY" = "true" ] && [ "$AGE_MIN" -lt 180 ]; then
-              KEEP=$((KEEP + 1)); continue
-            fi
-            if [ -z "$R_STATUS" ] && [ "$AGE_MIN" -gt 45 ]; then
-              DELETE="never registered after ${AGE_MIN}m (registration was attempted this cycle)"
-            elif [ "$R_STATUS" = "offline" ] && [ "$AGE_MIN" -gt 15 ]; then
-              # bootstrap reboots into the interactive session; fresh instances are
-              # briefly offline between config and the post-reboot logon
-              DELETE="runner offline (spent ephemeral or dead)"
-            fi
-
-            if [ -n "$DELETE" ]; then
-              echo "deleting $VM -- $DELETE"
-              [ -n "$R_ID" ] && gh api -X DELETE "repos/$REPO/actions/runners/$R_ID" || true
-              # Wait so the capacity check below can create the replacement now.
-              az vm delete -g "$RG" -n "$VM" --yes || true
-            else
-              KEEP=$((KEEP + 1))
-            fi
-          done
-
-          # ---- pass 3: enforce the active fixed-size pool -------------------------
-          DESIRED=$FLOOR
-          [ "$DESIRED" -gt "${MAX_RUNNERS:-20}" ] && DESIRED=${MAX_RUNNERS:-20}
-          # az vmss scale is bidirectional: pushing a target BELOW the real capacity
-          # scale-INS the newest instances -- which is exactly what happens when the
-          # eventually-consistent vm listing hides fresh VMs from KEEP. Scale-out only
-          # ever raises capacity (sku.capacity is authoritative, listings are not);
-          # scale-in happens exclusively through the explicit per-VM deletes above.
-          CAPACITY=$(az vmss show -g "$RG" -n "$VMSS" --query sku.capacity -o tsv 2>/dev/null || echo 0)
-          echo "keep=$KEEP desired=$DESIRED capacity=$CAPACITY"
-          if [ "$KEEP" -lt "$DESIRED" ] && [ "$DESIRED" -gt "$CAPACITY" ]; then
-            az vmss scale -g "$RG" -n "$VMSS" --new-capacity "$DESIRED" --no-wait || true
-            echo "waiting for new instances to provision"
-            sleep 150
-            register_unregistered
-          elif [ "$KEEP" -lt "$DESIRED" ]; then
-            # capacity is already there; the instances just have not registered yet
-            register_unregistered
-          fi
-
-          # ---- pass 3b: trim surplus idle instances (oldest first) ---------------
-          if [ "$KEEP" -gt "$DESIRED" ]; then
-            # refresh state right before deleting: registration races and az listing
-            # lag make the snapshots minutes old by now, and a "surplus idle" VM may
-            # in fact be freshly registered and about to take a queued job
-            RUNNERS_JSON=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate \
-              --jq "[.runners[] | select([.labels[].name] | index(\"$RUNNER_LABEL\")) | {name, status, busy, id}]")
-            VMS_JSON=$(az vm list -g "$RG" --show-details \
-              --query "[?starts_with(name, '${VMSS}_')].{name: name, created: timeCreated, power: powerState}" -o json 2>/dev/null || echo "[]")
-            TRIM=$(( KEEP - DESIRED ))
-            echo "trimming $TRIM surplus idle instance(s)"
-            for VM in $(echo "$VMS_JSON" | jq -r 'sort_by(.created) | .[].name'); do
-              [ "$TRIM" -le 0 ] && break
-              R_BUSY=$(echo "$RUNNERS_JSON" | jq -r ".[] | select(.name == \"$VM\") | .busy")
-              [ "$R_BUSY" = "true" ] && continue
-              CREATED=$(echo "$VMS_JSON" | jq -r ".[] | select(.name == \"$VM\") | .created")
-              AGE_MIN=$(( (NOW - $(date -u -d "$CREATED" +%s)) / 60 ))
-              # a young VM is still booting/registering toward queued work, not surplus
-              [ "$AGE_MIN" -lt 20 ] && continue
-              az vm show -g "$RG" -n "$VM" --query name -o tsv >/dev/null 2>&1 || continue
-              R_ID=$(echo "$RUNNERS_JSON" | jq -r ".[] | select(.name == \"$VM\") | .id")
-              echo "trim: deleting idle $VM"
-              [ -n "$R_ID" ] && gh api -X DELETE "repos/$REPO/actions/runners/$R_ID" || true
-              az vm delete -g "$RG" -n "$VM" --yes --no-wait || true
-              TRIM=$(( TRIM - 1 ))
-            done
-          fi
-
-          # ---- pass 4: drop runner records with no matching VM -----------------
-          VMS_NOW=$(az vm list -g "$RG" --query "[?starts_with(name, '${VMSS}_')].name" -o tsv 2>/dev/null | tr '\n' ' ' || true)
-          for R_NAME in $(echo "$RUNNERS_JSON" | jq -r '.[] | select(.busy != true) | .name'); do
-            case " $VMS_NOW " in
-              *" $R_NAME "*) continue ;;
-            esac
-            R_ID=$(echo "$RUNNERS_JSON" | jq -r ".[] | select(.name == \"$R_NAME\") | .id")
-            echo "removing stale runner record $R_NAME"
-            gh api -X DELETE "repos/$REPO/actions/runners/$R_ID" || true
-          done
+      - name: Reconcile AppVeyor-style pools
+        if: steps.controller.outputs.ready == 'true'
+        shell: pwsh
+        run: /tmp/reconcile-runner-fleet.ps1
 
   spend-report:
     if: github.event.schedule == '0 7 * * 1'

--- a/.github/workflows/runner-scale-up.yml
+++ b/.github/workflows/runner-scale-up.yml
@@ -1,21 +1,13 @@
-# Manual recovery workflow that scales the dbatools-runners VMSS and registers an
-# ephemeral runner on every new instance. Normal event-driven scaling lives in
-# runner-reconcile.yml so GitHub concurrency cannot cancel one controller for another.
-#
-# The CI_RUNNER_PAT secret mints single-use registration tokens (GITHUB_TOKEN cannot).
-# Azure access is OIDC (federated credential on the dbatools-ci-github Entra app); no
-# client secrets exist anywhere in this pipeline.
+# Manual recovery entry point for the same idempotent pool controller used by
+# runner-reconcile. Keeping one implementation prevents recovery and normal scaling
+# from making conflicting capacity decisions.
 name: runner-scale-up
 
 on:
   workflow_dispatch:
     inputs:
-      ensure:
-        description: "Minimum instance count to ensure (capped by the active pool policy)"
-        required: false
-        default: ""
       boost_user:
-        description: "Maintainer whose push requested an immediate pool allocation"
+        description: "Actor whose pool should be heated immediately"
         required: false
         default: ""
 
@@ -30,8 +22,9 @@ concurrency:
 
 jobs:
   scale-up:
+    if: github.ref == 'refs/heads/development'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       GH_TOKEN: ${{ secrets.CI_RUNNER_PAT }}
       REPO: ${{ github.repository }}
@@ -42,9 +35,10 @@ jobs:
       BOOST_USERS: ${{ vars.BOOST_USERS }}
       BOOST_COUNT: ${{ vars.BOOST_COUNT }}
       BOOST_HOURS: ${{ vars.BOOST_HOURS }}
-      TRIGGER_ACTOR: ${{ inputs.boost_user || github.actor }}
+      BOOST_TRIGGER: ${{ inputs.boost_user || github.actor }}
       RUNNER_LABEL: dbatools-modern
       RAW_BASE: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}
+      BOOTSTRAP_PATH: /tmp/bootstrap-runner.ps1
     steps:
       - name: Azure login (OIDC)
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
@@ -53,142 +47,26 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Compute demand and scale out
-        id: scale
+      - name: Download fleet controller
+        id: controller
         run: |
           set -euo pipefail
-
-          gh_api_retry() {
-            local attempt status
-            for attempt in 1 2 3; do
-              if gh api "$@"; then
-                return 0
-              else
-                status=$?
-              fi
-              echo "GitHub API attempt $attempt of 3 failed" >&2
-              if [ "$attempt" -lt 3 ]; then
-                sleep $((attempt * 3))
-              fi
-            done
-            return "$status"
-          }
-
-          QUEUED="${{ inputs.ensure }}"
-          QUEUED="${QUEUED:-0}"
-
-          IDLE=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate \
-            --jq "[.runners[] | select(.status == \"online\" and .busy == false) | select([.labels[].name] | index(\"$RUNNER_LABEL\"))] | length")
-
-          # sku.capacity is authoritative; az vm list is eventually consistent and can
-          # hide fresh instances. Basing the target on a stale listing would make the
-          # bidirectional `az vmss scale` DELETE the newest instances (scale-in).
-          CAPACITY=$(az vmss show -g "$RG" -n "$VMSS" --query sku.capacity -o tsv 2>/dev/null || echo 0)
-
-          NEED=$(( QUEUED - IDLE ))
-          [ "$NEED" -lt 0 ] && NEED=0
-          TARGET=$(( CAPACITY + NEED ))
-          POOL_LIMIT=${COMMUNITY_COUNT:-5}
-          ACTIVE_COUNT=0
-          EVENTS_AVAILABLE=true
-          EVENTS="[]"
-          if [ -n "${BOOST_USERS:-}" ]; then
-            CUTOFF=$(date -u -d "${BOOST_HOURS:-2} hours ago" +%Y-%m-%dT%H:%M:%SZ)
-            if ! EVENTS=$(gh_api_retry --paginate "repos/$REPO/events?per_page=100" 2>/dev/null); then
-              EVENTS_AVAILABLE=false
-            fi
+          echo "ready=false" >> "$GITHUB_OUTPUT"
+          if ! curl --retry 3 --retry-all-errors --retry-delay 3 -fsSL \
+              "$RAW_BASE/.github/runners/reconcile-runner-fleet.ps1" \
+              -o /tmp/reconcile-runner-fleet.ps1; then
+            echo "::warning::Fleet controller download exhausted retries; run recovery again after the transient clears."
+            exit 0
           fi
-          if [ "$EVENTS_AVAILABLE" = "true" ]; then
-            for BOOST_USER in $BOOST_USERS; do
-              USER_ACTIVE=false
-              if [ "$TRIGGER_ACTOR" = "$BOOST_USER" ]; then
-                USER_ACTIVE=true
-              else
-                RECENT=$(printf '%s' "$EVENTS" | jq -s --arg cutoff "$CUTOFF" --arg user "$BOOST_USER" \
-                  '[.[][] | select(.type == "PushEvent" and .created_at > $cutoff and .actor.login == $user)] | length')
-                [ "${RECENT:-0}" -gt 0 ] && USER_ACTIVE=true
-              fi
-              [ "$USER_ACTIVE" = "true" ] && ACTIVE_COUNT=$((ACTIVE_COUNT + 1))
-            done
-            if [ "$ACTIVE_COUNT" -gt 0 ]; then
-              POOL_LIMIT=$((ACTIVE_COUNT * ${BOOST_COUNT:-10}))
-            fi
-          else
-            # A transient event-feed outage must not make jobs wait or shrink a
-            # possibly active maintainer allocation.
-            POOL_LIMIT=${MAX_RUNNERS:-20}
+          if ! curl --retry 3 --retry-all-errors --retry-delay 3 -fsSL \
+              "$RAW_BASE/.github/runners/bootstrap-runner.ps1" \
+              -o "$BOOTSTRAP_PATH"; then
+            echo "::warning::Runner bootstrap download exhausted retries; run recovery again after the transient clears."
+            exit 0
           fi
-          [ "$POOL_LIMIT" -gt "${MAX_RUNNERS:-20}" ] && POOL_LIMIT=${MAX_RUNNERS:-20}
-          [ "$TARGET" -gt "${MAX_RUNNERS:-20}" ] && TARGET=${MAX_RUNNERS:-20}
-          [ "$TARGET" -gt "$POOL_LIMIT" ] && TARGET=$POOL_LIMIT
+          echo "ready=true" >> "$GITHUB_OUTPUT"
 
-          echo "actor=$TRIGGER_ACTOR active_maintainers=$ACTIVE_COUNT queued=$QUEUED idle=$IDLE capacity=$CAPACITY pool_limit=$POOL_LIMIT target=$TARGET"
-          if [ "$TARGET" -gt "$CAPACITY" ]; then
-            az vmss scale -g "$RG" -n "$VMSS" --new-capacity "$TARGET" --no-wait
-            echo "scaled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "scaled=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Register runners on unregistered instances
-        run: |
-          set -euo pipefail
-
-          gh_api_retry() {
-            local attempt status
-            for attempt in 1 2 3; do
-              if gh api "$@"; then
-                return 0
-              else
-                status=$?
-              fi
-              echo "GitHub API attempt $attempt of 3 failed" >&2
-              if [ "$attempt" -lt 3 ]; then
-                sleep $((attempt * 3))
-              fi
-            done
-            return "$status"
-          }
-
-          curl --retry 3 --retry-all-errors --retry-delay 3 -fsSL "$RAW_BASE/.github/runners/bootstrap-runner.ps1" -o /tmp/bootstrap-runner.ps1
-
-          # Wait for any scale-out to finish provisioning
-          for attempt in $(seq 1 20); do
-            NOT_READY=$(az vm list -g "$RG" --query "length([?starts_with(name, '${VMSS}_') && provisioningState != 'Succeeded'])" -o tsv 2>/dev/null || echo 0)
-            [ "$NOT_READY" = "0" ] && break
-            echo "waiting: $NOT_READY instance(s) still provisioning"
-            sleep 20
-          done
-
-          # two sweeps: instances that finish provisioning after the first pass would
-          # otherwise wait for the (often tardy) reconcile cron
-          for sweep in 1 2; do
-            REGISTERED=$(gh_api_retry "repos/$REPO/actions/runners?per_page=100" --paginate --jq '[.runners[].name] | join(" ")')
-            VMS=$(az vm list -g "$RG" --query "[?starts_with(name, '${VMSS}_') && provisioningState == 'Succeeded'].name" -o tsv 2>/dev/null || true)
-
-            MISSED=0
-            for VM in $VMS; do
-              case " $REGISTERED " in
-                *" $VM "*) continue ;;
-              esac
-              MISSED=$((MISSED + 1))
-              echo "registering $VM (sweep $sweep)"
-              TOKEN=$(gh_api_retry -X POST "repos/$REPO/actions/runners/registration-token" --jq .token)
-              (
-                OUT=$(az vm run-command invoke -g "$RG" -n "$VM" --command-id RunPowerShellScript \
-                  --scripts @/tmp/bootstrap-runner.ps1 \
-                  --parameters "Token=$TOKEN" "RunnerName=$VM" "Labels=$RUNNER_LABEL" \
-                  --query "value[0].message" -o tsv || true)
-                echo "$OUT" | tail -5
-                if echo "$OUT" | grep -q "SPENT-VM"; then
-                  echo "$VM already served a job -- deleting instead of reusing"
-                  az vm delete -g "$RG" -n "$VM" --yes --no-wait || true
-                fi
-              ) &
-            done
-            wait
-            echo "registration sweep $sweep complete ($MISSED handled)"
-            if [ "$sweep" = "1" ]; then
-              sleep 90
-            fi
-          done
+      - name: Reconcile AppVeyor-style pools
+        if: steps.controller.outputs.ready == 'true'
+        shell: pwsh
+        run: /tmp/reconcile-runner-fleet.ps1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Agent Instructions
+
+## Pull Request Integration
+
+**Always squash and merge pull requests that target `development`.** Never use a
+merge commit or rebase merge when integrating a PR into `development`.
+
+Follow the PowerShell and repository conventions in `CLAUDE.md` for all other work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,11 @@ Get-DbaDatabase - Add support for filtering by recovery model
 
 For multiple commands: `(do *Login*)` or `(do *Backup*, *Restore*)`
 
+### Pull Request Integration
+
+**ABSOLUTE RULE: Always squash and merge pull requests that target `development`.**
+Never use a merge commit or rebase merge when integrating a PR into `development`.
+
 ### .OUTPUTS Documentation
 
 All commands should have proper `.OUTPUTS` documentation. **Use the prompt at `.github/prompts/typesncolumns.md`** to generate proper documentation.


### PR DESCRIPTION
## Summary

Implements the AppVeyor-style Azure VMSS behavior discussed in #10422:

- `potatoqualitee`: 10 dedicated runners, cold-started by activity and kept hot for two hours
- `andreasjordan`: an independent 10-runner lane with the same two-hour window
- community: one shared 5-runner lane, also cold-started and kept hot for two hours
- no recent activity and no queued/running build: zero runners
- total fleet sizes therefore converge to 0/5/10/15/20/25, with `MAX_RUNNERS=25`

Each VM keeps its lane in the Azure `runnerPool` tag and registers with a matching GitHub runner label. Agents remain ephemeral: one job per VM, then the job-completion nudge replaces that lane's spent worker while the lane is hot.

## Build queue behavior

`ci-azure` now has one concurrency lane per actor pool and uses `queue: max`. One 10-job matrix build consumes a lane at a time; later builds in that lane wait instead of spreading across unrelated runs. Pool-specific runner labels prevent maintainer and community builds from stealing one another's capacity.

## Resilience

- GitHub and Azure control-plane operations retry three times.
- Exhausted transient control-plane failures warn and exit green so the next job nudge or hourly reconcile can recover.
- Logic/configuration errors remain real failures.
- Runner deletion rechecks the busy race and preserves a VM that accepted a job during cleanup.
- Controller/bootstrap downloads and reconcile dispatches have bounded retries and a green fallback.
- The safety reconcile runs hourly, not every 30 minutes.

## Activity window

Both pushes and PR open/reopen/synchronize events refresh the two-hour window, including commits from forked community PRs. A queued or running `ci-azure` build keeps its lane alive even if the clock expires.

## Validation

- All changed workflow YAML parses.
- All runner PowerShell scripts parse.
- Existing Actionlint passes for the controller workflows; Actionlint 1.7.12 only flags GitHub's newer `concurrency.queue` key and the intentional custom self-hosted label.
- Live allocator pass converged the VMSS to 10 VMs tagged for the `potatoqualitee` lane and registered the new pool-specific runner label.
