### PR TITLE
Get-DbaDbOrphanUser - Cover contained AG certificate users

### DIFF
--- a/tests/Get-DbaDbOrphanUser.Tests.ps1
+++ b/tests/Get-DbaDbOrphanUser.Tests.ps1
@@ -31,6 +31,13 @@ Describe $CommandName -Tag UnitTests {
                     LoginType = "SqlLogin"
                     Name      = "sql_orphan"
                 }
+                $script:certificateUser = [PSCustomObject]@{
+                    Login     = ""
+                    ID        = 7
+                    Sid       = [byte[]](1..16)
+                    LoginType = "Certificate"
+                    Name      = "dbm_monitor"
+                }
                 $script:windowsOrphanUser = [PSCustomObject]@{
                     Login     = "CONTOSO\win_orphan"
                     ID        = 6
@@ -51,7 +58,7 @@ Describe $CommandName -Tag UnitTests {
                     Name            = "containeddb"
                     IsAccessible    = $true
                     ContainmentType = [Microsoft.SqlServer.Management.Smo.ContainmentType]::Partial
-                    Users           = @($script:sqlOrphanUser, $script:windowsOrphanUser)
+                    Users           = @($script:sqlOrphanUser, $script:certificateUser, $script:windowsOrphanUser)
                 }
                 $server = $script:baseServer | Select-Object *
                 $server | Add-Member -NotePropertyName versionMajor -NotePropertyValue 11 -Force
@@ -67,6 +74,7 @@ Describe $CommandName -Tag UnitTests {
                 $results = @(Get-DbaDbOrphanUser -SqlInstance "sql2012")
 
                 $results.Count | Should -Be 1
+                $results.User | Should -Not -Contain "dbm_monitor"
                 $results[0].User | Should -Be "CONTOSO\win_orphan"
             }
 
@@ -91,6 +99,30 @@ Describe $CommandName -Tag UnitTests {
 
                 $results.Count | Should -Be 1
                 $results[0].User | Should -Be "sql_orphan"
+            }
+
+            It "reports certificate users as orphans in non-contained databases" {
+                $database = [PSCustomObject]@{
+                    Name            = "regularDb"
+                    IsAccessible    = $true
+                    ContainmentType = [Microsoft.SqlServer.Management.Smo.ContainmentType]::None
+                    Users           = @($script:certificateUser)
+                }
+                $server = $script:baseServer | Select-Object *
+                $server | Add-Member -NotePropertyName versionMajor -NotePropertyValue 11 -Force
+                $server | Add-Member -NotePropertyName Databases -NotePropertyValue @($database) -Force
+
+                Mock Connect-DbaInstance {
+                    $server
+                }
+                Mock Stop-Function {
+                    throw "Stop-Function called"
+                }
+
+                $results = @(Get-DbaDbOrphanUser -SqlInstance "sql2012")
+
+                $results.Count | Should -Be 1
+                $results[0].User | Should -Be "dbm_monitor"
             }
         }
     }


### PR DESCRIPTION
## Summary

adds a certificate-mapped contained-database fixture for the availability-group system-user case- proves contained databases exclude that certificate user while still reporting Windows orphans- adds a non-contained positive control proving the same certificate fixture remains orphan-eligible

## Why
The production fix was already merged in #10270, where contained databases skip the combined SQL login/certificate orphan predicate. This PR adds the missing issue-specific regression coverage without duplicating or changing production behavior.

Closes #9789
## Validation

Pester 6: 4 runnable unit tests passed, 0 failed
- git diff --check: clean
- Claude Opus high-effort review: READY, no findings (2 rounds)