### PR TITLE
Install-DbaFirstResponderKit: Added ability to create certificates to let public execute FRK procedures

### DIFF
--- a/public/Install-DbaFirstResponderKit.ps1
+++ b/public/Install-DbaFirstResponderKit.ps1
@@ -40,6 +40,13 @@ function Install-DbaFirstResponderKit {
         Specifies specific script files to install instead of the entire First Responder Kit. Accepts multiple script names and wildcards.
         Use this to install only the procedures you need (like sp_Blitz.sql, sp_BlitzCache.sql) or to run official install scripts (Install-All-Scripts.sql, Install-Azure.sql). Also supports Uninstall.sql to remove the toolkit.
 
+    .PARAMETER LetPublicExecute
+        Signs the specified stored procedures with a certificate called "FirstResponderKitCertificate" that lets members of the public server role (that is, everyone) execute those procedures as if they have the CONTROL SERVER permission.
+        This follows the pattern set in the "How to Grant Permissions to Non-DBAs" example at https://www.brentozar.com/askbrent/
+        If you are installing to a non-master database, then the public server role will be given GRANT CONNECT in that database.
+        To prevent abuse, we remove the private key from the certificate after use.
+        Drops any user or login called "FirstResponderKitLogin" and drops any certificate called "FirstResponderKitCertificate" before running.
+
     .PARAMETER Force
         Forces a fresh download of the First Responder Kit from GitHub even if a cached version already exists locally.
         Use this when you want to ensure you have the absolute latest version or when the cached version may be corrupted.
@@ -131,6 +138,10 @@ function Install-DbaFirstResponderKit {
         PS C:\> Install-DbaFirstResponderKit -SqlInstance sql2016 -OnlyScript Uninstall.sql
 
         Uninstalls the First Responder Kit by running the official uninstall script.
+    .EXAMPLE
+        PS C:\> Install-DbaFirstResponderKit -SqlInstance sql2016 -LetPublicExecute sp_BlitzFirst, sp_BlitzIndex
+
+        Installs all scripts, but lets the everyone execute sp_BlitzFirst and sp_BlitzIndex even if they do not have high permissions.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Medium")]
     param (
@@ -144,9 +155,10 @@ function Install-DbaFirstResponderKit {
         [ValidateSet('Install-All-Scripts.sql', 'Install-Azure.sql',
             'sp_Blitz.sql', 'sp_BlitzFirst.sql', 'sp_BlitzIndex.sql', 'sp_BlitzCache.sql', 'sp_BlitzWho.sql',
             'sp_BlitzAnalysis.sql', 'sp_BlitzBackups.sql', 'sp_BlitzLock.sql',
-            'sp_DatabaseRestore.sql', 'sp_ineachdb.sql',
+            'sp_DatabaseRestore.sql', 'sp_ineachdb.sql', 'sp_kill.sql',
             'SqlServerVersions.sql', 'Uninstall.sql')]
         [string[]]$OnlyScript,
+        [string[]]$LetPublicExecute,
         [switch]$Force,
         [switch]$EnableException
     )
@@ -240,6 +252,78 @@ function Install-DbaFirstResponderKit {
                             $baseres.Status = 'Installed'
                         }
                         $baseres
+                    }
+                }
+                if ($LetPublicExecute) {
+                    Write-Message -Level Verbose -Message "Signing $LetPublicExecute for $database on $instance."
+                    try {
+                        # For idempotency.
+                        # Cannot use Get-DbaDbUser here. It does not see certificate-mapped users.
+                        $userDrop = "
+                        IF EXISTS (SELECT 1 FROM sys.database_principals WHERE name = 'FirstResponderKitLogin')
+                        BEGIN
+                            DROP USER [FirstResponderKitLogin];
+                        END
+                        "
+                        Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $userDrop -EnableException
+                        Get-DbaLogin -SqlInstance $server -Login FirstResponderKitLogin | Remove-DbaLogin
+                        foreach ($proc in $LetPublicExecute) {
+                            $signatureDrop = "
+                            IF EXISTS (SELECT 1 FROM sys.crypt_properties WHERE major_id = OBJECT_ID('$proc') AND crypt_type = 'SPVC')
+                            BEGIN
+                                DROP SIGNATURE FROM $proc BY CERTIFICATE FirstResponderKitCertificate;
+                            END
+                            "
+                            Invoke-DbaQuery -SqlInstance $server -Database master -Query $signatureDrop -EnableException
+                        }
+                        # Will fail if signatures remain.
+                        # The block above assumes that you are either creating from scratch or only replacing what already exists.
+                        $certDrop = "
+                        IF EXISTS (SELECT 1 FROM sys.certificates WHERE name = 'FirstResponderKitCertificate')
+                        BEGIN
+                            DROP CERTIFICATE FirstResponderKitCertificate;
+                        END;
+                        "
+                        Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $certDrop -EnableException
+                        Invoke-DbaQuery -SqlInstance $server -Database master -Query $certDrop -EnableException
+                        # From https://www.brentozar.com/askbrent/ but tweaked to work outside of master.
+                        # Many steps taken from https://www.sommarskog.se/grantperm.html#serverleveluserdbcert
+                        # See issue #10368
+                        $certMake = "
+                        CREATE CERTIFICATE FirstResponderKitCertificate
+                        ENCRYPTION BY PASSWORD = '5OClockSomewhere-Dr0ppedSoon'
+                        WITH SUBJECT = 'CONTROL SERVER certificate for the First Responder Kit',
+                        START_DATE = '20010101', EXPIRY_DATE = '21000101';
+                        "
+                        Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $certMake -EnableException
+                        foreach ($proc in $LetPublicExecute) {
+                            Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "ADD SIGNATURE TO $proc BY CERTIFICATE FirstResponderKitCertificate WITH PASSWORD = '5OClockSomewhere-Dr0ppedSoon';" -EnableException
+                        }
+                        Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "ALTER CERTIFICATE FirstResponderKitCertificate REMOVE PRIVATE KEY;" -EnableException
+                        if ($Database -ne 'master') {
+                            $certClone = "
+                            DECLARE @public_key varbinary(MAX) = certencoded(cert_id('FirstResponderKitCertificate')),
+                                    @sql nvarchar(MAX);
+
+                            SELECT @sql =
+                            'USE master;
+                            CREATE CERTIFICATE FirstResponderKitCertificate 
+                                FROM BINARY = ' + convert(varchar(MAX), @public_key, 1);
+
+                            EXEC(@SQL) 
+                            "
+                            Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $certClone -EnableException
+                        }
+                        New-DbaLogin -SqlInstance $server -Login FirstResponderKitLogin -MapToCertificate FirstResponderKitCertificate
+                        Invoke-DbaQuery -SqlInstance $server -Database master -Query "GRANT CONTROL SERVER TO FirstResponderKitLogin;" -EnableException
+                        if ($Database -ne 'master') {
+                            Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "GRANT CONNECT TO [public];" -EnableException
+                        }
+                        foreach ($proc in $LetPublicExecute) {
+                            Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "GRANT EXECUTE ON $proc TO [public];" -EnableException
+                        }
+                    } catch {
+                        Write-Message -Level Warning -Message "Certificate signing failed for $database on $instance." -ErrorRecord $_
                     }
                 }
             }

