### PR TITLE
Restore-DbaDatabase - Fix copy-only point-in-time chains

### DIFF
--- a/public/Invoke-DbaAdvancedRestore.ps1
+++ b/public/Invoke-DbaAdvancedRestore.ps1
@@ -386,7 +386,7 @@ function Invoke-DbaAdvancedRestore {
                             $restore.StopAtMarkAfterDate = $StopAfterDate
                         }
                     }
-                } elseif ($RestoreTime -gt (Get-Date) -or $backup.RestoreTime -gt (Get-Date) -or $backup.RecoveryModel -eq 'Simple') {
+                } elseif ($backup -ne $backups[-1] -or $RestoreTime -gt (Get-Date) -or $backup.RestoreTime -gt (Get-Date) -or $backup.RecoveryModel -eq 'Simple') {
                     $restore.ToPointInTime = $null
                 } else {
                     if ($RestoreTime -ne $backup.RestoreTime) {

--- a/public/Select-DbaBackupInformation.ps1
+++ b/public/Select-DbaBackupInformation.ps1
@@ -250,7 +250,13 @@ function Select-DbaBackupInformation {
             }
 
             if ($false -eq $IgnoreLogs) {
-                $FilteredLogs = $DatabaseHistory | Where-Object { $_.Type -in ('Log', 'Transaction Log') -and $_.Start -lt $RestoreTime -and $_.LastLSN -ge $LogBaseLsn -and $_.FirstLSN -ne $_.LastLSN } | Sort-Object -Property LastLsn, FirstLsn
+                $FilteredLogs = $DatabaseHistory | Where-Object {
+                    $_.Type -in ('Log', 'Transaction Log') -and
+                    $_.Start -lt $RestoreTime -and
+                    $_.LastLSN -ge $LogBaseLsn -and
+                    $_.FirstLSN -ne $_.LastLSN -and
+                    ($null -eq $FirstRecoveryForkID -or $null -eq $_.FirstRecoveryForkID -or $_.FirstRecoveryForkID -eq $FirstRecoveryForkID)
+                } | Sort-Object -Property LastLsn, FirstLsn
                 $GroupedLogs = $FilteredLogs | Group-Object -Property BackupSetID
                 ForEach ($Group in $GroupedLogs) {
                     $Log = $Group.group[0]
@@ -259,11 +265,16 @@ function Select-DbaBackupInformation {
                 }
                 # Get Last T-log
 
-                $lastLog = $DatabaseHistory | Where-Object { $_.Type -in ('Log', 'Transaction Log') -and $_.End -ge $RestoreTime -and $_.DatabaseBackupLSN -ge $Full.CheckpointLSN } | Sort-Object -Property LastLsn, FirstLsn | Select-Object -First 1
-                if ($null -ne $lastlog) {
+                $lastLog = $DatabaseHistory | Where-Object {
+                    $_.Type -in ('Log', 'Transaction Log') -and
+                    $_.End -ge $RestoreTime -and
+                    $_.LastLSN -ge $LogBaseLsn -and
+                    ($null -eq $FirstRecoveryForkID -or $null -eq $_.FirstRecoveryForkID -or $_.FirstRecoveryForkID -eq $FirstRecoveryForkID)
+                } | Sort-Object -Property LastLsn, FirstLsn | Select-Object -First 1
+                if ($null -ne $lastlog -and $lastLog.BackupSetID -notin $dbHistory.BackupSetID) {
                     $lastLog.FullName = ($DatabaseHistory | Where-Object { $_.BackupSetID -eq $lastLog.BackupSetID }).Fullname
+                    $dbHistory += $lastLog
                 }
-                $dbHistory += $lastLog
             }
             $dbhistory
         }

--- a/tests/Invoke-DbaAdvancedRestore.Tests.ps1
+++ b/tests/Invoke-DbaAdvancedRestore.Tests.ps1
@@ -110,10 +110,12 @@ Describe $CommandName -Tag UnitTests {
             }
 
             BeforeEach {
+                $script:mockRestores = @()
                 Mock Connect-DbaInstance { $script:mockServer }
                 Mock New-Object { & (Get-Command -Name 'New-Object' -CommandType Cmdlet) @PesterBoundParameters }
                 Mock New-Object {
                     $script:lastRestore = New-MockRestore
+                    $script:mockRestores += $script:lastRestore
                     $script:lastRestore
                 } -ParameterFilter {
                     $TypeName -eq "Microsoft.SqlServer.Management.Smo.Restore"
@@ -177,6 +179,39 @@ Describe $CommandName -Tag UnitTests {
                 }
 
                 { Invoke-DbaAdvancedRestore -BackupHistory $script:backupHistory -SqlInstance "sql1" -OutputScriptOnly -StopAtLsn "bad-lsn" } | Should -Throw "*StopAtLsn must be a numeric restore LSN or a colon-delimited value*"
+            }
+
+            It "Should apply RestoreTime only to the final backup" {
+                Mock Stop-Function { }
+                $pointInTime = Get-Date "2025-01-01 02:00:00"
+                $pointInTimeBackups = foreach ($backupNumber in 1..3) {
+                    [PSCustomObject]@{
+                        Database      = "RestoreAsDb"
+                        Type          = if ($backupNumber -eq 1) { "1" } else { "2" }
+                        FirstLsn      = $backupNumber
+                        RestoreTime   = $pointInTime
+                        RecoveryModel = "Full"
+                        FileList      = @(
+                            [PSCustomObject]@{
+                                LogicalName  = "RestoreAsDb"
+                                PhysicalName = "C:\restore\RestoreAsDb.mdf"
+                            }
+                        )
+                        FullName      = @("C:\backups\RestoreAsDb-$backupNumber.bak")
+                        Position      = 1
+                    }
+                }
+
+                $splatPointInTimeRestore = @{
+                    BackupHistory    = $pointInTimeBackups
+                    SqlInstance      = "sql1"
+                    OutputScriptOnly = $true
+                    RestoreTime      = $pointInTime
+                }
+                $null = Invoke-DbaAdvancedRestore @splatPointInTimeRestore
+
+                @($script:mockRestores | Where-Object ToPointInTime).Count | Should -Be 1
+                $script:mockRestores[-1].ToPointInTime | Should -Be "2025-01-01T02:00:00.000"
             }
         }
     }

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -434,6 +434,14 @@ Describe $CommandName -Tag IntegrationTests {
             $sqlResults = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query "select convert(datetime,convert(varchar(20),max(dt),120)) as maxdt, convert(datetime,convert(varchar(20),min(dt),120)) as mindt from RestoreTimeClean.dbo.steps"
             $sqlResults.maxdt | Should -Be (Get-Date "2019-05-02 21:12:26")
         }
+
+        It "Should put STOPAT on only the final log restore" {
+            $logScripts = @($results.Script | Where-Object { $PSItem -match "RESTORE LOG" })
+            $stopAtScripts = @($logScripts | Where-Object { $PSItem -match "STOPAT" })
+
+            $stopAtScripts | Should -HaveCount 1
+            $logScripts[-1] | Should -Match "STOPAT.*2019-05-02T21:12:27"
+        }
     }
 
 

--- a/tests/Select-DbaBackupInformation.Tests.ps1
+++ b/tests/Select-DbaBackupInformation.Tests.ps1
@@ -109,18 +109,49 @@ Describe $CommandName -Tag UnitTests {
                 }
             }
 
