### PR TITLE
Invoke-ManagedComputerCommand - Throw instead of returning nothing and support SQL Server 2025

### DIFF
--- a/private/functions/Invoke-ManagedComputerCommand.ps1
+++ b/private/functions/Invoke-ManagedComputerCommand.ps1
@@ -96,6 +96,7 @@ function Invoke-ManagedComputerCommand {
         Invoke-Command2 @parms
     } catch {
         # Log the failure and prepare to connect remotely
+        $localException = $PSItem
         Write-Message -Level Verbose -Message "Local connection attempt to $computer failed | $PSItem. Connecting remotely."
         $hostname = $resolved.FullComputerName
 
@@ -103,10 +104,15 @@ function Invoke-ManagedComputerCommand {
         # Now, we will attempt to connect remotely with different versions
 
         # Set the maximum and minimum versions for the loop
-        $MaxVersion = 16
+        # This is the major version of the SqlWmiManagement assembly that we try to load on the target computer,
+        # so $MaxVersion has to be raised whenever a new major version of SQL Server is released.
+        # 17 = SQL Server 2025, 16 = SQL Server 2022, 15 = SQL Server 2019, 14 = SQL Server 2017, ...
+        $MaxVersion = 17
         $MinVersion = 8
 
         # Iterate through versions from maximum to minimum
+        $connected = $false
+        $remoteException = $null
         foreach ($version in ($MaxVersion..$MinVersion)) {
             try {
                 # Set the desired version in the ArgumentList
@@ -117,11 +123,18 @@ function Invoke-ManagedComputerCommand {
                 Invoke-Command2 @parms -ComputerName $hostname
 
                 # Operation succeeded, exit the loop
+                $connected = $true
                 break
             } catch {
                 # Log the failure and proceed to the next version
+                $remoteException = $PSItem
                 Write-Message -Level Verbose -Message "Connecting remotely to: '$computer' using version: '$version' failed. | $PSItem"
             }
+        }
+
+        # If we would not throw here, the calling command would silently get no result at all and would not be able to tell the user what went wrong
+        if (-not $connected) {
+            throw "Failed to connect to SQL WMI on $computer. Local connection attempt failed with: $localException | Last remote connection attempt (version $MinVersion) failed with: $remoteException"
         }
     }
 }

--- a/tests/Invoke-ManagedComputerCommand.Tests.ps1
+++ b/tests/Invoke-ManagedComputerCommand.Tests.ps1
@@ -6,6 +6,26 @@ param(
 )
 
 Describe $CommandName -Tag UnitTests {
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            # This is a private command, so we have to ask the module for it.
+            # We must not do this inside of InModuleScope, because $TestConfig is not available there.
+            $commandInfo = & (Get-Module dbatools) { Get-Command -Name Invoke-ManagedComputerCommand }
+            $hasParameters = $commandInfo.Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "ComputerName",
+                "Credential",
+                "ScriptBlock",
+                "ArgumentList",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe $CommandName -Tag UnitTests {
     InModuleScope dbatools {
         BeforeAll {
             Mock -CommandName Test-ElevationRequirement -MockWith { $true }
@@ -14,21 +34,6 @@ Describe $CommandName -Tag UnitTests {
                     IpAddress        = "10.0.0.1"
                     FullComputerName = "mockedserver.contoso.com"
                 }
-            }
-        }
-
-        Context "Parameter validation" {
-            It "Should have the expected parameters" {
-                $hasParameters = (Get-Command Invoke-ManagedComputerCommand).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
-                $expectedParameters = $TestConfig.CommonParameters
-                $expectedParameters += @(
-                    "ComputerName",
-                    "Credential",
-                    "ScriptBlock",
-                    "ArgumentList",
-                    "EnableException"
-                )
-                Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
             }
         }
 

--- a/tests/Invoke-ManagedComputerCommand.Tests.ps1
+++ b/tests/Invoke-ManagedComputerCommand.Tests.ps1
@@ -1,0 +1,101 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName = "dbatools",
+    $CommandName = "Invoke-ManagedComputerCommand",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    InModuleScope dbatools {
+        BeforeAll {
+            Mock -CommandName Test-ElevationRequirement -MockWith { $true }
+            Mock -CommandName Resolve-DbaNetworkName -MockWith {
+                [PSCustomObject]@{
+                    IpAddress        = "10.0.0.1"
+                    FullComputerName = "mockedserver.contoso.com"
+                }
+            }
+        }
+
+        Context "Parameter validation" {
+            It "Should have the expected parameters" {
+                $hasParameters = (Get-Command Invoke-ManagedComputerCommand).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+                $expectedParameters = $TestConfig.CommonParameters
+                $expectedParameters += @(
+                    "ComputerName",
+                    "Credential",
+                    "ScriptBlock",
+                    "ArgumentList",
+                    "EnableException"
+                )
+                Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+            }
+        }
+
+        Context "When the local connection attempt succeeds" {
+            BeforeAll {
+                Mock -CommandName Invoke-Command2 -MockWith { "LocalResult" }
+
+                $localResult = Invoke-ManagedComputerCommand -ComputerName "mockedserver" -ScriptBlock { $wmi.Services } 3>$null 4>$null
+            }
+
+            It "Returns the result of the local connection attempt" {
+                $localResult | Should -Be "LocalResult"
+            }
+
+            It "Does not try to connect remotely" {
+                Should -Invoke -CommandName Invoke-Command2 -Times 1 -Exactly -Scope Context
+            }
+        }
+
+        Context "When the local connection attempt fails but a remote connection attempt succeeds" {
+            BeforeAll {
+                $script:invokeCommandCount = 0
+                Mock -CommandName Invoke-Command2 -MockWith {
+                    $script:invokeCommandCount++
+                    if ($script:invokeCommandCount -eq 1) {
+                        throw "SQL Server WMI provider is not available on 10.0.0.1."
+                    }
+                    "RemoteResult"
+                }
+
+                $remoteResult = Invoke-ManagedComputerCommand -ComputerName "mockedserver" -ScriptBlock { $wmi.Services } 3>$null 4>$null
+            }
+
+            It "Returns the result of the remote connection attempt" {
+                $remoteResult | Should -Be "RemoteResult"
+            }
+
+            It "Stops as soon as one version works" {
+                # One local attempt plus one remote attempt with the highest version.
+                Should -Invoke -CommandName Invoke-Command2 -Times 2 -Exactly -Scope Context
+            }
+        }
+
+        Context "When all connection attempts fail" {
+            BeforeAll {
+                Mock -CommandName Invoke-Command2 -MockWith { throw "SQL Server WMI provider is not available on 10.0.0.1." }
+
+                $thrownMessage = $null
+                try {
+                    $failedResult = Invoke-ManagedComputerCommand -ComputerName "mockedserver" -ScriptBlock { $wmi.Services } 3>$null 4>$null
+                } catch {
+                    $thrownMessage = $PSItem.Exception.Message
+                }
+            }
+
+            It "Throws instead of silently returning nothing" {
+                $thrownMessage | Should -BeLike "*Failed to connect to SQL WMI on mockedserver*"
+            }
+
+            It "Includes the reason of the last failed attempt in the message" {
+                $thrownMessage | Should -BeLike "*SQL Server WMI provider is not available on 10.0.0.1.*"
+            }
+
+            It "Tries all versions from 17 down to 8" {
+                # One local attempt plus ten remote attempts for the versions 17 to 8.
+                Should -Invoke -CommandName Invoke-Command2 -Times 11 -Exactly -Scope Context
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Problem

When the local connection attempt failed, the command looped through the versions 16 to 8 to load a matching SqlWmiManagement assembly on the target computer. If all of those attempts failed as well, the `foreach` just ended - no throw, no message, no output at all. The calling command silently continued to work with `$null`, and `-EnableException` never fired because `Get-DbaStartupParameter` and friends never saw an error.

This is what caused `New-DbaFirewallRule -Type DAC` to fail with the misleading message `Cannot bind argument to parameter 'Path' because it is null.` on a fresh SQL Server 2025 instance: `Get-DbaStartupParameter` returned nothing, so the path to ERRORLOG was `$null`.

`Update-DbaServiceAccount` was affected in an even worse way - it reported `Successful` for an account change that never happened.

### Changes

* Throw when the local attempt and all remote attempts fail. The message contains both the reason of the local failure and the reason of the last remote failure.
* Raise `$MaxVersion` from 16 to 17, so a computer that only has SQL Server 2025 installed is supported as well.

All callers already wrap the call in `try`/`catch` with `Stop-Function`, so they now report the real problem instead of failing later on with a confusing message.

### Tests

New `tests/Invoke-ManagedComputerCommand.Tests.ps1` with 8 unit tests covering the local success path, the remote fallback path and the all-attempts-failed path. Verified that 3 of them fail against the previous code.

Smoke tested on a computer without SQL Server, where the command now returns a real error instead of `$null`:

```
Failed to connect to SQL WMI on ADMIN01. Local connection attempt failed with:
Exception calling "Initialize" with "0" argument(s): "SQL Server WMI provider is not available on 192.168.3.20."
| Last remote connection attempt (version 8) failed with:
Exception calling "Initialize" with "0" argument(s): "SQL Server WMI provider is not available on 192.168.3.20."
```

### Note for a possible follow-up

The assembly probe uses `FullName -like "*$version.0*"`, which only matches GAC folders like `v4.0_17.0.0.0`. Should SQL Server 2025 register `SqlWmiManagement` as `17.100.0.0`, version 17 would still not be found - but with this change you now get a real exception naming that instead of silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
