### PR TITLE
Network certificate commands - Find the configured certificate even when it is archived

### DIFF
--- a/public/Get-DbaNetworkConfiguration.ps1
+++ b/public/Get-DbaNetworkConfiguration.ps1
@@ -200,7 +200,8 @@ function Get-DbaNetworkConfiguration {
                 try {
                     $acceptedSPNs = (Get-ItemProperty -Path $regPath -Name AcceptedSPNs).AcceptedSPNs
                     $thumbprint = (Get-ItemProperty -Path $regPath -Name Certificate).Certificate
-                    $cert = Get-ChildItem Cert:\LocalMachine -Recurse -ErrorAction SilentlyContinue | Where-Object Thumbprint -eq $thumbprint | Select-Object -First 1
+                    # -Force is needed to also find archived certificates, as SQL Server keeps using a certificate that has been archived.
+                    $cert = Get-ChildItem Cert:\LocalMachine -Recurse -Force -ErrorAction SilentlyContinue | Where-Object Thumbprint -eq $thumbprint | Select-Object -First 1
                     $extendedProtection = switch ((Get-ItemProperty -Path $regPath -Name ExtendedProtection).ExtendedProtection) { 0 { $false } 1 { $true } }
                     $forceEncryption = switch ((Get-ItemProperty -Path $regPath -Name ForceEncryption).ForceEncryption) { 0 { $false } 1 { $true } }
                     $hideInstance = switch ((Get-ItemProperty -Path $regPath -Name HideInstance).HideInstance) { 0 { $false } 1 { $true } }

--- a/public/Set-DbaNetworkCertificate.ps1
+++ b/public/Set-DbaNetworkCertificate.ps1
@@ -177,7 +177,8 @@ function Set-DbaNetworkCertificate {
                 if ($thumbprint) {
                     $verbose += "Certificate thumbprint to set: $thumbprint"
 
-                    $cert = Get-ChildItem Cert:\LocalMachine\My -ErrorAction Stop | Where-Object { $_.Thumbprint -eq $thumbprint }
+                    # -Force is needed to also find archived certificates, as SQL Server can use a certificate that has been archived.
+                    $cert = Get-ChildItem Cert:\LocalMachine\My -Force -ErrorAction Stop | Where-Object { $_.Thumbprint -eq $thumbprint }
                     $keyPath = $env:ProgramData + "\Microsoft\Crypto\RSA\MachineKeys\"
                     if ($PSVersionTable.PSVersion.Major -ge 6) {
                         $keyName = $cert.PrivateKey.Key.UniqueName

--- a/public/Test-DbaNetworkCertificate.ps1
+++ b/public/Test-DbaNetworkCertificate.ps1
@@ -155,7 +155,8 @@ function Test-DbaNetworkCertificate {
             $networkName = if ($vsname) { $vsname } else { hostname }
 
             # Find the certificate by thumbprint in LocalMachine\My
-            $cert = Get-ChildItem -Path Cert:\LocalMachine\My -ErrorAction SilentlyContinue | Where-Object Thumbprint -eq $thumbprint
+            # -Force is needed to also find archived certificates, as SQL Server keeps using a certificate that has been archived.
+            $cert = Get-ChildItem -Path Cert:\LocalMachine\My -Force -ErrorAction SilentlyContinue | Where-Object Thumbprint -eq $thumbprint
 
             if ($null -eq $cert) {
                 [PSCustomObject]@{

--- a/tests/Set-DbaNetworkCertificate.Tests.ps1
+++ b/tests/Set-DbaNetworkCertificate.Tests.ps1
@@ -110,6 +110,45 @@ Describe $CommandName -Tag IntegrationTests {
         $WarnVar | Should -BeNullOrEmpty
     }
 
+    It "Still finds the configured certificate after it has been archived" {
+        # Auto-renewed certificates are archived as soon as the successor is issued, but SQL Server keeps using
+        # them until it is reconfigured. Archived certificates are hidden from Get-ChildItem without -Force.
+        $configuredThumbprint = (Get-DbaNetworkCertificate -SqlInstance $TestConfig.InstanceRestart -EnableException).Thumbprint
+        $configuredThumbprint | Should -Not -BeNullOrEmpty
+
+        $setArchived = {
+            param ($Thumbprint, $Archived)
+            (Get-ChildItem -Path "Cert:\LocalMachine\My\$Thumbprint" -Force).Archived = $Archived
+        }
+
+        try {
+            $splatArchive = @{
+                ComputerName = $computerName
+                ScriptBlock  = $setArchived
+                ArgumentList = $configuredThumbprint, $true
+            }
+            $null = Invoke-Command2 @splatArchive
+
+            $archivedCertificate = Get-DbaNetworkCertificate -SqlInstance $TestConfig.InstanceRestart -EnableException
+            $archivedCertificate.Thumbprint | Should -Be $configuredThumbprint
+
+            $splatTestArchived = @{
+                SqlInstance     = $TestConfig.InstanceRestart
+                Thumbprint      = $configuredThumbprint
+                EnableException = $true
+            }
+            $archivedSuitability = Test-DbaNetworkCertificate @splatTestArchived
+            $archivedSuitability.CertificateFound | Should -BeTrue
+        } finally {
+            $splatUnarchive = @{
+                ComputerName = $computerName
+                ScriptBlock  = $setArchived
+                ArgumentList = $configuredThumbprint, $false
+            }
+            $null = Invoke-Command2 @splatUnarchive
+        }
+    }
+
     It "Unsets the certificate" {
         $result = Set-DbaNetworkCertificate -SqlInstance $TestConfig.InstanceRestart -UnsetCertificate -RestartService
         $result.CertificateThumbprint | Should -BeNullOrEmpty


### PR DESCRIPTION
Fixes #10462

## Problem

`Get-DbaNetworkCertificate` returns nothing for an instance whose certificate has been archived. This happens with auto-renewed certificates: they are archived as soon as the successor is issued, but SQL Server keeps using them until it is reconfigured.

The certificate provider hides archived certificates unless `-Force` is passed. So `Get-DbaNetworkConfiguration` reads the thumbprint from `SuperSocketNetLib\Certificate` correctly, but the store lookup returns nothing and every derived property (`FriendlyName`, `DnsNameList`, `Thumbprint`, `Generated`, `Expires`, `IssuedTo`, `IssuedBy`) is empty. `Get-DbaNetworkCertificate` filters on `Where-Object Thumbprint`, so the instance disappears from the output entirely.

## Change

Added `-Force` to the three lookups that find the *already configured* certificate by thumbprint:

* `Get-DbaNetworkConfiguration` - the reported bug
* `Test-DbaNetworkCertificate` - reported `CertificateFound = $false` for an archived certificate
* `Set-DbaNetworkCertificate` - threw "Can't find private key path" when re-applying an archived thumbprint

The scan for *suitable* certificates in `Get-DbaNetworkConfiguration` is deliberately left unchanged - an archived certificate should not be recommended as a candidate.

## Test

Added one integration test to `Set-DbaNetworkCertificate.Tests.ps1`, where an instance with a configured certificate already exists. It archives the configured certificate, asserts that `Get-DbaNetworkCertificate` still returns the thumbprint and that `Test-DbaNetworkCertificate -Thumbprint` reports `CertificateFound`, then un-archives it in a `finally` block so the existing cleanup can still remove it.

Thanks to @haxr for the precise report and for pinpointing both the cause and the correct scope of the fix.