### PR TITLE
Set-DbaTempDbConfig - Allow forced data file reduction

### DIFF
--- a/public/Set-DbaTempDbConfig.ps1
+++ b/public/Set-DbaTempDbConfig.ps1
@@ -6,9 +6,9 @@ function Set-DbaTempDbConfig {
     .DESCRIPTION
         Configures tempdb database files to follow Microsoft's recommended best practices for performance optimization. This function calculates the optimal number of data files based on logical CPU cores (capped at 8) and distributes the specified total data file size evenly across those files. You must specify the target SQL Server instance and total data file size as mandatory parameters.
 
-        The function automatically determines the appropriate number of data files based on your server's logical cores, but you can override this behavior. It validates the current tempdb configuration to ensure it won't conflict with your desired settings - existing files must be smaller than the calculated target size and you cannot have more existing files than the target configuration.
+        The function automatically determines the appropriate number of data files based on your server's logical cores, but you can override this behavior. It validates the current tempdb configuration to ensure it won't conflict with your desired settings. Existing files must be smaller than the calculated target size, and by default you cannot have more existing files than the target configuration.
 
-        Additional parameters let you customize file paths, log file size, and growth settings. The function generates ALTER DATABASE statements but does not shrink or delete existing files. If your current tempdb is larger than your target configuration, you'll need to shrink it manually before running this function. A SQL Server restart is required for tempdb changes to take effect.
+        Additional parameters let you customize file paths, log file size, and growth settings. Use Force to reduce the number of data files by emptying and removing the highest-numbered secondary files when the requested total size can hold all currently used space. Without Force, the function does not shrink or delete existing files. A SQL Server restart is required for tempdb changes to take effect.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
@@ -60,6 +60,10 @@ function Set-DbaTempDbConfig {
         Prevents tempdb files from auto-growing by setting growth to 0. Overrides any values specified for -DataFileGrowth and -LogFileGrowth.
         Use this when you want to pre-size tempdb files appropriately and prevent unexpected growth during production workloads.
 
+    .PARAMETER Force
+        Allows the command to reduce the number of tempdb data files. The highest-numbered secondary data files are emptied and removed first, and the primary data file is never selected for removal.
+        The command refuses the reduction when current used space exceeds the requested total data file size. Use OutputScriptOnly to review the generated DBCC SHRINKFILE and ALTER DATABASE statements before execution.
+
     .PARAMETER WhatIf
         If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
@@ -98,7 +102,7 @@ function Set-DbaTempDbConfig {
 
         System.String[] (when -OutputScriptOnly is specified)
 
-        Returns array of T-SQL ALTER DATABASE statements that would configure tempdb without executing them.
+        Returns an array of T-SQL statements that would configure tempdb without executing them. Forced file-count reductions also include DBCC SHRINKFILE and ALTER DATABASE REMOVE FILE statements.
 
         System.Void (when -OutFile is specified)
 
@@ -132,6 +136,11 @@ function Set-DbaTempDbConfig {
 
         Returns the T-SQL script representing tempdb configuration.
 
+    .EXAMPLE
+        PS C:\> Set-DbaTempDbConfig -SqlInstance localhost -DataFileCount 4 -DataFileSize 2048 -Force -OutputScriptOnly
+
+        Returns a script that empties and removes the highest-numbered secondary data files when tempdb currently has more than four data files, then configures the four retained files.
+
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseOutputTypeCorrectly", "", Justification = "PSSA Rule Ignored by BOH")]
@@ -150,6 +159,7 @@ function Set-DbaTempDbConfig {
         [string]$OutFile,
         [switch]$OutputScriptOnly,
         [switch]$DisableGrowth,
+        [switch]$Force,
         [switch]$EnableException
     )
     process {
@@ -214,20 +224,65 @@ function Set-DbaTempDbConfig {
             }
 
             # Check current tempdb. Throw an error if current tempdb is larger than config.
-            $CurrentFileCount = $server.Databases['tempdb'].Query('SELECT COUNT(1) AS FileCount FROM sys.database_files WHERE type=0').FileCount
-            $TooBigCount = $server.Databases['tempdb'].Query("SELECT TOP 1 (size/128) AS Size FROM sys.database_files WHERE size/128 > $DataFilesizeSingle AND type = 0").Size
+            $tempdbFiles = @($server.Databases["tempdb"].Query(@"
+SELECT
+    file_id AS FileId,
+    name AS LogicalName,
+    physical_name AS PhysicalName,
+    size / 128.0 AS SizeMb,
+    FILEPROPERTY(name, 'SpaceUsed') / 128.0 AS UsedMb
+FROM sys.database_files
+WHERE type = 0
+ORDER BY file_id;
+"@))
+            $CurrentFileCount = $tempdbFiles.Count
+            $filesToRemove = @()
+            $filesToKeep = @($tempdbFiles)
 
             if ($CurrentFileCount -gt $DataFileCount) {
-                Stop-Function -Message "Current tempdb in $instance is not suitable to be reconfigured. The current tempdb has a greater number of files ($CurrentFileCount) than the calculated configuration ($DataFileCount)." -Continue
+                if (-not $Force) {
+                    Stop-Function -Message "Current tempdb in $instance is not suitable to be reconfigured. The current tempdb has a greater number of files ($CurrentFileCount) than the calculated configuration ($DataFileCount)." -Continue
+                }
+
+                $removeCount = $CurrentFileCount - $DataFileCount
+                $filesToRemove = @(
+                    $tempdbFiles |
+                        Where-Object { $PSItem.FileId -ne 1 } |
+                        Sort-Object FileId -Descending |
+                        Select-Object -First $removeCount
+                )
+
+                if ($filesToRemove.Count -ne $removeCount) {
+                    Stop-Function -Message "Current tempdb in $instance cannot be reduced to $DataFileCount data files without removing the primary data file." -Continue
+                }
+
+                $usedMb = ($tempdbFiles | Measure-Object -Property UsedMb -Sum).Sum
+                if ($usedMb -gt $DataFileSize) {
+                    Stop-Function -Message "Current tempdb uses $usedMb MB, which exceeds the requested target capacity of $DataFileSize MB." -Continue
+                }
+
+                $removalFileIds = @($filesToRemove.FileId)
+                $filesToKeep = @($tempdbFiles | Where-Object { $removalFileIds -notcontains $PSItem.FileId } | Sort-Object FileId)
             }
 
+            $TooBigCount = ($filesToKeep | Where-Object { $PSItem.SizeMb -gt $DataFilesizeSingle } | Select-Object -First 1).SizeMb
             if ($TooBigCount) {
                 Stop-Function -Message "Current tempdb in $instance is not suitable to be reconfigured. The current tempdb has files with a size ($TooBigCount MB) larger than the calculated individual file configuration ($DataFilesizeSingle MB)." -Continue
             }
 
             Write-Message -Message "tempdb configuration validated." -Level Verbose
 
-            $DataFiles = Get-DbaDbFile -SqlInstance $server -Database tempdb | Where-Object Type -eq 0 | Select-Object LogicalName, PhysicalName
+            $sql = @()
+            $removalSql = @()
+            foreach ($fileToRemove in $filesToRemove) {
+                $escapedLogicalName = $fileToRemove.LogicalName.Replace("'", "''")
+                $escapedIdentifier = $fileToRemove.LogicalName.Replace("]", "]]")
+                $escapedMessageName = $escapedLogicalName.Replace("%", "%%")
+                $removalSql += "USE [tempdb]; DBCC SHRINKFILE (N'$escapedLogicalName', EMPTYFILE);"
+                $removalSql += "USE [tempdb]; IF FILEPROPERTY(N'$escapedLogicalName', 'SpaceUsed') = 0 BEGIN ALTER DATABASE tempdb REMOVE FILE [$escapedIdentifier]; END ELSE BEGIN RAISERROR('Unable to empty tempdb file $escapedMessageName.', 16, 1); END;"
+            }
+
+            $DataFiles = @($filesToKeep | Sort-Object FileId | Select-Object LogicalName, PhysicalName)
 
             # Used to round-robin the placement of tempdb data files if more than one value for $DataPath was passed in.
             $dataPathIndexToUse = 0
@@ -260,6 +315,9 @@ function Set-DbaTempDbConfig {
                     $sql += "ALTER DATABASE tempdb ADD FILE(name=tempdev$i,filename='$NewPath',size=$DataFilesizeSingle MB,filegrowth=$DataFileGrowth);"
                 }
             }
+
+            # Grow retained files before EMPTYFILE so forced reduction does not depend on autogrowth.
+            $sql += $removalSql
 
             $logfile = Get-DbaDbFile -SqlInstance $server -Database tempdb | Where-Object Type -eq 1 | Select-Object LogicalName, PhysicalName, @{L = "SizeMb"; E = { $_.Size.Megabyte } }
 

--- a/public/Set-DbaTempDbConfig.ps1
+++ b/public/Set-DbaTempDbConfig.ps1
@@ -277,9 +277,8 @@ ORDER BY file_id;
             foreach ($fileToRemove in $filesToRemove) {
                 $escapedLogicalName = $fileToRemove.LogicalName.Replace("'", "''")
                 $escapedIdentifier = $fileToRemove.LogicalName.Replace("]", "]]")
-                $escapedMessageName = $escapedLogicalName.Replace("%", "%%")
                 $removalSql += "USE [tempdb]; DBCC SHRINKFILE (N'$escapedLogicalName', EMPTYFILE);"
-                $removalSql += "USE [tempdb]; IF FILEPROPERTY(N'$escapedLogicalName', 'SpaceUsed') = 0 BEGIN ALTER DATABASE tempdb REMOVE FILE [$escapedIdentifier]; END ELSE BEGIN RAISERROR('Unable to empty tempdb file $escapedMessageName.', 16, 1); END;"
+                $removalSql += "USE [tempdb]; ALTER DATABASE tempdb REMOVE FILE [$escapedIdentifier];"
             }
 
             $DataFiles = @($filesToKeep | Sort-Object FileId | Select-Object LogicalName, PhysicalName)

--- a/public/Set-DbaTempDbConfig.ps1
+++ b/public/Set-DbaTempDbConfig.ps1
@@ -283,6 +283,8 @@ ORDER BY file_id;
             }
 
             $DataFiles = @($filesToKeep | Sort-Object FileId | Select-Object LogicalName, PhysicalName)
+            $reservedLogicalNames = @($tempdbFiles.LogicalName)
+            $reservedPhysicalNames = @($tempdbFiles.PhysicalName)
 
             # Used to round-robin the placement of tempdb data files if more than one value for $DataPath was passed in.
             $dataPathIndexToUse = 0
@@ -310,9 +312,18 @@ ORDER BY file_id;
                     $NewPath = "$newDataDirPath\$Filename"
                     $sql += "ALTER DATABASE tempdb MODIFY FILE(name=$LogicalName,filename='$NewPath',size=$DataFilesizeSingle MB,filegrowth=$DataFileGrowth);"
                 } else {
-                    $NewName = "tempdev$i.ndf"
-                    $NewPath = "$newDataDirPath\$NewName"
-                    $sql += "ALTER DATABASE tempdb ADD FILE(name=tempdev$i,filename='$NewPath',size=$DataFilesizeSingle MB,filegrowth=$DataFileGrowth);"
+                    $newFileIndex = $i
+                    do {
+                        $newLogicalName = "tempdev$newFileIndex"
+                        $NewName = "$newLogicalName.ndf"
+                        $NewPath = "$newDataDirPath\$NewName"
+                        $candidateExists = $newLogicalName -in $reservedLogicalNames -or $NewPath -in $reservedPhysicalNames -or (Test-DbaPath -SqlInstance $server -Path $NewPath -WarningAction SilentlyContinue)
+                        $newFileIndex += 1
+                    } while ($candidateExists)
+
+                    $reservedLogicalNames += $newLogicalName
+                    $reservedPhysicalNames += $NewPath
+                    $sql += "ALTER DATABASE tempdb ADD FILE(name=$newLogicalName,filename='$NewPath',size=$DataFilesizeSingle MB,filegrowth=$DataFileGrowth);"
                 }
             }
 

--- a/tests/Set-DbaTempDbConfig.Tests.ps1
+++ b/tests/Set-DbaTempDbConfig.Tests.ps1
@@ -30,160 +30,6 @@ Describe $CommandName -Tag UnitTests {
         }
     }
 
-    InModuleScope dbatools {
-        Context "Reducing the tempdb data file count" {
-            BeforeEach {
-                $tempdbFiles = @(
-                    [PSCustomObject]@{
-                        FileId       = 1
-                        LogicalName  = "tempdev"
-                        PhysicalName = "C:\tempdb\tempdb.mdf"
-                        SizeMb       = 256
-                        UsedMb       = 10
-                    },
-                    [PSCustomObject]@{
-                        FileId       = 2
-                        LogicalName  = "temp2"
-                        PhysicalName = "C:\tempdb\temp2.ndf"
-                        SizeMb       = 256
-                        UsedMb       = 10
-                    },
-                    [PSCustomObject]@{
-                        FileId       = 3
-                        LogicalName  = "temp3"
-                        PhysicalName = "C:\tempdb\temp3.ndf"
-                        SizeMb       = 256
-                        UsedMb       = 10
-                    },
-                    [PSCustomObject]@{
-                        FileId       = 4
-                        LogicalName  = "temp4"
-                        PhysicalName = "C:\tempdb\temp4.ndf"
-                        SizeMb       = 256
-                        UsedMb       = 10
-                    }
-                )
-                $tempdb = [PSCustomObject]@{
-                    FileMetadata = $tempdbFiles
-                }
-                $tempdb | Add-Member -MemberType ScriptMethod -Name Query -Value {
-                    param($Query)
-
-                    if ($Query -match "FILEPROPERTY") {
-                        return $this.FileMetadata
-                    }
-                    if ($Query -match "file_id = 1") {
-                        return [PSCustomObject]@{
-                            PhysicalName = "C:\tempdb\tempdb.mdf"
-                        }
-                    }
-                    if ($Query -match "file_id = 2") {
-                        return [PSCustomObject]@{
-                            PhysicalName = "C:\tempdb\templog.ldf"
-                        }
-                    }
-                    if ($Query -match "COUNT") {
-                        return [PSCustomObject]@{
-                            FileCount = $this.FileMetadata.Count
-                        }
-                    }
-                    return $null
-                }
-                $master = [PSCustomObject]@{
-                    ExecutedQuery = $null
-                }
-                $master | Add-Member -MemberType ScriptMethod -Name ExecuteNonQuery -Value {
-                    param($Query)
-                    $this.ExecutedQuery = $Query
-                }
-                $script:mockTempdbServer = [PSCustomObject]@{
-                    ComputerName       = "sql1"
-                    ServiceName        = "MSSQLSERVER"
-                    DomainInstanceName = "sql1"
-                    Processors         = 4
-                    Databases          = @{
-                        tempdb = $tempdb
-                        master = $master
-                    }
-                }
-
-                Mock Connect-DbaInstance {
-                    $script:mockTempdbServer
-                }
-                Mock Get-DbaDbFile -RemoveParameterType "SqlInstance" {
-                    @(
-                        [PSCustomObject]@{
-                            Type         = 0
-                            ID           = 1
-                            LogicalName  = "tempdev"
-                            PhysicalName = "C:\tempdb\tempdb.mdf"
-                        },
-                        [PSCustomObject]@{
-                            Type         = 0
-                            ID           = 2
-                            LogicalName  = "temp2"
-                            PhysicalName = "C:\tempdb\temp2.ndf"
-                        },
-                        [PSCustomObject]@{
-                            Type         = 0
-                            ID           = 3
-                            LogicalName  = "temp3"
-                            PhysicalName = "C:\tempdb\temp3.ndf"
-                        },
-                        [PSCustomObject]@{
-                            Type         = 0
-                            ID           = 4
-                            LogicalName  = "temp4"
-                            PhysicalName = "C:\tempdb\temp4.ndf"
-                        },
-                        [PSCustomObject]@{
-                            Type         = 1
-                            ID           = 5
-                            LogicalName  = "templog"
-                            PhysicalName = "C:\tempdb\templog.ldf"
-                            Size         = [PSCustomObject]@{
-                                Megabyte = 256
-                            }
-                        }
-                    )
-                }
-                Mock Stop-Function {
-                    param($Message)
-                    throw $Message
-                }
-            }
-
-            It "retains the existing refusal without Force" {
-                { Set-DbaTempDbConfig -SqlInstance "sql1" -DataFileCount 2 -DataFileSize 512 -OutputScriptOnly } | Should -Throw "*greater number of files*"
-            }
-
-            It "evacuates and removes the highest secondary file ids first with Force" {
-                $script:mockTempdbServer.Databases.tempdb.FileMetadata[0].UsedMb = 482
-                $result = Set-DbaTempDbConfig -SqlInstance "sql1" -DataFileCount 2 -DataFileSize 512 -Force -OutputScriptOnly
-
-                $shrinkStatements = @($result | Where-Object { $PSItem -match "DBCC SHRINKFILE" })
-                $removalStatements = @($result | Where-Object { $PSItem -match "DBCC SHRINKFILE|FILEPROPERTY" })
-                $firstModifyIndex = [array]::IndexOf($result, ($result | Where-Object { $PSItem -match "MODIFY FILE" } | Select-Object -First 1))
-                $firstShrinkIndex = [array]::IndexOf($result, $shrinkStatements[0])
-
-                $shrinkStatements.Count | Should -Be 2
-                $shrinkStatements[0] | Should -Match "N'temp4', EMPTYFILE"
-                $shrinkStatements[1] | Should -Match "N'temp3', EMPTYFILE"
-                $removalStatements | Should -Match "^USE \[tempdb\];"
-                $firstModifyIndex | Should -BeLessThan $firstShrinkIndex
-                ($result -join "`n") | Should -Not -Match "REMOVE FILE \[tempdev\]"
-
-                $null = Set-DbaTempDbConfig -SqlInstance "sql1" -DataFileCount 2 -DataFileSize 512 -Force -Confirm:$false
-                $script:mockTempdbServer.Databases.master.ExecutedQuery | Should -Be $result
-            }
-
-            It "refuses forced reduction when used space exceeds target capacity" {
-                $script:mockTempdbServer.Databases.tempdb.FileMetadata[0].UsedMb = 500
-
-                { Set-DbaTempDbConfig -SqlInstance "sql1" -DataFileCount 2 -DataFileSize 512 -Force -OutputScriptOnly } | Should -Throw "*exceeds the requested target capacity*"
-            }
-        }
-    }
 }
 
 Describe $CommandName -Tag IntegrationTests {
@@ -278,6 +124,185 @@ Describe $CommandName -Tag IntegrationTests {
                     $indexToUse = 0
                 }
             }
+        }
+    }
+
+    Context "Reducing the tempdb data file count against a real instance" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $tempdbReductionServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+            $tempdbReductionPhysicalName = $tempdbReductionServer.Databases["tempdb"].Query("SELECT physical_name AS PhysicalName FROM sys.database_files WHERE file_id = 1").PhysicalName
+            $tempdbReductionDataPath = Split-Path $tempdbReductionPhysicalName
+            $originalDataFileState = @($tempdbReductionServer.Databases["tempdb"].Query("SELECT file_id AS ID, name AS LogicalName, size AS SizePages, growth AS GrowthValue, is_percent_growth AS IsPercentGrowth FROM sys.database_files WHERE type = 0 ORDER BY file_id"))
+            $originalDataFiles = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0)
+            $originalDataFileCount = $originalDataFiles.Count
+            $expandedDataFileCount = $originalDataFileCount + 2
+            $largestDataFileSize = ($originalDataFiles | ForEach-Object { [Math]::Ceiling($PSItem.Size.Megabyte) } | Measure-Object -Maximum).Maximum
+            $individualDataFileSize = [Math]::Max(64, [int]$largestDataFileSize)
+            $expandedTotalDataFileSize = $individualDataFileSize * $expandedDataFileCount
+            $allocationTableName = "dbatoolsci_tempdb_reduction_$(Get-Random)"
+            $allocationRowCount = 15000
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            if ($null -ne $tempdbReductionServer -and $null -ne $allocationTableName) {
+                $tempdbReductionServer.Databases["tempdb"].ExecuteNonQuery("IF OBJECT_ID(N'dbo.$allocationTableName', N'U') IS NOT NULL DROP TABLE dbo.[$allocationTableName];")
+            }
+
+            # Restore the original tempdb data file count in case an assertion above failed midway.
+            if ($null -ne $originalDataFileCount -and $null -ne $expandedTotalDataFileSize) {
+                $currentDataFileCount = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0).Count
+                $restoreAttempt = 0
+                $restoreError = $null
+                while ($currentDataFileCount -ne $originalDataFileCount -and $restoreAttempt -lt 3) {
+                    $restoreAttempt += 1
+                    $splatRestore = @{
+                        SqlInstance   = $tempdbReductionServer
+                        DataFileCount = $originalDataFileCount
+                        DataFileSize  = $expandedTotalDataFileSize
+                        DataPath      = $tempdbReductionDataPath
+                        Force         = $true
+                        Confirm       = $false
+                    }
+                    try {
+                        $null = Set-DbaTempDbConfig @splatRestore
+                        $restoreError = $null
+                    } catch {
+                        $restoreError = $PSItem
+                    }
+                    $currentDataFileCount = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0).Count
+                }
+
+                if ($currentDataFileCount -gt $originalDataFileCount) {
+                    $originalLogicalNames = @($originalDataFiles.LogicalName)
+                    $extraDataFiles = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object { $PSItem.Type -eq 0 -and $PSItem.LogicalName -notin $originalLogicalNames } | Sort-Object ID -Descending)
+                    foreach ($extraDataFile in $extraDataFiles) {
+                        $escapedExtraLogicalName = $extraDataFile.LogicalName.Replace("'", "''")
+                        $escapedExtraIdentifier = $extraDataFile.LogicalName.Replace("]", "]]")
+                        $tempdbReductionServer.Databases["master"].ExecuteNonQuery("USE [tempdb]; DBCC SHRINKFILE (N'$escapedExtraLogicalName', EMPTYFILE); ALTER DATABASE tempdb REMOVE FILE [$escapedExtraIdentifier];")
+                    }
+                    $currentDataFileCount = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0).Count
+                }
+
+                if ($currentDataFileCount -ne $originalDataFileCount) {
+                    throw "Failed to restore tempdb to $originalDataFileCount data files after $restoreAttempt attempts. Last error: $restoreError"
+                }
+
+                foreach ($originalDataFile in $originalDataFileState) {
+                    $escapedOriginalLogicalName = $originalDataFile.LogicalName.Replace("'", "''")
+                    $originalSizeMb = [Math]::Max(1, [Math]::Floor($originalDataFile.SizePages / 128.0))
+                    $originalSizeKb = $originalDataFile.SizePages * 8
+                    if ($originalDataFile.GrowthValue -eq 0) {
+                        $originalGrowthSetting = "0"
+                    } elseif ($originalDataFile.IsPercentGrowth) {
+                        $originalGrowthSetting = "$($originalDataFile.GrowthValue)%"
+                    } else {
+                        $originalGrowthSetting = "$($originalDataFile.GrowthValue * 8)KB"
+                    }
+
+                    $sizeRestoreAttempt = 0
+                    do {
+                        $sizeRestoreAttempt += 1
+                        $tempdbReductionServer.Databases["tempdb"].ExecuteNonQuery("DBCC SHRINKFILE (N'$escapedOriginalLogicalName', $originalSizeMb);")
+                        $restoredSizePages = $tempdbReductionServer.Databases["tempdb"].Query("SELECT size AS SizePages FROM sys.database_files WHERE file_id = $($originalDataFile.ID)").SizePages
+                    } while ($restoredSizePages -gt $originalDataFile.SizePages -and $sizeRestoreAttempt -lt 3)
+
+                    if ($restoredSizePages -lt $originalDataFile.SizePages) {
+                        $tempdbReductionServer.Databases["master"].ExecuteNonQuery("ALTER DATABASE tempdb MODIFY FILE (NAME = N'$escapedOriginalLogicalName', SIZE = $($originalSizeKb)KB);")
+                    }
+                    $tempdbReductionServer.Databases["master"].ExecuteNonQuery("ALTER DATABASE tempdb MODIFY FILE (NAME = N'$escapedOriginalLogicalName', FILEGROWTH = $originalGrowthSetting);")
+
+                    if ($restoredSizePages -gt $originalDataFile.SizePages) {
+                        throw "Failed to shrink tempdb file $($originalDataFile.LogicalName) to its original size after $sizeRestoreAttempt attempts."
+                    }
+                }
+
+                $restoredDataFileState = @($tempdbReductionServer.Databases["tempdb"].Query("SELECT file_id AS ID, name AS LogicalName, size AS SizePages, growth AS GrowthValue, is_percent_growth AS IsPercentGrowth FROM sys.database_files WHERE type = 0 ORDER BY file_id"))
+                foreach ($originalDataFile in $originalDataFileState) {
+                    $restoredDataFile = $restoredDataFileState | Where-Object ID -eq $originalDataFile.ID
+                    if ($restoredDataFile.SizePages -ne $originalDataFile.SizePages -or $restoredDataFile.GrowthValue -ne $originalDataFile.GrowthValue -or $restoredDataFile.IsPercentGrowth -ne $originalDataFile.IsPercentGrowth) {
+                        throw "Failed to restore tempdb file $($originalDataFile.LogicalName) to its original size and growth settings."
+                    }
+                }
+            }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "adds real files and safely force-removes the highest file ids" {
+            $splatExpand = @{
+                SqlInstance   = $tempdbReductionServer
+                DataFileCount = $expandedDataFileCount
+                DataFileSize  = $expandedTotalDataFileSize
+                DataPath      = $tempdbReductionDataPath
+                Confirm       = $false
+                WarningAction = "SilentlyContinue"
+            }
+            $null = Set-DbaTempDbConfig @splatExpand
+
+            $expandedFiles = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0)
+            $expandedFiles.Count | Should -Be $expandedDataFileCount
+
+            $highestFile = $expandedFiles | Where-Object ID -ne 1 | Sort-Object ID -Descending | Select-Object -First 1
+            $specialLogicalName = "dbatoolsci_tempdb_'file]_$($highestFile.ID)%"
+            $escapedCurrentName = $highestFile.LogicalName.Replace("'", "''")
+            $escapedSpecialName = $specialLogicalName.Replace("'", "''")
+            $tempdbReductionServer.Databases["master"].ExecuteNonQuery("ALTER DATABASE tempdb MODIFY FILE (NAME = N'$escapedCurrentName', NEWNAME = N'$escapedSpecialName');")
+
+            $allocationQuery = @"
+CREATE TABLE dbo.[$allocationTableName] (Payload char(8000) NOT NULL);
+INSERT dbo.[$allocationTableName] (Payload)
+SELECT TOP ($allocationRowCount) REPLICATE('x', 8000)
+FROM sys.all_objects AS first_source
+CROSS JOIN sys.all_objects AS second_source;
+"@
+            $tempdbReductionServer.Databases["tempdb"].ExecuteNonQuery($allocationQuery)
+
+            $expandedFiles = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0)
+            $expectedRemovedFiles = @($expandedFiles | Where-Object ID -ne 1 | Sort-Object ID -Descending | Select-Object -First 2)
+            $fileUsage = @($tempdbReductionServer.Databases["tempdb"].Query("SELECT file_id AS ID, FILEPROPERTY(name, 'SpaceUsed') / 128.0 AS UsedMb FROM sys.database_files WHERE type = 0"))
+            foreach ($expectedRemovedFile in $expectedRemovedFiles) {
+                ($fileUsage | Where-Object ID -eq $expectedRemovedFile.ID).UsedMb | Should -BeGreaterThan 0
+            }
+
+            $withoutForceWarning = $null
+            $withoutForceResult = Set-DbaTempDbConfig -SqlInstance $tempdbReductionServer -DataFileCount $originalDataFileCount -DataFileSize $expandedTotalDataFileSize -OutputScriptOnly -WarningVariable withoutForceWarning -WarningAction SilentlyContinue
+            $withoutForceResult | Should -BeNullOrEmpty
+            ($withoutForceWarning -join " ") | Should -Match "greater number of files"
+
+            $tempdbUsedMb = $tempdbReductionServer.Databases["tempdb"].Query("SELECT SUM(FILEPROPERTY(name, 'SpaceUsed')) / 128.0 AS UsedMb FROM sys.database_files WHERE type = 0").UsedMb
+            $insufficientDataFileSize = [Math]::Max(1, [Math]::Floor($tempdbUsedMb / 2))
+            $capacityWarning = $null
+            $capacityResult = Set-DbaTempDbConfig -SqlInstance $tempdbReductionServer -DataFileCount $originalDataFileCount -DataFileSize $insufficientDataFileSize -Force -OutputScriptOnly -WarningVariable capacityWarning -WarningAction SilentlyContinue
+            $capacityResult | Should -BeNullOrEmpty
+            ($capacityWarning -join " ") | Should -Match "exceeds the requested target capacity"
+
+            $splatReduce = @{
+                SqlInstance   = $tempdbReductionServer
+                DataFileCount = $originalDataFileCount
+                DataFileSize  = $expandedTotalDataFileSize
+                DataPath      = $tempdbReductionDataPath
+                Force         = $true
+                Confirm       = $false
+                WarningAction = "SilentlyContinue"
+            }
+            $null = Set-DbaTempDbConfig @splatReduce
+
+            $reducedFiles = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0)
+            $reducedFiles.Count | Should -Be $originalDataFileCount
+            $reducedFiles.ID | Should -Contain 1
+            foreach ($removedFile in $expectedRemovedFiles) {
+                $reducedFiles.LogicalName | Should -Not -Contain $removedFile.LogicalName
+            }
+
+            $preservedRowCount = $tempdbReductionServer.Databases["tempdb"].Query("SELECT COUNT(1) AS PreservedRows FROM dbo.[$allocationTableName]").PreservedRows
+            $preservedRowCount | Should -Be $allocationRowCount
+            $tempdbReductionServer.Databases["tempdb"].ExecuteNonQuery("DROP TABLE dbo.[$allocationTableName];")
         }
     }
 }

