### PR TITLE
Sync-DbaAvailabilityGroup - Open one shared dedicated admin connection instead of three

### DIFF
--- a/private/functions/Test-DacConnection.ps1
+++ b/private/functions/Test-DacConnection.ps1
@@ -1,0 +1,66 @@
+function Test-DacConnection {
+    <#
+    .SYNOPSIS
+        Internal function.
+
+    .DESCRIPTION
+        Tests whether a connection that was passed in is already a dedicated admin connection (DAC).
+
+        SQL Server only allows one DAC per instance, so commands that need a DAC to decrypt passwords
+        have to reuse an existing one instead of opening a second one. Connect-DbaInstance prefixes the
+        server name with "ADMIN:" when -DedicatedAdminConnection is used, so that prefix is what marks
+        a connection as a DAC.
+
+        This function is used by the following public functions:
+        - Copy-DbaCredential
+        - Copy-DbaDbMail
+        - Copy-DbaLinkedServer
+        - Export-DbaCredential
+        - Export-DbaInstance
+        - Export-DbaLinkedServer
+        - Invoke-DbaDbDecryptObject
+        - Start-DbaMigration
+        - Sync-DbaAvailabilityGroup
+
+    .PARAMETER InputObject
+        The connection to test. Accepts a DbaInstanceParameter (as used by the SqlInstance and Source
+        parameters of the public commands) or an SMO server object. Anything that is not a connection
+        to an already connected instance returns $false.
+
+    .NOTES
+        Tags: Connection, DAC
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .EXAMPLE
+        Test-DacConnection -InputObject $Source
+
+        Returns $true if $Source is a server object that is connected via a dedicated admin connection.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [AllowNull()]
+        $InputObject
+    )
+
+    if ($null -eq $InputObject) {
+        return $false
+    }
+
+    if ($InputObject.GetType().FullName -eq "Dataplat.Dbatools.Parameter.DbaInstanceParameter") {
+        # Only a DbaInstanceParameter of type Server holds an already connected server object
+        if ($InputObject.Type -ne "Server") {
+            return $false
+        }
+        $server = $InputObject.InputObject
+    } else {
+        $server = $InputObject
+    }
+
+    # Depending on how the connection was built, the "ADMIN:" prefix is visible on the server object, on the connection context, or both
+    return [bool]($server.Name -match "^ADMIN:" -or $server.ConnectionContext.ServerInstance -match "^ADMIN:")
+}

