### PR TITLE
Fix Availability always reporting cross-platform

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -385,10 +385,11 @@ foreach ($command in $replAliases.GetEnumerator()) {
 }
 #endregion Aliases
 
-# apparently this is no longer required? :O
-if ($PSVersionTable.PSVersion.Major -lt 5) {
-    # region Commands
-    $script:xplat = @(
+# These lists are not just used for Export-ModuleMember below - Get-DbaHelp reads them
+# to work out the Availability of each command, which ends up in bin/dbatools-index.json
+# and on dbatools.io. They must be defined on every PowerShell version.
+# region Commands
+$script:xplat = @(
         'Start-DbaMigration',
         'Copy-DbaDatabase',
         'Copy-DbaLogin',
@@ -1126,6 +1127,8 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Get-DbaErrorLog'
     )
 
+# apparently this is no longer required? :O
+if ($PSVersionTable.PSVersion.Major -lt 5) {
     # If a developer or appveyor calls the psm1 directly, they want all functions
     # So do not explicitly export because everything else is then implicitly excluded
     if (-not $script:serialimport) {


### PR DESCRIPTION
## Problem

Every command in `bin/dbatools-index.json` reports `Availability: "Windows, Linux, macOS"` — all 718 of them. `Get-DbaFirewallRule`, `Install-DbaInstance`, `Get-DbaWindowsLog` and 156 others are Windows only, but [dbatools.io](https://dbatools.io/Get-DbaFirewallRule/) and docs.dbatools.io both render that field, so they advertise Linux and macOS support for commands that cannot run there.

## Cause

`$script:xplat`, `$script:windowsonly` and `$script:noncoresmo` are defined inside an `if ($PSVersionTable.PSVersion.Major -lt 5)` block, so on PowerShell 5.1 and 7.x they are all `$null`.

`Get-DbaHelp` reads them to set Availability:

```powershell
begin {
    $availability = 'Windows, Linux, macOS'
}
process {
    if ($Name -in $script:noncoresmo -or $Name -in $script:windowsonly) {
        $availability = 'Windows only'
    }
```

`-in $null` is always false, so the override never fires and every command keeps the default. `Find-DbaCommand -Rebuild` then writes that into the index at release time.

This came in with 0eb72452 (dbatools 2.0, Nov 2022), which wrapped the block to skip the explicit `Export-ModuleMember` on modern PowerShell. The lists are used for more than exporting, so they need to stay unconditional.

## Fix

Move the version gate down so it wraps only the `Export-ModuleMember` logic it was written for. The list definitions become unconditional again. 7 lines.

## Verification

On PowerShell 7.6.3:

| | before | after |
|---|---|---|
| `$script:windowsonly` | 0 | 128 |
| `$script:noncoresmo` | 0 | 31 |
| `$script:xplat` | 0 | 561 |

```
Get-DbaFirewallRule -> Windows only
Get-DbaPbmPolicy    -> Windows only
Get-DbaDatabase     -> Windows, Linux, macOS
```

- Exported command count unchanged at **732** before and after, so nothing changed about what the module exposes.
- `Find-DbaCommand -Rebuild` produces **159** `Windows only` and **562** `Windows, Linux, macOS`, matching `windowsonly` (128) + `noncoresmo` (31) exactly.
- Spot-checked a rebuilt record against the shipped one: identical on every field except `Availability`.

`bin/dbatools-index.json` is deliberately not included — it is regenerated at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
