### PR TITLE
Set-DbaMaxMemory: Add parameter Credential to be able to pass it to Test-DbaMaxMemory

### DIFF
--- a/public/Set-DbaMaxMemory.ps1
+++ b/public/Set-DbaMaxMemory.ps1
@@ -28,6 +28,9 @@ function Set-DbaMaxMemory {
 
         For MFA support, please use Connect-DbaInstance.
 
+    .PARAMETER Credential
+        Windows Credential with permission to log on to the server running the SQL instance
+
     .PARAMETER Max
         Specifies the explicit maximum memory value in megabytes for SQL Server to use. When provided, this overrides the automatic memory recommendation calculation.
         Use this when you need a specific memory allocation that differs from the calculated recommendation, such as reserving memory for other applications or setting conservative limits for shared servers.
@@ -92,6 +95,7 @@ function Set-DbaMaxMemory {
     param (
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
+        [PSCredential]$Credential,
         [int]$Max,
         [Parameter(ValueFromPipeline)]
         [PSCustomObject[]]$InputObject,
@@ -104,7 +108,7 @@ function Set-DbaMaxMemory {
     }
     process {
         if ($SqlInstance) {
-            $InputObject += Test-DbaMaxMemory -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $InputObject += Test-DbaMaxMemory -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Credential $Credential
         }
 
         foreach ($result in $InputObject) {

--- a/tests/Set-DbaMaxMemory.Tests.ps1
+++ b/tests/Set-DbaMaxMemory.Tests.ps1
@@ -13,6 +13,7 @@ Describe $CommandName -Tag UnitTests {
             $expectedParameters += @(
                 "SqlInstance",
                 "SqlCredential",
+                "Credential",
                 "Max",
                 "InputObject",
                 "EnableException"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Test-DbaMaxMemory needs Credential if the user that runns the command does not have access to the target. So Set-DbaMaxMemory needs this as well as it calls Test-DbaMaxMemory.