### PR TITLE
Restore-DbaDatabase - Allow Managed Instance XTP restore paths

### DIFF
--- a/public/Test-DbaBackupInformation.ps1
+++ b/public/Test-DbaBackupInformation.ps1
@@ -160,6 +160,8 @@ function Test-DbaBackupInformation {
                 $DBHistoryPhysicalPathsExists = ($DBHistoryPhysicalPathsTest | Where-Object FileExists -eq $True).FilePath
                 $pathSep = Get-DbaPathSep -Server $RestoreInstance
                 foreach ($path in $DBHistoryPhysicalPaths) {
+                    # Managed Instance assigns a new path to orphaned memory-optimized containers during restore.
+                    $isManagedInstanceXtpContainer = $RestoreInstance.DatabaseEngineEdition -eq "SqlManagedInstance" -and $path -like "*.xtp"
                     if (($DBHistoryPhysicalPathsTest | Where-Object FilePath -eq $path).FileExists) {
                         if ($path -in $DBFileCheck) {
                             #If the Files are owned by the db we're restoring check for Continue or WithReplace. If not, then report error otherwise just carry on
@@ -170,7 +172,7 @@ function Test-DbaBackupInformation {
                         } elseif ($path -in $OtherFileCheck) {
                             Write-Message -Message "File $path already exists on $SqlInstance and owned by another database, cannot restore" -Level Warning
                             $VerificationErrors++
-                        } elseif ($path -in $DBHistoryPhysicalPathsExists -and $RestoreInstance.VersionMajor -gt 8) {
+                        } elseif ($path -in $DBHistoryPhysicalPathsExists -and $RestoreInstance.VersionMajor -gt 8 -and -not $isManagedInstanceXtpContainer) {
                             Write-Message -Message "File $path already exists on $($SqlInstance.ComputerName), not owned by any database in $SqlInstance, will not overwrite." -Level Warning
                             $VerificationErrors++
                         }

--- a/tests/Test-DbaBackupInformation.Tests.ps1
+++ b/tests/Test-DbaBackupInformation.Tests.ps1
@@ -23,6 +23,67 @@ Describe $CommandName -Tag UnitTests {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
+
+    InModuleScope dbatools {
+        Context "Azure SQL Managed Instance file validation" {
+            BeforeEach {
+                $script:mockServer = [PSCustomObject]@{
+                    Name                  = "sqlmi"
+                    ComputerName          = "sqlmi"
+                    VersionMajor          = 12
+                    DatabaseEngineEdition = "SqlManagedInstance"
+                    ServiceAccount        = ""
+                }
+                $script:mockServer.PSObject.TypeNames.Insert(0, "Microsoft.SqlServer.Management.Smo.Server")
+                $script:backupHistory = [PSCustomObject]@{
+                    Database         = "testdb"
+                    OriginalDatabase = "testdb"
+                    FileList         = @(
+                        [PSCustomObject]@{
+                            PhysicalName = "C:\data\orphan.xtp"
+                        }
+                    )
+                    FullName         = "https://storage/backups/testdb.bak"
+                }
+
+                Mock Connect-DbaInstance { $script:mockServer }
+                Mock Get-DbaDbPhysicalFile { @() }
+                Mock Get-DbaDatabase { $null }
+                Mock Get-DbaPathSep { "\" }
+                Mock Test-DbaLsnChain { $true }
+                Mock Test-DbaPath {
+                    $Path | ForEach-Object {
+                        [PSCustomObject]@{
+                            FilePath   = $PSItem
+                            FileExists = $true
+                        }
+                    }
+                }
+            }
+
+            It "allows an orphaned XTP container because Managed Instance assigns a new path" {
+                $output = $script:backupHistory | Test-DbaBackupInformation -SqlInstance "sqlmi" -WarningAction SilentlyContinue
+
+                $output.IsVerified | Should -BeTrue
+            }
+
+            It "continues to reject other orphaned files on Managed Instance" {
+                $script:backupHistory.FileList[0].PhysicalName = "C:\data\orphan.mdf"
+
+                $output = $script:backupHistory | Test-DbaBackupInformation -SqlInstance "sqlmi" -WarningAction SilentlyContinue
+
+                $output.IsVerified | Should -BeFalse
+            }
+
+            It "continues to reject orphaned XTP containers outside Managed Instance" {
+                $script:mockServer.DatabaseEngineEdition = "Enterprise"
+
+                $output = $script:backupHistory | Test-DbaBackupInformation -SqlInstance "sql1" -WarningAction SilentlyContinue
+
+                $output.IsVerified | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe $CommandName -Tag IntegrationTests {


### PR DESCRIPTION
## Summary

- allow orphaned `.xtp` container paths during restore preflight on Azure SQL Managed Instance
- keep existing collision protection for files owned by the target or another database
- keep rejecting normal orphan files on Managed Instance and orphaned XTP containers on other SQL editions
- add focused unit coverage for all three cases

## Root cause

`Test-DbaBackupInformation` treated an orphaned memory-optimized container as a normal file collision. Managed Instance assigns a fresh XTP container path during native restore, so the preflight check rejected a restore that SQL MI handles safely.

## Validation

- Pester 5.3.1: `tests/Test-DbaBackupInformation.Tests.ps1` excluding `IntegrationTests` — 4 passed, 0 failed
- PowerShell parser: command and test files clean
- `git diff --check`: clean
- independent `claude -p --model opus --effort high` review: clean

Fixes #10386