### PR TITLE
appveyor.prep - Make directory setup idempotent

### DIFF
--- a/tests/appveyor.prep.Tests.ps1
+++ b/tests/appveyor.prep.Tests.ps1
@@ -1,0 +1,33 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName = "dbatools",
+    $CommandName = "appveyor.prep",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    BeforeAll {
+        $prepScriptPath = Join-Path $PSScriptRoot "appveyor.prep.ps1"
+        $prepTokens = $null
+        $prepParseErrors = $null
+        $prepAst = [System.Management.Automation.Language.Parser]::ParseFile($prepScriptPath, [ref]$prepTokens, [ref]$prepParseErrors)
+        $directoryCommands = $prepAst.FindAll( {
+                param($ast)
+
+                $ast -is [System.Management.Automation.Language.CommandAst] -and
+                $ast.GetCommandName() -eq "New-Item"
+            }, $true)
+    }
+
+    It "creates required directories idempotently" {
+        foreach ($requiredPath in "C:\Users\appveyor\Documents\DbatoolsExport", "C:\Temp") {
+            $matchingCommands = @($directoryCommands | Where-Object { $PSItem.Extent.Text -match [regex]::Escape("-Path $requiredPath") })
+            $matchingCommands.Count | Should -Be 1
+
+            $parameterNames = $matchingCommands[0].CommandElements |
+                Where-Object { $PSItem -is [System.Management.Automation.Language.CommandParameterAst] } |
+                ForEach-Object ParameterName
+            $parameterNames | Should -Contain "Force"
+        }
+    }
+}

--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -55,10 +55,10 @@ Install-Module -Name Pester -Force -SkipPublisherCheck -RequiredVersion 6.0.0
 
 # Setup DbatoolsConfig Path.DbatoolsExport path
 Write-Host -Object "appveyor.prep: Create Path.DbatoolsExport" -ForegroundColor DarkGreen
-$null = New-Item -Path C:\Users\appveyor\Documents\DbatoolsExport -ItemType Directory
+$null = New-Item -Path C:\Users\appveyor\Documents\DbatoolsExport -ItemType Directory -Force
 
 Write-Host -Object "appveyor.prep: Creating temp directory" -ForegroundColor DarkGreen
-$null = New-Item -Path C:\Temp -ItemType Directory
+$null = New-Item -Path C:\Temp -ItemType Directory -Force
 
 Write-Host -Object "appveyor.prep: Configuring WSMan" -ForegroundColor DarkGreen
 $null = Set-WSManQuickConfig -Force


### PR DESCRIPTION
## Summary

- makes `Path.DbatoolsExport` and `C:\Temp` directory creation safe when the runner image already contains those directories
- adds a focused Pester regression that guards both setup commands against losing idempotent creation

## Root cause

The GitHub Actions runner image pre-creates both directories, but `tests/appveyor.prep.ps1` called `New-Item -ItemType Directory` without `-Force`. PowerShell emitted non-terminating `DirectoryExist` errors, so the preparation step passed while producing misleading error output.

## Validation

- TDD red: the new regression failed because both commands exposed only `Path` and `ItemType`, with `Force` absent
- Pester 6: 15 passed, 0 failed across `appveyor.prep.Tests.ps1`, `appveyor.common.Tests.ps1`, and `dbatools.Tests.ps1`
- PSScriptAnalyzer 1.18.2 severity Error: 0 findings on both changed files
- Windows PowerShell 5.1: creating the same disposable directory twice with `-Force -ErrorAction Stop` completed without errors
- `git diff --check`: clean
- Claude Opus high-effort review pass 2: READY, no Critical or Important findings
