### PR TITLE
CI - Skip the Azure access-token test when no credentials are present (do Copy-DbaDbTableData)

### DIFF
--- a/.github/scripts/gh-actions.ps1
+++ b/.github/scripts/gh-actions.ps1
@@ -1,5 +1,6 @@
 Describe "Integration Tests" -Tag "IntegrationTests" {
     $hasAzureServicePrincipal = [bool]($env:TENANTID -and $env:CLIENTID -and $env:CLIENTSECRET)
+    $hasAzureSqlAccess = [bool]($env:AZURE_SQL_ACCESS_TOKEN -or $hasAzureServicePrincipal)
 
     BeforeAll {
         $password = ConvertTo-SecureString "dbatools.IO" -AsPlainText -Force
@@ -269,7 +270,7 @@ exec sp_addrolemember 'userrole','bob';
         (Get-DbaDatabase -SqlInstance $server -Database test).Name | Should -Be "test"
     }
 
-    It -Skip:([bool]$env:DBATOOLS_GALLERY_TEST) "copies table data to Azure SQL using an access token" {
+    It -Skip:([bool]$env:DBATOOLS_GALLERY_TEST -or -not $hasAzureSqlAccess) "copies table data to Azure SQL using an access token" {
         $PSDefaultParameterValues.Clear()
         $sourceInstance = if ($env:DBATOOLS_SQL_SOURCE) { $env:DBATOOLS_SQL_SOURCE } else { "localhost" }
         $sourceTableName = "dbatools_copy_access_token_$([guid]::NewGuid().ToString('N'))"


### PR DESCRIPTION
## Problem

The `copies table data to Azure SQL using an access token` test in `.github/scripts/gh-actions.ps1` throws instead of skipping when no Azure credentials are available:

```
RuntimeException: The Azure SQL access-token integration test requires AZURE_SQL_ACCESS_TOKEN or TENANTID, CLIENTID, and CLIENTSECRET.
at <ScriptBlock>, .github/scripts/gh-actions.ps1:287
```

Runs that have no access to repository secrets — dependabot PRs and fork PRs — hit this every time. It is currently red on #10464, which only bumps action versions and has nothing to do with Azure.

## Fix

Every other Azure test in this file already guards with `-Skip:(-not $hasAzureServicePrincipal)`. This one now does the same, extended to also accept a bare `AZURE_SQL_ACCESS_TOKEN`:

- new discovery-time `$hasAzureSqlAccess` = access token **or** service principal
- `-Skip:([bool]$env:DBATOOLS_GALLERY_TEST -or -not $hasAzureSqlAccess)`

The `throw` in the body is left in place as a safety net. On runs that *do* have secrets — pushes to `development` and authorized PR runs — the test still executes exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)