### PR TITLE
Get-DbaStartupParameter - Fix Simple losing the drive letter of the paths

### DIFF
--- a/public/Get-DbaStartupParameter.ps1
+++ b/public/Get-DbaStartupParameter.ps1
@@ -138,9 +138,9 @@ function Get-DbaStartupParameter {
                             ComputerName    = $computerName
                             InstanceName    = $instanceName
                             SqlInstance     = $ogInstance
-                            MasterData      = $masterData.TrimStart('-d')
-                            MasterLog       = $masterLog.TrimStart('-l')
-                            ErrorLog        = $errorLog.TrimStart('-e')
+                            MasterData      = $masterData -replace "^-[dD]", ""
+                            MasterLog       = $masterLog -replace "^-[lL]", ""
+                            ErrorLog        = $errorLog -replace "^-[eE]", ""
                             TraceFlags      = $traceFlags
                             DebugFlags      = $debugFlags
                             ParameterString = $wmisvc.StartupParameters
@@ -192,9 +192,9 @@ function Get-DbaStartupParameter {
                             ComputerName         = $computerName
                             InstanceName         = $instanceName
                             SqlInstance          = $ogInstance
-                            MasterData           = $masterData -replace '^-[dD]', ''
-                            MasterLog            = $masterLog -replace '^-[lL]', ''
-                            ErrorLog             = $errorLog -replace '^-[eE]', ''
+                            MasterData           = $masterData -replace "^-[dD]", ""
+                            MasterLog            = $masterLog -replace "^-[lL]", ""
+                            ErrorLog             = $errorLog -replace "^-[eE]", ""
                             TraceFlags           = $traceFlags
                             DebugFlags           = $debugFlags
                             CommandPromptStart   = $commandPrompt

--- a/tests/Get-DbaStartupParameter.Tests.ps1
+++ b/tests/Get-DbaStartupParameter.Tests.ps1
@@ -38,7 +38,7 @@ Describe $CommandName -Tag UnitTests {
                 & $localScriptBlock @ArgumentList
             } -ModuleName dbatools
 
-            { Get-DbaStartupParameter -SqlInstance "localhost" -EnableException } | Should -Throw
+            { Get-DbaStartupParameter -SqlInstance "localhost" -EnableException } | Should -Throw -ExpectedMessage "*SQL Server service*was not found*"
         }
 
         It "Throws when multiple SQL Server services match the instance name" {
@@ -68,7 +68,7 @@ Describe $CommandName -Tag UnitTests {
                 & $localScriptBlock @ArgumentList
             } -ModuleName dbatools
 
-            { Get-DbaStartupParameter -SqlInstance "localhost" -EnableException } | Should -Throw
+            { Get-DbaStartupParameter -SqlInstance "localhost" -EnableException } | Should -Throw -ExpectedMessage "*Multiple SQL Server services*were found*"
         }
     }
 

--- a/tests/Get-DbaStartupParameter.Tests.ps1
+++ b/tests/Get-DbaStartupParameter.Tests.ps1
@@ -32,7 +32,10 @@ Describe $CommandName -Tag UnitTests {
                 $wmi = [PSCustomObject]@{
                     Services = @()
                 }
-                & $ScriptBlock @ArgumentList
+                # $ScriptBlock was created inside the module, so invoking it directly would run it in the module scope, where $wmi is not visible.
+                # Recreating it here binds it to this scope, so it can use the $wmi defined above.
+                $localScriptBlock = [scriptblock]::Create($ScriptBlock.ToString())
+                & $localScriptBlock @ArgumentList
             } -ModuleName dbatools
 
             { Get-DbaStartupParameter -SqlInstance "localhost" -EnableException } | Should -Throw
@@ -59,10 +62,88 @@ Describe $CommandName -Tag UnitTests {
                         }
                     )
                 }
-                & $ScriptBlock @ArgumentList
+                # $ScriptBlock was created inside the module, so invoking it directly would run it in the module scope, where $wmi is not visible.
+                # Recreating it here binds it to this scope, so it can use the $wmi defined above.
+                $localScriptBlock = [scriptblock]::Create($ScriptBlock.ToString())
+                & $localScriptBlock @ArgumentList
             } -ModuleName dbatools
 
             { Get-DbaStartupParameter -SqlInstance "localhost" -EnableException } | Should -Throw
