### PR TITLE
CI - Clear stale native exit codes after successful stages (do Test-DbaLastBackup)

### DIFF
--- a/tests/gha.shim.ps1
+++ b/tests/gha.shim.ps1
@@ -186,6 +186,9 @@ function Invoke-GhaStage {
         exit 1
     }
     $stageWatch.Stop()
+    # GitHub's PowerShell wrapper exits with a stale native command status even
+    # after the AppVeyor stage itself succeeds. A thrown stage still exits above.
+    $global:LASTEXITCODE = 0
     Write-Host -Object "===== stage done: $Script ($([int]$stageWatch.Elapsed.TotalSeconds)s) =====" -ForegroundColor Green
 }
 


### PR DESCRIPTION
## What changed

Clear a stale native `$LASTEXITCODE` after an AppVeyor-compatible stage returns successfully. Thrown stages still exit immediately with status 1.

## Why

The Azure runner completed `Test-DbaLastBackup.Tests.ps1` and `appveyor.post.ps1` successfully, but GitHub's PowerShell wrapper inherited an earlier native exit code and marked the job failed. AppVeyor does not treat that stale status as the stage result.

## Impact

Successful test stages no longer become false-red GitHub Actions jobs. Real stage exceptions and Pester failures still fail the run.

## Validation

- PowerShell parser validation passed.
- `git diff --check` passed.
- This PR is scoped to `(do Test-DbaLastBackup)` to reproduce the previously false-red matrix job.