### PR TITLE
Tests - Balance EnableException set/remove in four test files

### DIFF
--- a/tests/Copy-DbaAgentJobStep.Tests.ps1
+++ b/tests/Copy-DbaAgentJobStep.Tests.ps1
@@ -71,6 +71,8 @@ Describe $CommandName -Tag IntegrationTests {
         # Cleanup all created jobs
         $null = Remove-DbaAgentJob -SqlInstance $TestConfig.InstanceCopy1 -Job $sourceJobName, $pipelineJobName -ErrorAction SilentlyContinue
         $null = Remove-DbaAgentJob -SqlInstance $TestConfig.InstanceCopy2 -Job $sourceJobName, $pipelineJobName -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Command synchronizes job steps properly" {

--- a/tests/Remove-DbaDbRole.Tests.ps1
+++ b/tests/Remove-DbaDbRole.Tests.ps1
@@ -113,6 +113,8 @@ Describe $CommandName -Tag IntegrationTests {
             # Create a unique role and schema for each test
             $testRole = "dbatoolssci_role_$(Get-Random)"
             $diffSchema = "dbatoolssci_diffsch_$(Get-Random)"
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterEach {

--- a/tests/Set-DbaDbMailAccount.Tests.ps1
+++ b/tests/Set-DbaDbMailAccount.Tests.ps1
@@ -74,6 +74,8 @@ Describe $CommandName -Tag IntegrationTests {
         $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
         $mailAccountSettings = "EXEC msdb.dbo.sysmail_delete_account_sp @account_name = '$accountName';"
         $server.query($mailAccountSettings)
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Updates mail account properties" {

--- a/tests/Update-DbaServiceAccount.Tests.ps1
+++ b/tests/Update-DbaServiceAccount.Tests.ps1
@@ -59,6 +59,9 @@ Describe $CommandName -Tag IntegrationTests {
         $newLogin.LoginType = "WindowsUser"
         $newLogin.Create()
         $server.Roles["sysadmin"].AddMember($winLogin)
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     AfterAll {


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose

Four test files set `$PSDefaultParameterValues["*-Dba*:EnableException"] = $true` more often than they removed it again. Every enable is now matched by a remove.

This is not only a layout fix. In three of the four files the unmatched enable leaked `EnableException` out of the setup block it was meant to cover and into the `It` blocks, which is exactly where we want it *off* so that a command's warning behaviour can be asserted.

| File | Where it leaked | Effect |
| --- | --- | --- |
| `Copy-DbaAgentJobStep` | `AfterAll` | Cosmetic — last block to run |
| `Remove-DbaDbRole` | `BeforeEach` | Every `It` in "Schema ownership handling" ran with `EnableException` on, including the one asserting that a role with a populated schema warns rather than throws without `-Force` |
| `Set-DbaDbMailAccount` | `AfterAll` | Cosmetic |
| `Update-DbaServiceAccount` | `BeforeAll` | The entire integration `Describe` ran with `EnableException` on, undercutting the six `$WarnVar | Should -BeNullOrEmpty` assertions |

### Approach

One `$PSDefaultParameterValues.Remove("*-Dba*:EnableException")` added at the end of each offending block, matching the surrounding style of each file. `Update-DbaServiceAccount` also gets the standard explanatory comment, since that file already carries the matching comment on the enable.

No test logic, assertions or setup were changed — nine added lines in total, no deletions.

### Commands to test

All four test files pass against a live lab (SQL Server 2019/2022/2025 on a domain lab):

| Test file | Result |
| --- | --- |
| `Copy-DbaAgentJobStep.Tests.ps1` | 6/6 passed |
| `Remove-DbaDbRole.Tests.ps1` | 9/9 passed |
| `Set-DbaDbMailAccount.Tests.ps1` | 11/11 passed |
| `Update-DbaServiceAccount.Tests.ps1` | 18/18 passed |

`Update-DbaServiceAccount` is the notable one, since removing `EnableException` from the whole `Describe` changes how the whole file behaves. Service accounts on the target instance were captured before the run and confirmed restored afterwards, with no leftover local account.

### Learning

Found with a layout checker that walks every file in `tests/` and asserts, among other things, that each `$PSDefaultParameterValues["*-Dba*:EnableException"] = $true` is matched by a `.Remove()`. After this change that assertion passes for every test file in the repo.

The checker deliberately does not care *where* the two statements sit — both of these are in use and both are fine:

```
BeforeAll { enable ... remove }   and   AfterAll { enable ... remove }
BeforeAll { enable ... }          and   AfterAll { ... remove }
```

What has to hold is only that every enable is matched by a remove.

(this text was created by Claude)