### PR TITLE
Set-DbaExtendedProtection - Support accepted SPNs

### DIFF
--- a/public/Get-DbaExtendedProtection.ps1
+++ b/public/Get-DbaExtendedProtection.ps1
@@ -8,7 +8,7 @@ function Get-DbaExtendedProtection {
 
         This function queries the Windows registry directly rather than connecting to SQL Server, so it requires Windows-level access to the target server. The setting corresponds to what you see in SQL Server Configuration Manager under Network Configuration > Protocols properties, but can be checked programmatically across multiple instances for compliance auditing.
 
-        Returns the current setting as both a numeric value (0, 1, 2) and descriptive text (Off, Allowed, Required) to help DBAs understand the security configuration and plan any necessary changes.
+        Returns the current setting as both a numeric value (0, 1, 2) and descriptive text (Off, Allowed, Required), together with the accepted SPNs configured for service binding validation.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
@@ -49,6 +49,7 @@ function Get-DbaExtendedProtection {
         - InstanceName: The SQL Server instance name
         - SqlInstance: The full SQL Server instance name (computer\instance)
         - ExtendedProtection: The current Extended Protection setting as a string combining the numeric value (0, 1, or 2) and its text description (Off, Allowed, or Required), formatted as "numeric - text" (e.g., "1 - Allowed")
+        - AcceptedSpns: The accepted service principal names configured for Extended Protection, returned as individual strings
 
     .EXAMPLE
         PS C:\> Get-DbaExtendedProtection
@@ -123,13 +124,16 @@ function Get-DbaExtendedProtection {
 
             $scriptblock = {
                 $regPath = "Registry::HKEY_LOCAL_MACHINE\$($args[0])\MSSQLServer\SuperSocketNetLib"
-                $extendedProtection = (Get-ItemProperty -Path $regPath -Name ExtendedProtection).ExtendedProtection
+                $settings = Get-ItemProperty -Path $regPath
+                $extendedProtection = $settings.ExtendedProtection
+                $acceptedSpns = @($settings.AcceptedSPNs -split ";" | Where-Object { -not [string]::IsNullOrWhiteSpace($PSItem) })
 
                 [PSCustomObject]@{
                     ComputerName       = $env:COMPUTERNAME
                     InstanceName       = $args[2]
                     SqlInstance        = $args[1]
                     ExtendedProtection = "$extendedProtection - $(switch ($extendedProtection) { 0 { "Off" } 1 { "Allowed" } 2 { "Required" } })"
+                    AcceptedSpns       = $acceptedSpns
                 }
             }
 

--- a/public/Set-DbaExtendedProtection.ps1
+++ b/public/Set-DbaExtendedProtection.ps1
@@ -21,6 +21,10 @@ function Set-DbaExtendedProtection {
         Use "Off" to disable Extended Protection, "Allowed" to accept both protected and unprotected connections, or "Required" to enforce Extended Protection for all client connections.
         Defaults to "Off" when not specified. Setting to "Required" may prevent older applications from connecting unless they support Extended Protection authentication.
 
+    .PARAMETER AcceptedSpn
+        Specifies the service principal names SQL Server accepts for Extended Protection service binding. Multiple values are stored as a semicolon-delimited registry value.
+        When this parameter is supplied without Value, the current Extended Protection level is left unchanged. Pass an empty string to clear the accepted SPN list.
+
     .PARAMETER WhatIf
         If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
@@ -53,6 +57,7 @@ function Set-DbaExtendedProtection {
         - InstanceName: The SQL Server instance name (e.g., MSSQLSERVER, SQL2019)
         - SqlInstance: The full SQL Server instance name in computer\instance format
         - ExtendedProtection: The Extended Protection setting value with human-readable description (e.g., "0 - Off", "1 - Allowed", "2 - Required")
+        - AcceptedSpns: The accepted service principal names configured for Extended Protection, returned as individual strings
 
     .EXAMPLE
         PS C:\> Set-DbaExtendedProtection
@@ -75,6 +80,11 @@ function Set-DbaExtendedProtection {
         Set Extended Protection of SQL Engine for the SQL2008R2SP2 on sql01 to "Allowed". Uses Windows Credentials to both connect and modify the registry.
 
     .EXAMPLE
+        PS C:\> Set-DbaExtendedProtection -SqlInstance sql01 -AcceptedSpn "MSSQLSvc/sql01.domain.local:1433", "MSSQLSvc/sql01:1433"
+
+        Sets the accepted SPNs for Extended Protection without changing the current Extended Protection level.
+
+    .EXAMPLE
         PS C:\> Set-DbaExtendedProtection -SqlInstance sql01\SQL2008R2SP2 -WhatIf
 
         Shows what would happen if the command were executed.
@@ -87,9 +97,15 @@ function Set-DbaExtendedProtection {
         [PSCredential]$Credential,
         [ValidateSet(0, "Off", 1, "Allowed", 2, "Required")]
         [object]$Value = "Off",
+        [AllowEmptyString()]
+        [string[]]$AcceptedSpn,
         [switch]$EnableException
     )
     begin {
+        $setAcceptedSpn = Test-Bound -ParameterName AcceptedSpn
+        $setExtendedProtection = (Test-Bound -ParameterName Value) -or -not $setAcceptedSpn
+        $acceptedSpnValue = $AcceptedSpn -join ";"
+
         # Check value and set the integer value
         if (($Value -notin 0, 1, 2) -and ($null -ne $Value)) {
             $Value = switch ($Value) { "Off" { 0 } "Allowed" { 1 } "Required" { 2 } }
@@ -147,23 +163,34 @@ function Set-DbaExtendedProtection {
             Write-Message -Level Verbose -Message "InstanceName: $instancename" -Target $instance
             Write-Message -Level Verbose -Message "VSNAME: $vsname" -Target $instance
             Write-Message -Level Verbose -Message "Value: $Value" -Target $instance
+            if ($setAcceptedSpn) {
+                Write-Message -Level Verbose -Message "Accepted SPNs: $acceptedSpnValue" -Target $instance
+            }
 
             $scriptblock = {
                 $regPath = "Registry::HKEY_LOCAL_MACHINE\$($args[0])\MSSQLServer\SuperSocketNetLib"
-                Set-ItemProperty -Path $regPath -Name ExtendedProtection -Value $args[3]
-                $extendedProtection = (Get-ItemProperty -Path $regPath -Name ExtendedProtection).ExtendedProtection
+                if ($args[4]) {
+                    Set-ItemProperty -Path $regPath -Name ExtendedProtection -Value $args[3]
+                }
+                if ($args[5]) {
+                    Set-ItemProperty -Path $regPath -Name AcceptedSPNs -Value $args[6]
+                }
+                $settings = Get-ItemProperty -Path $regPath
+                $extendedProtection = $settings.ExtendedProtection
+                $acceptedSpns = @($settings.AcceptedSPNs -split ";" | Where-Object { -not [string]::IsNullOrWhiteSpace($PSItem) })
 
                 [PSCustomObject]@{
                     ComputerName       = $env:COMPUTERNAME
                     InstanceName       = $args[2]
                     SqlInstance        = $args[1]
                     ExtendedProtection = "$extendedProtection - $(switch ($extendedProtection) { 0 { "Off" } 1 { "Allowed" } 2 { "Required" } })"
+                    AcceptedSpns       = $acceptedSpns
                 }
             }
-            if (Test-ShouldProcess -Context $PSCmdlet -Target "local" -Action "Connecting to $instance to modify the ExtendedProtection value in $regRoot for $($instance.InstanceName)") {
+            if (Test-ShouldProcess -Context $PSCmdlet -Target "local" -Action "Connecting to $instance to modify Extended Protection settings in $regRoot for $($instance.InstanceName)") {
                 try {
-                    Invoke-Command2 -ComputerName $resolved.FullComputerName -Credential $Credential -ArgumentList $regRoot, $vsname, $instancename, $Value -ScriptBlock $scriptblock -ErrorAction Stop | Select-Object -Property * -ExcludeProperty PSComputerName, RunspaceId, PSShowComputerName
-                    Write-Message -Level Critical -Message "ExtendedProtection was successfully set on $($resolved.FullComputerName) for the $instancename instance. The change takes effect immediately for new connections." -Target $instance
+                    Invoke-Command2 -ComputerName $resolved.FullComputerName -Credential $Credential -ArgumentList $regRoot, $vsname, $instancename, $Value, $setExtendedProtection, $setAcceptedSpn, $acceptedSpnValue -ScriptBlock $scriptblock -ErrorAction Stop | Select-Object -Property * -ExcludeProperty PSComputerName, RunspaceId, PSShowComputerName
+                    Write-Message -Level Critical -Message "Extended Protection settings were successfully set on $($resolved.FullComputerName) for the $instancename instance. The change takes effect immediately for new connections." -Target $instance
                 } catch {
                     Stop-Function -Message "Failed to connect to $($resolved.FullComputerName) using PowerShell remoting" -ErrorRecord $_ -Target $instance -Continue
                 }

--- a/tests/Get-DbaExtendedProtection.Tests.ps1
+++ b/tests/Get-DbaExtendedProtection.Tests.ps1
@@ -18,6 +18,42 @@ Describe $CommandName -Tag UnitTests {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
+
+    InModuleScope dbatools {
+        Context "Accepted SPNs" {
+            BeforeEach {
+                Mock Resolve-DbaNetworkName {
+                    [PSCustomObject]@{ FullComputerName = "sql1" }
+                }
+                Mock Invoke-ManagedComputerCommand {
+                    [PSCustomObject]@{
+                        DisplayName        = "SQL Server (MSSQLSERVER)"
+                        ServiceAccount     = "NT Service\MSSQLSERVER"
+                        AdvancedProperties = @(
+                            [PSCustomObject]@{ Name = "REGROOT"; Value = "Software\Microsoft\Microsoft SQL Server\MSSQL16.MSSQLSERVER" },
+                            [PSCustomObject]@{ Name = "VSNAME"; Value = "sql1" }
+                        )
+                    }
+                }
+                Mock Get-ItemProperty {
+                    [PSCustomObject]@{
+                        ExtendedProtection = 1
+                        AcceptedSPNs       = "MSSQLSvc/sql1.domain.local:1433;MSSQLSvc/sql1:1433"
+                    }
+                }
+                Mock Invoke-Command2 {
+                    & $ScriptBlock @ArgumentList
+                }
+                Mock Stop-Function { throw $Message }
+            }
+
+            It "returns accepted SPNs as individual values" {
+                $result = Get-DbaExtendedProtection -SqlInstance "sql1" -Confirm:$false
+
+                $result.AcceptedSpns | Should -Be @("MSSQLSvc/sql1.domain.local:1433", "MSSQLSvc/sql1:1433")
+            }
+        }
+    }
 }
 
 Describe $CommandName -Tag IntegrationTests {

--- a/tests/Set-DbaExtendedProtection.Tests.ps1
+++ b/tests/Set-DbaExtendedProtection.Tests.ps1
@@ -14,9 +14,80 @@ Describe $CommandName -Tag UnitTests {
                 "SqlInstance",
                 "Credential",
                 "Value",
+                "AcceptedSpn",
                 "EnableException"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+
+    InModuleScope dbatools {
+        Context "Accepted SPNs" {
+            BeforeEach {
+                $script:acceptedSpnValue = "existing"
+                $script:extendedProtectionValue = 1
+                Mock Resolve-DbaNetworkName {
+                    [PSCustomObject]@{ FullComputerName = "sql1" }
+                }
+                Mock Invoke-ManagedComputerCommand {
+                    [PSCustomObject]@{
+                        DisplayName        = "SQL Server (MSSQLSERVER)"
+                        ServiceAccount     = "NT Service\MSSQLSERVER"
+                        AdvancedProperties = @(
+                            [PSCustomObject]@{ Name = "REGROOT"; Value = "Software\Microsoft\Microsoft SQL Server\MSSQL16.MSSQLSERVER" },
+                            [PSCustomObject]@{ Name = "VSNAME"; Value = "sql1" }
+                        )
+                    }
+                }
+                Mock Set-ItemProperty {
+                    if ($Name -eq "AcceptedSPNs") {
+                        $script:acceptedSpnValue = $Value
+                    }
+                    if ($Name -eq "ExtendedProtection") {
+                        $script:extendedProtectionValue = $Value
+                    }
+                }
+                Mock Get-ItemProperty {
+                    [PSCustomObject]@{
+                        ExtendedProtection = $script:extendedProtectionValue
+                        AcceptedSPNs       = $script:acceptedSpnValue
+                    }
+                }
+                Mock Invoke-Command2 {
+                    & $ScriptBlock @ArgumentList
+                }
+                Mock Test-ShouldProcess { $true }
+                Mock Stop-Function { throw $Message }
+            }
+
+            It "writes accepted SPNs as a semicolon-delimited registry value" {
+                $acceptedSpns = @("MSSQLSvc/sql1.domain.local:1433", "MSSQLSvc/sql1:1433")
+
+                $result = Set-DbaExtendedProtection -SqlInstance "sql1" -Value Required -AcceptedSpn $acceptedSpns -Confirm:$false
+
+                $script:acceptedSpnValue | Should -Be ($acceptedSpns -join ";")
+                $result.AcceptedSpns | Should -Be $acceptedSpns
+            }
+
+            It "leaves accepted SPNs unchanged when AcceptedSpn is omitted" {
+                $null = Set-DbaExtendedProtection -SqlInstance "sql1" -Value Required -Confirm:$false
+
+                Should -Invoke Set-ItemProperty -ParameterFilter { $Name -eq "AcceptedSPNs" } -Exactly 0 -Scope It
+            }
+
+            It "leaves Extended Protection unchanged when only AcceptedSpn is supplied" {
+                $null = Set-DbaExtendedProtection -SqlInstance "sql1" -AcceptedSpn "MSSQLSvc/sql1:1433" -Confirm:$false
+
+                $script:extendedProtectionValue | Should -Be 1
+                Should -Invoke Set-ItemProperty -ParameterFilter { $Name -eq "ExtendedProtection" } -Exactly 0 -Scope It
+            }
+
+            It "clears accepted SPNs when an empty string is supplied" {
+                $null = Set-DbaExtendedProtection -SqlInstance "sql1" -AcceptedSpn "" -Confirm:$false
+
+                $script:acceptedSpnValue | Should -Be ""
+                Should -Invoke Set-ItemProperty -ParameterFilter { $Name -eq "AcceptedSPNs" -and $Value -eq "" } -Exactly 1 -Scope It
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- return configured accepted SPNs from `Get-DbaExtendedProtection`
- add `-AcceptedSpn` to `Set-DbaExtendedProtection` and serialize multiple SPNs using SQL Server's semicolon-delimited registry format
- preserve the current Extended Protection level when only accepted SPNs are changed
- add focused unit coverage for reads, writes, omission behavior, the SPN-only safety invariant, and clearing the list

## Why

SQL Server exposes Accepted NTLM SPNs alongside Extended Protection, but dbatools could not read or set that value. The setter also needs explicit bound-parameter tracking so an SPN-only update does not trigger the command's legacy default of setting Extended Protection to Off.

## Validation

- PowerShell parser: clean for both commands and both test files
- `git diff --check`: clean
- Pester 5.3.1 focused non-integration tests: 7 passed, 0 failed
- Claude Opus high-effort review: CLEAN on round 2

Fixes #10393