### PR TITLE
Invoke-ManualPester - Fix -PassThru under Pester 6

### DIFF
--- a/private/testing/Invoke-ManualPester.ps1
+++ b/private/testing/Invoke-ManualPester.ps1
@@ -312,7 +312,7 @@ function Invoke-ManualPester {
                 $pester5Config = New-PesterConfiguration
                 $pester5Config.Run.Path = $f.FullName
                 if ($PassThru) {
-                    $pester5config.Run.PassThru = $passThru
+                    $pester5config.Run.PassThru = $true
                 }
                 $pester5config.Output.Verbosity = $show
                 if ($Coverage) {


### PR DESCRIPTION
## Summary

`Invoke-ManualPester -PassThru` throws `SetValueInvocationException` since the helper moved to `Import-Module Pester -RequiredVersion 6.0.0`: Pester 6.0.0 no longer implicitly converts a `SwitchParameter` to `Pester.BoolOption`, so `$pester5config.Run.PassThru = $passThru` fails (Pester 5.7.1 accepted the conversion). The Pester 4 path is unaffected because it passes the switch through normal parameter binding.

## What changed

- `private/functions/../testing/Invoke-ManualPester.ps1`: assign `$true` to `Run.PassThru` inside the existing `if ($PassThru)` guard, matching the `CodeCoverage.Enabled = $true` idiom a few lines below.

## Verification

- Before: `Invoke-ManualPester -Path tests\Select-DbaBackupInformation.Tests.ps1 -PassThru` threw `Cannot convert the "True" value of type "System.Management.Automation.SwitchParameter" to type "Pester.BoolOption"` and returned nothing.
- After: same call runs clean and returns the Pester result object (TotalCount/PassedCount populated).

(do Select-DbaBackupInformation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)