### PR TITLE
Test-DbaBackupStorageCompatibility - Add S3 multipart risk assessment

### DIFF
--- a/.github/scripts/gh-s3actions.ps1
+++ b/.github/scripts/gh-s3actions.ps1
@@ -100,6 +100,43 @@ Describe "S3 Backup Integration Tests" -Tag "IntegrationTests", "S3" {
             $result.BackupPath | Should -BeLike "s3://*"
         }
 
+        It "Should assess the real S3 backup history" {
+            $backupHistory = Get-DbaDbBackupHistory -SqlInstance localhost -SqlCredential $cred -Database $script:TestDbName -LastFull
+            $backupHistory.Path | Should -BeLike "$($script:S3BaseUrl)/*"
+
+            $result = Test-DbaBackupStorageCompatibility -SqlInstance localhost -SqlCredential $cred -Database $script:TestDbName
+
+            $result.Database | Should -Be $script:TestDbName
+            $result.Type | Should -Be "S3"
+            $result.BackupFileCount | Should -Be 1
+            $result.EffectiveBackupSizeBytes | Should -BeGreaterThan 0
+            $result.EstimatedPartsPerFile | Should -BeGreaterThan 0
+            $result.IsCompatible | Should -BeTrue
+            $result.Status | Should -Be "Compatible"
+
+            $expectedProperties = @(
+                "ComputerName",
+                "InstanceName",
+                "SqlInstance",
+                "Database",
+                "Type",
+                "LastFullBackup",
+                "BackupSizeBytes",
+                "CompressedBackupSizeBytes",
+                "EffectiveBackupSizeBytes",
+                "BackupFileCount",
+                "MaxTransferSize",
+                "EstimatedPartsPerFile",
+                "PercentOfLimit",
+                "IsCompatible",
+                "Status",
+                "RecommendedFileCount",
+                "RecommendedMaxTransferSizeBytes",
+                "Recommendation"
+            )
+            $result.PSObject.Properties.Name | Should -Be $expectedProperties
+        }
+
         It "Should backup database to S3 using AzureBaseUrl alias for backward compatibility" {
             $backupFile = "$($script:TestDbName)_full_alias.bak"
 
@@ -558,6 +595,76 @@ Describe "S3 Backup Integration Tests" -Tag "IntegrationTests", "S3" {
     #        # S3 URLs should pass validation - they are skipped for cloud paths
     #    }
     #}
+
+    Context "Test-DbaBackupStorageCompatibility multipart monitoring" {
+        BeforeAll {
+            $script:S3RiskDbName = "dbatoolsci_s3risk"
+            $script:S3RiskBackupFile = "$($script:S3RiskDbName)_full.bak"
+
+            $null = New-DbaDatabase -SqlInstance localhost -SqlCredential $cred -Name $script:S3RiskDbName -RecoveryModel Simple
+
+            $server = Connect-DbaInstance -SqlInstance localhost -SqlCredential $cred
+            $server.Query("
+                CREATE TABLE dbo.MultipartRiskData
+                (
+                    Id INT IDENTITY(1, 1) NOT NULL,
+                    Payload BINARY(8000) NOT NULL
+                );
+
+                INSERT dbo.MultipartRiskData (Payload)
+                SELECT TOP (70000) CRYPT_GEN_RANDOM(8000)
+                FROM sys.all_objects AS first_source
+                CROSS JOIN sys.all_objects AS second_source;
+
+                CHECKPOINT;
+            ", $script:S3RiskDbName)
+
+            $splatBackup = @{
+                SqlInstance       = "localhost"
+                SqlCredential     = $cred
+                Database          = $script:S3RiskDbName
+                StorageBaseUrl    = $script:S3BaseUrl
+                StorageCredential = $script:S3CredentialName
+                FilePath          = $script:S3RiskBackupFile
+                Type              = "Full"
+                CompressBackup    = $false
+            }
+            $script:S3RiskBackupResult = Backup-DbaDatabase @splatBackup
+        }
+
+        AfterAll {
+            $null = Remove-DbaDatabase -SqlInstance localhost -SqlCredential $cred -Database $script:S3RiskDbName -Confirm:$false
+        }
+
+        It "Should report a real S3 multipart warning in monitor mode" {
+            $script:S3RiskBackupResult.BackupComplete | Should -BeTrue
+
+            $backupHistory = Get-DbaDbBackupHistory -SqlInstance localhost -SqlCredential $cred -Database $script:S3RiskDbName -LastFull
+            $backupHistory.Path | Should -BeLike "$($script:S3BaseUrl)/*"
+
+            $monitorWarnings = @()
+            $splatTest = @{
+                SqlInstance     = "localhost"
+                SqlCredential   = $cred
+                Database        = $script:S3RiskDbName
+                MaxTransferSize = 5242880
+                Threshold       = 1
+                Monitor         = $true
+                WarningVariable = "+monitorWarnings"
+                WarningAction   = "SilentlyContinue"
+            }
+            $result = Test-DbaBackupStorageCompatibility @splatTest
+
+            $result.Database | Should -Be $script:S3RiskDbName
+            $result.Type | Should -Be "S3"
+            $result.EffectiveBackupSizeBytes | Should -BeGreaterOrEqual 524288000
+            $result.EstimatedPartsPerFile | Should -BeGreaterOrEqual 100
+            $result.PercentOfLimit | Should -BeGreaterOrEqual 1
+            $result.IsCompatible | Should -BeTrue
+            $result.Status | Should -Be "Warning"
+            $monitorWarnings.Message -join "`n" | Should -Match "compatibility risks found for 1 database"
+        }
+    }
 
     Context "Cleanup" {
         It "Should remove the S3 credential" {

--- a/.github/workflows/integration-tests-s3.yml
+++ b/.github/workflows/integration-tests-s3.yml
@@ -11,10 +11,13 @@ on:
       - "public/Get-DbaBackupInformation.ps1"
       - "public/Test-DbaLastBackup.ps1"
       - "public/Test-DbaBackupInformation.ps1"
+      - "public/Test-DbaBackupStorageCompatibility.ps1"
+      - "private/functions/Get-DbaS3BackupStorageEstimate.ps1"
       - "private/functions/Read-DbaBackupHeader.ps1"
       - "private/functions/Invoke-DbaAdvancedRestore.ps1"
       - ".github/workflows/integration-tests-s3.yml"
       - ".github/scripts/gh-s3actions.ps1"
+      - "tests/Test-DbaBackupStorageCompatibility.Tests.ps1"
   pull_request:
     paths:
       - "public/Backup-DbaDatabase.ps1"
@@ -22,10 +25,13 @@ on:
       - "public/Get-DbaBackupInformation.ps1"
       - "public/Test-DbaLastBackup.ps1"
       - "public/Test-DbaBackupInformation.ps1"
+      - "public/Test-DbaBackupStorageCompatibility.ps1"
+      - "private/functions/Get-DbaS3BackupStorageEstimate.ps1"
       - "private/functions/Read-DbaBackupHeader.ps1"
       - "private/functions/Invoke-DbaAdvancedRestore.ps1"
       - ".github/workflows/integration-tests-s3.yml"
       - ".github/scripts/gh-s3actions.ps1"
+      - "tests/Test-DbaBackupStorageCompatibility.Tests.ps1"
   workflow_dispatch:
 
 defaults:

--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -680,6 +680,7 @@
         'Test-DbaAgPolicyState',
         'Test-DbaAvailabilityGroup',
         'Test-DbaBackupInformation',
+        'Test-DbaBackupStorageCompatibility',
         'Test-DbaBuild',
         'Test-DbaCmConnection',
         'Test-DbaComputerCertificateExpiration',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -654,6 +654,7 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Format-DbaBackupInformation',
         'Get-DbaAgentJobStep',
         'Test-DbaBackupInformation',
+        'Test-DbaBackupStorageCompatibility',
         'Invoke-DbaBalanceDataFiles',
         'Select-DbaBackupInformation',
         'New-DbaDacPackage',

--- a/private/functions/Get-DbaS3BackupStorageEstimate.ps1
+++ b/private/functions/Get-DbaS3BackupStorageEstimate.ps1
@@ -1,0 +1,69 @@
+function Get-DbaS3BackupStorageEstimate {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [decimal]$EffectiveBackupSizeBytes,
+        [Parameter(Mandatory)]
+        [int]$BackupFileCount,
+        [Parameter(Mandatory)]
+        [long]$MaxTransferSize,
+        [Parameter(Mandatory)]
+        [int]$Threshold
+    )
+
+    $estimatedPartsPerFile = [long][Math]::Ceiling($EffectiveBackupSizeBytes / $BackupFileCount / $MaxTransferSize)
+    $percentOfLimit = [Math]::Round(($estimatedPartsPerFile / [decimal]10000) * 100, 2)
+    $partLimitExceeded = $estimatedPartsPerFile -gt 10000
+    $fileLimitExceeded = $BackupFileCount -gt 64
+    $isCompatible = -not ($partLimitExceeded -or $fileLimitExceeded)
+
+    if ($partLimitExceeded -and $fileLimitExceeded) {
+        $status = "ExceedsLimits"
+    } elseif ($partLimitExceeded) {
+        $status = "ExceedsPartLimit"
+    } elseif ($fileLimitExceeded) {
+        $status = "ExceedsFileLimit"
+    } elseif ($percentOfLimit -ge $Threshold) {
+        $status = "Warning"
+    } else {
+        $status = "Compatible"
+    }
+
+    $recommendedFileCount = $null
+    $recommendedMaxTransferSize = $null
+    $recommendation = $null
+    if ($fileLimitExceeded) {
+        $recommendedFileCount = 64
+        $recommendation = "S3-compatible backups support at most 64 URLs. Reduce the backup file count and recalculate the estimated parts per file."
+    }
+    if ($partLimitExceeded) {
+        $requiredFiles = [int][Math]::Ceiling($EffectiveBackupSizeBytes / ([decimal]10000 * $MaxTransferSize))
+        if ($requiredFiles -le 64) {
+            $recommendedFileCount = $requiredFiles
+            $recommendation = "Use at least $requiredFiles S3 URLs at the current MAXTRANSFERSIZE."
+        } elseif ($MaxTransferSize -lt 20971520) {
+            $requiredFilesAtMaximum = [int][Math]::Ceiling($EffectiveBackupSizeBytes / ([decimal]10000 * 20971520))
+            if ($requiredFilesAtMaximum -le 64) {
+                $recommendedFileCount = $requiredFilesAtMaximum
+                $recommendedMaxTransferSize = 20971520
+                $recommendation = "Use MAXTRANSFERSIZE 20971520 with backup compression and at least $requiredFilesAtMaximum S3 URLs."
+            } else {
+                $recommendation = "The current effective backup size exceeds the S3 multipart limit even at 20 MiB and 64 URLs. Reduce backup size with compression or change the backup design."
+            }
+        } else {
+            $recommendation = "The current effective backup size exceeds the S3 multipart limit at the selected MAXTRANSFERSIZE. Reduce backup size with compression or change the backup design."
+        }
+    } elseif ($status -eq "Warning") {
+        $recommendation = "The estimate is approaching the 10,000-part limit. Monitor backup growth or increase the file count before moving this backup to S3-compatible storage."
+    }
+
+    [PSCustomObject]@{
+        EstimatedPartsPerFile           = $estimatedPartsPerFile
+        PercentOfLimit                  = $percentOfLimit
+        IsCompatible                    = $isCompatible
+        Status                          = $status
+        RecommendedFileCount            = $recommendedFileCount
+        RecommendedMaxTransferSizeBytes = $recommendedMaxTransferSize
+        Recommendation                  = $recommendation
+    }
+}

--- a/public/Test-DbaBackupStorageCompatibility.ps1
+++ b/public/Test-DbaBackupStorageCompatibility.ps1
@@ -1,0 +1,266 @@
+function Test-DbaBackupStorageCompatibility {
+    <#
+    .SYNOPSIS
+        Estimates whether recent database backups fit cloud storage limits.
+
+    .DESCRIPTION
+        Evaluates the most recent full backup for each selected database against the limits of a cloud backup storage provider. The initial provider is S3-compatible object storage for SQL Server 2022 and later.
+
+        S3-compatible SQL Server backups support at most 64 URLs and 10,000 multipart upload parts per URL. This command estimates parts per URL by evenly dividing the effective backup size across the backup file count. It uses compressed size when the backup history reports one, otherwise it uses the uncompressed size.
+
+        The estimate helps identify backup configurations that need more URLs, a larger MAXTRANSFERSIZE, or compression before moving to S3-compatible storage. It does not validate credentials, network access, or a specific object storage implementation.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. S3-compatible backup evaluation requires SQL Server 2022 or later.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        Specifies one or more databases to evaluate. By default, all accessible databases with full backup history are evaluated.
+
+    .PARAMETER ExcludeDatabase
+        Specifies one or more databases to exclude from evaluation.
+
+    .PARAMETER Type
+        Specifies the cloud backup storage provider. The only currently supported value, and the default, is S3.
+
+    .PARAMETER MaxTransferSize
+        Specifies the MAXTRANSFERSIZE value in bytes used to estimate multipart upload parts. S3-compatible SQL Server backups support values from 5 MiB through 20 MiB. The default is 10 MiB (10485760 bytes).
+
+        Values other than 10 MiB require backup compression when the backup is written.
+
+    .PARAMETER Threshold
+        Specifies the percentage of the 10,000-part limit at which a compatible backup is reported as Warning. The default is 90.
+
+    .PARAMETER Monitor
+        Returns only Warning or incompatible results. After returning those results, signals an InvalidResult through Stop-Function when one or more risks were found.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Backup, S3, Cloud, AWS
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Test-DbaBackupStorageCompatibility
+
+    .OUTPUTS
+        PSCustomObject
+
+        Returns one estimate per database with full backup history. With -Monitor, returns only Warning or incompatible estimates.
+
+        Properties:
+        - ComputerName: Computer name of the SQL Server instance (string)
+        - InstanceName: SQL Server service name (string)
+        - SqlInstance: Full SQL Server instance name (string)
+        - Database: Database evaluated (string)
+        - Type: Storage provider evaluated; currently S3 (string)
+        - LastFullBackup: Start time of the most recent full backup (DateTime)
+        - BackupSizeBytes: Uncompressed backup size in bytes (decimal)
+        - CompressedBackupSizeBytes: Compressed backup size in bytes, or zero when unavailable (decimal)
+        - EffectiveBackupSizeBytes: Size used for the estimate; compressed size when available, otherwise uncompressed size (decimal)
+        - BackupFileCount: Number of files in the backup set (int)
+        - MaxTransferSize: MAXTRANSFERSIZE used for the estimate, in bytes (long)
+        - EstimatedPartsPerFile: Estimated multipart upload parts for each evenly striped backup file (long)
+        - PercentOfLimit: Estimated parts as a percentage of the 10,000-part S3 limit (decimal)
+        - IsCompatible: Whether the estimate is within both the part and 64-URL limits (bool)
+        - Status: Compatible, Warning, ExceedsPartLimit, ExceedsFileLimit, or ExceedsLimits (string)
+        - RecommendedFileCount: Suggested number of backup URLs when calculable, otherwise null (int)
+        - RecommendedMaxTransferSizeBytes: Suggested MAXTRANSFERSIZE in bytes when calculable, otherwise null (long)
+        - Recommendation: Conservative configuration guidance for Warning or incompatible estimates, otherwise null (string)
+
+    .EXAMPLE
+        PS C:\> Test-DbaBackupStorageCompatibility -SqlInstance sql2022
+
+        Evaluates the most recent full backup for every accessible database on sql2022 using the S3 default MAXTRANSFERSIZE of 10 MiB.
+
+    .EXAMPLE
+        PS C:\> Test-DbaBackupStorageCompatibility -SqlInstance sql2022 -Database Sales -MaxTransferSize 20971520
+
+        Evaluates the Sales database using a 20 MiB MAXTRANSFERSIZE estimate. A backup written with this value requires compression.
+
+    .EXAMPLE
+        PS C:\> Test-DbaBackupStorageCompatibility -SqlInstance sql2022 -Threshold 80 -Monitor
+
+        Returns only databases at or above 80 percent of the S3 part limit or outside an S3 limit, and signals when any are found.
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [object[]]$Database,
+        [object[]]$ExcludeDatabase,
+        [ValidateSet("S3")]
+        [string]$Type = "S3",
+        [ValidateRange(5242880, 20971520)]
+        [long]$MaxTransferSize = 10485760,
+        [ValidateRange(1, 100)]
+        [int]$Threshold = 90,
+        [switch]$Monitor,
+        [switch]$EnableException
+    )
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                $splatConnect = @{
+                    SqlInstance    = $instance
+                    SqlCredential  = $SqlCredential
+                    MinimumVersion = 16
+                }
+                $server = Connect-DbaInstance @splatConnect
+            } catch {
+                $splatStopConnection = @{
+                    Message     = "Failure"
+                    Category    = "ConnectionError"
+                    ErrorRecord = $PSItem
+                    Target      = $instance
+                    Continue    = $true
+                }
+                Stop-Function @splatStopConnection
+            }
+
+            $databases = @($server.Databases | Where-Object IsAccessible)
+            if ($Database) {
+                $databases = @($databases | Where-Object Name -In $Database)
+            }
+            if ($ExcludeDatabase) {
+                $databases = @($databases | Where-Object Name -NotIn $ExcludeDatabase)
+            }
+
+            $monitorProblemCount = 0
+            foreach ($db in $databases) {
+                $splatBackupHistory = @{
+                    SqlInstance     = $server
+                    Database        = $db.Name
+                    LastFull        = $true
+                    EnableException = $EnableException
+                }
+                $lastBackup = Get-DbaDbBackupHistory @splatBackupHistory
+                if (-not $lastBackup) {
+                    Write-Message -Level Verbose -Message "No full backup history found for database $($db.Name)."
+                    continue
+                }
+
+                $backupFileCount = @($lastBackup.Path | Where-Object { $null -ne $PSItem }).Count
+                if ($backupFileCount -eq 0) {
+                    Write-Message -Level Warning -Message "The most recent full backup for database $($db.Name) does not contain backup file paths and cannot be evaluated."
+                    continue
+                }
+
+                if ($lastBackup.TotalSize.PSObject.Properties["Byte"]) {
+                    $backupSizeBytes = [decimal]$lastBackup.TotalSize.Byte
+                } else {
+                    $backupSizeBytes = [decimal]$lastBackup.TotalSize
+                }
+                if ($lastBackup.CompressedBackupSize.PSObject.Properties["Byte"]) {
+                    $compressedBackupSizeBytes = [decimal]$lastBackup.CompressedBackupSize.Byte
+                } else {
+                    $compressedBackupSizeBytes = [decimal]$lastBackup.CompressedBackupSize
+                }
+                if ($compressedBackupSizeBytes -gt 0) {
+                    $effectiveBackupSizeBytes = $compressedBackupSizeBytes
+                } else {
+                    $effectiveBackupSizeBytes = $backupSizeBytes
+                }
+
+                $estimatedPartsPerFile = [long][Math]::Ceiling($effectiveBackupSizeBytes / $backupFileCount / $MaxTransferSize)
+                $percentOfLimit = [Math]::Round(($estimatedPartsPerFile / [decimal]10000) * 100, 2)
+                $partLimitExceeded = $estimatedPartsPerFile -gt 10000
+                $fileLimitExceeded = $backupFileCount -gt 64
+                $isCompatible = -not ($partLimitExceeded -or $fileLimitExceeded)
+
+                if ($partLimitExceeded -and $fileLimitExceeded) {
+                    $status = "ExceedsLimits"
+                } elseif ($partLimitExceeded) {
+                    $status = "ExceedsPartLimit"
+                } elseif ($fileLimitExceeded) {
+                    $status = "ExceedsFileLimit"
+                } elseif ($percentOfLimit -ge $Threshold) {
+                    $status = "Warning"
+                } else {
+                    $status = "Compatible"
+                }
+
+                $recommendedFileCount = $null
+                $recommendedMaxTransferSize = $null
+                $recommendation = $null
+                if ($fileLimitExceeded) {
+                    $recommendedFileCount = 64
+                    $recommendation = "S3-compatible backups support at most 64 URLs. Reduce the backup file count and recalculate the estimated parts per file."
+                }
+                if ($partLimitExceeded) {
+                    $requiredFiles = [int][Math]::Ceiling($effectiveBackupSizeBytes / ([decimal]10000 * $MaxTransferSize))
+                    if ($requiredFiles -le 64) {
+                        $recommendedFileCount = $requiredFiles
+                        $recommendation = "Use at least $requiredFiles S3 URLs at the current MAXTRANSFERSIZE."
+                    } elseif ($MaxTransferSize -lt 20971520) {
+                        $requiredFilesAtMaximum = [int][Math]::Ceiling($effectiveBackupSizeBytes / ([decimal]10000 * 20971520))
+                        if ($requiredFilesAtMaximum -le 64) {
+                            $recommendedFileCount = $requiredFilesAtMaximum
+                            $recommendedMaxTransferSize = 20971520
+                            $recommendation = "Use MAXTRANSFERSIZE 20971520 with backup compression and at least $requiredFilesAtMaximum S3 URLs."
+                        } else {
+                            $recommendation = "The current effective backup size exceeds the S3 multipart limit even at 20 MiB and 64 URLs. Reduce backup size with compression or change the backup design."
+                        }
+                    } else {
+                        $recommendation = "The current effective backup size exceeds the S3 multipart limit at the selected MAXTRANSFERSIZE. Reduce backup size with compression or change the backup design."
+                    }
+                } elseif ($status -eq "Warning") {
+                    $recommendation = "The estimate is approaching the 10,000-part limit. Monitor backup growth or increase the file count before moving this backup to S3-compatible storage."
+                }
+
+                $result = [PSCustomObject]@{
+                    ComputerName                    = $server.ComputerName
+                    InstanceName                    = $server.ServiceName
+                    SqlInstance                     = $server.DomainInstanceName
+                    Database                        = $db.Name
+                    Type                            = $Type
+                    LastFullBackup                  = $lastBackup.Start
+                    BackupSizeBytes                 = $backupSizeBytes
+                    CompressedBackupSizeBytes       = $compressedBackupSizeBytes
+                    EffectiveBackupSizeBytes        = $effectiveBackupSizeBytes
+                    BackupFileCount                 = $backupFileCount
+                    MaxTransferSize                 = $MaxTransferSize
+                    EstimatedPartsPerFile           = $estimatedPartsPerFile
+                    PercentOfLimit                  = $percentOfLimit
+                    IsCompatible                    = $isCompatible
+                    Status                          = $status
+                    RecommendedFileCount            = $recommendedFileCount
+                    RecommendedMaxTransferSizeBytes = $recommendedMaxTransferSize
+                    Recommendation                  = $recommendation
+                }
+
+                if ($Monitor) {
+                    if ($status -ne "Compatible") {
+                        $monitorProblemCount++
+                        $result
+                    }
+                } else {
+                    $result
+                }
+            }
+
+            if ($Monitor -and $monitorProblemCount -gt 0) {
+                $splatStop = @{
+                    Message         = "S3 backup storage compatibility risks found for $monitorProblemCount database(s)."
+                    Category        = "InvalidResult"
+                    EnableException = $EnableException
+                }
+                Stop-Function @splatStop
+            }
+        }
+    }
+}

