### PR TITLE
Update-DbaMaintenanceSolution - Clarify Force warning

### DIFF
--- a/public/Update-DbaMaintenanceSolution.ps1
+++ b/public/Update-DbaMaintenanceSolution.ps1
@@ -96,7 +96,7 @@ function Update-DbaMaintenanceSolution {
     begin {
         if ($Force) {
             $ConfirmPreference = "none"
-            Write-Message -Level Warning -Message "Force is no longer required because Update-DbaMaintenanceSolution refreshes its source on every invocation."
+            Write-Message -Level Warning -Message "Force is no longer required to bypass the cached copy because Update-DbaMaintenanceSolution refreshes its source on every invocation. Force still suppresses confirmation prompts."
         }
 
         if ($Solution -contains 'All') {

--- a/tests/Update-DbaMaintenanceSolution.Tests.ps1
+++ b/tests/Update-DbaMaintenanceSolution.Tests.ps1
@@ -93,6 +93,14 @@ Describe $CommandName -Tag UnitTests {
                     $Level -eq "Warning" -and $Message -like "*Force*refresh*every invocation*"
                 }
             }
+
+            It "explains that Force still suppresses confirmation prompts" {
+                $null = Update-DbaMaintenanceSolution -SqlInstance "sql1" -Force -Confirm:$false
+
+                Should -Invoke Write-Message -Times 1 -Exactly -ParameterFilter {
+                    $Level -eq "Warning" -and $Message -like "*Force*still suppresses confirmation prompts*"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- clarify that `Force` is only redundant for bypassing the maintenance-solution cache
- retain and explicitly document that `Force` still suppresses confirmation prompts
- add focused regression coverage for the warning text

## Why

The Opus/high review of #10424 found that the previous warning could lead users to remove `Force` and unexpectedly receive confirmation prompts, even though the command still sets `$ConfirmPreference = "none"` when `Force` is supplied.

## Verification

- `tests/Update-DbaMaintenanceSolution.Tests.ps1`: 7 passed, 0 failed (Pester 5.7.1)
- PSScriptAnalyzer 1.18.2: clean for `public/Update-DbaMaintenanceSolution.ps1`
- PowerShell parser: clean for both changed files
- `git diff --check origin/development...HEAD`: clean
- Claude Opus/high follow-up review: `VERDICT: CLEAN`

This changes only the warning text and adds a regression test; command behavior is unchanged.