--- a/public/Install-DbaFirstResponderKit.ps1
+++ b/public/Install-DbaFirstResponderKit.ps1
@@ -40,7 +40,7 @@ function Install-DbaFirstResponderKit {
         Specifies specific script files to install instead of the entire First Responder Kit. Accepts multiple script names and wildcards.
         Use this to install only the procedures you need (like sp_Blitz.sql, sp_BlitzCache.sql) or to run official install scripts (Install-All-Scripts.sql, Install-Azure.sql). Also supports Uninstall.sql to remove the toolkit.
 
-    .PARAMETER LetPublicExecute
+    .PARAMETER PublicExecute
         Signs the specified stored procedures with a certificate called "FirstResponderKitCertificate" that lets members of the public server role (that is, everyone) execute those procedures as if they have the CONTROL SERVER permission.
         This follows the pattern set in the "How to Grant Permissions to Non-DBAs" example at https://www.brentozar.com/askbrent/
         If you are installing to a non-master database, then the public server role will be given GRANT CONNECT in that database.
@@ -139,7 +139,7 @@ function Install-DbaFirstResponderKit {
 
         Uninstalls the First Responder Kit by running the official uninstall script.
     .EXAMPLE
-        PS C:\> Install-DbaFirstResponderKit -SqlInstance sql2016 -LetPublicExecute sp_BlitzFirst, sp_BlitzIndex
+        PS C:\> Install-DbaFirstResponderKit -SqlInstance sql2016 -PublicExecute sp_BlitzFirst, sp_BlitzIndex
 
         Installs all scripts, but lets the everyone execute sp_BlitzFirst and sp_BlitzIndex even if they do not have high permissions.
     #>
@@ -158,7 +158,7 @@ function Install-DbaFirstResponderKit {
             'sp_DatabaseRestore.sql', 'sp_ineachdb.sql', 'sp_kill.sql',
             'SqlServerVersions.sql', 'Uninstall.sql')]
         [string[]]$OnlyScript,
-        [string[]]$LetPublicExecute,
+        [string[]]$PublicExecute,
         [switch]$Force,
         [switch]$EnableException
     )