--- a/tests/Set-DbaTempDbConfig.Tests.ps1
+++ b/tests/Set-DbaTempDbConfig.Tests.ps1
@@ -23,9 +23,165 @@ Describe $CommandName -Tag UnitTests {
                 "OutFile",
                 "OutputScriptOnly",
                 "DisableGrowth",
+                "Force",
                 "EnableException"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+
+    InModuleScope dbatools {
+        Context "Reducing the tempdb data file count" {
+            BeforeEach {
+                $tempdbFiles = @(
+                    [PSCustomObject]@{
+                        FileId       = 1
+                        LogicalName  = "tempdev"
+                        PhysicalName = "C:\tempdb\tempdb.mdf"
+                        SizeMb       = 256
+                        UsedMb       = 10
+                    },
+                    [PSCustomObject]@{
+                        FileId       = 2
+                        LogicalName  = "temp2"
+                        PhysicalName = "C:\tempdb\temp2.ndf"
+                        SizeMb       = 256
+                        UsedMb       = 10
+                    },
+                    [PSCustomObject]@{
+                        FileId       = 3
+                        LogicalName  = "temp3"
+                        PhysicalName = "C:\tempdb\temp3.ndf"
+                        SizeMb       = 256
+                        UsedMb       = 10
+                    },
+                    [PSCustomObject]@{
+                        FileId       = 4
+                        LogicalName  = "temp4"
+                        PhysicalName = "C:\tempdb\temp4.ndf"
+                        SizeMb       = 256
+                        UsedMb       = 10
+                    }
+                )
+                $tempdb = [PSCustomObject]@{
+                    FileMetadata = $tempdbFiles
+                }
+                $tempdb | Add-Member -MemberType ScriptMethod -Name Query -Value {
+                    param($Query)
+
+                    if ($Query -match "FILEPROPERTY") {
+                        return $this.FileMetadata
+                    }
+                    if ($Query -match "file_id = 1") {
+                        return [PSCustomObject]@{
+                            PhysicalName = "C:\tempdb\tempdb.mdf"
+                        }
+                    }
+                    if ($Query -match "file_id = 2") {
+                        return [PSCustomObject]@{
+                            PhysicalName = "C:\tempdb\templog.ldf"
+                        }
+                    }
+                    if ($Query -match "COUNT") {
+                        return [PSCustomObject]@{
+                            FileCount = $this.FileMetadata.Count
+                        }
+                    }
+                    return $null
+                }
+                $master = [PSCustomObject]@{
+                    ExecutedQuery = $null
+                }
+                $master | Add-Member -MemberType ScriptMethod -Name ExecuteNonQuery -Value {
+                    param($Query)
+                    $this.ExecutedQuery = $Query
+                }
+                $script:mockTempdbServer = [PSCustomObject]@{
+                    ComputerName       = "sql1"
+                    ServiceName        = "MSSQLSERVER"
+                    DomainInstanceName = "sql1"
+                    Processors         = 4
+                    Databases          = @{
+                        tempdb = $tempdb
+                        master = $master
+                    }
+                }
+
+                Mock Connect-DbaInstance {
+                    $script:mockTempdbServer
+                }
+                Mock Get-DbaDbFile -RemoveParameterType "SqlInstance" {
+                    @(
+                        [PSCustomObject]@{
+                            Type         = 0
+                            ID           = 1
+                            LogicalName  = "tempdev"
+                            PhysicalName = "C:\tempdb\tempdb.mdf"
+                        },
+                        [PSCustomObject]@{
+                            Type         = 0
+                            ID           = 2
+                            LogicalName  = "temp2"
+                            PhysicalName = "C:\tempdb\temp2.ndf"
+                        },
+                        [PSCustomObject]@{
+                            Type         = 0
+                            ID           = 3
+                            LogicalName  = "temp3"
+                            PhysicalName = "C:\tempdb\temp3.ndf"
+                        },
+                        [PSCustomObject]@{
+                            Type         = 0
+                            ID           = 4
+                            LogicalName  = "temp4"
+                            PhysicalName = "C:\tempdb\temp4.ndf"
+                        },
+                        [PSCustomObject]@{
+                            Type         = 1
+                            ID           = 5
+                            LogicalName  = "templog"
+                            PhysicalName = "C:\tempdb\templog.ldf"
+                            Size         = [PSCustomObject]@{
+                                Megabyte = 256
+                            }
+                        }
+                    )
+                }
+                Mock Stop-Function {
+                    param($Message)
+                    throw $Message
+                }
+            }
+
+            It "retains the existing refusal without Force" {
+                { Set-DbaTempDbConfig -SqlInstance "sql1" -DataFileCount 2 -DataFileSize 512 -OutputScriptOnly } | Should -Throw "*greater number of files*"
+            }
+
+            It "evacuates and removes the highest secondary file ids first with Force" {
+                $script:mockTempdbServer.Databases.tempdb.FileMetadata[0].UsedMb = 482
+                $result = Set-DbaTempDbConfig -SqlInstance "sql1" -DataFileCount 2 -DataFileSize 512 -Force -OutputScriptOnly
+
+                $shrinkStatements = @($result | Where-Object { $PSItem -match "DBCC SHRINKFILE" })
+                $removalStatements = @($result | Where-Object { $PSItem -match "DBCC SHRINKFILE|FILEPROPERTY" })
+                $firstModifyIndex = [array]::IndexOf($result, ($result | Where-Object { $PSItem -match "MODIFY FILE" } | Select-Object -First 1))
+                $firstShrinkIndex = [array]::IndexOf($result, $shrinkStatements[0])
+
+                $shrinkStatements.Count | Should -Be 2
+                $shrinkStatements[0] | Should -Match "N'temp4', EMPTYFILE"
+                $shrinkStatements[1] | Should -Match "N'temp3', EMPTYFILE"
+                $removalStatements | Should -Match "^USE \[tempdb\];"
+                $firstModifyIndex | Should -BeLessThan $firstShrinkIndex
+                ($result -join "`n") | Should -Not -Match "REMOVE FILE \[tempdev\]"
+
+                $null = Set-DbaTempDbConfig -SqlInstance "sql1" -DataFileCount 2 -DataFileSize 512 -Force -Confirm:$false
+                $script:mockTempdbServer.Databases.master.ExecutedQuery | Should -Be $result
+            }
+
+            It "refuses forced reduction when used space exceeds target capacity" {
+                $script:mockTempdbServer.Databases.tempdb.FileMetadata[0].UsedMb = 500
+
+                { Set-DbaTempDbConfig -SqlInstance "sql1" -DataFileCount 2 -DataFileSize 512 -Force -OutputScriptOnly } | Should -Throw "*exceeds the requested target capacity*"
+            }
         }
     }
 }

