### PR TITLE
CLAUDE.md - Keep the (do ...) pattern out of pull request titles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,9 +172,9 @@ When adding a new command, register it in **TWO places**:
 1. **dbatools.psd1** - In the `FunctionsToExport` array
 2. **dbatools.psm1** - In the explicit command export section
 
-### Commit Messages and Pull Request Naming
+### Commit Messages
 
-**CRITICAL: Always include the `(do ...)` pattern** to limit CI test runs:
+**CRITICAL: Always include the `(do ...)` pattern in the commit message** to limit CI test runs:
 
 ```
 Get-DbaDatabase - Add support for filtering by recovery model
@@ -183,6 +183,14 @@ Get-DbaDatabase - Add support for filtering by recovery model
 ```
 
 For multiple commands: `(do *Login*)` or `(do *Backup*, *Restore*)`
+
+### Pull Request Naming
+
+**Do NOT put the `(do ...)` pattern in pull request titles.** On a pull request, CI derives the tests to run from the files the branch changed, so the marker adds nothing and only makes the title hard to read. Keep the title plain and descriptive:
+
+```
+Sync-DbaAvailabilityGroup - Open one shared dedicated admin connection instead of three
+```
 
 ### Pull Request Integration
 


### PR DESCRIPTION
`CLAUDE.md` currently puts commit messages and PR titles under one heading, "Commit Messages and Pull Request Naming", and says to always include the `(do ...)` marker. Reading it that way produces PR titles like the one #10475 was opened with:

```
Sync-DbaAvailabilityGroup - Open one shared dedicated admin connection instead of three (do Sync-DbaAvailabilityGroup, Start-DbaMigration, Export-DbaInstance, Invoke-DbaDbDecryptObject, *Credential*, *DbMail*, *LinkedServer*)
```

This splits the section in two: the rule for commit messages stays exactly as it is, and PR titles get their own rule saying to leave the marker out.

## Why

On a pull request the test set is already derived from the changed files. `tests/appveyor.common.ps1` collects the changed `public/*.ps1`, `private/functions/*.ps1` and `tests/*.Tests.ps1` of the branch, maps them to test files, and then expands that set with `Get-AllTestsIndications` to pick up dependencies. That runs whenever `APPVEYOR_PULL_REQUEST_NUMBER` is set, so it covers every PR build.

The `(do ...)` regex is applied afterwards, on top of that result. So on a PR the marker cannot widen the set, only narrow it - and if its patterns do not happen to cover every changed command, it silently removes tests that the changed-file detection had correctly selected.

Worth knowing when reviewing: for a `pull_request` event the message the regex reads is the **PR title**, not the commits on the branch. `ci-azure.yml` sets `DBATOOLS_COMMIT_MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title || inputs.message }}`, and `tests/gha.shim.ps1` splits that into `APPVEYOR_REPO_COMMIT_MESSAGE`. So a marker in the title is not merely cosmetic on a PR build, it is the thing that filters the already-narrowed set.

## One consequence to decide on

Squash merging uses the PR title as the first line of the commit on `development`. Dropping the marker from titles therefore also drops it from those commits, and a push to `development` has no PR number, so no changed-file detection - that build runs the full suite. Most merged commits in `development` already have no marker, so this looks like the current norm rather than a change, but it is your call whether that is what you want.

If you would rather keep the marker for that reason, the alternative is to keep it out of the *title* and put it in the PR *body*, which squash merging carries into the commit message body where the regex also reads it (`APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED`). Happy to change this PR to say that instead.

## Note

No CI run on this one: `ci-azure.yml` has `paths-ignore: "**/*.md"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