@@ -254,8 +254,8 @@ function Install-DbaFirstResponderKit {
                         $baseres
                     }
                 }
-                if ($LetPublicExecute) {
-                    Write-Message -Level Verbose -Message "Signing $LetPublicExecute for $database on $instance."
+                if ($PublicExecute) {
+                    Write-Message -Level Verbose -Message "Signing $PublicExecute for $database on $instance."
                     try {
                         # For idempotency.
                         # Cannot use Get-DbaDbUser here. It does not see certificate-mapped users.
@@ -267,7 +267,7 @@ function Install-DbaFirstResponderKit {
                         "
                         Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $userDrop -EnableException
                         Get-DbaLogin -SqlInstance $server -Login FirstResponderKitLogin | Remove-DbaLogin
-                        foreach ($proc in $LetPublicExecute) {
+                        foreach ($proc in $PublicExecute) {
                             $signatureDrop = "
                             IF EXISTS (SELECT 1 FROM sys.crypt_properties WHERE major_id = OBJECT_ID('$proc') AND crypt_type = 'SPVC')
                             BEGIN
@@ -296,7 +296,7 @@ function Install-DbaFirstResponderKit {
                         START_DATE = '20010101', EXPIRY_DATE = '21000101';
                         "
                         Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $certMake -EnableException
-                        foreach ($proc in $LetPublicExecute) {
+                        foreach ($proc in $PublicExecute) {
                             Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "ADD SIGNATURE TO $proc BY CERTIFICATE FirstResponderKitCertificate WITH PASSWORD = '5OClockSomewhere-Dr0ppedSoon';" -EnableException
                         }
                         Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "ALTER CERTIFICATE FirstResponderKitCertificate REMOVE PRIVATE KEY;" -EnableException
@@ -319,7 +319,7 @@ function Install-DbaFirstResponderKit {
                         if ($Database -ne 'master') {
                             Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "GRANT CONNECT TO [public];" -EnableException
                         }
-                        foreach ($proc in $LetPublicExecute) {
+                        foreach ($proc in $PublicExecute) {
                             Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "GRANT EXECUTE ON $proc TO [public];" -EnableException
                         }
                     } catch {

--- a/public/Install-DbaFirstResponderKit.ps1
+++ b/public/Install-DbaFirstResponderKit.ps1
@@ -307,10 +307,10 @@ function Install-DbaFirstResponderKit {
 
                             SELECT @sql =
                             'USE master;
-                            CREATE CERTIFICATE FirstResponderKitCertificate 
+                            CREATE CERTIFICATE FirstResponderKitCertificate
                                 FROM BINARY = ' + convert(varchar(MAX), @public_key, 1);
 
-                            EXEC(@SQL) 
+                            EXEC(@SQL)
                             "
                             Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $certClone -EnableException
                         }

--- a/tests/Install-DbaFirstResponderKit.Tests.ps1
+++ b/tests/Install-DbaFirstResponderKit.Tests.ps1
@@ -143,19 +143,23 @@ Describe $CommandName -Tag IntegrationTests {
             $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
             $server.Query("CREATE DATABASE $database")
 
-            $server.Query("CREATE LOGIN AsGoodAsPublic WITH PASSWORD = '<enterStrongPasswordHere>';")
-            $password = ConvertTo-SecureString "<enterStrongPasswordHere>" -AsPlainText
-            $public = [PsCredential]::New("AsGoodAsPublic", $password)
-            
-            $FirstResponderKitParams = @{
+            # Each context uses its own login so that a context whose AfterAll does not complete cannot fail the next one with "already exists".
+            $loginName = "AsGoodAsPublic_$(Get-Random)"
+            $queryCreateLogin = @"
+CREATE LOGIN [$loginName] WITH PASSWORD = '<enterStrongPasswordHere>';
+"@
+            $server.Query($queryCreateLogin)
+            $password = ConvertTo-SecureString "<enterStrongPasswordHere>" -AsPlainText -Force
+            $public = New-Object System.Management.Automation.PSCredential($loginName, $password)
+
+            $splatFirstResponderKit = @{
                 SqlInstance      = $TestConfig.InstanceMulti1
                 Database         = $database
-                Branch           = 'main'
+                Branch           = "main"
                 Force            = $true
-                LetPublicExecute = @('sp_BlitzFirst', 'sp_BlitzIndex')
+                LetPublicExecute = @("sp_BlitzFirst", "sp_BlitzIndex")
             }
-            
-            $resultsDownload = Install-DbaFirstResponderKit @FirstResponderKitParams
+            $null = Install-DbaFirstResponderKit @splatFirstResponderKit
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
@@ -166,44 +170,46 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             Remove-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Database $database
-            Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login AsGoodAsPublic -Force
+            Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login $loginName -Force
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Lets public execute sp_BlitzFirst when signed for" {
             $splatPublicBlitzFirst = @{
-                SqlInstance      = $TestConfig.InstanceMulti1
-                Database         = $database
-                Query            = "EXECUTE sp_BlitzFirst @SinceStartup = 1;"
-                SqlCredential    = $public
-                EnableException  = $true
+                SqlInstance     = $TestConfig.InstanceMulti1
+                Database        = $database
+                Query           = "EXECUTE sp_BlitzFirst @SinceStartup = 1;"
+                SqlCredential   = $public
+                EnableException = $true
             }
             { Invoke-DbaQuery @splatPublicBlitzFirst } | Should -Not -Throw
         }
-        
+
         It "Does not let public execute sp_Blitz when not signed for" {
             $splatPublicBlitz = @{
-                SqlInstance      = $TestConfig.InstanceMulti1  
-                Database         = $database
-                Query            = "EXECUTE sp_Blitz;"
-                SqlCredential    = $public
-                EnableException  = $true
+                SqlInstance     = $TestConfig.InstanceMulti1
+                Database        = $database
+                Query           = "EXECUTE sp_Blitz;"
+                SqlCredential   = $public
+                EnableException = $true
             }
-            { Invoke-DbaQuery @splatPublicBlitz } | Should -Throw
+            # The login can connect to the database because LetPublicExecute granted CONNECT to public,
+            # so the only thing that may stop it is the missing EXECUTE permission on the unsigned procedure.
+            { Invoke-DbaQuery @splatPublicBlitz } | Should -Throw -ExpectedMessage "*EXECUTE permission*"
         }
-         
+
         It "Lets admin execute sp_Blitz when not signed for" {
             $splatAdminBlitz = @{
-                SqlInstance      = $TestConfig.InstanceMulti1  
-                Database         = $database
-                Query            = "EXECUTE sp_Blitz @Help = 1"
-                EnableException  = $true
+                SqlInstance     = $TestConfig.InstanceMulti1
+                Database        = $database
+                Query           = "EXECUTE sp_Blitz @Help = 1"
+                EnableException = $true
             }
             { Invoke-DbaQuery @splatAdminBlitz } | Should -Not -Throw
         }
     }
-    
+
     Context "Testing without certificate signing" {
         BeforeAll {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
@@ -213,18 +219,22 @@ Describe $CommandName -Tag IntegrationTests {
             $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
             $server.Query("CREATE DATABASE $database")
 
-            $server.Query("CREATE LOGIN AsGoodAsPublic WITH PASSWORD = '<enterStrongPasswordHere>';")
-            $password = ConvertTo-SecureString "<enterStrongPasswordHere>" -AsPlainText
-            $public = [PsCredential]::New("AsGoodAsPublic", $password)
+            # Each context uses its own login so that a context whose AfterAll does not complete cannot fail the next one with "already exists".
+            $loginName = "AsGoodAsPublic_$(Get-Random)"
+            $queryCreateLogin = @"
+CREATE LOGIN [$loginName] WITH PASSWORD = '<enterStrongPasswordHere>';
+"@
+            $server.Query($queryCreateLogin)
+            $password = ConvertTo-SecureString "<enterStrongPasswordHere>" -AsPlainText -Force
+            $public = New-Object System.Management.Automation.PSCredential($loginName, $password)
 
-            $FirstResponderKitParams = @{
-                SqlInstance      = $TestConfig.InstanceMulti1
-                Database         = $database
-                Branch           = 'main'
-                Force            = $true
+            $splatFirstResponderKit = @{
+                SqlInstance = $TestConfig.InstanceMulti1
+                Database    = $database
+                Branch      = "main"
+                Force       = $true
             }
-            
-            $resultsDownload = Install-DbaFirstResponderKit @FirstResponderKitParams
+            $null = Install-DbaFirstResponderKit @splatFirstResponderKit
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
@@ -235,39 +245,43 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             Remove-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Database $database
-            Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login AsGoodAsPublic -Force
+            Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login $loginName -Force
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
+        # Without LetPublicExecute the command never grants CONNECT to public, so the login is stopped
+        # one step earlier than in the signing contexts: it cannot open the database at all.
+        # Asserting that message still proves the login exists and authenticated, which a bare
+        # Should -Throw would not - a wrong password fails with "Login failed for user" instead.
         It "Does not let public execute sp_BlitzFirst" {
             $splatPublicBlitzFirst = @{
-                SqlInstance      = $TestConfig.InstanceMulti1
-                Database         = $database
-                Query            = "EXECUTE sp_BlitzFirst @SinceStartup = 1;"
-                SqlCredential    = $public
-                EnableException  = $true
+                SqlInstance     = $TestConfig.InstanceMulti1
+                Database        = $database
+                Query           = "EXECUTE sp_BlitzFirst @SinceStartup = 1;"
+                SqlCredential   = $public
+                EnableException = $true
             }
-            { Invoke-DbaQuery @splatPublicBlitzFirst } | Should -Throw
+            { Invoke-DbaQuery @splatPublicBlitzFirst } | Should -Throw -ExpectedMessage "*Cannot open database*"
         }
-        
+
         It "Does not let public execute sp_Blitz" {
             $splatPublicBlitz = @{
-                SqlInstance      = $TestConfig.InstanceMulti1  
-                Database         = $database
-                Query            = "EXECUTE sp_Blitz;"
-                SqlCredential    = $public
-                EnableException  = $true
+                SqlInstance     = $TestConfig.InstanceMulti1
+                Database        = $database
+                Query           = "EXECUTE sp_Blitz;"
+                SqlCredential   = $public
+                EnableException = $true
             }
-            { Invoke-DbaQuery @splatPublicBlitz } | Should -Throw
+            { Invoke-DbaQuery @splatPublicBlitz } | Should -Throw -ExpectedMessage "*Cannot open database*"
         }
-         
+
         It "Lets admin execute sp_Blitz" {
             $splatAdminBlitz = @{
-                SqlInstance      = $TestConfig.InstanceMulti1  
-                Database         = $database
-                Query            = "EXECUTE sp_Blitz @Help = 1"
-                EnableException  = $true
+                SqlInstance     = $TestConfig.InstanceMulti1
+                Database        = $database
+                Query           = "EXECUTE sp_Blitz @Help = 1"
+                EnableException = $true
             }
             { Invoke-DbaQuery @splatAdminBlitz } | Should -Not -Throw
         }
@@ -279,21 +293,25 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
-            $database = 'master'
+            $database = "master"
 
-            $server.Query("CREATE LOGIN AsGoodAsPublic WITH PASSWORD = '<enterStrongPasswordHere>';")
-            $password = ConvertTo-SecureString "<enterStrongPasswordHere>" -AsPlainText
-            $public = [PsCredential]::New("AsGoodAsPublic", $password)
-            
-            $FirstResponderKitParams = @{
+            # Each context uses its own login so that a context whose AfterAll does not complete cannot fail the next one with "already exists".
+            $loginName = "AsGoodAsPublic_$(Get-Random)"
+            $queryCreateLogin = @"
+CREATE LOGIN [$loginName] WITH PASSWORD = '<enterStrongPasswordHere>';
+"@
+            $server.Query($queryCreateLogin)
+            $password = ConvertTo-SecureString "<enterStrongPasswordHere>" -AsPlainText -Force
+            $public = New-Object System.Management.Automation.PSCredential($loginName, $password)
+
+            $splatFirstResponderKit = @{
                 SqlInstance      = $TestConfig.InstanceMulti1
-                Database         = 'master' 
-                Branch           = 'main'
+                Database         = $database
+                Branch           = "main"
                 Force            = $true
-                LetPublicExecute = @('sp_BlitzFirst', 'sp_BlitzIndex')
+                LetPublicExecute = @("sp_BlitzFirst", "sp_BlitzIndex")
             }
-            
-            $resultsDownload = Install-DbaFirstResponderKit @FirstResponderKitParams
+            $null = Install-DbaFirstResponderKit @splatFirstResponderKit
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
@@ -303,8 +321,7 @@ Describe $CommandName -Tag IntegrationTests {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-            Remove-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Database $database
-            Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login AsGoodAsPublic -Force
+            Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login $loginName -Force
             Install-DbaFirstResponderKit -SqlInstance $TestConfig.InstanceMulti1 -OnlyScript Uninstall.sql
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
@@ -312,32 +329,34 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "Lets public execute sp_BlitzFirst when signed for" {
             $splatPublicBlitzFirst = @{
-                SqlInstance      = $TestConfig.InstanceMulti1
-                Database         = $database
-                Query            = "EXECUTE sp_BlitzFirst @SinceStartup = 1;"
-                SqlCredential    = $public
-                EnableException  = $true
+                SqlInstance     = $TestConfig.InstanceMulti1
+                Database        = $database
+                Query           = "EXECUTE sp_BlitzFirst @SinceStartup = 1;"
+                SqlCredential   = $public
+                EnableException = $true
             }
             { Invoke-DbaQuery @splatPublicBlitzFirst } | Should -Not -Throw
         }
-        
+
         It "Does not let public execute sp_Blitz when not signed for" {
             $splatPublicBlitz = @{
-                SqlInstance      = $TestConfig.InstanceMulti1  
-                Database         = $database
-                Query            = "EXECUTE sp_Blitz;"
-                SqlCredential    = $public
-                EnableException  = $true
+                SqlInstance     = $TestConfig.InstanceMulti1
+                Database        = $database
+                Query           = "EXECUTE sp_Blitz;"
+                SqlCredential   = $public
+                EnableException = $true
             }
-            { Invoke-DbaQuery @splatPublicBlitz } | Should -Throw
+            # Every login can reach master through guest, so the missing EXECUTE permission on the
+            # unsigned procedure is the only thing that can stop it here.
+            { Invoke-DbaQuery @splatPublicBlitz } | Should -Throw -ExpectedMessage "*EXECUTE permission*"
         }
-         
+
         It "Lets admin execute sp_Blitz when not signed for" {
             $splatAdminBlitz = @{
-                SqlInstance      = $TestConfig.InstanceMulti1  
-                Database         = $database
-                Query            = "EXECUTE sp_Blitz @Help = 1"
-                EnableException  = $true
+                SqlInstance     = $TestConfig.InstanceMulti1
+                Database        = $database
+                Query           = "EXECUTE sp_Blitz @Help = 1"
+                EnableException = $true
             }
             { Invoke-DbaQuery @splatAdminBlitz } | Should -Not -Throw
         }

--- a/tests/Install-DbaFirstResponderKit.Tests.ps1
+++ b/tests/Install-DbaFirstResponderKit.Tests.ps1
@@ -17,7 +17,7 @@ Describe $CommandName -Tag UnitTests {
                 "Database",
                 "LocalFile",
                 "OnlyScript",
-                "LetPublicExecute",
+                "PublicExecute",
                 "Force",
                 "EnableException"
             )
@@ -153,11 +153,11 @@ CREATE LOGIN [$loginName] WITH PASSWORD = '<enterStrongPasswordHere>';
             $public = New-Object System.Management.Automation.PSCredential($loginName, $password)
 
             $splatFirstResponderKit = @{
-                SqlInstance      = $TestConfig.InstanceMulti1
-                Database         = $database
-                Branch           = "main"
-                Force            = $true
-                LetPublicExecute = @("sp_BlitzFirst", "sp_BlitzIndex")
+                SqlInstance   = $TestConfig.InstanceMulti1
+                Database      = $database
+                Branch        = "main"
+                Force         = $true
+                PublicExecute = @("sp_BlitzFirst", "sp_BlitzIndex")
             }
             $null = Install-DbaFirstResponderKit @splatFirstResponderKit
 
@@ -194,7 +194,7 @@ CREATE LOGIN [$loginName] WITH PASSWORD = '<enterStrongPasswordHere>';
                 SqlCredential   = $public
                 EnableException = $true
             }
-            # The login can connect to the database because LetPublicExecute granted CONNECT to public,
+            # The login can connect to the database because PublicExecute granted CONNECT to public,
             # so the only thing that may stop it is the missing EXECUTE permission on the unsigned procedure.
             { Invoke-DbaQuery @splatPublicBlitz } | Should -Throw -ExpectedMessage "*EXECUTE permission*"
         }
@@ -250,7 +250,7 @@ CREATE LOGIN [$loginName] WITH PASSWORD = '<enterStrongPasswordHere>';
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
-        # Without LetPublicExecute the command never grants CONNECT to public, so the login is stopped
+        # Without PublicExecute the command never grants CONNECT to public, so the login is stopped
         # one step earlier than in the signing contexts: it cannot open the database at all.
         # Asserting that message still proves the login exists and authenticated, which a bare
         # Should -Throw would not - a wrong password fails with "Login failed for user" instead.
@@ -305,11 +305,11 @@ CREATE LOGIN [$loginName] WITH PASSWORD = '<enterStrongPasswordHere>';
             $public = New-Object System.Management.Automation.PSCredential($loginName, $password)
 
             $splatFirstResponderKit = @{
-                SqlInstance      = $TestConfig.InstanceMulti1
-                Database         = $database
-                Branch           = "main"
-                Force            = $true
-                LetPublicExecute = @("sp_BlitzFirst", "sp_BlitzIndex")
+                SqlInstance   = $TestConfig.InstanceMulti1
+                Database      = $database
+                Branch        = "main"
+                Force         = $true
+                PublicExecute = @("sp_BlitzFirst", "sp_BlitzIndex")
             }
             $null = Install-DbaFirstResponderKit @splatFirstResponderKit
 

--- a/tests/Install-DbaFirstResponderKit.Tests.ps1
+++ b/tests/Install-DbaFirstResponderKit.Tests.ps1
@@ -17,6 +17,7 @@ Describe $CommandName -Tag UnitTests {
                 "Database",
                 "LocalFile",
                 "OnlyScript",
+                "LetPublicExecute",
                 "Force",
                 "EnableException"
             )
@@ -130,6 +131,215 @@ Describe $CommandName -Tag IntegrationTests {
             Add-Content $sqlScript (New-Guid).ToString()
             $result = Install-DbaFirstResponderKit -SqlInstance $TestConfig.InstanceMulti2 -Database $database -WarningAction SilentlyContinue
             $result[0].Status -eq "Error" | Should -Be $true
+        }
+    }
+
+    Context "Testing certificate signing in user database" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $database = "dbatoolsci_frk_$(Get-Random)"
+            $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
+            $server.Query("CREATE DATABASE $database")
+
+            $server.Query("CREATE LOGIN AsGoodAsPublic WITH PASSWORD = '<enterStrongPasswordHere>';")
+            $password = ConvertTo-SecureString "<enterStrongPasswordHere>" -AsPlainText
+            $public = [PsCredential]::New("AsGoodAsPublic", $password)
+            
+            $FirstResponderKitParams = @{
+                SqlInstance      = $TestConfig.InstanceMulti1
+                Database         = $database
+                Branch           = 'main'
+                Force            = $true
+                LetPublicExecute = @('sp_BlitzFirst', 'sp_BlitzIndex')
+            }
+            
+            $resultsDownload = Install-DbaFirstResponderKit @FirstResponderKitParams
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            Remove-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Database $database
+            Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login AsGoodAsPublic -Force
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Lets public execute sp_BlitzFirst when signed for" {
+            $splatPublicBlitzFirst = @{
+                SqlInstance      = $TestConfig.InstanceMulti1
+                Database         = $database
+                Query            = "EXECUTE sp_BlitzFirst @SinceStartup = 1;"
+                SqlCredential    = $public
+                EnableException  = $true
+            }
+            { Invoke-DbaQuery @splatPublicBlitzFirst } | Should -Not -Throw
+        }
+        
+        It "Does not let public execute sp_Blitz when not signed for" {
+            $splatPublicBlitz = @{
+                SqlInstance      = $TestConfig.InstanceMulti1  
+                Database         = $database
+                Query            = "EXECUTE sp_Blitz;"
+                SqlCredential    = $public
+                EnableException  = $true
+            }
+            { Invoke-DbaQuery @splatPublicBlitz } | Should -Throw
+        }
+         
+        It "Lets admin execute sp_Blitz when not signed for" {
+            $splatAdminBlitz = @{
+                SqlInstance      = $TestConfig.InstanceMulti1  
+                Database         = $database
+                Query            = "EXECUTE sp_Blitz @Help = 1"
+                EnableException  = $true
+            }
+            { Invoke-DbaQuery @splatAdminBlitz } | Should -Not -Throw
+        }
+    }
+    
+    Context "Testing without certificate signing" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $database = "dbatoolsci_frk_$(Get-Random)"
+            $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
+            $server.Query("CREATE DATABASE $database")
+
+            $server.Query("CREATE LOGIN AsGoodAsPublic WITH PASSWORD = '<enterStrongPasswordHere>';")
+            $password = ConvertTo-SecureString "<enterStrongPasswordHere>" -AsPlainText
+            $public = [PsCredential]::New("AsGoodAsPublic", $password)
+
+            $FirstResponderKitParams = @{
+                SqlInstance      = $TestConfig.InstanceMulti1
+                Database         = $database
+                Branch           = 'main'
+                Force            = $true
+            }
+            
+            $resultsDownload = Install-DbaFirstResponderKit @FirstResponderKitParams
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            Remove-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Database $database
+            Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login AsGoodAsPublic -Force
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Does not let public execute sp_BlitzFirst" {
+            $splatPublicBlitzFirst = @{
+                SqlInstance      = $TestConfig.InstanceMulti1
+                Database         = $database
+                Query            = "EXECUTE sp_BlitzFirst @SinceStartup = 1;"
+                SqlCredential    = $public
+                EnableException  = $true
+            }
+            { Invoke-DbaQuery @splatPublicBlitzFirst } | Should -Throw
+        }
+        
+        It "Does not let public execute sp_Blitz" {
+            $splatPublicBlitz = @{
+                SqlInstance      = $TestConfig.InstanceMulti1  
+                Database         = $database
+                Query            = "EXECUTE sp_Blitz;"
+                SqlCredential    = $public
+                EnableException  = $true
+            }
+            { Invoke-DbaQuery @splatPublicBlitz } | Should -Throw
+        }
+         
+        It "Lets admin execute sp_Blitz" {
+            $splatAdminBlitz = @{
+                SqlInstance      = $TestConfig.InstanceMulti1  
+                Database         = $database
+                Query            = "EXECUTE sp_Blitz @Help = 1"
+                EnableException  = $true
+            }
+            { Invoke-DbaQuery @splatAdminBlitz } | Should -Not -Throw
+        }
+    }
+
+    Context "Testing certificate signing in master database" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
+            $database = 'master'
+
+            $server.Query("CREATE LOGIN AsGoodAsPublic WITH PASSWORD = '<enterStrongPasswordHere>';")
+            $password = ConvertTo-SecureString "<enterStrongPasswordHere>" -AsPlainText
+            $public = [PsCredential]::New("AsGoodAsPublic", $password)
+            
+            $FirstResponderKitParams = @{
+                SqlInstance      = $TestConfig.InstanceMulti1
+                Database         = 'master' 
+                Branch           = 'main'
+                Force            = $true
+                LetPublicExecute = @('sp_BlitzFirst', 'sp_BlitzIndex')
+            }
+            
+            $resultsDownload = Install-DbaFirstResponderKit @FirstResponderKitParams
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            Remove-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Database $database
+            Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login AsGoodAsPublic -Force
+            Install-DbaFirstResponderKit -SqlInstance $TestConfig.InstanceMulti1 -OnlyScript Uninstall.sql
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Lets public execute sp_BlitzFirst when signed for" {
+            $splatPublicBlitzFirst = @{
+                SqlInstance      = $TestConfig.InstanceMulti1
+                Database         = $database
+                Query            = "EXECUTE sp_BlitzFirst @SinceStartup = 1;"
+                SqlCredential    = $public
+                EnableException  = $true
+            }
+            { Invoke-DbaQuery @splatPublicBlitzFirst } | Should -Not -Throw
+        }
+        
+        It "Does not let public execute sp_Blitz when not signed for" {
+            $splatPublicBlitz = @{
+                SqlInstance      = $TestConfig.InstanceMulti1  
+                Database         = $database
+                Query            = "EXECUTE sp_Blitz;"
+                SqlCredential    = $public
+                EnableException  = $true
+            }
+            { Invoke-DbaQuery @splatPublicBlitz } | Should -Throw
+        }
+         
+        It "Lets admin execute sp_Blitz when not signed for" {
+            $splatAdminBlitz = @{
+                SqlInstance      = $TestConfig.InstanceMulti1  
+                Database         = $database
+                Query            = "EXECUTE sp_Blitz @Help = 1"
+                EnableException  = $true
+            }
+            { Invoke-DbaQuery @splatAdminBlitz } | Should -Not -Throw
         }
     }
 }


### PR DESCRIPTION
Be warned, this may be terrible! Specifically:

- It has been too many years since I've had to seriously think about certificates. Claude will surely outsmart me here.
- I am unsure what problem the `CREATE USER` part of [the original code](https://www.brentozar.com/askbrent/) was trying to solve.
-  I had to do a lot of this in T-SQL. I know of no PowerShell interface for certificates.
- The error handling probably isn't good enough, but I don't know certificates or our standards well enough to make it much better.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #10368)
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [X] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [X] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Added ability to create certificates to let public execute FRK procedures. Closes #10368

Also added `sp_kill` to existing ValidateSet.

### Approach
It started as an attempt to copy the "How to Grant Permissions to Non-DBAs" section [here](https://www.brentozar.com/askbrent/), but that set of steps assumes that you are in master. To make other databases also work, I had to expand that with the tricks [mentioned here](https://www.sommarskog.se/grantperm.html#serverleveluserdbcert).

### Commands to test
`Install-DbaFirstResponderKit` and specifically, the new `-LetPublicExecute` parameter.

### Screenshots
<img width="1117" height="207" alt="image" src="https://github.com/user-attachments/assets/30e1be32-c961-44c9-8070-c5588e8c7a14" />

### Learning

1. While running the integration tests locally, I found that `Invoke-ManualPester -Path ./tests/Install-DbaFirstResponderKit.Tests.ps1 -ScriptAnalyzer  -TestIntegration` fails if you don't have a `C:\Temp` folder. If you know what you're doing, then you can add a new `$config['temp'] = "/path/i/actually/have"` line to `dbatools/tests/constants.local.ps1`, but there is nothing anywhere to hint that you need to do that. Everything else I've ever wanted to change in `dbatools/tests/constants.local.ps1` already had a placeholder.
2. Trying to test this with `EXECUTE AS USER = 'guest'` was a very bad idea. It seems unable to take the permissions from the certificate.
3. `Get-DbaDbUser` does not see certificate-mapped users?
