### PR TITLE
Set-DbaNetworkCertificate - Honor Force for unsuitable certificates

### DIFF
--- a/public/Set-DbaNetworkCertificate.ps1
+++ b/public/Set-DbaNetworkCertificate.ps1
@@ -50,6 +50,10 @@ function Set-DbaNetworkCertificate {
         Unsets the currently configured network certificate for the SQL Server instance.
         This will remove the certificate configuration, and SQL Server will not use any certificate for SSL connections.
 
+    .PARAMETER Force
+        Configures the specified certificate even when suitability checks fail.
+        The certificate must still exist in the LocalMachine certificate store. Failed checks are reported as a warning.
+
     .PARAMETER RestartService
         Forces an automatic restart of the SQL Server service after setting the network certificate.
         Certificate changes require a service restart to take effect - without this switch you'll need to manually restart SQL Server.
@@ -105,6 +109,11 @@ function Set-DbaNetworkCertificate {
         Sets the network certificate for the SQL2008R2SP2 instance to the certificate with the thumbprint of 1223FB1ACBCA44D3EE9640F81B6BA14A92F3D6E2 in LocalMachine\My on sql1
 
     .EXAMPLE
+        PS C:\> Set-DbaNetworkCertificate -SqlInstance sql1\SQL2008R2SP2 -Thumbprint 1223FB1ACBCA44D3EE9640F81B6BA14A92F3D6E2 -Force
+
+        Sets the network certificate even when the certificate fails one or more suitability checks. Failed checks are reported as a warning.
+
+    .EXAMPLE
         PS C:\> Set-DbaNetworkCertificate -SqlInstance localhost\SQL2008R2SP2 -UnsetCertificate -RestartService
 
         Unsets the network certificate for the SQL2008R2SP2 instance and restarts the SQL Server service.
@@ -122,6 +131,7 @@ function Set-DbaNetworkCertificate {
         [Parameter(ValueFromPipelineByPropertyName)]
         [string]$Thumbprint,
         [switch]$UnsetCertificate,
+        [switch]$Force,
         [switch]$RestartService,
         [switch]$EnableException
     )
@@ -304,7 +314,14 @@ function Set-DbaNetworkCertificate {
                     if ($detailedCertTest.CertificateFound -and -not $detailedCertTest.SignatureAlgorithmValid) { $failedChecks += "SignatureAlgorithmInvalid" }
                     if ($detailedCertTest.CertificateFound -and -not $detailedCertTest.EnhancedKeyUsageValid) { $failedChecks += "EnhancedKeyUsageInvalid" }
                     if ($detailedCertTest.CertificateFound -and -not $detailedCertTest.ValidityPeriodOk) { $failedChecks += "ValidityPeriodExpiredOrInsufficient" }
-                    Stop-Function -Message "Certificate $Thumbprint is not suitable for SQL Server network encryption on $instance. Failed checks: $($failedChecks -join ', ')." -Target $instance -Continue
+                    if ($failedChecks.Count -eq 0) {
+                        $newThumbprint = $Thumbprint
+                    } elseif ($Force -and $detailedCertTest.CertificateFound) {
+                        Write-Message -Level Warning -Message "Certificate $Thumbprint is not suitable for SQL Server network encryption on $instance, but Force was specified. Failed checks: $($failedChecks -join ', ')." -Target $instance
+                        $newThumbprint = $Thumbprint
+                    } else {
+                        Stop-Function -Message "Certificate $Thumbprint is not suitable for SQL Server network encryption on $instance. Failed checks: $($failedChecks -join ', ')." -Target $instance -Continue
+                    }
                 }
             } else {
                 if ($certTest.ConfiguredCertificateValid) {

--- a/tests/Set-DbaNetworkCertificate.Tests.ps1
+++ b/tests/Set-DbaNetworkCertificate.Tests.ps1
@@ -16,6 +16,7 @@ Describe $CommandName -Tag UnitTests {
                 "Certificate",
                 "Thumbprint",
                 "UnsetCertificate",
+                "Force",
                 "RestartService",
                 "EnableException"
             )
@@ -75,6 +76,65 @@ Describe $CommandName -Tag UnitTests {
                     $Force -and
                     $EnableException
                 }
+            }
+        }
+
+        Context "Force" {
+            BeforeEach {
+                $script:certificateThumbprint = "0123456789ABCDEF0123456789ABCDEF01234567"
+
+                Mock Test-FunctionInterrupt { $false }
+                Mock Test-DbaNetworkCertificate {
+                    if ($Thumbprint) {
+                        [PSCustomObject]@{
+                            CertificateFound        = $true
+                            KeyUsagesValid          = $true
+                            DnsNamesValid           = $false
+                            PrivateKeyValid         = $true
+                            PublicKeyValid          = $true
+                            SignatureAlgorithmValid = $false
+                            EnhancedKeyUsageValid   = $true
+                            ValidityPeriodOk        = $true
+                        }
+                    } else {
+                        [PSCustomObject]@{
+                            ComputerName                    = "sql1"
+                            InstanceName                    = "MSSQLSERVER"
+                            SqlInstance                     = "sql1"
+                            ConfiguredCertificateThumbprint = $null
+                            ConfiguredCertificateValid      = $false
+                            SuitableCertificateAvailable    = $false
+                            SuitableCertificateCount        = 0
+                            SuitableCertificates            = @()
+                        }
+                    }
+                }
+                Mock Invoke-Command2 {
+                    [PSCustomObject]@{
+                        Verbose        = @()
+                        Exception      = $null
+                        ServiceAccount = "sql1\svc-sql"
+                    }
+                }
+                Mock Write-Message { }
+            }
+
+            It "configures an existing certificate when suitability checks fail and Force is used" {
+                $splatSetNetworkCertificate = @{
+                    SqlInstance = "sql1"
+                    Thumbprint  = $script:certificateThumbprint
+                    Force       = $true
+                    Confirm     = $false
+                }
+
+                $result = Set-DbaNetworkCertificate @splatSetNetworkCertificate
+
+                $result.CertificateThumbprint | Should -Be $script:certificateThumbprint
+                Should -Invoke -CommandName Write-Message -Exactly 1 -Scope It -ModuleName dbatools -ParameterFilter {
+                    $Level -eq "Warning" -and
+                    $Message -match "DnsNamesInvalid, SignatureAlgorithmInvalid"
+                }
+                Should -Invoke -CommandName Invoke-Command2 -Exactly 1 -Scope It -ModuleName dbatools
             }
         }
     }


### PR DESCRIPTION
## Summary

- adds an explicit `-Force` switch to `Set-DbaNetworkCertificate`
- keeps detailed certificate validation and warns with the failed checks when forcing
- still rejects a thumbprint that is not present in `LocalMachine\My`
- adds a focused regression test without changing existing test behavior

## Root cause

The 2.8 command refactor added strict suitability validation for an explicitly selected certificate. In 2.7.27 the command configured an installed certificate directly, so existing automation using legacy or wildcard certificates could no longer proceed. There was no opt-out for operators who intentionally accept those suitability failures.

## Validation

- Pester unit tests: 3 passed, 0 failed
- PowerShell parser: clean for command and test files
- `git diff --check`: clean
- independent `claude -p --model opus --effort high` review: `VERDICT: CLEAN`

Fixes #10412