--- a/public/Test-DbaBackupStorageCompatibility.ps1
+++ b/public/Test-DbaBackupStorageCompatibility.ps1
@@ -176,51 +176,13 @@ function Test-DbaBackupStorageCompatibility {
                     $effectiveBackupSizeBytes = $backupSizeBytes
                 }
 
-                $estimatedPartsPerFile = [long][Math]::Ceiling($effectiveBackupSizeBytes / $backupFileCount / $MaxTransferSize)
-                $percentOfLimit = [Math]::Round(($estimatedPartsPerFile / [decimal]10000) * 100, 2)
-                $partLimitExceeded = $estimatedPartsPerFile -gt 10000
-                $fileLimitExceeded = $backupFileCount -gt 64
-                $isCompatible = -not ($partLimitExceeded -or $fileLimitExceeded)
-
-                if ($partLimitExceeded -and $fileLimitExceeded) {
-                    $status = "ExceedsLimits"
-                } elseif ($partLimitExceeded) {
-                    $status = "ExceedsPartLimit"
-                } elseif ($fileLimitExceeded) {
-                    $status = "ExceedsFileLimit"
-                } elseif ($percentOfLimit -ge $Threshold) {
-                    $status = "Warning"
-                } else {
-                    $status = "Compatible"
+                $splatEstimate = @{
+                    EffectiveBackupSizeBytes = $effectiveBackupSizeBytes
+                    BackupFileCount          = $backupFileCount
+                    MaxTransferSize          = $MaxTransferSize
+                    Threshold                = $Threshold
                 }
-
-                $recommendedFileCount = $null
-                $recommendedMaxTransferSize = $null
-                $recommendation = $null
-                if ($fileLimitExceeded) {
-                    $recommendedFileCount = 64
-                    $recommendation = "S3-compatible backups support at most 64 URLs. Reduce the backup file count and recalculate the estimated parts per file."
-                }
-                if ($partLimitExceeded) {
-                    $requiredFiles = [int][Math]::Ceiling($effectiveBackupSizeBytes / ([decimal]10000 * $MaxTransferSize))
-                    if ($requiredFiles -le 64) {
-                        $recommendedFileCount = $requiredFiles
-                        $recommendation = "Use at least $requiredFiles S3 URLs at the current MAXTRANSFERSIZE."
-                    } elseif ($MaxTransferSize -lt 20971520) {
-                        $requiredFilesAtMaximum = [int][Math]::Ceiling($effectiveBackupSizeBytes / ([decimal]10000 * 20971520))
-                        if ($requiredFilesAtMaximum -le 64) {
-                            $recommendedFileCount = $requiredFilesAtMaximum
-                            $recommendedMaxTransferSize = 20971520
-                            $recommendation = "Use MAXTRANSFERSIZE 20971520 with backup compression and at least $requiredFilesAtMaximum S3 URLs."
-                        } else {
-                            $recommendation = "The current effective backup size exceeds the S3 multipart limit even at 20 MiB and 64 URLs. Reduce backup size with compression or change the backup design."
-                        }
-                    } else {
-                        $recommendation = "The current effective backup size exceeds the S3 multipart limit at the selected MAXTRANSFERSIZE. Reduce backup size with compression or change the backup design."
-                    }
-                } elseif ($status -eq "Warning") {
-                    $recommendation = "The estimate is approaching the 10,000-part limit. Monitor backup growth or increase the file count before moving this backup to S3-compatible storage."
-                }
+                $estimate = Get-DbaS3BackupStorageEstimate @splatEstimate
 
                 $result = [PSCustomObject]@{
                     ComputerName                    = $server.ComputerName
@@ -234,17 +196,17 @@ function Test-DbaBackupStorageCompatibility {
                     EffectiveBackupSizeBytes        = $effectiveBackupSizeBytes
                     BackupFileCount                 = $backupFileCount
                     MaxTransferSize                 = $MaxTransferSize
-                    EstimatedPartsPerFile           = $estimatedPartsPerFile
-                    PercentOfLimit                  = $percentOfLimit
-                    IsCompatible                    = $isCompatible
-                    Status                          = $status
-                    RecommendedFileCount            = $recommendedFileCount
-                    RecommendedMaxTransferSizeBytes = $recommendedMaxTransferSize
-                    Recommendation                  = $recommendation
+                    EstimatedPartsPerFile           = $estimate.EstimatedPartsPerFile
+                    PercentOfLimit                  = $estimate.PercentOfLimit
+                    IsCompatible                    = $estimate.IsCompatible
+                    Status                          = $estimate.Status
+                    RecommendedFileCount            = $estimate.RecommendedFileCount
+                    RecommendedMaxTransferSizeBytes = $estimate.RecommendedMaxTransferSizeBytes
+                    Recommendation                  = $estimate.Recommendation
                 }
 
                 if ($Monitor) {
-                    if ($status -ne "Compatible") {
+                    if ($estimate.Status -ne "Compatible") {
                         $monitorProblemCount++
                         $result
                     }

--- a/tests/Test-DbaBackupStorageCompatibility.Tests.ps1
+++ b/tests/Test-DbaBackupStorageCompatibility.Tests.ps1
@@ -1,0 +1,164 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Test-DbaBackupStorageCompatibility",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Database",
+                "ExcludeDatabase",
+                "Type",
+                "MaxTransferSize",
+                "Threshold",
+                "Monitor",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+
+    InModuleScope dbatools {
+        BeforeEach {
+            $script:mockStorageServer = [PSCustomObject]@{
+                ComputerName       = "sql1"
+                ServiceName        = "MSSQLSERVER"
+                DomainInstanceName = "sql1"
+                Databases          = @(
+                    [PSCustomObject]@{
+                        Name         = "TestDb"
+                        IsAccessible = $true
+                    }
+                )
+            }
+
+            Mock Connect-DbaInstance {
+                $script:mockStorageServer
+            }
+            Mock Stop-Function
+        }
+
+        It "calculates S3 parts from compressed backup size and recommends more files" {
+            Mock Get-DbaDbBackupHistory -RemoveParameterType "SqlInstance" {
+                [PSCustomObject]@{
+                    Start                = Get-Date "2026-01-01"
+                    TotalSize            = 220GB
+                    CompressedBackupSize = 200GB
+                    Path                 = @("s3://bucket/a.bak", "s3://bucket/b.bak")
+                }
+            }
+
+            $result = Test-DbaBackupStorageCompatibility -SqlInstance "sql1" -Database "TestDb"
+
+            $result.Type | Should -Be "S3"
+            $result.EffectiveBackupSizeBytes | Should -Be 214748364800
+            $result.BackupFileCount | Should -Be 2
+            $result.EstimatedPartsPerFile | Should -Be 10240
+            $result.PercentOfLimit | Should -Be 102.4
+            $result.IsCompatible | Should -BeFalse
+            $result.Status | Should -Be "ExceedsPartLimit"
+            $result.RecommendedFileCount | Should -Be 3
+            Should -Invoke Connect-DbaInstance -Times 1 -Exactly -ParameterFilter { $MinimumVersion -eq 16 }
+        }
+
+        It "treats exactly ten thousand parts as compatible" {
+            Mock Get-DbaDbBackupHistory -RemoveParameterType "SqlInstance" {
+                [PSCustomObject]@{
+                    Start                = Get-Date "2026-01-01"
+                    TotalSize            = 104857600000
+                    CompressedBackupSize = 0
+                    Path                 = @("s3://bucket/a.bak")
+                }
+            }
+
+            $result = Test-DbaBackupStorageCompatibility -SqlInstance "sql1"
+
+            $result.EstimatedPartsPerFile | Should -Be 10000
+            $result.IsCompatible | Should -BeTrue
+            $result.Status | Should -Be "Warning"
+        }
+
+        It "returns only risks and signals once in monitor mode" {
+            Mock Get-DbaDbBackupHistory -RemoveParameterType "SqlInstance" {
+                [PSCustomObject]@{
+                    Start                = Get-Date "2026-01-01"
+                    TotalSize            = 220GB
+                    CompressedBackupSize = 200GB
+                    Path                 = @("s3://bucket/a.bak", "s3://bucket/b.bak")
+                }
+            }
+
+            $result = Test-DbaBackupStorageCompatibility -SqlInstance "sql1" -Monitor
+
+            $result.Status | Should -Be "ExceedsPartLimit"
+            Should -Invoke Stop-Function -Times 1 -Exactly -ParameterFilter {
+                $Message -match "1 database" -and $Category -eq "InvalidResult"
+            }
+        }
+    }
+}
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $databaseName = "dbatoolsci_backupstorage_$(Get-Random)"
+        $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+        $null = New-DbaDatabase -SqlInstance $server -Name $databaseName
+        $null = Backup-DbaDatabase -SqlInstance $server -Database $databaseName
+        $result = Test-DbaBackupStorageCompatibility -SqlInstance $server -Database $databaseName
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $null = Remove-DbaDatabase -SqlInstance $server -Database $databaseName
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    It "returns a compatible S3 estimate for a small full backup" {
+        $result.Database | Should -Be $databaseName
+        $result.Type | Should -Be "S3"
+        $result.BackupFileCount | Should -BeGreaterThan 0
+        $result.EstimatedPartsPerFile | Should -BeGreaterThan 0
+        $result.IsCompatible | Should -BeTrue
+    }
+
+    It "returns the documented output properties" {
+        $expectedProperties = @(
+            "ComputerName",
+            "InstanceName",
+            "SqlInstance",
+            "Database",
+            "Type",
+            "LastFullBackup",
+            "BackupSizeBytes",
+            "CompressedBackupSizeBytes",
+            "EffectiveBackupSizeBytes",
+            "BackupFileCount",
+            "MaxTransferSize",
+            "EstimatedPartsPerFile",
+            "PercentOfLimit",
+            "IsCompatible",
+            "Status",
+            "RecommendedFileCount",
+            "RecommendedMaxTransferSizeBytes",
+            "Recommendation"
+        )
+
+        $result.PSObject.Properties.Name | Should -Be $expectedProperties
+    }
+}

--- a/tests/Test-DbaBackupStorageCompatibility.Tests.ps1
+++ b/tests/Test-DbaBackupStorageCompatibility.Tests.ps1
@@ -26,139 +26,22 @@ Describe $CommandName -Tag UnitTests {
     }
 
     InModuleScope dbatools {
-        BeforeEach {
-            $script:mockStorageServer = [PSCustomObject]@{
-                ComputerName       = "sql1"
-                ServiceName        = "MSSQLSERVER"
-                DomainInstanceName = "sql1"
-                Databases          = @(
-                    [PSCustomObject]@{
-                        Name         = "TestDb"
-                        IsAccessible = $true
-                    }
-                )
-            }
+        It "calculates multipart risk and recommends more files" {
+            $result = Get-DbaS3BackupStorageEstimate -EffectiveBackupSizeBytes 200GB -BackupFileCount 2 -MaxTransferSize 10MB -Threshold 90
 
-            Mock Connect-DbaInstance {
-                $script:mockStorageServer
-            }
-            Mock Stop-Function
-        }
-
-        It "calculates S3 parts from compressed backup size and recommends more files" {
-            Mock Get-DbaDbBackupHistory -RemoveParameterType "SqlInstance" {
-                [PSCustomObject]@{
-                    Start                = Get-Date "2026-01-01"
-                    TotalSize            = 220GB
-                    CompressedBackupSize = 200GB
-                    Path                 = @("s3://bucket/a.bak", "s3://bucket/b.bak")
-                }
-            }
-
-            $result = Test-DbaBackupStorageCompatibility -SqlInstance "sql1" -Database "TestDb"
-
-            $result.Type | Should -Be "S3"
-            $result.EffectiveBackupSizeBytes | Should -Be 214748364800
-            $result.BackupFileCount | Should -Be 2
             $result.EstimatedPartsPerFile | Should -Be 10240
             $result.PercentOfLimit | Should -Be 102.4
             $result.IsCompatible | Should -BeFalse
             $result.Status | Should -Be "ExceedsPartLimit"
             $result.RecommendedFileCount | Should -Be 3
-            Should -Invoke Connect-DbaInstance -Times 1 -Exactly -ParameterFilter { $MinimumVersion -eq 16 }
         }
 
         It "treats exactly ten thousand parts as compatible" {
-            Mock Get-DbaDbBackupHistory -RemoveParameterType "SqlInstance" {
-                [PSCustomObject]@{
-                    Start                = Get-Date "2026-01-01"
-                    TotalSize            = 104857600000
-                    CompressedBackupSize = 0
-                    Path                 = @("s3://bucket/a.bak")
-                }
-            }
-
-            $result = Test-DbaBackupStorageCompatibility -SqlInstance "sql1"
+            $result = Get-DbaS3BackupStorageEstimate -EffectiveBackupSizeBytes 104857600000 -BackupFileCount 1 -MaxTransferSize 10MB -Threshold 90
 
             $result.EstimatedPartsPerFile | Should -Be 10000
             $result.IsCompatible | Should -BeTrue
             $result.Status | Should -Be "Warning"
         }
-
-        It "returns only risks and signals once in monitor mode" {
-            Mock Get-DbaDbBackupHistory -RemoveParameterType "SqlInstance" {
-                [PSCustomObject]@{
-                    Start                = Get-Date "2026-01-01"
-                    TotalSize            = 220GB
-                    CompressedBackupSize = 200GB
-                    Path                 = @("s3://bucket/a.bak", "s3://bucket/b.bak")
-                }
-            }
-
-            $result = Test-DbaBackupStorageCompatibility -SqlInstance "sql1" -Monitor
-
-            $result.Status | Should -Be "ExceedsPartLimit"
-            Should -Invoke Stop-Function -Times 1 -Exactly -ParameterFilter {
-                $Message -match "1 database" -and $Category -eq "InvalidResult"
-            }
-        }
-    }
-}
-
-Describe $CommandName -Tag IntegrationTests {
-    BeforeAll {
-        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-
-        $databaseName = "dbatoolsci_backupstorage_$(Get-Random)"
-        $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
-        $null = New-DbaDatabase -SqlInstance $server -Name $databaseName
-        $null = Backup-DbaDatabase -SqlInstance $server -Database $databaseName
-        $result = Test-DbaBackupStorageCompatibility -SqlInstance $server -Database $databaseName
-
-        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-    }
-
-    AfterAll {
-        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-
-        $null = Remove-DbaDatabase -SqlInstance $server -Database $databaseName
-
-        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-    }
-
-    It "returns a compatible S3 estimate for a small full backup" {
-        $result.Database | Should -Be $databaseName
-        $result.Type | Should -Be "S3"
-        $result.BackupFileCount | Should -BeGreaterThan 0
-        $result.EstimatedPartsPerFile | Should -BeGreaterThan 0
-        $result.IsCompatible | Should -BeTrue
-    }
-
-    It "returns the documented output properties" {
-        $expectedProperties = @(
-            "ComputerName",
-            "InstanceName",
-            "SqlInstance",
-            "Database",
-            "Type",
-            "LastFullBackup",
-            "BackupSizeBytes",
-            "CompressedBackupSizeBytes",
-            "EffectiveBackupSizeBytes",
-            "BackupFileCount",
-            "MaxTransferSize",
-            "EstimatedPartsPerFile",
-            "PercentOfLimit",
-            "IsCompatible",
-            "Status",
-            "RecommendedFileCount",
-            "RecommendedMaxTransferSizeBytes",
-            "Recommendation"
-        )
-
-        $result.PSObject.Properties.Name | Should -Be $expectedProperties
     }
 }


### PR DESCRIPTION
## Summary

- adds the provider-neutral `Test-DbaBackupStorageCompatibility` command with initial S3 support
- estimates multipart parts from the latest full backup's effective size and stripe count
- reports the 64-URL and 10,000-parts-per-URL limits with structured statuses and recommendations
- supports monitor mode for automation
- keeps deterministic multipart arithmetic in a pure private helper with direct, mock-free boundary tests
- validates the public command against real SQL Server 2022 backup history stored in TLS-enabled MinIO

## Real S3 integration coverage

The S3 GitHub Action provisions SQL Server 2022 and MinIO. The tests create actual databases and send real backups through SQL Server's S3-compatible URL support.

- verifies a normal MinIO backup is read from real `msdb` history and reported as compatible
- verifies the complete documented output-property contract on that live result
- creates more than 500 MiB of incompressible SQL data and writes an uncompressed backup to MinIO
- runs `-Monitor` at the minimum supported 5 MiB transfer size and 1% threshold
- verifies the real backup returns `Warning` and emits the aggregate monitor warning

No `Connect-DbaInstance`, backup-history, or `Stop-Function` mocks remain in this command's behavioral tests.

## Design notes

The estimate prefers compressed backup size when available and otherwise uses total size. It assumes even striping across backup files and does not claim to validate production credentials or networking.

Exactly 10,000 parts is compatible; only values above the documented maximum are incompatible.

## Validation

- Pester 6 focused tests: 3 passed, 0 failed
- PowerShell parser: 4 changed files passed
- PSScriptAnalyzer severity Error: 0 findings
- S3 workflow YAML parsed successfully
- `git diff --check`: passed
- Claude Opus high-effort review: three-review cap completed; output-contract finding addressed on the live MinIO result
- current head `87ade9a23`: all ordinary checks, both real S3/MinIO workflows, and all 10 Azure runner lanes passed

Closes #10197
