### PR TITLE
Format-DbaBackupInformation - Preserve Azure Blob data-file URLs

### DIFF
--- a/public/Format-DbaBackupInformation.ps1
+++ b/public/Format-DbaBackupInformation.ps1
@@ -278,7 +278,13 @@ function Format-DbaBackupInformation {
                         $RestoreDir = $originalPath -replace '[/\\][^/\\]+$', ''
                     }
 
-                    $_.PhysicalName = $RestoreDir + $PathSep + $DatabaseFilePrefix + $baseName + $DatabaseFileSuffix + $extension
+                    $restorePathSeparator = $PathSep
+                    if ($RestoreDir -match "^[a-z][a-z0-9+.-]*://") {
+                        $restorePathSeparator = "/"
+                        $RestoreDir = $RestoreDir.TrimEnd("/")
+                    }
+
+                    $_.PhysicalName = $RestoreDir + $restorePathSeparator + $DatabaseFilePrefix + $baseName + $DatabaseFileSuffix + $extension
                     Write-Message -Message "PhysicalName = $($_.PhysicalName) " -Level Verbose
                 }
             }

--- a/tests/Format-DbaBackupInformation.Tests.ps1
+++ b/tests/Format-DbaBackupInformation.Tests.ps1
@@ -29,6 +29,41 @@ Describe $CommandName -Tag UnitTests {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
+
+    Context "Azure data file URLs" {
+        BeforeEach {
+            $history = [PSCustomObject]@{
+                Database = "TestDb"
+                Type     = "Full"
+                FullName = @("https://account.blob.core.windows.net/backups/TestDb.bak")
+                FileList = @(
+                    [PSCustomObject]@{
+                        LogicalName  = "TestDb"
+                        PhysicalName = "https://account.blob.core.windows.net/container/data/TestDb.mdf"
+                        Type         = "D"
+                    }
+                )
+            }
+        }
+
+        It "preserves an unchanged Azure data file URL" {
+            $result = Format-DbaBackupInformation -BackupHistory $history
+
+            $result.FileList[0].PhysicalName | Should -Be "https://account.blob.core.windows.net/container/data/TestDb.mdf"
+        }
+
+        It "uses URI separators when adding a file suffix" {
+            $result = Format-DbaBackupInformation -BackupHistory $history -DatabaseFileSuffix "_restored"
+
+            $result.FileList[0].PhysicalName | Should -Be "https://account.blob.core.windows.net/container/data/TestDb_restored.mdf"
+        }
+
+        It "uses URI separators for an Azure destination directory" {
+            $result = Format-DbaBackupInformation -BackupHistory $history -DataFileDirectory "https://account.blob.core.windows.net/newcontainer"
+
+            $result.FileList[0].PhysicalName | Should -Be "https://account.blob.core.windows.net/newcontainer/TestDb.mdf"
+        }
+    }
 }
 
 Describe $CommandName -Tag IntegrationTests {


### PR DESCRIPTION
## Summary

- preserves forward-slash separators for Azure Blob data-file URLs
- applies the same URI-aware join when file prefixes/suffixes or destination URL directories are used
- adds focused regressions for unchanged, renamed, and relocated URL paths

## Root cause

The earlier System.IO.FileInfo parsing failure had already been removed, but Format-DbaBackupInformation still reconstructed every physical path with the caller's filesystem PathSep (a backslash by default). On Windows that produced mixed paths such as https://.../data\\TestDb.mdf.

The formatter now uses / only when the selected restore directory has a URI scheme. Local filesystem behavior remains on PathSep.

Closes #8387

## Validation

- RED: all three new cases failed at the mixed separator before implementation
- Pester 6 unit tests: 4 passed, 0 failed
- Complete formatter file: 37 passed, 0 failed
- PSScriptAnalyzer 1.18.2 severity Error: 0 findings
- Claude Opus high-effort review: READY