### PR TITLE
New-DbaFirewallRule - Fix DAC rule failing with a misleading message about a null path

### DIFF
--- a/public/New-DbaFirewallRule.ps1
+++ b/public/New-DbaFirewallRule.ps1
@@ -402,9 +402,21 @@ function New-DbaFirewallRule {
                 # As we create firewall rules, we probably don't have access to the instance yet. So we have to get the port of the DAC via Invoke-Command2.
                 # Get-DbaStartupParameter also uses Invoke-Command2 to get the location of ERRORLOG.
                 # We only scan the current log because this command is typically run shortly after the installation and should include the needed information.
+                $errorLogPath = $null
                 try {
                     $errorLogPath = Get-DbaStartupParameter -SqlInstance $instance -Credential $Credential -Simple -EnableException | Select-Object -ExpandProperty ErrorLog
-                    $dacMessage = Invoke-Command2 -Raw -ComputerName $instance.ComputerName -ArgumentList $errorLogPath -ScriptBlock {
+                } catch {
+                    Stop-Function -Message "Failed to get the path to ERRORLOG on $($instance.ComputerName) for instance $($instance.InstanceName)." -Target $instance -ErrorRecord $_ -Continue
+                }
+
+                # Get-DbaStartupParameter can return no object at all or an object with an empty property ErrorLog.
+                # We have to test for that here, because otherwise we would fail later with a misleading message about a parameter that must not be null.
+                if (-not $errorLogPath) {
+                    Stop-Function -Message "Failed to get the path to ERRORLOG on $($instance.ComputerName) for instance $($instance.InstanceName), so the firewall rule for DAC cannot be created." -Target $instance -Continue
+                }
+
+                try {
+                    $dacMessage = Invoke-Command2 -Raw -ComputerName $instance.ComputerName -Credential $Credential -ArgumentList $errorLogPath -ScriptBlock {
                         Get-Content -Path $args[0] |
                             Select-String -Pattern 'Dedicated admin connection support was established for listening.+' |
                             Select-Object -Last 1 |

--- a/tests/New-DbaFirewallRule.Tests.ps1
+++ b/tests/New-DbaFirewallRule.Tests.ps1
@@ -76,6 +76,66 @@ Describe $CommandName -Tag UnitTests {
                 $result.LocalPort | Should -Be "1434"
             }
         }
+
+        Context "DAC rule when the path to ERRORLOG cannot be determined" {
+            BeforeAll {
+                Mock Invoke-Command2 { }
+                Mock Get-DbaStartupParameter { }
+
+                $dacErrorMessage = $null
+                try {
+                    New-DbaFirewallRule -SqlInstance "sql01\test" -Type DAC -EnableException -Confirm:$false
+                } catch {
+                    $dacErrorMessage = $PSItem.Exception.Message
+                }
+            }
+
+            It "Reports the missing ERRORLOG instead of failing on a null path" {
+                $dacErrorMessage | Should -BeLike "*Failed to get the path to ERRORLOG*"
+            }
+
+            It "Does not try to read the ERRORLOG" {
+                Should -Invoke Invoke-Command2 -Times 0 -Exactly -Scope Context
+            }
+        }
+
+        Context "DAC rule when the path to ERRORLOG is found" {
+            BeforeAll {
+                $dacPassword = ConvertTo-SecureString -String "dbatoolsci_password" -AsPlainText -Force
+                $dacCredential = New-Object System.Management.Automation.PSCredential ("dbatoolsci_user", $dacPassword)
+
+                Mock Get-DbaStartupParameter {
+                    [PSCustomObject]@{
+                        ErrorLog = "C:\SQLLog\ERRORLOG"
+                    }
+                }
+                Mock Invoke-Command2 -ParameterFilter { $Raw } -MockWith {
+                    "Dedicated admin connection support was established for listening remotely on port 1434."
+                }
+                Mock Invoke-Command2 -MockWith {
+                    [PSCustomObject]@{
+                        Successful  = $true
+                        CimInstance = [PSCustomObject]@{
+                            Status = "The rule was parsed successfully from the store"
+                        }
+                        Warning     = $null
+                        Error       = $null
+                        Exception   = $null
+                    }
+                }
+
+                $dacResult = New-DbaFirewallRule -SqlInstance "sql01\test" -Type DAC -Credential $dacCredential -Confirm:$false
+            }
+
+            It "Creates the firewall rule for the DAC port found in ERRORLOG" {
+                $dacResult.Type | Should -Be "DAC"
+                $dacResult.LocalPort | Should -Be "1434"
+            }
+
+            It "Uses the credential to read the ERRORLOG" {
+                Should -Invoke Invoke-Command2 -Times 1 -Exactly -Scope Context -ParameterFilter { $Raw -and $Credential.UserName -eq "dbatoolsci_user" }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Two problems in the block that creates the firewall rule for the dedicated admin connection (DAC).

### The path to ERRORLOG was used without any test

`Get-DbaStartupParameter` can return nothing at all, or an object whose `ErrorLog` property is empty. The result went straight into `Invoke-Command2 -ArgumentList $errorLogPath`, so the command failed inside the remote scriptblock with:

```
[New-DbaFirewallRule] Failed to execute command to get information for DAC on <computer> for instance <instance>.
| Cannot bind argument to parameter 'Path' because it is null.
```

That message points at the DAC and hides the real problem, which is that we could not get the startup parameters of the instance. The path is now tested and reported before it is used.

### The ERRORLOG was read without the Credential

The `Invoke-Command2` call that reads ERRORLOG did not pass `-Credential $Credential`, unlike every other remote call of this command. It only worked because `Invoke-Command2` caches the PSSession per computer and the session name does not include the credential, so an earlier call made with the credential was reused. Whenever that earlier call did not happen, the read ran as the current user.

### Tests

Two new contexts in the existing `InModuleScope` Describe of `tests/New-DbaFirewallRule.Tests.ps1`:

* the path to ERRORLOG cannot be determined - the command reports the missing ERRORLOG and never tries to read it
* the path to ERRORLOG is found - the rule is created for the DAC port from ERRORLOG and the credential is used to read it

3 of the 4 new tests fail against the previous code. The old run shows both bugs directly - `Invoke-Command2 ... -ArgumentList $null -Raw` for the first one, and an ERRORLOG read without `-Credential` while the call that creates the rule has it for the second one.

Unit tests and integration tests were run against a lab instance, the integration tests also cover this code path because the DAC block runs when `-Type` is not used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