+        }
+    }
+
+    Context "Startup parameter parsing" {
+        BeforeAll {
+            # The drive letters are lower case on purpose, because those are the ones that got lost in the past.
+            Mock Invoke-ManagedComputerCommand -MockWith {
+                param (
+                    $Server,
+                    $Credential,
+                    $ScriptBlock,
+                    $ArgumentList
+                )
+                $wmi = [PSCustomObject]@{
+                    Services = @(
+                        [PSCustomObject]@{
+                            DisplayName       = "SQL Server ($($ArgumentList[1]))"
+                            StartupParameters = "-dd:\SQLData\master.mdf;-ee:\SQLLog\ERRORLOG;-ll:\SQLLog\mastlog.ldf"
+                        }
+                    )
+                }
+                # $ScriptBlock was created inside the module, so invoking it directly would run it in the module scope, where $wmi is not visible.
+                # Recreating it here binds it to this scope, so it can use the $wmi defined above.
+                $localScriptBlock = [scriptblock]::Create($ScriptBlock.ToString())
+                & $localScriptBlock @ArgumentList
+            } -ModuleName dbatools
+        }
+
+        It "Keeps the drive letter of the paths with Simple" {
+            $simpleResult = Get-DbaStartupParameter -SqlInstance "localhost" -Simple -EnableException
+
+            $simpleResult.MasterData | Should -Be "d:\SQLData\master.mdf"
+            $simpleResult.MasterLog | Should -Be "l:\SQLLog\mastlog.ldf"
+            $simpleResult.ErrorLog | Should -Be "e:\SQLLog\ERRORLOG"
+        }
+
+        It "Keeps the drive letter of the paths without Simple" {
+            $detailedResult = Get-DbaStartupParameter -SqlInstance "localhost" -EnableException
+
+            $detailedResult.MasterData | Should -Be "d:\SQLData\master.mdf"
+            $detailedResult.MasterLog | Should -Be "l:\SQLLog\mastlog.ldf"
+            $detailedResult.ErrorLog | Should -Be "e:\SQLLog\ERRORLOG"
+        }
+    }
+
+    Context "Startup parameters without a path to ERRORLOG" {
+        BeforeAll {
+            Mock Invoke-ManagedComputerCommand -MockWith {
+                param (
+                    $Server,
+                    $Credential,
+                    $ScriptBlock,
+                    $ArgumentList
+                )
+                $wmi = [PSCustomObject]@{
+                    Services = @(
+                        [PSCustomObject]@{
+                            DisplayName       = "SQL Server ($($ArgumentList[1]))"
+                            StartupParameters = "-dd:\SQLData\master.mdf;-ll:\SQLLog\mastlog.ldf"
+                        }
+                    )
+                }
+                # $ScriptBlock was created inside the module, so invoking it directly would run it in the module scope, where $wmi is not visible.
+                # Recreating it here binds it to this scope, so it can use the $wmi defined above.
+                $localScriptBlock = [scriptblock]::Create($ScriptBlock.ToString())
+                & $localScriptBlock @ArgumentList
+            } -ModuleName dbatools
+        }
+
+        It "Returns an object with an empty ErrorLog instead of failing" {
+            $noErrorLogResult = Get-DbaStartupParameter -SqlInstance "localhost" -Simple -EnableException
+
+            $noErrorLogResult | Should -Not -BeNullOrEmpty
+            $noErrorLogResult.MasterData | Should -Be "d:\SQLData\master.mdf"
+            $noErrorLogResult.ErrorLog | Should -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
### The bug

The output with `-Simple` used `TrimStart` to remove the parameter prefix from the paths:

```powershell
MasterData = $masterData.TrimStart("-d")
MasterLog  = $masterLog.TrimStart("-l")
ErrorLog   = $errorLog.TrimStart("-e")
```

`String.TrimStart` takes a **set of characters**, not a string, so it removes every leading `-`, `d`, `l` or `e`. A path that lives on one of those drives loses its drive letter:

```
-ee:\SQLLog\ERRORLOG   ->   :\SQLLog\ERRORLOG
-dd:\SQLData\master.mdf ->  :\SQLData\master.mdf
```

And if the parameter was not present at all, `$errorLog` was `$null`, so the method call failed the whole command with `You cannot call a method on a null-valued expression.`

The output without `-Simple` was never affected - it already used `-replace "^-[dD]", ""`. Both branches now use the same expression. The three lines in the other branch only changed their quotes, the regular expressions are identical.

### The tests were not testing anything

While writing the tests for this I found that the existing mocks invoke the scriptblock of the command with the call operator:

```powershell
$wmi = [PSCustomObject]@{ Services = @( ... ) }
& $ScriptBlock @ArgumentList
```

The scriptblock is created inside the module, so `&` runs it in the module scope and it never sees the `$wmi` defined in the mock. `$wmi.Services` is `$null`, so the command always threw `SQL Server service '...' was not found`. Both existing tests only assert `Should -Throw`, so they passed - but not for the reason their names claim.

The scriptblock is now recreated in the scope of the mock, which binds it there:

```powershell
$localScriptBlock = [scriptblock]::Create($ScriptBlock.ToString())
& $localScriptBlock @ArgumentList
```

Both existing tests still pass, now for the right reason.

### Tests

Three new tests: the paths keep their drive letter with `-Simple`, the same with the default output, and startup parameters without `-e` return an object with an empty `ErrorLog` instead of failing.

Against the previous code the two new `-Simple` tests fail with exactly the two symptoms above (`:\SQLData\master.mdf` and the null-valued expression). Unit and integration tests were run against a lab instance, and the tests of `Set-DbaStartupParameter` were run as well because it consumes the default output.

### Context

This is the last of three separate bugs found while tracking down a `New-DbaFirewallRule -Type DAC` failure on a fresh SQL Server 2025 instance. It is independent of the other two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