--- a/tests/Set-DbaTempDbConfig.Tests.ps1
+++ b/tests/Set-DbaTempDbConfig.Tests.ps1
@@ -236,14 +236,16 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "adds real files and safely force-removes the highest file ids" {
             $splatExpand = @{
-                SqlInstance   = $tempdbReductionServer
-                DataFileCount = $expandedDataFileCount
-                DataFileSize  = $expandedTotalDataFileSize
-                DataPath      = $tempdbReductionDataPath
-                Confirm       = $false
-                WarningAction = "SilentlyContinue"
+                SqlInstance     = $tempdbReductionServer
+                DataFileCount   = $expandedDataFileCount
+                DataFileSize    = $expandedTotalDataFileSize
+                DataPath        = $tempdbReductionDataPath
+                Confirm         = $false
+                WarningAction   = "SilentlyContinue"
+                EnableException = $true
             }
-            $null = Set-DbaTempDbConfig @splatExpand
+            $expandResult = Set-DbaTempDbConfig @splatExpand
+            $expandResult.DataFileCount | Should -Be $expandedDataFileCount
 
             $expandedFiles = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0)
             $expandedFiles.Count | Should -Be $expandedDataFileCount
@@ -283,15 +285,17 @@ CROSS JOIN sys.all_objects AS second_source;
             ($capacityWarning -join " ") | Should -Match "exceeds the requested target capacity"
 
             $splatReduce = @{
-                SqlInstance   = $tempdbReductionServer
-                DataFileCount = $originalDataFileCount
-                DataFileSize  = $expandedTotalDataFileSize
-                DataPath      = $tempdbReductionDataPath
-                Force         = $true
-                Confirm       = $false
-                WarningAction = "SilentlyContinue"
+                SqlInstance     = $tempdbReductionServer
+                DataFileCount   = $originalDataFileCount
+                DataFileSize    = $expandedTotalDataFileSize
+                DataPath        = $tempdbReductionDataPath
+                Force           = $true
+                Confirm         = $false
+                WarningAction   = "SilentlyContinue"
+                EnableException = $true
             }
