### PR TITLE
Tests - Make weak throw assertions strict and stop an external outage from failing unrelated PRs

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -54,7 +54,7 @@ Pester v5 enforces strict organization of test code. Follow these rules:
 - **All setup code** must be in `BeforeAll` or `BeforeEach` blocks
 - **All cleanup code** must be in `AfterAll` or `AfterEach` blocks
 - **All test assertions** must be in `It` blocks
-- **No loose code** is allowed in `Describe` or `Context` blocks
+- **No loose code** is allowed in `Describe` or `Context` blocks, with one exception: computing a value that a `-Skip:` needs, see [Skip Conditions](#skip-conditions)
 - **Never use the `-ForEach` parameter** on any test blocks
 
 ### Standard Test Structure
@@ -269,6 +269,41 @@ It "Should test something" -Skip:"true" {
 }
 ```
 
+#### Computing a skip condition is the one exception to the no loose code rule
+
+Pester evaluates `-Skip:` while it discovers the tests, before any `BeforeAll` runs. A value computed in `BeforeAll` is therefore too late to be used by `-Skip:`. A variable that exists only to feed a `-Skip:` may be computed directly in the `Describe` block:
+
+```powershell
+Describe $CommandName -Tag IntegrationTests {
+    # These tests need the Microsoft Update Catalog. If it does not answer, every one of them waits
+    # 100 seconds for the default timeout of Invoke-WebRequest and then fails for a reason that has
+    # nothing to do with dbatools. So we probe it once here and skip the tests instead.
+    try {
+        $splatCatalog = @{
+            Uri             = "https://www.catalog.update.microsoft.com/Search.aspx?q=KB2992080"
+            UseBasicParsing = $true
+            TimeoutSec      = 30
+            ErrorAction     = "Stop"
+        }
+        $catalogReachable = (Invoke-WebRequest @splatCatalog).StatusCode -eq 200
+    } catch {
+        $catalogReachable = $false
+    }
+
+    Context "Downloading from the Microsoft Update Catalog" -Skip:(-not $catalogReachable) {
+        # It blocks
+    }
+}
+```
+
+Keep the exception narrow:
+
+- Compute only what the `-Skip:` needs. Everything else still belongs in `BeforeAll`.
+- Skip only when the precondition is provably missing. If the dependency answers, the tests have to run and a real regression has to fail them. Never skip on a result that a bug could also produce.
+- Write a comment that says what is skipped and why, so the next person does not remove it.
+
+Examples in the tree: `Get-DbaKbUpdate.Tests.ps1` and `Save-DbaKbUpdate.Tests.ps1` test whether the Microsoft Update Catalog answers, `New-DbaFirewallRule.Tests.ps1` tests whether the instance uses dynamic ports.
+
 ### Array Operations
 
 - Use `$results.Status.Count` for accurate counting in dbatools context
@@ -419,7 +454,7 @@ Describe $CommandName -Tag IntegrationTests {
 - [ ] All setup code is in `BeforeAll` or `BeforeEach` blocks
 - [ ] All cleanup code is in `AfterAll` or `AfterEach` blocks
 - [ ] All test assertions are in `It` blocks
-- [ ] No loose code in `Describe` or `Context` blocks
+- [ ] No loose code in `Describe` or `Context` blocks, except computing a `-Skip:` condition
 - [ ] No `-ForEach` parameters used on test blocks
 
 **Variable Scoping:**

--- a/tests/Get-DbaBuild.Tests.ps1
+++ b/tests/Get-DbaBuild.Tests.ps1
@@ -125,8 +125,8 @@ Describe $CommandName -Tag UnitTests {
         It "Doesn't accept 'Build', 'SqlInstance'" {
             { Get-DbaBuild -Build "10.0.1600" -SqlInstance "localhost" -EnableException -ErrorAction Stop } | Should -Throw
         }
-        It "Doesn't accept 'Build', 'SqlInstance'" {
-            { Get-DbaBuild -Build "10.0.1600" -SqlInstance "localhost" -EnableException -ErrorAction Stop } | Should -Throw
+        It "Does not accept Kb and SqlInstance" {
+            { Get-DbaBuild -Kb "4052908" -SqlInstance "localhost" -EnableException -ErrorAction Stop } | Should -Throw
         }
         It "Doesn't accept 'Build', 'MajorVersion'" {
             { Get-DbaBuild -Build "10.0.1600" -MajorVersion "2016" -EnableException -ErrorAction Stop } | Should -Throw

--- a/tests/Get-DbaComputerSystem.Tests.ps1
+++ b/tests/Get-DbaComputerSystem.Tests.ps1
@@ -22,7 +22,7 @@ Describe $CommandName -Tag UnitTests {
     Context "Validate input" {
         It "Cannot resolve hostname of computer" {
             Mock Resolve-DbaNetworkName { $null }
-            { Get-DbaComputerSystem -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw
+            { Get-DbaComputerSystem -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw -ExpectedMessage "*DNS name DoesNotExist142 not found*"
         }
     }
 }

--- a/tests/Get-DbaKbUpdate.Tests.ps1
+++ b/tests/Get-DbaKbUpdate.Tests.ps1
@@ -22,56 +22,77 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
-    It "successfully connects and parses link and title" {
-        $results = Get-DbaKbUpdate -Name KB4057119
-        $results.Link -match "download.windowsupdate.com"
-        $results.Title -match "Cumulative Update"
-        $results.KBLevel | Should -Be 4057119
+    # These tests query the Microsoft Update Catalog. If that site does not answer, every one of them
+    # needs 100 seconds to time out and then fails for a reason that has nothing to do with dbatools.
+    # So we probe the catalog once here and skip the tests if it does not answer. We only skip if it
+    # is provably down - if it answers, the tests run as before and a real regression still fails them.
+    #
+    # We have to probe the search page and not the start page: on 2026-07-31 the start page answered
+    # in one second while every search timed out, so a probe of the start page would not have helped.
+    try {
+        $splatCatalog = @{
+            Uri             = "https://www.catalog.update.microsoft.com/Search.aspx?q=KB4057119"
+            UseBasicParsing = $true
+            TimeoutSec      = 30
+            ErrorAction     = "Stop"
+        }
+        $catalogReachable = (Invoke-WebRequest @splatCatalog).StatusCode -eq 200
+    } catch {
+        $catalogReachable = $false
     }
 
-    It "test with the -Simple param" {
-        $results = Get-DbaKbUpdate -Name KB4577194 -Simple
-        $results.Link -match "download.windowsupdate.com"
-        $results.Title -match "Cumulative Update"
-        $results.KBLevel | Should -Be 4577194
-    }
-
-    # see https://github.com/dataplat/dbatools/issues/6745
-    It "Calling script uses a variable named filter" {
-        $filter = "SQLServer*-KB-*x64*.exe"
-
-        $results = Get-DbaKbUpdate -Name KB4564903
-        $results.KBLevel | Should -Be 4564903
-        $results.Link -match "download.windowsupdate.com"
-        $results.Title -match "Cumulative Update"
-    }
-
-    It "Call with multiple KBs" {
-        $results = Get-DbaKbUpdate -Name KB4057119, KB4577194, KB4564903
-
-        # basic retry logic in case the first download didn't get all of the files
-        if ($null -eq $results -or $results.Count -ne 3) {
-            Write-Message -Level Warning -Message "Retrying..."
-            Start-Sleep -s 30
-            $results = Get-DbaKbUpdate -Name KB4057119, KB4577194, KB4564903
+    Context "Querying the Microsoft Update Catalog" -Skip:(-not $catalogReachable) {
+        It "successfully connects and parses link and title" {
+            $results = Get-DbaKbUpdate -Name KB4057119
+            $results.Link -match "download.windowsupdate.com"
+            $results.Title -match "Cumulative Update"
+            $results.KBLevel | Should -Be 4057119
         }
 
-        $results.KBLevel | Should -Contain 4057119
-        $results.KBLevel | Should -Contain 4577194
-        $results.KBLevel | Should -Contain 4564903
-    }
+        It "test with the -Simple param" {
+            $results = Get-DbaKbUpdate -Name KB4577194 -Simple
+            $results.Link -match "download.windowsupdate.com"
+            $results.Title -match "Cumulative Update"
+            $results.KBLevel | Should -Be 4577194
+        }
 
-    It "Call without specific language" {
-        $results = Get-DbaKbUpdate -Name KB5003279
-        $results.KBLevel | Should -Be 5003279
-        $results.Classification -match "Service Packs"
-        $results.Link -match "-enu_"
-    }
+        # see https://github.com/dataplat/dbatools/issues/6745
+        It "Calling script uses a variable named filter" {
+            $filter = "SQLServer*-KB-*x64*.exe"
 
-    It "Call with specific language" {
-        $results = Get-DbaKbUpdate -Name KB5003279 -Language ja
-        $results.KBLevel | Should -Be 5003279
-        $results.Classification -match "Service Packs"
-        $results.Link -match "-jpn_"
+            $results = Get-DbaKbUpdate -Name KB4564903
+            $results.KBLevel | Should -Be 4564903
+            $results.Link -match "download.windowsupdate.com"
+            $results.Title -match "Cumulative Update"
+        }
+
+        It "Call with multiple KBs" {
+            $results = Get-DbaKbUpdate -Name KB4057119, KB4577194, KB4564903
+
+            # basic retry logic in case the first download didn't get all of the files
+            if ($null -eq $results -or $results.Count -ne 3) {
+                Write-Message -Level Warning -Message "Retrying..."
+                Start-Sleep -s 30
+                $results = Get-DbaKbUpdate -Name KB4057119, KB4577194, KB4564903
+            }
+
+            $results.KBLevel | Should -Contain 4057119
+            $results.KBLevel | Should -Contain 4577194
+            $results.KBLevel | Should -Contain 4564903
+        }
+
+        It "Call without specific language" {
+            $results = Get-DbaKbUpdate -Name KB5003279
+            $results.KBLevel | Should -Be 5003279
+            $results.Classification -match "Service Packs"
+            $results.Link -match "-enu_"
+        }
+
+        It "Call with specific language" {
+            $results = Get-DbaKbUpdate -Name KB5003279 -Language ja
+            $results.KBLevel | Should -Be 5003279
+            $results.Classification -match "Service Packs"
+            $results.Link -match "-jpn_"
+        }
     }
 }

--- a/tests/Get-DbaOperatingSystem.Tests.ps1
+++ b/tests/Get-DbaOperatingSystem.Tests.ps1
@@ -22,7 +22,7 @@ Describe $CommandName -Tag UnitTests {
     Context "Validate input" {
         It "Cannot resolve hostname of computer" {
             Mock Resolve-DbaNetworkName { $null }
-            { Get-DbaOperatingSystem -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw
+            { Get-DbaOperatingSystem -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw -ExpectedMessage "*DNS name DoesNotExist142 not found*"
         }
     }
 }

--- a/tests/Get-DbaService.Tests.ps1
+++ b/tests/Get-DbaService.Tests.ps1
@@ -27,7 +27,7 @@ Describe $CommandName -Tag UnitTests {
     Context "Validate input" {
         It "Cannot resolve hostname of computer" {
             Mock Resolve-DbaNetworkName { $null }
-            { Get-DbaService -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw
+            { Get-DbaService -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw -ExpectedMessage "*DNS name DoesNotExist142 not found*"
         }
     }
 }

--- a/tests/Get-XpDirTreeRestoreFile.Tests.ps1
+++ b/tests/Get-XpDirTreeRestoreFile.Tests.ps1
@@ -15,13 +15,13 @@ Describe $CommandName -Tag UnitTests {
         Context "Test Connection and User Rights" {
             It "Should throw on an invalid SQL Connection" {
                 #mock Test-SQLConnection {(1..12) | %{[System.Collections.ArrayList]$t += @{ConnectSuccess = $false}}}
-                Mock Connect-DbaInstance { throw }
-                { Get-XpDirTreeRestoreFile -path c:\dummy -SqlInstance bad\bad -EnableException } | Should -Throw
+                Mock Connect-DbaInstance { throw "Mocked connection failure" }
+                { Get-XpDirTreeRestoreFile -path c:\dummy -SqlInstance bad\bad -EnableException } | Should -Throw -ExpectedMessage "Mocked connection failure"
             }
             It "Should throw if SQL Server can't see the path" {
                 Mock Test-DbaPath { $false }
                 Mock Connect-DbaInstance { [DbaInstanceParameter]"bad\bad" }
-                { Get-XpDirTreeRestoreFile -path c:\dummy -SqlInstance bad\bad -EnableException } | Should -Throw
+                { Get-XpDirTreeRestoreFile -path c:\dummy -SqlInstance bad\bad -EnableException } | Should -Throw -ExpectedMessage "*cannot access c:\dummy*"
             }
         }
         Context "Non recursive filestructure" {

--- a/tests/Save-DbaKbUpdate.Tests.ps1
+++ b/tests/Save-DbaKbUpdate.Tests.ps1
@@ -44,6 +44,27 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
+    # Save-DbaKbUpdate resolves the KB through Get-DbaKbUpdate, so these tests query the Microsoft
+    # Update Catalog as well. If that site does not answer, every one of them needs 100 seconds to
+    # time out and then fails for a reason that has nothing to do with dbatools. So we probe the
+    # catalog once here and skip the tests if it does not answer. We only skip if it is provably
+    # down - if it answers, the tests run as before and a real regression still fails them.
+    #
+    # We have to probe the search page and not the start page: on 2026-07-31 the start page answered
+    # in one second while every search timed out, so a probe of the start page would not have helped.
+    # The same probe is used in Get-DbaKbUpdate.Tests.ps1.
+    try {
+        $splatCatalog = @{
+            Uri             = "https://www.catalog.update.microsoft.com/Search.aspx?q=KB2992080"
+            UseBasicParsing = $true
+            TimeoutSec      = 30
+            ErrorAction     = "Stop"
+        }
+        $catalogReachable = (Invoke-WebRequest @splatCatalog).StatusCode -eq 200
+    } catch {
+        $catalogReachable = $false
+    }
+
     BeforeAll {
         # Create unique temp path for this test run to avoid conflicts
         $tempPath = "$($TestConfig.Temp)\$CommandName-$(Get-Random)"
@@ -55,57 +76,59 @@ Describe $CommandName -Tag IntegrationTests {
         Remove-Item -Path $tempPath -Recurse -ErrorAction SilentlyContinue
     }
 
-    It "downloads a small update" {
-        $results = Save-DbaKbUpdate -Name KB2992080 -Architecture All -Path $tempPath
-        $results.Name -match "aspnet"
-        $filesToRemove += $results.FullName
-    }
+    Context "Downloading from the Microsoft Update Catalog" -Skip:(-not $catalogReachable) {
+        It "downloads a small update" {
+            $results = Save-DbaKbUpdate -Name KB2992080 -Architecture All -Path $tempPath
+            $results.Name -match "aspnet"
+            $filesToRemove += $results.FullName
+        }
 
-    It "supports piping" {
-        $results = Get-DbaKbUpdate -Name KB2992080 | Select-Object -First 1 | Save-DbaKbUpdate -Architecture All -Path $tempPath
-        $results.Name -match "aspnet"
-        $filesToRemove += $results.FullName
-    }
+        It "supports piping" {
+            $results = Get-DbaKbUpdate -Name KB2992080 | Select-Object -First 1 | Save-DbaKbUpdate -Architecture All -Path $tempPath
+            $results.Name -match "aspnet"
+            $filesToRemove += $results.FullName
+        }
 
-    It "Download multiple updates" {
-        $results = Save-DbaKbUpdate -Name KB2992080, KB4513696 -Architecture All -Path $tempPath
-
-        # basic retry logic in case the first download didn't get all of the files
-        if ($null -eq $results -or $results.Count -ne 2) {
-            Write-Message -Level Warning -Message "Retrying..."
-            if ($results.Count -gt 0) {
-                $filesToRemove += $results.FullName
-            }
-            Start-Sleep -s 30
+        It "Download multiple updates" {
             $results = Save-DbaKbUpdate -Name KB2992080, KB4513696 -Architecture All -Path $tempPath
-        }
 
-        $results.Count | Should -Be 2
-        $filesToRemove += $results.FullName
-
-        # download multiple updates via piping
-        $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Architecture All -Path $tempPath
-
-        # basic retry logic in case the first download didn't get all of the files
-        if ($null -eq $results -or $results.Count -ne 2) {
-            Write-Message -Level Warning -Message "Retrying..."
-            if ($results.Count -gt 0) {
-                $filesToRemove += $results.FullName
+            # basic retry logic in case the first download didn't get all of the files
+            if ($null -eq $results -or $results.Count -ne 2) {
+                Write-Message -Level Warning -Message "Retrying..."
+                if ($results.Count -gt 0) {
+                    $filesToRemove += $results.FullName
+                }
+                Start-Sleep -s 30
+                $results = Save-DbaKbUpdate -Name KB2992080, KB4513696 -Architecture All -Path $tempPath
             }
-            Start-Sleep -s 30
+
+            $results.Count | Should -Be 2
+            $filesToRemove += $results.FullName
+
+            # download multiple updates via piping
             $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Architecture All -Path $tempPath
+
+            # basic retry logic in case the first download didn't get all of the files
+            if ($null -eq $results -or $results.Count -ne 2) {
+                Write-Message -Level Warning -Message "Retrying..."
+                if ($results.Count -gt 0) {
+                    $filesToRemove += $results.FullName
+                }
+                Start-Sleep -s 30
+                $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Architecture All -Path $tempPath
+            }
+
+            $results.Count | Should -Be 2
+            $filesToRemove += $results.FullName
         }
 
-        $results.Count | Should -Be 2
-        $filesToRemove += $results.FullName
-    }
+        # see https://github.com/dataplat/dbatools/issues/6745
+        It "Ensuring that variable scope doesn't impact the command negatively" {
+            $filter = "SQLServer*-KB-*x64*.exe"
 
-    # see https://github.com/dataplat/dbatools/issues/6745
-    It "Ensuring that variable scope doesn't impact the command negatively" {
-        $filter = "SQLServer*-KB-*x64*.exe"
-
-        $results = Save-DbaKbUpdate -Name KB4513696 -Architecture All -Path $tempPath
-        $results.Count | Should -Be 1
-        $filesToRemove += $results.FullName
+            $results = Save-DbaKbUpdate -Name KB4513696 -Architecture All -Path $tempPath
+            $results.Count | Should -Be 1
+            $filesToRemove += $results.FullName
+        }
     }
 }

--- a/tests/Test-DbaDbRecoveryModel.Tests.ps1
+++ b/tests/Test-DbaDbRecoveryModel.Tests.ps1
@@ -90,13 +90,15 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "Should Throw Error for a DB Connection Error" {
-            Mock Connect-DbaInstance { Throw } -ModuleName dbatools
-            { Test-DbaDbRecoveryModel -SqlInstance $TestConfig.InstanceSingle -EnableException } | Should -Throw
+            # The mock throws a distinctive message, so we can be sure that the command failed while connecting and not somewhere else.
+            Mock Connect-DbaInstance { throw "Mocked connection failure" } -ModuleName dbatools
+            { Test-DbaDbRecoveryModel -SqlInstance $TestConfig.InstanceSingle -EnableException } | Should -Throw -ExpectedMessage "Mocked connection failure"
         }
 
         It "Should Throw Error for Output Error" {
-            Mock Select-DefaultView { Throw } -ModuleName dbatools
-            { Test-DbaDbRecoveryModel -SqlInstance $TestConfig.InstanceSingle -EnableException } | Should -Throw
+            # The mock throws a distinctive message, so we can be sure that the command really got as far as the output.
+            Mock Select-DefaultView { throw "Mocked output failure" } -ModuleName dbatools
+            { Test-DbaDbRecoveryModel -SqlInstance $TestConfig.InstanceSingle -EnableException } | Should -Throw -ExpectedMessage "Mocked output failure"
         }
     }
 

--- a/tests/Test-DbaPath.Tests.ps1
+++ b/tests/Test-DbaPath.Tests.ps1
@@ -63,7 +63,7 @@ Describe $CommandName -Tag UnitTests {
             }
 
             It "Honors EnableException when xp_fileexist execution fails" {
-                { Test-DbaPath -SqlInstance "sql1" -Path "C:\temp\file1.bak" -EnableException } | Should -Throw
+                { Test-DbaPath -SqlInstance "sql1" -Path "C:\temp\file1.bak" -EnableException } | Should -Throw -ExpectedMessage "*xp_fileexist*"
             }
         }
     }


### PR DESCRIPTION
Follow-up to #10473. While fixing the mocks there it turned out that both tests of `Get-DbaStartupParameter` had been passing for the wrong reason: they only asserted `Should -Throw`, so the error about a service that was not found satisfied them just as well as the error the test name describes. A survey of the whole test suite found 116 `Should -Throw` assertions, 47 of them without any expected message. Most of those are fine, because they test parameter validation and nothing else can run before the throw. Nine of them are not.

### The nine

| File | Test |
| --- | --- |
| `Test-DbaDbRecoveryModel` | Should Throw Error for a DB Connection Error |
| `Test-DbaDbRecoveryModel` | Should Throw Error for Output Error |
| `Get-XpDirTreeRestoreFile` | Should throw on an invalid SQL Connection |
| `Get-XpDirTreeRestoreFile` | Should throw if SQL Server can't see the path |
| `Test-DbaPath` | Honors EnableException when xp_fileexist execution fails |
| `Get-DbaComputerSystem` | Cannot resolve hostname of computer |
| `Get-DbaOperatingSystem` | Cannot resolve hostname of computer |
| `Get-DbaService` | Cannot resolve hostname of computer |
| `Get-DbaStartupParameter` | (both, already done in #10473) |

### Changes

`Test-DbaDbRecoveryModel` and `Get-XpDirTreeRestoreFile` mocked a command with a bare `throw`, which produces the message `ScriptHalted` for every one of them - two tests that describe two different failures asserted on the very same indistinguishable message. The mocks now throw a distinctive message and the test asserts on it.

The other tests assert on the message the command really produces. All messages were captured from an actual run first, not guessed:

* `Test-DbaPath` -> `*xp_fileexist*`
* `Get-XpDirTreeRestoreFile` (path) -> `*cannot access c:\dummy*`
* the three hostname tests -> `*DNS name DoesNotExist142 not found*`

### Proof that this helps

With both mocks of `Test-DbaDbRecoveryModel` in place at the same time, so that the command dies while connecting and never reaches the output:

```
[+] OLD assertion passes even though it died at connect, not at output
[-] NEW assertion fails because it died at connect, not at output
    Expected an exception with message like 'Mocked output failure' to be thrown,
    but the message was 'Mocked connection failure'.
```

### Also in here

`Get-DbaBuild` had the same test for `Build` and `SqlInstance` twice, with identical bodies. The second one now covers `Kb` and `SqlInstance`, which was the only pair of mutually exclusive parameters without a test. Its name does not use single quotes like the tests around it, because the style check of the repository does not allow them.

### Not changed

The three hostname tests contain `Mock Resolve-DbaNetworkName { $null }` without `-ModuleName dbatools`. The mock therefore never applies to the command inside the module, and the tests really depend on DNS failing for `DoesNotExist142` - which is what the new expected message documents. Making those mocks effective is a separate change and not a trivial one: with a working mock `Get-DbaService` does not throw at all any more.

### Tests

All seven test files were run against a lab instance, unit and integration, everything passes and the lab is left clean. The structural checks report only the nine failures that already exist in other files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Also: stop an external outage from failing unrelated PRs

`Get-DbaKbUpdate.Tests.ps1` queries the Microsoft Update Catalog. When that site does not answer, each of its six tests waits 100 seconds for the default timeout of `Invoke-WebRequest` and then fails. With the three attempts of the CI that is half an hour of red build for a reason that has nothing to do with dbatools. The file is in no group of `pester.groups.ps1`, so it runs in the `default` scenario of every single pull request - it turned this PR red while the catalog was down, and it would do the same to anyone else.

The tests now run inside a context that is skipped when the catalog does not answer. We only skip when it is provably down: if the catalog answers, the tests run exactly as before and a real regression still fails them.

One detail worth keeping: the probe asks for the **search** page, not the start page. While writing this the start page answered in one second while every search timed out, so a probe of the start page would have skipped nothing. My first attempt did exactly that and the tests still ran into their timeouts.

Measured against the live outage:

| | before | after |
| --- | --- | --- |
| result | failed | passed, 6 skipped |
| duration | ~30 min over 3 attempts | 31 s |

And verified the other direction with the same code shape pointed at an endpoint that does answer: 1 passed, 0 skipped - so the skip is conditional and does not silently swallow the suite.
