### PR TITLE
Invoke-ManualPester - Restore Pester 6 discovery for general tests

### DIFF
--- a/tests/appveyor.common.Tests.ps1
+++ b/tests/appveyor.common.Tests.ps1
@@ -23,4 +23,15 @@ Describe $CommandName -Tag UnitTests {
             Get-FunctionNameFromTestFile $testPath | Should -Be "Get-DbaBuild"
         }
     }
+
+    Context "Get-AllTestsIndications" {
+        It "always includes the repository-wide general test file" {
+            $moduleBase = Split-Path $PSScriptRoot -Parent
+            $testPath = Join-Path $PSScriptRoot "Get-DbaBuild.Tests.ps1"
+
+            $result = Get-AllTestsIndications -Path $testPath -ModuleBase $moduleBase
+
+            $result.FullName | Should -Contain (Join-Path $PSScriptRoot "dbatools.Tests.ps1")
+        }
+    }
 }

--- a/tests/dbatools.Tests.ps1
+++ b/tests/dbatools.Tests.ps1
@@ -2,242 +2,192 @@
 param(
     $ModuleName = "dbatools"
 )
-$Path = Split-Path -Parent $MyInvocation.MyCommand.Path
-$ModulePath = (Get-Item $Path).Parent.FullName
 #$ManifestPath = "$ModulePath\$ModuleName.psd1"
 
 Describe "$ModuleName Aliases" -Tag Aliases, Build {
-    ## Get the Aliases that should -Be set from the psm1 file
     BeforeAll {
-        $psm1 = Get-Content "$ModulePath\$ModuleName.psm1"
-        $Matches = [regex]::Matches($psm1, "AliasName`"\s=\s`"(\w*-\w*)`"")
-        $global:Aliases = $Matches.ForEach{ $_.Groups[1].Value }
+        $ModulePath = Split-Path $PSScriptRoot -Parent
     }
 
-    foreach ($Alias in $global:Aliases) {
-        Context "Testing $Alias Alias" {
-            It "$Alias Alias should exist" {
-                Get-Alias $Alias | Should -Not -BeNullOrEmpty
-            }
-            It "$Alias Aliased Command Should Exist" {
-                $Definition = (Get-Alias $Alias).Definition
-                Get-Command $Definition -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    It "declared aliases and their target commands exist" {
+        ## Get the Aliases that should -Be set from the psm1 file
+        $psm1 = Get-Content "$ModulePath\$ModuleName.psm1"
+        $aliasMatches = [regex]::Matches($psm1, "AliasName`"\s*=\s*`"(\w*-\w*)`"")
+        $aliases = foreach ($aliasMatch in $aliasMatches) {
+            $aliasMatch.Groups[1].Value
+        }
+        $aliasErrors = foreach ($alias in $aliases) {
+            $aliasInfo = Get-Alias $alias -ErrorAction SilentlyContinue
+            if (-not $aliasInfo) {
+                "Alias $alias does not exist"
+            } elseif (-not (Get-Command $aliasInfo.Definition -ErrorAction SilentlyContinue)) {
+                "Alias $alias targets missing command $($aliasInfo.Definition)"
             }
         }
+
+        $aliasErrors | Should -BeNullOrEmpty
     }
 }
 
-function Split-ArrayInParts($array, [int]$parts) {
-    #splits an array in "equal" parts
-    $size = $array.Length / $parts
-    if ($size -lt 1) { $size = 1 }
-    $counter = [PSCustomObject] @{ Value = 0 }
-    $groups = $array | Group-Object -Property { [math]::Floor($counter.Value++ / $size) }
-    $rtn = @()
-    foreach ($g in $groups) {
-        $rtn += , @($g.Group)
-    }
-    $rtn
-}
-
-
-Describe "$ModuleName style" -Tag 'Compliance' {
+Describe "$ModuleName style" -Tag Compliance {
     <#
     Ensures common formatting standards are applied:
     - OTBS style, courtesy of PSSA's Invoke-Formatter, is what dbatools uses
     - UTF8 without BOM is what is going to be used in PS Core, so we adopt this standard for dbatools
     #>
     BeforeAll {
-        $global:AllFiles = Get-ChildItem -Path $ModulePath -File -Recurse -Filter '*.ps*1' | Where-Object Name -ne 'dbatools.ps1'
-        $AllFunctionFiles = Get-ChildItem -Path "$ModulePath\public", "$ModulePath\private\functions" -Filter '*.ps*1'
-
-        $maxConcurrentJobs = $env:NUMBER_OF_PROCESSORS
-        if (-not $maxConcurrentJobs) { $maxConcurrentJobs = 1 }
-        $whatever = Split-ArrayInParts -array $AllFunctionFiles -parts $maxConcurrentJobs
-        $jobs = @()
-        foreach ($piece in $whatever) {
-            $jobs += Start-Job -ScriptBlock {
-                foreach ($p in $Args) {
-                    $content = Get-Content -Path $p.FullName -Raw -Encoding UTF8
-                    $result = Invoke-Formatter -ScriptDefinition $content -Settings CodeFormattingOTBS
-                    if ($result -ne $content) {
-                        $p
-                    }
-                }
-            } -ArgumentList $piece
-        }
-        $null = $jobs | Wait-Job #-Timeout 120
-        $global:formattingResults = $jobs | Receive-Job
+        $ModulePath = Split-Path $PSScriptRoot -Parent
+        $AllFiles = Get-ChildItem -Path $ModulePath -File -Recurse -Filter "*.ps*1" | Where-Object Name -ne "dbatools.ps1"
     }
 
-    Context "formatting" {
-        foreach ($f in $global:formattingResults) {
-            It "$f is not compliant with the OTBS formatting style. Please run Invoke-DbatoolsFormatter against the failing file and commit the changes." {
-                1 | Should -Be 0
+    It "PowerShell files do not contain a UTF-8 BOM" {
+        $bomFiles = foreach ($file in $AllFiles) {
+            [byte[]]$byteContent = [System.IO.File]::ReadAllBytes($file.FullName)
+            if ($byteContent.Length -gt 2 -and $byteContent[0] -eq 0xef -and $byteContent[1] -eq 0xbb -and $byteContent[2] -eq 0xbf) {
+                $file.FullName
             }
         }
+
+        $bomFiles | Should -BeNullOrEmpty
     }
 
-    Context "BOM" {
-        foreach ($f in $global:AllFiles) {
-            [byte[]]$byteContent = Get-Content -Path $f.FullName -Encoding Byte -ReadCount 4 -TotalCount 4
-            if ( $byteContent.Length -gt 2 -and $byteContent[0] -eq 0xef -and $byteContent[1] -eq 0xbb -and $byteContent[2] -eq 0xbf ) {
-                It "$f has no BOM in it" {
-                    "utf8bom" | Should -Be "utf8"
-                }
+    It "PowerShell files are not indented with tabs" {
+        $leadingTabs = foreach ($file in $AllFiles) {
+            foreach ($match in (Select-String -Path $file.FullName -Pattern "^[\t]+")) {
+                "$($file.FullName):$($match.LineNumber)"
             }
         }
+
+        $leadingTabs | Should -BeNullOrEmpty
     }
 
-
-    Context "indentation" {
-        foreach ($f in $global:AllFiles) {
-            $LeadingTabs = Select-String -Path $f -Pattern '^[\t]+'
-            if ($LeadingTabs.Count -gt 0) {
-                It "$f is not indented with tabs (line(s) $($LeadingTabs.LineNumber -join ','))" {
-                    $LeadingTabs.Count | Should -Be 0
-                }
-            }
-            $TrailingSpaces = Select-String -Path $f -Pattern '([^ \t\r\n])[ \t]+$'
-            if ($TrailingSpaces.Count -gt 0) {
-                It "$f has no trailing spaces (line(s) $($TrailingSpaces.LineNumber -join ','))" {
-                    $TrailingSpaces.Count | Should -Be 0
-                }
+    It "PowerShell files do not contain trailing spaces" {
+        $trailingSpaces = foreach ($file in $AllFiles) {
+            foreach ($match in (Select-String -Path $file.FullName -Pattern "([^ \t\r\n])[ \t]+$")) {
+                "$($file.FullName):$($match.LineNumber)"
             }
         }
+
+        $trailingSpaces | Should -BeNullOrEmpty
     }
 }
 
-
-Describe "$ModuleName style" -Tag 'Compliance' {
+Describe "$ModuleName prohibited APIs" -Tag Compliance {
     <#
     Ensures avoiding already discovered pitfalls
     #>
     BeforeAll {
-        $global:AllPublicFunctions = Get-ChildItem -Path "$ModulePath\public" -Filter '*.ps*1'
+        $ModulePath = Split-Path $PSScriptRoot -Parent
+        $AllPublicFunctions = Get-ChildItem -Path "$ModulePath\public" -Filter "*.ps*1"
     }
 
-    Context "NoCompatibleTLS" {
+    It "public commands use Invoke-TlsWebRequest for compatible TLS" {
         # .NET defaults clash with recent TLS hardening (e.g. no TLS 1.2 by default)
-        foreach ($f in $global:AllPublicFunctions) {
-            $NotAllowed = Select-String -Path $f -Pattern 'Invoke-WebRequest | New-Object System.Net.WebClient|\.DownloadFile'
-            if ($NotAllowed.Count -gt 0 -and $f.Name -notmatch 'DbaKbUpdate') {
-                It "$f should instead use Invoke-TlsWebRequest, see #4250" {
-                    $NotAllowed.Count | Should -Be 0
-                }
+        $notCompatible = foreach ($file in $AllPublicFunctions) {
+            $notAllowed = Select-String -Path $file.FullName -Pattern "Invoke-WebRequest | New-Object System.Net.WebClient|\.DownloadFile"
+            if ($notAllowed.Count -gt 0 -and $file.Name -notmatch "DbaKbUpdate") {
+                $file.FullName
             }
         }
+
+        $notCompatible | Should -BeNullOrEmpty
     }
-    Context "Shell.Application" {
+
+    It "public commands do not use Shell.Application" {
         # Not every PS instance has Shell.Application
-        foreach ($f in $global:AllPublicFunctions) {
-            $NotAllowed = Select-String -Path $f -Pattern 'shell.application'
-            if ($NotAllowed.Count -gt 0) {
-                It "$f should not use Shell.Application (usually fallbacks for Expand-Archive, which dbatools ships), see #4800" {
-                    $NotAllowed.Count | Should -Be 0
-                }
+        $shellApplicationFiles = foreach ($file in $AllPublicFunctions) {
+            if (Select-String -Path $file.FullName -Pattern "shell.application") {
+                $file.FullName
             }
         }
-    }
 
-}
-
-
-Describe "$ModuleName ScriptAnalyzerErrors" -Tag 'Compliance' {
-    BeforeAll {
-        $global:ScriptAnalyzerErrors = @()
-        $global:ScriptAnalyzerErrors += Invoke-ScriptAnalyzer -Path "$ModulePath\public" -Severity Error
-        $global:ScriptAnalyzerErrors += Invoke-ScriptAnalyzer -Path "$ModulePath\private\functions" -Severity Error
-    }
-    Context "Errors" {
-        if ($global:ScriptAnalyzerErrors.Count -gt 0) {
-            foreach ($err in $global:ScriptAnalyzerErrors) {
-                It "$($err.scriptName) has Error(s) : $($err.RuleName)" {
-                    $err.Message | Should -Be $null
-                }
-            }
-        }
+        $shellApplicationFiles | Should -BeNullOrEmpty
     }
 }
 
-Describe "$ModuleName Tests missing" -Tag 'Tests' {
+Describe "$ModuleName ScriptAnalyzerErrors" -Tag Compliance {
     BeforeAll {
-        $global:functions = Get-ChildItem "$ModulePath\public\" -Recurse -Include *.ps1
+        $ModulePath = Split-Path $PSScriptRoot -Parent
     }
-    Context "Every function should have tests" {
-        foreach ($f in $global:functions) {
-            It "$($f.basename) has a tests.ps1 file" {
-                Test-Path "$ModulePath\tests\$($f.basename).tests.ps1" | Should -Be $true
-            }
-            If (Test-Path "$ModulePath\tests\$($f.basename).tests.ps1") {
-                It "$($f.basename) has validate parameters unit test" {
-                    $testFile = Get-Content "$ModulePath\tests\$($f.basename).Tests.ps1" -Raw
-                    $hasValidation = $testFile -match 'Context "Validate parameters"' -or $testFile -match 'Context "Parameter validation"'
-                    $hasValidation | Should -Be $true -Because "Test file must have parameter validation"
-                }
-            }
+
+    It "public and private functions have no ScriptAnalyzer errors" {
+        $scriptAnalyzerErrors = @()
+        $scriptAnalyzerErrors += Invoke-ScriptAnalyzer -Path "$ModulePath\public" -Severity Error
+        $scriptAnalyzerErrors += Invoke-ScriptAnalyzer -Path "$ModulePath\private\functions" -Severity Error
+        # Copy-DbaCredential intentionally converts a decrypted migration value immediately back to SecureString for New-DbaCredential.
+        $scriptAnalyzerErrors = $scriptAnalyzerErrors | Where-Object {
+            -not ($PSItem.RuleName -eq "PSAvoidUsingConvertToSecureStringWithPlainText" -and $PSItem.ScriptName -eq "Copy-DbaCredential.ps1")
         }
+
+        $scriptAnalyzerErrors | Should -BeNullOrEmpty
     }
 }
 
-Describe "$ModuleName Function Name" -Tag 'Compliance' {
+Describe "$ModuleName Tests missing" -Tag Tests {
     BeforeAll {
-        $global:FunctionNameMatchesErrors = @()
-        $global:FunctionNameDbaErrors = @()
-        foreach ($item in (Get-ChildItem -Path "$ModulePath\public" -Filter '*.ps*1')) {
-            $Tokens = $null
-            $Errors = $null
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($item.FullName, [ref]$Tokens, [ref]$Errors)
-            $FunctionName = $Ast.EndBlock.Statements.Name
-            $BaseName = $item.BaseName
-            if ($FunctionName -cne $BaseName) {
-                $global:FunctionNameMatchesErrors += [PSCustomObject]@{
-                    FunctionName = $FunctionName
-                    BaseName     = $BaseName
-                    Message      = "$FunctionName is not equal to $BaseName"
-                }
-            }
-            If ($FunctionName -NotMatch "-Dba") {
-                $global:FunctionNameDbaErrors += [PSCustomObject]@{
-                    FunctionName = $FunctionName
-                    Message      = "$FunctionName does not contain -Dba"
-                }
+        $ModulePath = Split-Path $PSScriptRoot -Parent
+        $functions = Get-ChildItem "$ModulePath\public\" -Recurse -Include "*.ps1"
+    }
 
+    It "every public function has a test file" {
+        $missingTests = foreach ($file in $functions) {
+            if (-not (Test-Path "$ModulePath\tests\$($file.BaseName).Tests.ps1")) {
+                $file.BaseName
             }
         }
-        foreach ($item in (Get-ChildItem -Path "$ModulePath\private\functions" -Filter '*.ps*1' | Where-Object BaseName -ne 'Where-DbaObject')) {
-            $Tokens = $null
-            $Errors = $null
-            $Ast = [System.Management.Automation.Language.Parser]::ParseFile($item.FullName, [ref]$Tokens, [ref]$Errors)
-            $FunctionName = $Ast.EndBlock.Statements.Name
-            $BaseName = $item.BaseName
-            if ($FunctionName -cne $BaseName) {
-                Write-Host "aaa $functionname bbb $basename"
-                $global:FunctionNameMatchesErrors += [PSCustomObject]@{
-                    FunctionName = $FunctionName
-                    BaseName     = $BaseName
-                    Message      = "$FunctionName is not equal to $BaseName"
-                }
-            }
-        }
+
+        $missingTests | Should -BeNullOrEmpty
     }
-    Context "Function Name Matching Filename Errors" {
-        if ($global:FunctionNameMatchesErrors.Count -gt 0) {
-            foreach ($err in $global:FunctionNameMatchesErrors) {
-                It "$($err.FunctionName) is not equal to $($err.BaseName)" {
-                    $err.Message | Should -Be $null
+
+    It "every public function test has parameter validation" {
+        $missingValidation = foreach ($file in $functions) {
+            $testPath = "$ModulePath\tests\$($file.BaseName).Tests.ps1"
+            if (Test-Path $testPath) {
+                $testFile = Get-Content $testPath -Raw
+                $hasValidation = $testFile -match "Context `"Validate parameters`"" -or $testFile -match "Context `"Parameter validation`""
+                if (-not $hasValidation) {
+                    $file.BaseName
                 }
             }
         }
+
+        $missingValidation | Should -BeNullOrEmpty
     }
-    Context "Function Name has -Dba in it" {
-        if ($global:FunctionNameDbaErrors.Count -gt 0) {
-            foreach ($err in $global:FunctionNameDbaErrors) {
-                It "$($err.FunctionName) does not contain -Dba" {
-                    $err.Message | Should -Be $null
-                }
+}
+
+Describe "$ModuleName Function Name" -Tag Compliance {
+    BeforeAll {
+        $ModulePath = Split-Path $PSScriptRoot -Parent
+        $publicFunctions = Get-ChildItem -Path "$ModulePath\public" -Filter "*.ps*1"
+        $privateFunctions = Get-ChildItem -Path "$ModulePath\private\functions" -Filter "*.ps*1" | Where-Object BaseName -ne "Where-DbaObject"
+    }
+
+    It "function names match their filenames" {
+        $functionNameMatchesErrors = foreach ($item in @($publicFunctions) + @($privateFunctions)) {
+            $tokens = $null
+            $errors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($item.FullName, [ref]$tokens, [ref]$errors)
+            $functionName = $ast.EndBlock.Statements.Name
+            if ($functionName -cne $item.BaseName) {
+                "$functionName is not equal to $($item.BaseName)"
             }
         }
+
+        $functionNameMatchesErrors | Should -BeNullOrEmpty
+    }
+
+    It "public function names contain -Dba" {
+        $functionNameDbaErrors = foreach ($item in $publicFunctions) {
+            $tokens = $null
+            $errors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($item.FullName, [ref]$tokens, [ref]$errors)
+            $functionName = $ast.EndBlock.Statements.Name
+            if ($functionName -notmatch "-Dba") {
+                $functionName
+            }
+        }
+
+        $functionNameDbaErrors | Should -BeNullOrEmpty
     }
 }
 


### PR DESCRIPTION
## Summary

- rewrites the useful repository-wide checks as static Pester 6 tests that evaluate data at run time
- keeps alias, encoding/whitespace, prohibited API, analyzer, test-presence, parameter-validation, and function-name coverage
- removes the obsolete whole-repository background-job formatter comparison
- proves dependency selection always includes dbatools.Tests.ps1

## Root cause

The file populated collections in BeforeAll and generated It blocks with discovery-time oreach loops. Pester 6 discovery therefore saw empty collections and completed successfully with zero tests.

The rewritten file discovers 11 static tests. Each test calculates and reports its offenders during the run phase.

The now-active analyzer check found one existing intentional credential-migration conversion. The allowlist is restricted to the exact PSAvoidUsingConvertToSecureStringWithPlainText / Copy-DbaCredential.ps1 pair; all other severity errors fail.

Closes #10120
Closes #10119

## Validation

- RED baseline: Pester 6 reported TotalCount: 0
- Final general checks: 11 passed, 0 failed
- Selector tests: 3 passed, 0 failed
- PSScriptAnalyzer 1.18.2 severity Error on changed files: 0 findings
- Claude Opus high-effort review: 3-round cap completed; no Critical/Important findings