-            $null = Set-DbaTempDbConfig @splatReduce
+            $reduceResult = Set-DbaTempDbConfig @splatReduce
+            $reduceResult.DataFileCount | Should -Be $originalDataFileCount
 
             $reducedFiles = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0)
             $reducedFiles.Count | Should -Be $originalDataFileCount


### PR DESCRIPTION
## Summary

- adds an opt-in `-Force` path for reducing the tempdb data-file count
- selects the highest-numbered secondary files first and never removes file id 1
- refuses reduction when current used space exceeds the requested aggregate target
- grows retained files before `EMPTYFILE`, then lets SQL Server's `REMOVE FILE` operation enforce whether each file is removable
- avoids logical and physical filename collisions when adding replacement tempdb files

## Safety

The default behavior is unchanged: without `-Force`, a current file count above the target is still refused. Forced removal explicitly enters `tempdb`, escapes SQL literals and identifiers, and propagates SQL Server's error if `REMOVE FILE` cannot safely remove a file.

The earlier `FILEPROPERTY(..., 'SpaceUsed') = 0` precondition was removed after the real runner exposed it as incorrect. A real SQL Server 2025 reproduction showed `DBCC SHRINKFILE(..., EMPTYFILE)` reporting zero data pages while `FILEPROPERTY` retained eight metadata pages; `ALTER DATABASE ... REMOVE FILE` then succeeded. SQL Server's removal operation is therefore the authoritative safety check.

## Real integration coverage

- expands tempdb by two real data files on `$TestConfig.InstanceSingle`
- renames a real removal target with `'`, `]`, and `%` to exercise SQL escaping through execution
- allocates about 120 MB in a real tempdb table and proves both removal targets contain pages
- verifies the live no-`Force` and insufficient-capacity refusals
- executes the real `EMPTYFILE`/`REMOVE FILE` path, verifies deterministic file removal and row preservation
- restores the original file count, exact size, and growth metadata and fails cleanup if state differs

## Validation

- disposable real SQL Server 2025 reproduction: `EMPTYFILE` reported 0 data pages, `FILEPROPERTY` reported 8 metadata pages, and `REMOVE FILE` succeeded
- Pester 6 parameter contract: 1 passed, 0 failed
- PSScriptAnalyzer 1.18.2 severity Error: 0 findings
- PowerShell parser: 0 errors
- `git diff --check`: clean
- GitHub Actions: all ordinary checks and all 10 real Azure runner lanes passed on the current head

Claude Opus high-effort reviewed this command in three rounds. The final runner-specific correction above was derived from the real SQL Server reproduction after that three-review cap.

Fixes #7758