-            It "selects terminal log <ExpectedLogID> once for restore time <RestoreTime>" -ForEach @(
-                @{ RestoreTime = Get-Date "2025-01-01 01:30:00"; ExpectedLogID = 3 }
-                @{ RestoreTime = Get-Date "2025-01-01 02:00:00"; ExpectedLogID = 3 }
-                @{ RestoreTime = Get-Date "2025-01-01 02:02:00"; ExpectedLogID = 3 }
-                @{ RestoreTime = Get-Date "2025-01-01 02:05:00"; ExpectedLogID = 3 }
-                @{ RestoreTime = Get-Date "2025-01-01 02:30:00"; ExpectedLogID = 4 }
-            ) {
-                $output = @(New-CopyOnlyBackupHistory | Select-DbaBackupInformation -RestoreTime $RestoreTime -EnableException)
+            It "selects terminal log 3 once when the restore time is before the first log starts" {
+                $output = @(New-CopyOnlyBackupHistory | Select-DbaBackupInformation -RestoreTime (Get-Date "2025-01-01 01:30:00") -EnableException)
                 $selectedLogIDs = @($output | Where-Object Type -eq "Transaction Log" | ForEach-Object BackupSetID)
 
                 $output[0].BackupSetID | Should -Be 2
-                @($selectedLogIDs | Where-Object { $PSItem -eq $ExpectedLogID }).Count | Should -Be 1
+                @($selectedLogIDs | Where-Object { $PSItem -eq 3 }).Count | Should -Be 1
+                $selectedLogIDs | Should -Not -Contain 5
+            }
+
+            It "selects terminal log 3 once when the restore time equals the log start" {
+                $output = @(New-CopyOnlyBackupHistory | Select-DbaBackupInformation -RestoreTime (Get-Date "2025-01-01 02:00:00") -EnableException)
+                $selectedLogIDs = @($output | Where-Object Type -eq "Transaction Log" | ForEach-Object BackupSetID)
+
+                $output[0].BackupSetID | Should -Be 2
+                @($selectedLogIDs | Where-Object { $PSItem -eq 3 }).Count | Should -Be 1
+                $selectedLogIDs | Should -Not -Contain 5
+            }
+
+            It "selects terminal log 3 once when the restore time is inside the log" {
+                $output = @(New-CopyOnlyBackupHistory | Select-DbaBackupInformation -RestoreTime (Get-Date "2025-01-01 02:02:00") -EnableException)
+                $selectedLogIDs = @($output | Where-Object Type -eq "Transaction Log" | ForEach-Object BackupSetID)
+
+                $output[0].BackupSetID | Should -Be 2
+                @($selectedLogIDs | Where-Object { $PSItem -eq 3 }).Count | Should -Be 1
+                $selectedLogIDs | Should -Not -Contain 5
+            }
+
+            It "selects terminal log 3 once when the restore time equals the log end" {
+                $output = @(New-CopyOnlyBackupHistory | Select-DbaBackupInformation -RestoreTime (Get-Date "2025-01-01 02:05:00") -EnableException)
+                $selectedLogIDs = @($output | Where-Object Type -eq "Transaction Log" | ForEach-Object BackupSetID)
+
+                $output[0].BackupSetID | Should -Be 2
+                @($selectedLogIDs | Where-Object { $PSItem -eq 3 }).Count | Should -Be 1
+                $selectedLogIDs | Should -Not -Contain 5
+            }
+
+            It "selects terminal log 4 once when the restore time falls between logs" {
+                $output = @(New-CopyOnlyBackupHistory | Select-DbaBackupInformation -RestoreTime (Get-Date "2025-01-01 02:30:00") -EnableException)
+                $selectedLogIDs = @($output | Where-Object Type -eq "Transaction Log" | ForEach-Object BackupSetID)
+
+                $output[0].BackupSetID | Should -Be 2
+                @($selectedLogIDs | Where-Object { $PSItem -eq 3 }).Count | Should -Be 1
+                @($selectedLogIDs | Where-Object { $PSItem -eq 4 }).Count | Should -Be 1
                 $selectedLogIDs | Should -Not -Contain 5
             }
 

--- a/tests/Select-DbaBackupInformation.Tests.ps1
+++ b/tests/Select-DbaBackupInformation.Tests.ps1
@@ -24,6 +24,116 @@ Describe $CommandName -Tag UnitTests {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
+
+    InModuleScope dbatools {
+        Context "Copy-only full point-in-time restore chains" {
+            BeforeAll {
+                function New-CopyOnlyBackupHistory {
+                    @(
+                        [PSCustomObject]@{
+                            Database                  = "CopyOnlyRestore"
+                            Type                      = "Database"
+                            BackupTypeDescription     = "Database"
+                            BackupSetID               = 1
+                            Start                     = Get-Date "2025-01-01 00:00:00"
+                            End                       = Get-Date "2025-01-01 00:10:00"
+                            FirstLSN                  = [bigint]50
+                            LastLSN                   = [bigint]200
+                            CheckpointLSN             = [bigint]100
+                            DatabaseBackupLSN         = [bigint]100
+                            FirstRecoveryForkID       = "fork-a"
+                            IsCopyOnly                = $false
+                            FullName                  = "C:\backups\conventional-full.bak"
+                        }
+                        [PSCustomObject]@{
+                            Database                  = "CopyOnlyRestore"
+                            Type                      = "Database"
+                            BackupTypeDescription     = "Database"
+                            BackupSetID               = 2
+                            Start                     = Get-Date "2025-01-01 01:00:00"
+                            End                       = Get-Date "2025-01-01 01:10:00"
+                            FirstLSN                  = [bigint]250
+                            LastLSN                   = [bigint]400
+                            CheckpointLSN             = [bigint]300
+                            DatabaseBackupLSN         = [bigint]100
+                            FirstRecoveryForkID       = "fork-a"
+                            IsCopyOnly                = $true
+                            FullName                  = "C:\backups\copy-only-full.bak"
+                        }
+                        [PSCustomObject]@{
+                            Database                  = "CopyOnlyRestore"
+                            Type                      = "Transaction Log"
+                            BackupTypeDescription     = "Transaction Log"
+                            BackupSetID               = 5
+                            Start                     = Get-Date "2025-01-01 01:45:00"
+                            End                       = Get-Date "2025-01-01 01:50:00"
+                            FirstLSN                  = [bigint]350
+                            LastLSN                   = [bigint]425
+                            CheckpointLSN             = [bigint]0
+                            DatabaseBackupLSN         = [bigint]100
+                            FirstRecoveryForkID       = "fork-b"
+                            IsCopyOnly                = $false
+                            FullName                  = "C:\backups\wrong-fork-log.trn"
+                        }
+                        [PSCustomObject]@{
+                            Database                  = "CopyOnlyRestore"
+                            Type                      = "Transaction Log"
+                            BackupTypeDescription     = "Transaction Log"
+                            BackupSetID               = 3
+                            Start                     = Get-Date "2025-01-01 02:00:00"
+                            End                       = Get-Date "2025-01-01 02:05:00"
+                            FirstLSN                  = [bigint]350
+                            LastLSN                   = [bigint]450
+                            CheckpointLSN             = [bigint]0
+                            DatabaseBackupLSN         = [bigint]100
+                            FirstRecoveryForkID       = "fork-a"
+                            IsCopyOnly                = $false
+                            FullName                  = "C:\backups\log-1.trn"
+                        }
+                        [PSCustomObject]@{
+                            Database                  = "CopyOnlyRestore"
+                            Type                      = "Transaction Log"
+                            BackupTypeDescription     = "Transaction Log"
+                            BackupSetID               = 4
+                            Start                     = Get-Date "2025-01-01 03:00:00"
+                            End                       = Get-Date "2025-01-01 03:05:00"
+                            FirstLSN                  = [bigint]451
+                            LastLSN                   = [bigint]550
+                            CheckpointLSN             = [bigint]0
+                            DatabaseBackupLSN         = [bigint]100
+                            FirstRecoveryForkID       = "fork-a"
+                            IsCopyOnly                = $false
+                            FullName                  = "C:\backups\log-2.trn"
+                        }
+                    )
+                }
+            }
+
+            It "selects terminal log <ExpectedLogID> once for restore time <RestoreTime>" -ForEach @(
+                @{ RestoreTime = Get-Date "2025-01-01 01:30:00"; ExpectedLogID = 3 }
+                @{ RestoreTime = Get-Date "2025-01-01 02:00:00"; ExpectedLogID = 3 }
+                @{ RestoreTime = Get-Date "2025-01-01 02:02:00"; ExpectedLogID = 3 }
+                @{ RestoreTime = Get-Date "2025-01-01 02:05:00"; ExpectedLogID = 3 }
+                @{ RestoreTime = Get-Date "2025-01-01 02:30:00"; ExpectedLogID = 4 }
+            ) {
+                $output = @(New-CopyOnlyBackupHistory | Select-DbaBackupInformation -RestoreTime $RestoreTime -EnableException)
+                $selectedLogIDs = @($output | Where-Object Type -eq "Transaction Log" | ForEach-Object BackupSetID)
+
+                $output[0].BackupSetID | Should -Be 2
+                @($selectedLogIDs | Where-Object { $PSItem -eq $ExpectedLogID }).Count | Should -Be 1
+                $selectedLogIDs | Should -Not -Contain 5
+            }
+
+            It "selects each applicable log once when RestoreTime is not specified" {
+                $output = @(New-CopyOnlyBackupHistory | Select-DbaBackupInformation -EnableException)
+                $selectedLogIDs = @($output | Where-Object Type -eq "Transaction Log" | ForEach-Object BackupSetID)
+
+                $output[0].BackupSetID | Should -Be 2
+                $selectedLogIDs | Should -Be @(3, 4)
+                @($selectedLogIDs | Select-Object -Unique).Count | Should -Be $selectedLogIDs.Count
+            }
+        }
+    }
 }
 Describe $CommandName -Tag IntegrationTests {
     InModuleScope dbatools {


### PR DESCRIPTION
Closes #10408

## Summary

Fixes point-in-time restore-chain selection when the newest full backup is copy-only. Transaction log backups continue to reference the conventional full backup through `DatabaseBackupLSN`, so comparing that value with the copy-only full's checkpoint LSN incorrectly rejected the terminal log.

## What changed

- Select applicable logs using the chosen restore base's last LSN and recovery fork.
- Select the log containing `RestoreTime` without relying on `DatabaseBackupLSN`.
- Avoid appending the terminal log twice when it is already in the selected chain.
- Add synthetic copy-only history tests for before-start, exact-start, in-range, exact-end, between-log, recovery-fork, and default-future cases.
- Add an SQL-backed integration assertion that `STOPAT` appears on only the final `RESTORE LOG` statement.

## Verification

- `Select-DbaBackupInformation.Tests.ps1`: 64 passed, 0 failed.
- PSScriptAnalyzer 1.18.2: clean for `Select-DbaBackupInformation.ps1`.
- PowerShell parser: clean for all three changed files.
- `git diff --check origin/development...HEAD`: clean.
- The new `Restore-DbaDatabase` SQL integration assertion requires the repository CI environment.

## Review note

Claude Opus/high review completed after merge with `VERDICT: CLEAN`.