### PR TITLE
Set-DbaAgentSchedule - Keep the frequency settings when they are not part of the change

### DIFF
--- a/public/Set-DbaAgentSchedule.ps1
+++ b/public/Set-DbaAgentSchedule.ps1
@@ -202,8 +202,16 @@ function Set-DbaAgentSchedule {
     begin {
         if ($Force) { $ConfirmPreference = 'none' }
 
+        # Only touch the frequency of an existing schedule if the user asked for it.
+        # An unbound -FrequencyType is $null, which is "-notin" the list below, so it used to fall
+        # through to the default of 1 (OneTime) and silently overwrite the recurrence of the schedule.
+        # SQL Server then clears the interval and subday values, because they carry no meaning for a
+        # one-time schedule, so a call that only changed the start time destroyed the whole pattern.
+        $frequencyTypeBound = Test-Bound -ParameterName FrequencyType
+        $frequencyIntervalBound = Test-Bound -ParameterName FrequencyInterval
+
         # Check of the FrequencyType value is of type string and set the integer value
-        if ($FrequencyType -notin 1, 4, 8, 16, 32, 64, 128) {
+        if ($frequencyTypeBound -and $FrequencyType -notin 1, 4, 8, 16, 32, 64, 128) {
             [int]$FrequencyType =
             switch ($FrequencyType) {
                 "Once" { 1 }
@@ -262,10 +270,13 @@ function Set-DbaAgentSchedule {
             return
         }
 
+        # Create the interval to hold the value(s)
+        # This has to be initialized outside of the block below, because that block is skipped
+        # when no frequency type was passed in and the interval is still read further down.
+        [int]$Interval = 0
+
         # Check of the FrequencyInterval value is of type string and set the integer value
         if (($null -ne $FrequencyType)) {
-            # Create the interval to hold the value(s)
-            [int]$Interval = 0
 
             # If the FrequencyInterval is set for the daily FrequencyType
             if ($FrequencyType -eq 4) {
@@ -434,7 +445,9 @@ function Set-DbaAgentSchedule {
                         $JobSchedule = $server.JobServer.Jobs[$j].JobSchedules[$Schedule][0]
 
                         # Set the frequency interval to make up for newly created schedules without an interval
-                        if ($JobSchedule.FrequencyInterval -eq 0 -and $Interval -lt 1) {
+                        # Only when the user is changing the frequency at all - otherwise a call that just
+                        # changes the start time would write an interval the user never asked for.
+                        if (($frequencyTypeBound -or $frequencyIntervalBound) -and $JobSchedule.FrequencyInterval -eq 0 -and $Interval -lt 1) {
                             $Interval = 1
                         }
 

--- a/tests/Set-DbaAgentSchedule.Tests.ps1
+++ b/tests/Set-DbaAgentSchedule.Tests.ps1
@@ -349,4 +349,74 @@ Describe $CommandName -Tag IntegrationTests {
             }
         }
     }
+
+    Context "Should keep the frequency settings when they are not part of the change" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $splatNewKeepSchedule = @{
+                SqlInstance             = $TestConfig.InstanceSingle
+                Schedule                = "dbatoolsci_keepfrequency"
+                Job                     = "dbatoolsci_setschedule1"
+                FrequencyType           = "Daily"
+                FrequencyInterval       = "EveryDay"
+                FrequencySubdayType     = "Hours"
+                FrequencySubdayInterval = 4
+                StartTime               = "060000"
+                Force                   = $true
+            }
+            $null = New-DbaAgentSchedule @splatNewKeepSchedule
+
+            # Changing only the start time must not touch the recurrence (#10461)
+            $splatSetStartTime = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Job         = "dbatoolsci_setschedule1"
+                Schedule    = "dbatoolsci_keepfrequency"
+                StartTime   = "235900"
+            }
+            $null = Set-DbaAgentSchedule @splatSetStartTime
+            $startTimeResult = Get-DbaAgentSchedule -SqlInstance $TestConfig.InstanceSingle -Schedule "dbatoolsci_keepfrequency"
+
+            # The same is true for a call that only enables the schedule
+            $splatSetEnabled = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Job         = "dbatoolsci_setschedule1"
+                Schedule    = "dbatoolsci_keepfrequency"
+                Enabled     = $true
+            }
+            $null = Set-DbaAgentSchedule @splatSetEnabled
+            $enabledResult = Get-DbaAgentSchedule -SqlInstance $TestConfig.InstanceSingle -Schedule "dbatoolsci_keepfrequency"
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = Get-DbaAgentSchedule -SqlInstance $TestConfig.InstanceSingle |
+                Where-Object Name -like "dbatools*" |
+                Remove-DbaAgentSchedule -Force
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Should have changed the start time" {
+            $startTimeResult.ActiveStartTimeOfDay | Should -Be ([TimeSpan]"23:59:00")
+        }
+
+        It "Should have kept the frequency settings after changing the start time" {
+            $startTimeResult.FrequencyTypes | Should -Be "Daily"
+            $startTimeResult.FrequencyInterval | Should -Be 1
+            $startTimeResult.FrequencySubDayTypes | Should -Be "Hour"
+            $startTimeResult.FrequencySubDayInterval | Should -Be 4
+        }
+
+        It "Should have kept the frequency settings after enabling the schedule" {
+            $enabledResult.IsEnabled | Should -BeTrue
+            $enabledResult.FrequencyTypes | Should -Be "Daily"
+            $enabledResult.FrequencyInterval | Should -Be 1
+            $enabledResult.FrequencySubDayTypes | Should -Be "Hour"
+            $enabledResult.FrequencySubDayInterval | Should -Be 4
+        }
+    }
 }


### PR DESCRIPTION
Fixes #10461

## Problem

Changing only the start time of an existing schedule silently destroyed its recurrence pattern:

| | FrequencyTypes | FrequencyInterval | SubDayTypes | SubDayInterval |
|---|---|---|---|---|
| before | Daily | 1 | Hour | 4 |
| after `-StartTime 235900` | OneTime | 0 | Unknown | 0 |

It is broader than the start time. **Any** call that omits `-FrequencyType` did this - `-NewName`, `-StartDate`, `-Enabled` and `-Disabled` included. A call of `Set-DbaAgentSchedule -Enabled` alone was enough to wreck a production schedule.

## Mechanism

An unbound `-FrequencyType` is `$null`. `$null -notin 1, 4, 8, 16, 32, 64, 128` is `$true`, so the conversion switch ran, nothing matched, and `default { 1 }` set it to `1` (OneTime). The guard that decides whether to write the value is `if ($FrequencyType -ge 1)`, which a defaulted `1` satisfies, so the schedule was converted to one-time. SQL Server then clears the interval and subday columns, because they carry no meaning for a one-time schedule - which is why the whole pattern was lost rather than just the type.

## Change

* `Test-Bound` now decides whether the frequency is written at all, so an unbound `-FrequencyType` stays `$null` and the existing `-ge 1` guards no longer fire
* `$Interval` is initialized outside the block that is skipped when no frequency type is passed, since it is still read further down
* The compensation for newly created schedules without an interval only applies when the caller is actually changing the frequency, so a start time change no longer writes an interval nobody asked for

## What deliberately did not change

`New-DbaAgentSchedule` contains the same `default { 1 }` and keeps it. Defaulting to OneTime is correct when *creating* a schedule - there is no existing recurrence to lose. `Set-DbaAgentJob` and `Set-DbaAgentJobStep` do not use this pattern at all, so the defect is confined to this one command.

The subday, relative interval and recurrence factor parameters already had guards that unbound values could not satisfy, so they are left alone.

## Testing

Added one context to `Set-DbaAgentSchedule.Tests.ps1` covering both a `-StartTime`-only and an `-Enabled`-only change against a daily/every-4-hours schedule.

Verified in a lab against SQL Server 2019:

* with the fix: 10/10 tests pass
* with the fix reverted and the tests kept: the two frequency-preservation tests fail with `Expected 'Daily', but got OneTime` - the exact symptom from the issue

Thanks to @Ratty25 for the clear report and the reproduction steps.