### PR TITLE
Get-DbaKbUpdate - Add TimeoutSec so a silent update catalog cannot hang the command

### DIFF
--- a/public/Get-DbaKbUpdate.ps1
+++ b/public/Get-DbaKbUpdate.ps1
@@ -18,6 +18,10 @@ function Get-DbaKbUpdate {
         Filters results to show only updates for a specific language when multiple language versions exist. Service Packs typically have separate files per language, while Cumulative Updates usually include all languages in one file.
         Use this when you need updates for non-English environments or want to download language-specific packages. Accepts standard language codes like "en" for English, "de" for German, or "ja" for Japanese.
 
+    .PARAMETER TimeoutSec
+        Specifies how many seconds each request to the Microsoft Update Catalog may take before it is abandoned. Defaults to 30 seconds.
+        Use this when the catalog is slow or unreachable. Invoke-WebRequest has no timeout of its own by default, so a catalog that accepts the connection but never answers used to hang the command forever, and a single call makes one request per update plus one per detail page.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -113,6 +117,8 @@ function Get-DbaKbUpdate {
         [string[]]$Name,
         [switch]$Simple,
         [string]$Language,
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$TimeoutSec = 30,
         [switch]$EnableException
     )
     begin {
@@ -145,9 +151,9 @@ function Get-DbaKbUpdate {
             }
 
             if ($script:websession -and $script:websession.Headers."Accept-Language" -eq $Language) {
-                Invoke-WebRequest @Args -WebSession $script:websession -UseBasicParsing -ErrorAction Stop
+                Invoke-WebRequest @Args -WebSession $script:websession -UseBasicParsing -TimeoutSec $TimeoutSec -ErrorAction Stop
             } else {
-                Invoke-WebRequest @Args -SessionVariable websession -Headers @{ "accept-language" = $Language } -UseBasicParsing -ErrorAction Stop
+                Invoke-WebRequest @Args -SessionVariable websession -Headers @{ "accept-language" = $Language } -UseBasicParsing -TimeoutSec $TimeoutSec -ErrorAction Stop
                 $script:websession = $websession
             }
 

--- a/tests/Get-DbaKbUpdate.Tests.ps1
+++ b/tests/Get-DbaKbUpdate.Tests.ps1
@@ -14,9 +14,43 @@ Describe $CommandName -Tag UnitTests {
                 "Name",
                 "Simple",
                 "Language",
+                "TimeoutSec",
                 "EnableException"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+
+    # The timeout only shows up in the call to Invoke-WebRequest, so there is nothing an integration
+    # test could assert without an unreachable host. We mock inside the module - a mock without
+    # -ModuleName never applies to the code under test and would silently test nothing.
+    Context "Passing the timeout to the web request" {
+        BeforeAll {
+            Mock -CommandName Invoke-WebRequest -ModuleName dbatools -MockWith { }
+        }
+
+        It "Uses 30 seconds when TimeoutSec is not specified" {
+            $null = Get-DbaKbUpdate -Name KB4057119 -WarningAction SilentlyContinue
+            $splatShouldInvoke = @{
+                CommandName     = "Invoke-WebRequest"
+                ModuleName      = "dbatools"
+                ParameterFilter = { $TimeoutSec -eq 30 }
+            }
+            Should -Invoke @splatShouldInvoke
+        }
+
+        It "Uses the value of TimeoutSec when it is specified" {
+            $null = Get-DbaKbUpdate -Name KB4057119 -TimeoutSec 7 -WarningAction SilentlyContinue
+            $splatShouldInvoke = @{
+                CommandName     = "Invoke-WebRequest"
+                ModuleName      = "dbatools"
+                ParameterFilter = { $TimeoutSec -eq 7 }
+            }
+            Should -Invoke @splatShouldInvoke
+        }
+
+        It "Rejects a timeout of zero" {
+            { Get-DbaKbUpdate -Name KB4057119 -TimeoutSec 0 } | Should -Throw -ExpectedMessage "*minimum allowed range*"
         }
     }
 }


### PR DESCRIPTION
`Get-DbaKbUpdate` scrapes the Microsoft Update Catalog through a nested `Invoke-KbTlsWebRequest` helper that never passed a timeout. `Invoke-WebRequest` has no timeout of its own by default, so a catalog that accepts the connection but never answers made the command wait forever. One call makes a search request, a download-dialog request per update and, unless `-Simple` is used, one or two detail-page requests per update, so a stalled catalog is not a single wait.

Measured on this branch against a listener that accepts the TCP connection and never sends a byte, with no explicit timeout:

| Edition | Result |
| --- | --- |
| PowerShell 7.6.3 | still waiting after 150s |
| Windows PowerShell 5.1 | still waiting after 600s |

## What changed

- New `-TimeoutSec` parameter, `[ValidateRange(1, [int]::MaxValue)]`, default 30 seconds, passed to both branches of `Invoke-KbTlsWebRequest` (reused session and new session), so every catalog request is covered.
- `0` is rejected on purpose. It means "indefinite" on PowerShell 7 but does not behave the same on Windows PowerShell 5.1, and a platform-dependent silent difference is worse than an error.

## Cross-edition note

On PowerShell 7.4 and later `-TimeoutSec` is an alias of `-ConnectionTimeoutSeconds`, on Windows PowerShell it is the real parameter name. Both were checked end to end: `-TimeoutSec 3` against a non-routable address aborts after 3.1s on 7.6.3 and 3.3s on 5.1.

The unit tests filter on `$TimeoutSec`, which is the portable choice. Pester exposes both the alias and the formal name on PowerShell 7, but only `$TimeoutSec` exists on 5.1, so a filter on `$ConnectionTimeoutSeconds` would silently stop matching there.

## Tests

Parameter validation updated, plus three unit tests: the default reaches `Invoke-WebRequest`, an explicit value reaches it, and `0` is rejected. They mock `Invoke-WebRequest` **with** `-ModuleName dbatools`; a mock without it never applies inside the module and would test nothing. A timeout has no observable integration behaviour without an unreachable host, so this is deliberately unit-level.

- Unit tests: 4/4 pass.
- `TestTestLayout.ps1` and `TestTestfiles.Tests.ps1`: this file is clean, remaining failures are pre-existing.

The integration tests currently fail on `development` as well: the catalog answers 200 in about a second but renders no results table and no download buttons, for `windows`, `KB5003279` and `KB4057119` alike. Confirmed by stashing this change and getting the same empty result from the unmodified command. Unrelated to this PR, but it does show that the reachability probe added in #10474 only checks `StatusCode -eq 200` and so does not catch this shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)