### PR TITLE
Use Azure tag API for runner pools

### DIFF
--- a/.github/runners/reconcile-runner-fleet.ps1
+++ b/.github/runners/reconcile-runner-fleet.ps1
@@ -160,9 +160,14 @@ function Get-RunnerForVm {
 
 function Set-VmPool {
     param([string]$VmName, [string]$Pool)
+    # Use the dedicated tag API. `az vm update --set tags.*` can invoke Azure's
+    # unrelated zone-movement validation and reject otherwise valid VM tag changes.
+    $vmId = Invoke-AzJson -Arguments @(
+        "vm", "show", "--resource-group", $resourceGroup, "--name", $VmName, "--query", "id"
+    ) -Operation "read resource ID for $VmName"
     $null = Invoke-NativeText -Tool "az" -Arguments @(
-        "vm", "update", "--resource-group", $resourceGroup, "--name", $VmName,
-        "--set", "tags.runnerPool=$Pool", "--only-show-errors", "--output", "none"
+        "tag", "update", "--resource-id", $vmId, "--operation", "Merge",
+        "--tags", "runnerPool=$Pool", "--only-show-errors", "--output", "none"
     ) -Operation "tag $VmName for pool $Pool"
     Write-Host "assigned $VmName to pool $Pool"
 }


### PR DESCRIPTION
## Summary

Use Azure's dedicated tag API when assigning VMSS instances to runner pools.

The first autonomous reconcile after #10427 exposed an Azure CLI regression: `az vm update --set tags.runnerPool=...` attempted an unrelated zone-movement operation and Azure rejected it. The controller retried three times and exited green as designed, but could not register the replacement fleet.

## Fix

- Resolve the VM resource ID.
- Merge `runnerPool` through `az tag update`.
- Preserve all existing VM tags.
- Keep the same bounded retry and transient-failure behavior.

## Validation

- PowerShell parser passes.
- `git diff --check` passes.
- Live tag API probe succeeded.
- A full live reconcile assigned all 10 pool tags, registered 10 dedicated agents, and reported `desired=10 vms=10 online=10 busy=10`; the queued development matrix started on all ten.
