### PR TITLE
New-DbaDatabase - Add containment type option

### DIFF
--- a/public/New-DbaDatabase.ps1
+++ b/public/New-DbaDatabase.ps1
@@ -35,6 +35,9 @@ function New-DbaDatabase {
     .PARAMETER RecoveryModel
         Sets the recovery model which determines how transaction log backups work and how much data loss is acceptable. Simple recovery model doesn't require log backups but limits point-in-time recovery, Full enables complete point-in-time recovery with log backups, BulkLogged offers a compromise for bulk operations. If not specified, inherits from the model database.
 
+    .PARAMETER ContainmentType
+        Sets the containment type for the new database. Use Partial to create a partially contained database, or None to create a non-contained database. Database containment requires SQL Server 2012 or later. If not specified, inherits from the model database.
+
     .PARAMETER Owner
         Specifies which SQL Server login will be assigned as the database owner (dbo). Use this to assign ownership to a specific service account or administrator instead of the default creator. The login must already exist on the SQL Server instance. If not specified, the connecting user becomes the database owner.
 
@@ -115,6 +118,7 @@ function New-DbaDatabase {
         - Status: Current database status (Normal for a new database)
         - IsAccessible: Boolean indicating if the database is currently accessible
         - RecoveryModel: Database recovery model (Simple, Full, or BulkLogged as specified)
+        - ContainmentType: Database containment type (None or Partial as specified)
         - LogReuseWaitStatus: Status of transaction log reuse
         - Size: Database size in megabytes (MB)
         - Compatibility: Database compatibility level
@@ -136,6 +140,11 @@ function New-DbaDatabase {
         New-DbaDatabase -SqlInstance sql1 -Name dbatools, dbachecks
 
         Creates a database named dbatools and a database named dbachecks on sql1
+
+    .EXAMPLE
+        New-DbaDatabase -SqlInstance sql1 -Name containeddb -ContainmentType Partial
+
+        Creates a partially contained database named containeddb on sql1
 
     .EXAMPLE
         New-DbaDatabase -SqlInstance sql1, sql2, sql3 -Name multidb, multidb2 -SecondaryFilesize 20 -SecondaryFileGrowth 20 -LogSize 20 -LogGrowth 20
@@ -186,6 +195,8 @@ function New-DbaDatabase {
         [string]$Collation,
         [ValidateSet('Simple', 'Full', 'BulkLogged')]
         [string]$RecoveryModel,
+        [ValidateSet("None", "Partial")]
+        [string]$ContainmentType,
         [string]$Owner,
         [string]$DataFilePath,
         [string]$LogFilePath,
@@ -229,6 +240,10 @@ function New-DbaDatabase {
 
             if ($advancedconfig -and $server.VersionMajor -eq 8) {
                 Stop-Function -Message "Advanced configuration options are not available to SQL Server 2000. Aborting creation of database on $instance" -Target $instance -Continue
+            }
+
+            if ($ContainmentType -and $server.VersionMajor -lt 11) {
+                Stop-Function -Message "Database containment is not available before SQL Server 2012. Aborting creation of database on $instance" -Target $instance -Continue
             }
 
             # validate the collation
@@ -307,6 +322,11 @@ function New-DbaDatabase {
                 if ($RecoveryModel) {
                     Write-Message -Message "Setting recovery model to $RecoveryModel" -Level Verbose
                     $newdb.RecoveryModel = $RecoveryModel
+                }
+
+                if ($ContainmentType) {
+                    Write-Message -Message "Setting containment type to $ContainmentType" -Level Verbose
+                    $newdb.ContainmentType = $ContainmentType
                 }
 
                 if ($advancedconfig) {

--- a/tests/New-DbaDatabase.Tests.ps1
+++ b/tests/New-DbaDatabase.Tests.ps1
@@ -16,6 +16,7 @@ Describe $CommandName -Tag UnitTests {
                 "Name",
                 "Collation",
                 "Recoverymodel",
+                "ContainmentType",
                 "Owner",
                 "DataFilePath",
                 "LogFilePath",
@@ -174,6 +175,24 @@ Describe $CommandName -Tag UnitTests {
                 $script:executedPathQueries | Should -BeNullOrEmpty
                 $script:createdDataFiles[0].FileName | Should -Be "https://storage.blob.core.windows.net/data/db1.mdf"
                 $script:createdLogFiles[0].FileName | Should -Be "https://storage.blob.core.windows.net/log/db1_log.ldf"
+            }
+
+            It "sets containment type before database creation" {
+                Mock New-Object {
+                    $script:createdDatabase = [PSCustomObject]@{
+                        Name            = $ArgumentList[1]
+                        ContainmentType = $null
+                        Filegroups      = New-MockCollection
+                        LogFiles        = New-MockCollection
+                    }
+                    $script:createdDatabase
+                } -ParameterFilter {
+                    $TypeName -eq "Microsoft.SqlServer.Management.Smo.Database"
+                } -ModuleName dbatools
+
+                $null = New-DbaDatabase -SqlInstance "sql1" -Name "db1" -ContainmentType "Partial" -DataFilePath "C:\" -LogFilePath "L:\" -WhatIf
+
+                $script:createdDatabase.ContainmentType | Should -Be "Partial"
             }
         }
     }


### PR DESCRIPTION
## Summary

- add `-ContainmentType` with `None` and `Partial` values
- set the SMO database containment type before creation
- reject containment requests on SQL Server versions older than 2012
- document the parameter and add focused unit coverage

## Why

`New-DbaDatabase` could set recovery model during creation but required a separate query to configure database containment.

## Validation

- Pester 5.3.1: `tests/New-DbaDatabase.Tests.ps1` excluding `IntegrationTests` — 4 passed, 0 failed
- PowerShell parser: command and test files clean
- `git diff --check`: clean
- independent `claude -p --model opus --effort high` review: clean

Fixes #9218