### PR TITLE
Set-DbaDbCompression - Scope indexed view compression

### DIFF
--- a/public/Set-DbaDbCompression.ps1
+++ b/public/Set-DbaDbCompression.ps1
@@ -26,7 +26,11 @@ function Set-DbaDbCompression {
 
     .PARAMETER Table
         Specifies which tables to compress within the selected databases. Accepts multiple table names and works with wildcard patterns.
-        When omitted, all eligible tables in the database will be processed. Use this to target specific large tables or avoid compressing certain tables.
+        When both Table and View are omitted, all eligible tables and indexed views in the database are processed. Use this to target specific large tables or avoid compressing other objects.
+
+    .PARAMETER View
+        Specifies which indexed views to compress within the selected databases. Accepts multiple view names, including database- and schema-qualified names.
+        When View is specified without Table, only matching indexed views are processed. View requires an explicit CompressionType of Page, Row, or None because Recommended analysis supports tables only.
 
     .PARAMETER CompressionType
         Specifies the type of compression to apply: Recommended, Page, Row, or None. Default is 'Recommended' which analyzes each object and applies the optimal compression type.
@@ -115,6 +119,11 @@ function Set-DbaDbCompression {
         Utilizes Page compression for tables table1 and table2 in DBName on ServerA with no time limit.
 
     .EXAMPLE
+        PS C:\> Set-DbaDbCompression -SqlInstance ServerA -Database DBName -CompressionType Page -View "dbo.SalesSummary"
+
+        Utilizes Page compression only for indexes on the dbo.SalesSummary indexed view in DBName on ServerA.
+
+    .EXAMPLE
         PS C:\> Set-DbaDbCompression -SqlInstance ServerA -Database DBName -PercentCompression 25 | Out-GridView
 
         Will compress tables/indexes within the specified database that would show any % improvement with compression and with no time limit. The results will be piped into a nicely formatted GridView.
@@ -149,6 +158,7 @@ function Set-DbaDbCompression {
         [string[]]$Database,
         [string[]]$ExcludeDatabase,
         [string[]]$Table,
+        [string[]]$View,
         [ValidateSet("Recommended", "Page", "Row", "None")]
         [string]$CompressionType = "Recommended",
         [int]$MaxRunTime = 0,
@@ -161,6 +171,11 @@ function Set-DbaDbCompression {
 
 
     process {
+        if ($View -and $CompressionType -eq "Recommended") {
+            Stop-Function -Message "View requires an explicit CompressionType of Page, Row, or None because Recommended analysis supports tables only."
+            return
+        }
+
         $starttime = Get-Date
         foreach ($instance in $SqlInstance) {
             try {
@@ -262,7 +277,10 @@ function Set-DbaDbCompression {
                     }
                 } else {
                     if ($Pscmdlet.ShouldProcess($db, "Applying $CompressionType compression")) {
-                        $tables = $server.Databases[$($db.name)].Tables
+                        $tables = @()
+                        if ($Table -or -not $View) {
+                            $tables = $server.Databases[$($db.name)].Tables
+                        }
                         if ($Table) {
                             $tableParts = $Table | ForEach-Object { Get-ObjectNameParts -ObjectName $_ }
                             $tables = foreach ($tablePart in $tableParts) {
@@ -270,6 +288,21 @@ function Set-DbaDbCompression {
                                     $_.Name -eq $tablePart.Name -and
                                     $tablePart.Schema -in ($_.Schema, $null) -and
                                     $tablePart.Database -in ($db.Name, $null)
+                                }
+                            }
+                        }
+
+                        $views = @()
+                        if ($View -or -not $Table) {
+                            $views = $server.Databases[$($db.name)].Views | Where-Object { $PSItem.Indexes }
+                        }
+                        if ($View) {
+                            $viewParts = $View | ForEach-Object { Get-ObjectNameParts -ObjectName $PSItem }
+                            $views = foreach ($viewPart in $viewParts) {
+                                $server.Databases[$($db.name)].Views | Where-Object {
+                                    $PSItem.Name -eq $viewPart.Name -and
+                                    $viewPart.Schema -in ($PSItem.Schema, $null) -and
+                                    $viewPart.Database -in ($db.Name, $null)
                                 }
                             }
                         }
@@ -365,7 +398,7 @@ function Set-DbaDbCompression {
                                 }
                             }
                         }
-                        foreach ($index in $($server.Databases[$($db.name)].Views | Where-Object { $_.Indexes }).Indexes) {
+                        foreach ($index in $views.Indexes) {
                             $parentView = $index.Parent
                             foreach ($p in $($index.PhysicalPartitions | Where-Object { $_.DataCompression -ne $CompressionType })) {
                                 Write-Message -Level Verbose -Message "Compressing $($index.IndexType) $($index.Name) Partition $($p.PartitionNumber)"

--- a/tests/Set-DbaDbCompression.Tests.ps1
+++ b/tests/Set-DbaDbCompression.Tests.ps1
@@ -16,6 +16,7 @@ Describe $CommandName -Tag UnitTests {
                 "Database",
                 "ExcludeDatabase",
                 "Table",
+                "View",
                 "CompressionType",
                 "MaxRunTime",
                 "PercentCompression",
@@ -65,6 +66,7 @@ namespace SetDbaDbCompressionTest {
         public string Status { get; set; }
         public string CompatibilityLevel { get; set; }
         public object[] Tables { get; set; }
+        public object[] Views { get; set; }
 
         public override string ToString() {
             return Name;
@@ -103,6 +105,70 @@ namespace SetDbaDbCompressionTest {
 
                     $table
                 }
+
+                function New-MockCompressionView {
+                    param(
+                        [string]$Schema,
+                        [string]$Name
+                    )
+
+                    $view = [PSCustomObject]@{
+                        Name    = $Name
+                        Schema  = $Schema
+                        Indexes = @()
+                    }
+                    $index = [PSCustomObject]@{
+                        Name                     = "CX_$Name"
+                        Parent                   = $view
+                        IsMemoryOptimized        = $false
+                        IndexType                = "ClusteredIndex"
+                        IsOnlineRebuildSupported = $false
+                        OnlineIndexOperation     = $false
+                        SortInTempdb             = $false
+                        Id                       = 1
+                        PhysicalPartitions       = @(
+                            [PSCustomObject]@{
+                                PartitionNumber = 1
+                                DataCompression = "NONE"
+                            }
+                        )
+                    }
+                    $index | Add-Member -Force -MemberType ScriptMethod -Name Rebuild -Value {
+                        $script:rebuiltViews += $this.Parent.Schema
+                    }
+                    $view.Indexes = @($index)
+
+                    $view
+                }
+
+                function New-MockCompressionFixture {
+                    param(
+                        [object[]]$Tables,
+                        [object[]]$Views
+                    )
+
+                    $mockDatabase = New-Object "SetDbaDbCompressionTest.MockDatabase"
+                    $mockDatabase.Name = "db1"
+                    $mockDatabase.IsAccessible = $true
+                    $mockDatabase.IsSystemObject = 0
+                    $mockDatabase.Status = "Normal"
+                    $mockDatabase.CompatibilityLevel = "Version160"
+                    $mockDatabase.Tables = $Tables
+                    $mockDatabase.Views = $Views
+
+                    $mockDatabases = New-Object "SetDbaDbCompressionTest.MockCollection[System.Object]"
+                    $mockDatabases.Add("db1", $mockDatabase)
+
+                    [PSCustomObject]@{
+                        ComputerName       = "sql1"
+                        ServiceName        = "MSSQLSERVER"
+                        DomainInstanceName = "sql1"
+                        EngineEdition      = "Enterprise"
+                        VersionMajor       = 16
+                        isAzure            = $false
+                        Databases          = $mockDatabases
+                    }
+                }
             }
 
             It "honors schema-qualified -Table input" {
@@ -139,6 +205,73 @@ namespace SetDbaDbCompressionTest {
                 $results.Count | Should -Be 1
                 $results[0].Schema | Should -Be "sales"
                 $script:rebuiltSchemas | Should -Be @("sales")
+            }
+
+            It "does not process indexed views when Table is specified" {
+                $script:rebuiltSchemas = @()
+                $script:rebuiltViews = @()
+                $mockServer = New-MockCompressionFixture -Tables @(
+                    (New-MockCompressionTable -Schema "dbo" -Name "Customer"),
+                    (New-MockCompressionTable -Schema "sales" -Name "Customer")
+                ) -Views @(
+                    (New-MockCompressionView -Schema "dbo" -Name "CustomerView")
+                )
+
+                Mock Connect-DbaInstance { $mockServer }
+                Mock Stop-Function { throw $Message }
+
+                $results = @(Set-DbaDbCompression -SqlInstance "sql1" -Database "db1" -Table "sales.Customer" -CompressionType Row)
+
+                $results | Should -HaveCount 1
+                $results[0].Schema | Should -Be "sales"
+                $script:rebuiltViews | Should -BeNullOrEmpty
+            }
+
+            It "processes only the requested schema-qualified indexed view" {
+                $script:rebuiltSchemas = @()
+                $script:rebuiltViews = @()
+                $mockServer = New-MockCompressionFixture -Tables @(
+                    (New-MockCompressionTable -Schema "dbo" -Name "Customer")
+                ) -Views @(
+                    (New-MockCompressionView -Schema "dbo" -Name "CustomerView"),
+                    (New-MockCompressionView -Schema "sales" -Name "CustomerView")
+                )
+
+                Mock Connect-DbaInstance { $mockServer }
+                Mock Stop-Function { throw $Message }
+
+                $results = @(Set-DbaDbCompression -SqlInstance "sql1" -Database "db1" -View "sales.CustomerView" -CompressionType Row)
+
+                $results | Should -HaveCount 1
+                $results[0].Schema | Should -Be "sales"
+                $results[0].TableName | Should -Be "CustomerView"
+                $script:rebuiltSchemas | Should -BeNullOrEmpty
+                $script:rebuiltViews | Should -Be @("sales")
+            }
+
+            It "continues to process tables and indexed views when neither filter is specified" {
+                $script:rebuiltSchemas = @()
+                $script:rebuiltViews = @()
+                $mockServer = New-MockCompressionFixture -Tables @(
+                    (New-MockCompressionTable -Schema "dbo" -Name "Customer")
+                ) -Views @(
+                    (New-MockCompressionView -Schema "dbo" -Name "CustomerView")
+                )
+
+                Mock Connect-DbaInstance { $mockServer }
+                Mock Stop-Function { throw $Message }
+
+                $results = @(Set-DbaDbCompression -SqlInstance "sql1" -Database "db1" -CompressionType Row)
+
+                $results | Should -HaveCount 2
+                $script:rebuiltSchemas | Should -Be @("dbo")
+                $script:rebuiltViews | Should -Be @("dbo")
+            }
+
+            It "rejects View with Recommended compression" {
+                Mock Stop-Function { throw $Message }
+
+                { Set-DbaDbCompression -SqlInstance "sql1" -View "dbo.CustomerView" } | Should -Throw "*explicit CompressionType*"
             }
         }
     }


### PR DESCRIPTION
## Summary

- stop `-Table` calls from rebuilding every indexed view in the database
- add `-View` with database- and schema-qualified matching
- preserve all-table/all-indexed-view behavior when neither filter is supplied
- allow combined table and view selections
- reject `-View` with `Recommended`, whose analyzer supports tables only
- add focused coverage for every selection mode

## Root cause

The direct-compression path filtered tables but always enumerated the database's entire indexed-view collection afterward, so a targeted table operation also compressed unrelated views.

## Validation

- Pester 5.3.1: `tests/Set-DbaDbCompression.Tests.ps1` excluding `IntegrationTests` — 6 passed, 0 failed
- PowerShell parser: command and test files clean
- `git diff --check`: clean
- independent `claude -p --model opus --effort high` review: clean

Fixes #8537