--- a/public/Copy-DbaCredential.ps1
+++ b/public/Copy-DbaCredential.ps1
@@ -156,7 +156,7 @@ function Copy-DbaCredential {
             if ($ExcludePassword) { $dacNeeded = $false } else { $dacNeeded = $true }
 
             # Do we have a dedicated admin connection already?
-            $dacConnected = $Source.Type -eq 'Server' -and $Source.InputObject.Name -match '^ADMIN:'
+            $dacConnected = Test-DacConnection -InputObject $Source
 
             $dacOpened = $false
             if ($dacNeeded) {

--- a/public/Copy-DbaDbMail.ps1
+++ b/public/Copy-DbaDbMail.ps1
@@ -390,7 +390,7 @@ function Copy-DbaDbMail {
             if ($ExcludePassword) { $dacNeeded = $false } else { $dacNeeded = $true }
 
             # Do we have a dedicated admin connection already?
-            $dacConnected = $Source.Type -eq 'Server' -and $Source.InputObject.Name -match '^ADMIN:'
+            $dacConnected = Test-DacConnection -InputObject $Source
 
             $dacOpened = $false
             if ($dacNeeded) {

--- a/public/Copy-DbaLinkedServer.ps1
+++ b/public/Copy-DbaLinkedServer.ps1
@@ -329,7 +329,7 @@ function Copy-DbaLinkedServer {
             if ($ExcludePassword) { $dacNeeded = $false } else { $dacNeeded = $true }
 
             # Do we have a dedicated admin connection already?
-            $dacConnected = $Source.Type -eq 'Server' -and $Source.InputObject.Name -match '^ADMIN:'
+            $dacConnected = Test-DacConnection -InputObject $Source
 
             $dacOpened = $false
             if ($dacNeeded) {

--- a/public/Export-DbaCredential.ps1
+++ b/public/Export-DbaCredential.ps1
@@ -115,7 +115,7 @@ function Export-DbaCredential {
                 if ($ExcludePassword) { $dacNeeded = $false } else { $dacNeeded = $true }
 
                 # Do we have a dedicated admin connection already?
-                $dacConnected = $instance.Type -eq 'Server' -and $instance.InputObject.Name -match '^ADMIN:'
+                $dacConnected = Test-DacConnection -InputObject $instance
 
                 $dacOpened = $false
                 if ($dacNeeded) {

--- a/public/Export-DbaInstance.ps1
+++ b/public/Export-DbaInstance.ps1
@@ -283,7 +283,7 @@ function Export-DbaInstance {
                     if ($ExcludePassword) { $dacNeeded = $false }
 
                     # Do we have a dedicated admin connection already?
-                    $dacConnected = $instance.Type -eq 'Server' -and $instance.InputObject.Name -match '^ADMIN:'
+                    $dacConnected = Test-DacConnection -InputObject $instance
 
                     if ($dacNeeded) {
                         if ($dacConnected) {

--- a/public/Export-DbaLinkedServer.ps1
+++ b/public/Export-DbaLinkedServer.ps1
@@ -129,7 +129,7 @@ function Export-DbaLinkedServer {
                 if ($ExcludePassword) { $dacNeeded = $false } else { $dacNeeded = $true }
 
                 # Do we have a dedicated admin connection already?
-                $dacConnected = $instance.Type -eq 'Server' -and $instance.InputObject.Name -match '^ADMIN:'
+                $dacConnected = Test-DacConnection -InputObject $instance
 
                 $dacOpened = $false
                 if ($dacNeeded) {

--- a/public/Invoke-DbaDbDecryptObject.ps1
+++ b/public/Invoke-DbaDbDecryptObject.ps1
@@ -198,7 +198,7 @@ function Invoke-DbaDbDecryptObject {
             # Try to connect to instance
             try {
                 # Do we have a dedicated admin connection already?
-                $dacConnected = $instance.Type -eq "Server" -and $instance.InputObject.ConnectionContext.ServerInstance -match "^ADMIN:"
+                $dacConnected = Test-DacConnection -InputObject $instance
                 $dacOpened = $false
                 if ($dacConnected) {
                     Write-Message -Level Verbose -Message "Reusing dedicated admin connection."

--- a/public/Start-DbaMigration.ps1
+++ b/public/Start-DbaMigration.ps1
@@ -367,7 +367,7 @@ function Start-DbaMigration {
             if ($ExcludePassword) { $dacNeeded = $false }
 
             # Do we have a dedicated admin connection already?
-            $dacConnected = $Source.Type -eq "Server" -and $Source.InputObject.ConnectionContext.ServerInstance -match "^ADMIN:"
+            $dacConnected = Test-DacConnection -InputObject $Source
 
             $dacOpened = $false
             if ($dacNeeded) {

--- a/public/Sync-DbaAvailabilityGroup.ps1
+++ b/public/Sync-DbaAvailabilityGroup.ps1
@@ -28,6 +28,8 @@ function Sync-DbaAvailabilityGroup {
 
         The command copies ALL objects of each enabled type - it doesn't filter based on which objects are actually used by the availability group databases. Use the exclusion parameters to limit scope when needed.
 
+        Copying credentials, database mail accounts and linked servers includes the stored passwords, and decrypting those requires a dedicated admin connection (DAC) to the primary. As SQL Server only allows one DAC per instance, this command opens a single DAC and hands it to all three of those copy operations instead of letting each of them open its own. Use -ExcludePassword if no DAC should be opened at all.
+
     .PARAMETER Primary
         The primary replica SQL Server instance for the availability group. This is the source server from which all server-level objects will be copied.
         Required when not using InputObject parameter. Server version must be SQL Server 2012 or higher.
@@ -199,6 +201,21 @@ function Sync-DbaAvailabilityGroup {
             }
         }
 
+        # If we already got a dedicated admin connection, we reuse it for the commands that need it.
+        # As the DAC is a single restricted session, we open an additional normal connection for all the other commands.
+        $serverDac = $null
+        if (Test-DacConnection -InputObject $server) {
+            Write-Message -Level Verbose -Message "Reusing dedicated admin connection for password retrieval."
+            $serverDac = $server
+            try {
+                Write-Message -Level Verbose -Message "Opening additional normal connection for all commands that don't require a dedicated admin connection."
+                $server = Connect-DbaInstance -SqlInstance $serverDac.DomainInstanceName -SqlCredential $PrimarySqlCredential
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $serverDac.DomainInstanceName
+                return
+            }
+        }
+
         if ($AvailabilityGroup) {
             $InputObject += Get-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $AvailabilityGroup
         }
@@ -220,8 +237,9 @@ function Sync-DbaAvailabilityGroup {
         }
 
         $thiscombo = [PSCustomObject]@{
-            PrimaryServer   = $server
-            SecondaryServer = $secondaries
+            PrimaryServer    = $server
+            PrimaryServerDac = $serverDac
+            SecondaryServer  = $secondaries
         }
 
         # In the event that someone pipes in an availability group, this will keep the sync from running a bunch of times
@@ -245,6 +263,7 @@ function Sync-DbaAvailabilityGroup {
         # now that all combinations have been figured out, begin sync without duplicating work
         foreach ($ag in $allcombos) {
             $server = $ag.PrimaryServer
+            $serverDac = $ag.PrimaryServerDac
             $secondaries = $ag.SecondaryServer
 
             $stepCounter = 0
@@ -282,19 +301,47 @@ function Sync-DbaAvailabilityGroup {
                 Copy-DbaCustomError -Source $server -Destination $secondaries -Force:$Force
             }
 
+            # Do we need a dedicated admin connection to the primary for password retrieval?
+            # If not all of the three are excluded, we do. If passwords are excluded, we don't.
+            $dacNeeded = -not $ExcludePassword -and ($Exclude -notcontains "Credentials" -or $Exclude -notcontains "DatabaseMail" -or $Exclude -notcontains "LinkedServers")
+
+            # We open the DAC as late as possible and close it as early as possible, because SQL Server only allows one DAC per instance.
+            $dacOpened = $false
+            if ($dacNeeded -and -not $serverDac) {
+                Write-Message -Level Verbose -Message "Opening dedicated admin connection for password retrieval."
+                $serverDac = Connect-DbaInstance -SqlInstance $server -SqlCredential $PrimarySqlCredential -DedicatedAdminConnection -WarningAction SilentlyContinue
+                if ($serverDac) {
+                    $dacOpened = $true
+                } else {
+                    Write-Message -Level Warning -Message "Could not establish dedicated admin connection to $server, so the commands that copy passwords will try to open their own. Use -ExcludePassword to skip the passwords."
+                }
+            }
+
+            # The commands that copy passwords use the dedicated admin connection, all the others use the normal connection.
+            if ($serverDac) {
+                $passwordServer = $serverDac
+            } else {
+                $passwordServer = $server
+            }
+
             if ($Exclude -notcontains "Credentials") {
                 Write-ProgressHelper -Activity $activity -StepNumber ($stepCounter++) -Message "Syncing SQL credentials"
-                Copy-DbaCredential -Source $server -Destination $secondaries -Credential $Credential -ExcludePassword:$ExcludePassword -Force:$Force
+                Copy-DbaCredential -Source $passwordServer -Destination $secondaries -Credential $Credential -ExcludePassword:$ExcludePassword -Force:$Force
             }
 
             if ($Exclude -notcontains "DatabaseMail") {
                 Write-ProgressHelper -Activity $activity -StepNumber ($stepCounter++) -Message "Syncing database mail"
-                Copy-DbaDbMail -Source $server -Destination $secondaries -Credential $Credential -ExcludePassword:$ExcludePassword -Force:$Force
+                Copy-DbaDbMail -Source $passwordServer -Destination $secondaries -Credential $Credential -ExcludePassword:$ExcludePassword -Force:$Force
             }
 
             if ($Exclude -notcontains "LinkedServers") {
                 Write-ProgressHelper -Activity $activity -StepNumber ($stepCounter++) -Message "Syncing linked servers"
-                Copy-DbaLinkedServer -Source $server -Destination $secondaries -Credential $Credential -ExcludePassword:$ExcludePassword -Force:$Force
+                Copy-DbaLinkedServer -Source $passwordServer -Destination $secondaries -Credential $Credential -ExcludePassword:$ExcludePassword -Force:$Force
+            }
+
+            # Disconnect is important because it is a DAC, but only if we opened it ourselves.
+            if ($dacOpened) {
+                $null = $serverDac | Disconnect-DbaInstance -WhatIf:$false
             }
 
             if ($Exclude -notcontains "SystemTriggers") {

--- a/tests/Sync-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/Sync-DbaAvailabilityGroup.Tests.ps1
@@ -33,7 +33,7 @@ Describe $CommandName -Tag UnitTests {
     }
 
     Context "Connection behavior" {
-        It "Should let Copy-DbaCredential manage dedicated admin connections" {
+        It "Should open one dedicated admin connection and share it with all password-aware copy commands" {
             InModuleScope "dbatools" {
                 function Test-FunctionInterrupt { $false }
                 function Write-ProgressHelper { }
@@ -45,12 +45,27 @@ Describe $CommandName -Tag UnitTests {
                     )
 
                     if ($DedicatedAdminConnection) {
-                        $script:dacConnections += $SqlInstance.ToString()
+                        $script:dacConnections += $SqlInstance.Name
+                        [PSCustomObject]@{
+                            Name               = "ADMIN:$($SqlInstance.Name)"
+                            DomainInstanceName = $SqlInstance.DomainInstanceName
+                        }
+                    } else {
+                        [PSCustomObject]@{
+                            Name               = $SqlInstance.ToString()
+                            DomainInstanceName = $SqlInstance.ToString()
+                        }
                     }
+                }
+                function Disconnect-DbaInstance {
+                    [CmdletBinding(SupportsShouldProcess)]
+                    param(
+                        [Parameter(ValueFromPipeline)]
+                        $InputObject
+                    )
 
-                    [PSCustomObject]@{
-                        Name               = $SqlInstance.ToString()
-                        DomainInstanceName = $SqlInstance.ToString()
+                    process {
+                        $script:disconnectedConnections += $InputObject.Name
                     }
                 }
                 function Copy-DbaCredential {
@@ -69,8 +84,136 @@ Describe $CommandName -Tag UnitTests {
                         ExcludePassword = $ExcludePassword.IsPresent
                     }
                 }
+                function Copy-DbaDbMail {
+                    param(
+                        $Source,
+                        $Destination,
+                        $Credential,
+                        [switch]$ExcludePassword,
+                        [switch]$Force
+                    )
+
+                    $script:copyDbMailCall = [PSCustomObject]@{
+                        Source = $Source
+                    }
+                }
+                function Copy-DbaLinkedServer {
+                    param(
+                        $Source,
+                        $Destination,
+                        $Credential,
+                        [switch]$ExcludePassword,
+                        [switch]$Force
+                    )
+
+                    $script:copyLinkedServerCall = [PSCustomObject]@{
+                        Source = $Source
+                    }
+                }
 
                 $script:dacConnections = @()
+                $script:disconnectedConnections = @()
+                $script:copyCredentialCall = $null
+                $script:copyDbMailCall = $null
+                $script:copyLinkedServerCall = $null
+
+                $exclude = @(
+                    "AgentAlert",
+                    "AgentCategory",
+                    "AgentJob",
+                    "AgentOperator",
+                    "AgentProxy",
+                    "AgentSchedule",
+                    "CustomErrors",
+                    "DatabaseOwner",
+                    "LoginPermissions",
+                    "Logins",
+                    "SpConfigure",
+                    "SystemTriggers"
+                )
+                $securePassword = ConvertTo-SecureString "Password1!" -AsPlainText -Force
+                $credential = New-Object System.Management.Automation.PSCredential("contoso\syncuser", $securePassword)
+
+                $null = Sync-DbaAvailabilityGroup -Primary "sql1" -Secondary "sql2" -Credential $credential -Exclude $exclude
+
+                $script:dacConnections.Count | Should -Be 1
+                $script:dacConnections[0] | Should -Be "sql1"
+                $script:copyCredentialCall.Source.Name | Should -Be "ADMIN:sql1"
+                $script:copyDbMailCall.Source.Name | Should -Be "ADMIN:sql1"
+                $script:copyLinkedServerCall.Source.Name | Should -Be "ADMIN:sql1"
+                $script:disconnectedConnections.Count | Should -Be 1
+                $script:disconnectedConnections[0] | Should -Be "ADMIN:sql1"
+                $script:copyCredentialCall.Credential.UserName | Should -Be "contoso\syncuser"
+                $script:copyCredentialCall.ExcludePassword | Should -BeFalse
+            }
+        }
+
+        It "Should reuse a dedicated admin connection that is already open and use a normal connection for the other commands" {
+            InModuleScope "dbatools" {
+                function Test-FunctionInterrupt { $false }
+                function Write-ProgressHelper { }
+                function Connect-DbaInstance {
+                    param(
+                        $SqlInstance,
+                        $SqlCredential,
+                        [switch]$DedicatedAdminConnection
+                    )
+
+                    if ($DedicatedAdminConnection) {
+                        $script:dacConnections += $SqlInstance.Name
+                    }
+
+                    if ($SqlInstance.ToString() -eq "sql1") {
+                        # Simulates a primary that the user has already connected to with -DedicatedAdminConnection
+                        [PSCustomObject]@{
+                            Name               = "ADMIN:sql1"
+                            DomainInstanceName = "sql1.contoso.com"
+                        }
+                    } else {
+                        [PSCustomObject]@{
+                            Name               = $SqlInstance.ToString()
+                            DomainInstanceName = $SqlInstance.ToString()
+                        }
+                    }
+                }
+                function Disconnect-DbaInstance {
+                    [CmdletBinding(SupportsShouldProcess)]
+                    param(
+                        [Parameter(ValueFromPipeline)]
+                        $InputObject
+                    )
+
+                    process {
+                        $script:disconnectedConnections += $InputObject.Name
+                    }
+                }
+                function Copy-DbaSpConfigure {
+                    param(
+                        $Source,
+                        $Destination
+                    )
+
+                    $script:copySpConfigureCall = [PSCustomObject]@{
+                        Source = $Source
+                    }
+                }
+                function Copy-DbaCredential {
+                    param(
+                        $Source,
+                        $Destination,
+                        $Credential,
+                        [switch]$ExcludePassword,
+                        [switch]$Force
+                    )
+
+                    $script:copyCredentialCall = [PSCustomObject]@{
+                        Source = $Source
+                    }
+                }
+
+                $script:dacConnections = @()
+                $script:disconnectedConnections = @()
+                $script:copySpConfigureCall = $null
                 $script:copyCredentialCall = $null
 
                 $exclude = @(
@@ -86,17 +229,15 @@ Describe $CommandName -Tag UnitTests {
                     "LinkedServers",
                     "LoginPermissions",
                     "Logins",
-                    "SpConfigure",
                     "SystemTriggers"
                 )
-                $securePassword = ConvertTo-SecureString "Password1!" -AsPlainText -Force
-                $credential = New-Object System.Management.Automation.PSCredential("contoso\syncuser", $securePassword)
 
-                $null = Sync-DbaAvailabilityGroup -Primary "sql1" -Secondary "sql2" -Credential $credential -Exclude $exclude
+                $null = Sync-DbaAvailabilityGroup -Primary "sql1" -Secondary "sql2" -Exclude $exclude
 
                 $script:dacConnections | Should -BeNullOrEmpty
-                $script:copyCredentialCall.Credential.UserName | Should -Be "contoso\syncuser"
-                $script:copyCredentialCall.ExcludePassword | Should -BeFalse
+                $script:copyCredentialCall.Source.Name | Should -Be "ADMIN:sql1"
+                $script:copySpConfigureCall.Source.Name | Should -Be "sql1.contoso.com"
+                $script:disconnectedConnections | Should -BeNullOrEmpty
             }
         }
 


### PR DESCRIPTION
Fixes #10467

## Problem

`Sync-DbaAvailabilityGroup` passed the plain connection to `Copy-DbaCredential`, `Copy-DbaDbMail` and `Copy-DbaLinkedServer`, so the reuse detection in those three commands never triggered and each of them opened, used and closed its own dedicated admin connection. SQL Server allows only one DAC per instance, and three open/close cycles fired back-to-back intermittently failed with `An existing connection was forcibly closed by the remote host`, matching `Could not connect because the maximum number of '1' dedicated administrator connections already exists` in the error log of the primary.

This is a regression. The shared DAC was added in #10163 and removed again in #10346, which also added a unit test asserting that `Sync-DbaAvailabilityGroup` opens no DAC.

## Solution

`Sync-DbaAvailabilityGroup` opens a single DAC and passes it to all three commands, so their existing reuse detection triggers.

Not by restoring #10163 verbatim, though. That version replaced `$server` itself with the DAC, so every other command (`Copy-DbaSpConfigure`, `Copy-DbaLogin`, `Update-SqlDbOwner`, the agent copies, `Sync-DbaLoginPermission`) ran over the single restricted DAC session, and it made `Get-DbaAvailabilityGroup | Sync-DbaAvailabilityGroup` fail hard unless the caller had connected with `-DedicatedAdminConnection`. This PR follows the pattern that `Start-DbaMigration` already uses instead:

* `$server` stays a normal connection and keeps serving all the commands that do not need a DAC.
* A separate `$serverDac` is opened once and passed to the three password-aware commands.
* It is only opened when it is needed, meaning at least one of `Credentials`, `DatabaseMail` or `LinkedServers` is not excluded and `-ExcludePassword` is not set. It is opened directly before the credentials step and closed directly after the linked server step, so it is not held during the rest of the sync.
* A DAC that is already open, for example from `-Primary $dacServer` or from a piped availability group, is reused rather than replaced, and an additional normal connection is opened for everything else. No hard failure on the pipeline path.
* If the DAC cannot be opened, the command warns and lets the copy commands try on their own, which is what happens today. A DAC failure does not abort the whole sync.

The duplicated DAC detection in the affected commands is replaced by a new private function `Test-DacConnection`. It existed in two slightly different variants across eight commands, checking either `Name` or `ConnectionContext.ServerInstance`; the helper checks both, so detection can only get more reliable.

## Tests

The unit test that asserted no DAC is opened is inverted: exactly one DAC opened, the same connection passed to all three commands, one disconnect. A second test covers the reuse path: no new DAC, the DAC goes to the password commands, the normal connection goes to the others, and the caller's DAC is not disconnected.

Verified against real instances beyond the mocks. `Test-DacConnection` returns `$true` for a real DAC both as a server object and as a `DbaInstanceParameter`, and `$false` for a normal connection and for a plain instance name. An end-to-end run produces the intended trace:

```
[Sync-DbaAvailabilityGroup] Opening dedicated admin connection for password retrieval.
[Copy-DbaCredential]        Reusing dedicated admin connection for password retrieval.
[Copy-DbaDbMail]            Reusing dedicated admin connection for password retrieval.
[Copy-DbaLinkedServer]      Reusing dedicated admin connection for password retrieval.
[Disconnect-DbaInstance]    removing from connection hash
```

One DAC instead of three, no warnings. The reuse path was checked separately: `Copy-DbaSpConfigure` ran over the normal connection and the caller's DAC was still usable after the run.

## Note for the reporter

Going from three DAC connections to one materially reduces the exposure window, but it is worth being precise about what this does not prove. Each copy command already disconnected its DAC in its own `end` block and DAC connections are non-pooled, so three strictly sequential cycles should not normally collide unless the server-side teardown lags the client-side close or something else on the instance competes for the single DAC slot. If the error still shows up occasionally after this ships, the next thing to check is whether anything else grabs the DAC of the primary at that time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
