### PR TITLE
Tests - Make three dead mocks apply, harden the update catalog probe and clear the last top-level statements

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -276,8 +276,9 @@ Pester evaluates `-Skip:` while it discovers the tests, before any `BeforeAll` r
 ```powershell
 Describe $CommandName -Tag IntegrationTests {
     # These tests need the Microsoft Update Catalog. If it does not answer, every one of them waits
-    # 100 seconds for the default timeout of Invoke-WebRequest and then fails for a reason that has
-    # nothing to do with dbatools. So we probe it once here and skip the tests instead.
+    # for the timeout of Invoke-WebRequest and then fails for a reason that has nothing to do with
+    # dbatools. So we probe it once here and skip the tests instead. We probe for the download button
+    # the command itself looks for, because the catalog also answers 200 with an empty results page.
     try {
         $splatCatalog = @{
             Uri             = "https://www.catalog.update.microsoft.com/Search.aspx?q=KB2992080"
@@ -285,7 +286,8 @@ Describe $CommandName -Tag IntegrationTests {
             TimeoutSec      = 30
             ErrorAction     = "Stop"
         }
-        $catalogReachable = (Invoke-WebRequest @splatCatalog).StatusCode -eq 200
+        $catalogResponse = Invoke-WebRequest @splatCatalog
+        $catalogReachable = [bool]($catalogResponse.InputFields | Where-Object { $PSItem.type -eq "Button" -and $PSItem.class -eq "flatBlueButtonDownload focus-only" })
     } catch {
         $catalogReachable = $false
     }

--- a/tests/Get-DbaComputerSystem.Tests.ps1
+++ b/tests/Get-DbaComputerSystem.Tests.ps1
@@ -20,9 +20,11 @@ Describe $CommandName -Tag UnitTests {
         }
     }
     Context "Validate input" {
+        # The mock needs -ModuleName dbatools, otherwise it never applies to the code under test and
+        # the test only asserts that DNS really fails for DoesNotExist142 on the machine running it.
         It "Cannot resolve hostname of computer" {
-            Mock Resolve-DbaNetworkName { $null }
-            { Get-DbaComputerSystem -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw -ExpectedMessage "*DNS name DoesNotExist142 not found*"
+            Mock Resolve-DbaNetworkName -ModuleName dbatools { $null }
+            { Get-DbaComputerSystem -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw -ExpectedMessage "*Unable to resolve hostname of DoesNotExist142*"
         }
     }
 }

--- a/tests/Get-DbaDump.Tests.ps1
+++ b/tests/Get-DbaDump.Tests.ps1
@@ -21,24 +21,22 @@ Describe $CommandName -Tag UnitTests {
 }
 
 # Not sure what is up with appveyor but it does not support this at all
-if (-not $env:appveyor) {
-    Describe $CommandName -Tag IntegrationTests {
-        Context "Testing if memory dump is present" {
-            It "finds least one dump" {
-                $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
+    Context "Testing if memory dump is present" {
+        It "finds least one dump" {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-                $splatConnect = @{
-                    SqlInstance = $TestConfig.InstanceSingle
-                }
-                $server = Connect-DbaInstance @splatConnect
-                $server.Query("DBCC STACKDUMP")
-                $server.Query("DBCC STACKDUMP")
-
-                $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-
-                $results = Get-DbaDump -SqlInstance $TestConfig.InstanceSingle
-                $results.Count | Should -BeGreaterOrEqual 1
+            $splatConnect = @{
+                SqlInstance = $TestConfig.InstanceSingle
             }
+            $server = Connect-DbaInstance @splatConnect
+            $server.Query("DBCC STACKDUMP")
+            $server.Query("DBCC STACKDUMP")
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+
+            $results = Get-DbaDump -SqlInstance $TestConfig.InstanceSingle
+            $results.Count | Should -BeGreaterOrEqual 1
         }
     }
 }

--- a/tests/Get-DbaKbUpdate.Tests.ps1
+++ b/tests/Get-DbaKbUpdate.Tests.ps1
@@ -63,6 +63,11 @@ Describe $CommandName -Tag IntegrationTests {
     #
     # We have to probe the search page and not the start page: on 2026-07-31 the start page answered
     # in one second while every search timed out, so a probe of the start page would not have helped.
+    # And we have to probe for a download button and not for the status code: on 2026-08-01 the search
+    # page answered 200 in about a second but rendered no results table for any query, so a probe of
+    # the status code let the tests run and fail. The download button is what the command itself looks
+    # for, so this probe is true exactly when the command can work.
+    # The same probe is used in Save-DbaKbUpdate.Tests.ps1.
     try {
         $splatCatalog = @{
             Uri             = "https://www.catalog.update.microsoft.com/Search.aspx?q=KB4057119"
@@ -70,7 +75,8 @@ Describe $CommandName -Tag IntegrationTests {
             TimeoutSec      = 30
             ErrorAction     = "Stop"
         }
-        $catalogReachable = (Invoke-WebRequest @splatCatalog).StatusCode -eq 200
+        $catalogResponse = Invoke-WebRequest @splatCatalog
+        $catalogReachable = [bool]($catalogResponse.InputFields | Where-Object { $PSItem.type -eq "Button" -and $PSItem.class -eq "flatBlueButtonDownload focus-only" })
     } catch {
         $catalogReachable = $false
     }

--- a/tests/Get-DbaOperatingSystem.Tests.ps1
+++ b/tests/Get-DbaOperatingSystem.Tests.ps1
@@ -20,9 +20,11 @@ Describe $CommandName -Tag UnitTests {
     }
 
     Context "Validate input" {
+        # The mock needs -ModuleName dbatools, otherwise it never applies to the code under test and
+        # the test only asserts that DNS really fails for DoesNotExist142 on the machine running it.
         It "Cannot resolve hostname of computer" {
-            Mock Resolve-DbaNetworkName { $null }
-            { Get-DbaOperatingSystem -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw -ExpectedMessage "*DNS name DoesNotExist142 not found*"
+            Mock Resolve-DbaNetworkName -ModuleName dbatools { $null }
+            { Get-DbaOperatingSystem -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw -ExpectedMessage "*Unable to resolve hostname of DoesNotExist142*"
         }
     }
 }

--- a/tests/Get-DbaService.Tests.ps1
+++ b/tests/Get-DbaService.Tests.ps1
@@ -25,9 +25,13 @@ Describe $CommandName -Tag UnitTests {
     }
 
     Context "Validate input" {
+        # The mock needs -ModuleName dbatools, otherwise it never applies to the code under test and
+        # the test only asserts that DNS really fails for DoesNotExist142 on the machine running it.
+        # Unlike the other Get-Dba* commands, Get-DbaService calls Resolve-DbaNetworkName with
+        # EnableException and catches the exception, so the mock has to throw and not return $null.
         It "Cannot resolve hostname of computer" {
-            Mock Resolve-DbaNetworkName { $null }
-            { Get-DbaService -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw -ExpectedMessage "*DNS name DoesNotExist142 not found*"
+            Mock Resolve-DbaNetworkName -ModuleName dbatools { throw "dbatoolsci mocked resolution failure" }
+            { Get-DbaService -ComputerName "DoesNotExist142" -WarningAction Stop 3> $null } | Should -Throw -ExpectedMessage "*Failed to resolve or to connect to DoesNotExist142*dbatoolsci mocked resolution failure*"
         }
     }
 }

--- a/tests/Import-DbaParquet.Tests.ps1
+++ b/tests/Import-DbaParquet.Tests.ps1
@@ -5,19 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-if ($null -eq $PSDefaultParameterValues) {
-    $PSDefaultParameterValues = @{ }
-}
-
-$hasIntegrationConfig = $false
-if ($TestConfig -and $TestConfig.appveyorlabrepo -and $TestConfig.InstanceMulti1) {
-    $parquetFixturePath = Join-Path -Path $TestConfig.appveyorlabrepo -ChildPath "parquet"
-    $pathEcdc = Join-Path -Path $parquetFixturePath -ChildPath "ecdc_cases.parquet"
-    $pathBoundaries = Join-Path -Path $parquetFixturePath -ChildPath "world-administrative-boundaries.parquet"
-    $pathMixedTypes = Join-Path -Path $parquetFixturePath -ChildPath "mixed_types.parquet"
-    $hasIntegrationConfig = (Test-Path $pathEcdc) -and (Test-Path $pathBoundaries) -and (Test-Path $pathMixedTypes)
-}
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {
@@ -91,7 +78,19 @@ Describe $CommandName -Tag UnitTests {
     }
 }
 
-Describe $CommandName -Tag IntegrationTests -Skip:(-not $hasIntegrationConfig) {
+# These tests need the three Parquet fixtures from the appveyor lab repo. Pester evaluates -Skip:
+# during discovery, so the check cannot move into BeforeAll and is written out here instead of being
+# computed into a variable, because only Describe blocks are allowed at the top level of a test file.
+Describe $CommandName -Tag IntegrationTests -Skip:(
+    -not (
+        $TestConfig -and
+        $TestConfig.appveyorlabrepo -and
+        $TestConfig.InstanceMulti1 -and
+        (Test-Path -Path (Join-Path -Path $TestConfig.appveyorlabrepo -ChildPath "parquet\ecdc_cases.parquet")) -and
+        (Test-Path -Path (Join-Path -Path $TestConfig.appveyorlabrepo -ChildPath "parquet\world-administrative-boundaries.parquet")) -and
+        (Test-Path -Path (Join-Path -Path $TestConfig.appveyorlabrepo -ChildPath "parquet\mixed_types.parquet"))
+    )
+) {
     BeforeAll {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 

--- a/tests/New-DbaComputerCertificate.Tests.ps1
+++ b/tests/New-DbaComputerCertificate.Tests.ps1
@@ -91,72 +91,70 @@ Describe $CommandName -Tag UnitTests {
 }
 
 #Tests do not run in appveyor
-if (-not $env:appveyor) {
-    Describe $CommandName -Tag IntegrationTests {
-        Context "Can generate a new certificate with default settings" {
-            BeforeAll {
-                $defaultCert = New-DbaComputerCertificate -SelfSigned -EnableException
-            }
-
-            AfterAll {
-                Remove-DbaComputerCertificate -Thumbprint $defaultCert.Thumbprint
-            }
-
-            It "Returns the right EnhancedKeyUsageList" {
-                "$($defaultCert.EnhancedKeyUsageList)" -match "1\.3\.6\.1\.5\.5\.7\.3\.1" | Should -BeTrue
-            }
-
-            It "Returns the right FriendlyName" {
-                "$($defaultCert.FriendlyName)" -match "SQL Server" | Should -BeTrue
-            }
-
-            It "Returns the right default encryption algorithm" {
-                "$(($defaultCert | Select-Object @{n="SignatureAlgorithm";e={$PSItem.SignatureAlgorithm.FriendlyName}})).SignatureAlgorithm)" -match "sha256RSA" | Should -BeTrue
-            }
-
-            It "Returns the right default one year expiry date" {
-                $defaultCert.NotAfter -match ((Get-Date).Date).AddMonths(12) | Should -BeTrue
-            }
+Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
+    Context "Can generate a new certificate with default settings" {
+        BeforeAll {
+            $defaultCert = New-DbaComputerCertificate -SelfSigned -EnableException
         }
 
-        Context "Can generate a new certificate with custom settings" {
-            BeforeAll {
-                $customCert = New-DbaComputerCertificate -SelfSigned -HashAlgorithm "Sha256" -MonthsValid 60 -EnableException
-            }
-
-            AfterAll {
-                Remove-DbaComputerCertificate -Thumbprint $customCert.Thumbprint
-            }
-
-            It "Returns the right encryption algorithm" {
-                "$(($customCert | Select-Object @{n="SignatureAlgorithm";e={$PSItem.SignatureAlgorithm.FriendlyName}})).SignatureAlgorithm)" -match "sha256RSA" | Should -BeTrue
-            }
-
-            It "Returns the right five year (60 month) expiry date" {
-                $customCert.NotAfter -match ((Get-Date).Date).AddMonths(60) | Should -BeTrue
-            }
+        AfterAll {
+            Remove-DbaComputerCertificate -Thumbprint $defaultCert.Thumbprint
         }
 
-        Context "Can generate a document encryption certificate for Always Encrypted" {
-            BeforeAll {
-                $documentCert = New-DbaComputerCertificate -SelfSigned -DocumentEncryptionCert -EnableException
-            }
+        It "Returns the right EnhancedKeyUsageList" {
+            "$($defaultCert.EnhancedKeyUsageList)" -match "1\.3\.6\.1\.5\.5\.7\.3\.1" | Should -BeTrue
+        }
 
-            AfterAll {
-                Remove-DbaComputerCertificate -Thumbprint $documentCert.Thumbprint
-            }
+        It "Returns the right FriendlyName" {
+            "$($defaultCert.FriendlyName)" -match "SQL Server" | Should -BeTrue
+        }
 
-            It "Returns the Document Encryption EKU OID" {
-                "$($documentCert.EnhancedKeyUsageList)" -match "1\.3\.6\.1\.4\.1\.311\.10\.3\.11" | Should -BeTrue
-            }
+        It "Returns the right default encryption algorithm" {
+            "$(($defaultCert | Select-Object @{n="SignatureAlgorithm";e={$PSItem.SignatureAlgorithm.FriendlyName}})).SignatureAlgorithm)" -match "sha256RSA" | Should -BeTrue
+        }
 
-            It "Returns the IKE Intermediate EKU OID" {
-                "$($documentCert.EnhancedKeyUsageList)" -match "1\.3\.6\.1\.5\.5\.8\.2\.2" | Should -BeTrue
-            }
+        It "Returns the right default one year expiry date" {
+            $defaultCert.NotAfter -match ((Get-Date).Date).AddMonths(12) | Should -BeTrue
+        }
+    }
 
-            It "Does not include the Server Authentication EKU OID" {
-                "$($documentCert.EnhancedKeyUsageList)" -match "1\.3\.6\.1\.5\.5\.7\.3\.1" | Should -BeFalse
-            }
+    Context "Can generate a new certificate with custom settings" {
+        BeforeAll {
+            $customCert = New-DbaComputerCertificate -SelfSigned -HashAlgorithm "Sha256" -MonthsValid 60 -EnableException
+        }
+
+        AfterAll {
+            Remove-DbaComputerCertificate -Thumbprint $customCert.Thumbprint
+        }
+
+        It "Returns the right encryption algorithm" {
+            "$(($customCert | Select-Object @{n="SignatureAlgorithm";e={$PSItem.SignatureAlgorithm.FriendlyName}})).SignatureAlgorithm)" -match "sha256RSA" | Should -BeTrue
+        }
+
+        It "Returns the right five year (60 month) expiry date" {
+            $customCert.NotAfter -match ((Get-Date).Date).AddMonths(60) | Should -BeTrue
+        }
+    }
+
+    Context "Can generate a document encryption certificate for Always Encrypted" {
+        BeforeAll {
+            $documentCert = New-DbaComputerCertificate -SelfSigned -DocumentEncryptionCert -EnableException
+        }
+
+        AfterAll {
+            Remove-DbaComputerCertificate -Thumbprint $documentCert.Thumbprint
+        }
+
+        It "Returns the Document Encryption EKU OID" {
+            "$($documentCert.EnhancedKeyUsageList)" -match "1\.3\.6\.1\.4\.1\.311\.10\.3\.11" | Should -BeTrue
+        }
+
+        It "Returns the IKE Intermediate EKU OID" {
+            "$($documentCert.EnhancedKeyUsageList)" -match "1\.3\.6\.1\.5\.5\.8\.2\.2" | Should -BeTrue
+        }
+
+        It "Does not include the Server Authentication EKU OID" {
+            "$($documentCert.EnhancedKeyUsageList)" -match "1\.3\.6\.1\.5\.5\.7\.3\.1" | Should -BeFalse
         }
     }
 }

--- a/tests/Remove-DbaAgentJobSchedule.Tests.ps1
+++ b/tests/Remove-DbaAgentJobSchedule.Tests.ps1
@@ -5,25 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-class MockAgentServer {
-    [string]$Name
-    [string]$ComputerName
-    [string]$ServiceName
-    [string]$DomainInstanceName
-    [object]$JobServer
-
-    MockAgentServer([string]$Name) {
-        $this.Name = $Name
-        $this.ComputerName = $Name
-        $this.ServiceName = "MSSQLSERVER"
-        $this.DomainInstanceName = $Name
-    }
-
-    [string] ToString() {
-        return $this.Name
-    }
-}
-
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {
@@ -94,7 +75,18 @@ Describe $CommandName -Tag UnitTests {
                 }
                 $jobs | Add-Member -MemberType ScriptProperty -Name Name -Value { $this.Keys } -Force
 
-                $server = [MockAgentServer]::new("sql1")
+                # The command passes the server to $PSCmdlet.ShouldProcess, which only binds if the
+                # object converts to a string. So the mock server is a string carrying the properties
+                # the command reads, and not a PSCustomObject with an added ToString - PowerShell does
+                # not use an added ToString when binding a method argument. A class would work as well,
+                # but classes can only be declared at the top level of a file and only Describe blocks
+                # are allowed there.
+                $server = Add-Member -InputObject "sql1" -MemberType NoteProperty -Name Name -Value "sql1" -PassThru
+                $server = Add-Member -InputObject $server -MemberType NoteProperty -Name ComputerName -Value "sql1" -PassThru
+                $server = Add-Member -InputObject $server -MemberType NoteProperty -Name ServiceName -Value "MSSQLSERVER" -PassThru
+                $server = Add-Member -InputObject $server -MemberType NoteProperty -Name DomainInstanceName -Value "sql1" -PassThru
+                $server = Add-Member -InputObject $server -MemberType NoteProperty -Name JobServer -Value $null -PassThru
+
                 $jobServer = [PSCustomObject]@{
                     Parent = $server
                     Jobs   = $jobs

--- a/tests/Save-DbaKbUpdate.Tests.ps1
+++ b/tests/Save-DbaKbUpdate.Tests.ps1
@@ -52,6 +52,10 @@ Describe $CommandName -Tag IntegrationTests {
     #
     # We have to probe the search page and not the start page: on 2026-07-31 the start page answered
     # in one second while every search timed out, so a probe of the start page would not have helped.
+    # And we have to probe for a download button and not for the status code: on 2026-08-01 the search
+    # page answered 200 in about a second but rendered no results table for any query, so a probe of
+    # the status code let the tests run and fail. The download button is what the command itself looks
+    # for, so this probe is true exactly when the command can work.
     # The same probe is used in Get-DbaKbUpdate.Tests.ps1.
     try {
         $splatCatalog = @{
@@ -60,7 +64,8 @@ Describe $CommandName -Tag IntegrationTests {
             TimeoutSec      = 30
             ErrorAction     = "Stop"
         }
-        $catalogReachable = (Invoke-WebRequest @splatCatalog).StatusCode -eq 200
+        $catalogResponse = Invoke-WebRequest @splatCatalog
+        $catalogReachable = [bool]($catalogResponse.InputFields | Where-Object { $PSItem.type -eq "Button" -and $PSItem.class -eq "flatBlueButtonDownload focus-only" })
     } catch {
         $catalogReachable = $false
     }
@@ -80,13 +85,11 @@ Describe $CommandName -Tag IntegrationTests {
         It "downloads a small update" {
             $results = Save-DbaKbUpdate -Name KB2992080 -Architecture All -Path $tempPath
             $results.Name -match "aspnet"
-            $filesToRemove += $results.FullName
         }
 
         It "supports piping" {
             $results = Get-DbaKbUpdate -Name KB2992080 | Select-Object -First 1 | Save-DbaKbUpdate -Architecture All -Path $tempPath
             $results.Name -match "aspnet"
-            $filesToRemove += $results.FullName
         }
 
         It "Download multiple updates" {
@@ -95,15 +98,11 @@ Describe $CommandName -Tag IntegrationTests {
             # basic retry logic in case the first download didn't get all of the files
             if ($null -eq $results -or $results.Count -ne 2) {
                 Write-Message -Level Warning -Message "Retrying..."
-                if ($results.Count -gt 0) {
-                    $filesToRemove += $results.FullName
-                }
                 Start-Sleep -s 30
                 $results = Save-DbaKbUpdate -Name KB2992080, KB4513696 -Architecture All -Path $tempPath
             }
 
             $results.Count | Should -Be 2
-            $filesToRemove += $results.FullName
 
             # download multiple updates via piping
             $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Architecture All -Path $tempPath
@@ -111,15 +110,11 @@ Describe $CommandName -Tag IntegrationTests {
             # basic retry logic in case the first download didn't get all of the files
             if ($null -eq $results -or $results.Count -ne 2) {
                 Write-Message -Level Warning -Message "Retrying..."
-                if ($results.Count -gt 0) {
-                    $filesToRemove += $results.FullName
-                }
                 Start-Sleep -s 30
                 $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Architecture All -Path $tempPath
             }
 
             $results.Count | Should -Be 2
-            $filesToRemove += $results.FullName
         }
 
         # see https://github.com/dataplat/dbatools/issues/6745
@@ -128,7 +123,6 @@ Describe $CommandName -Tag IntegrationTests {
 
             $results = Save-DbaKbUpdate -Name KB4513696 -Architecture All -Path $tempPath
             $results.Count | Should -Be 1
-            $filesToRemove += $results.FullName
         }
     }
 }

--- a/tests/Update-DbaInstance.Tests.ps1
+++ b/tests/Update-DbaInstance.Tests.ps1
@@ -7,10 +7,10 @@ param(
 
 # TODO: This test needs a lot of care
 
-$exeDir = "C:\Temp\dbatools_$CommandName"
-
 Describe -skip $CommandName -Tag UnitTests {
     BeforeAll {
+        $exeDir = "C:\Temp\dbatools_$CommandName"
+
         # Prevent the functions from executing dangerous stuff and getting right responses where needed
         Mock -CommandName Invoke-Program -MockWith { [PSCustomObject]@{ Successful = $true; ExitCode = [uint32[]]3010 } } -ModuleName dbatools
         Mock -CommandName Test-PendingReboot -MockWith { $false } -ModuleName dbatools
@@ -853,6 +853,8 @@ Describe -skip $CommandName -Tag UnitTests {
 
 Describe -Skip "$CommandName Integration Tests" -Tag IntegrationTests {
     BeforeAll {
+        $exeDir = "C:\Temp\dbatools_$CommandName"
+
         #ignore restart requirements
         Mock -CommandName Test-PendingReboot -MockWith { $false } -ModuleName dbatools
         #ignore elevation requirements


### PR DESCRIPTION
Four small, unrelated test-only follow-ups that were found while fixing other things and deliberately left out of those PRs to keep them focused. One commit per concern, so they can be reviewed independently.

## Probe the update catalog for a download button instead of a status code

The `-Skip:` probe in `Get-DbaKbUpdate.Tests.ps1` and `Save-DbaKbUpdate.Tests.ps1` treated any 200 as "the catalog works". On 2026-08-01 the search page answered 200 in about a second but rendered no results table and no download buttons for any query, so the tests ran and failed instead of skipping - exactly what the probe was meant to prevent. It now looks for the download button the command itself parses, so the probe is true exactly when the command can work.

`tests/CLAUDE.md` documents this probe as the example of the skip-condition exception, so it got the same update.

The same commit removes the dead `$filesToRemove` in `Save-DbaKbUpdate.Tests.ps1`. It was appended to seven times but never initialised and never read - the cleanup happens through `$tempPath` in `AfterAll`.

## Make the three hostname resolution mocks actually apply

`Get-DbaComputerSystem`, `Get-DbaOperatingSystem` and `Get-DbaService` each had a `Mock Resolve-DbaNetworkName` without `-ModuleName dbatools`, so the mock never applied inside the module. The tests really depended on DNS failing for `DoesNotExist142` on whatever machine ran them, and they asserted on the message of `Resolve-DbaNetworkName` rather than on the command under test.

The mocks now target the module and the assertions moved to what each command does with an unresolvable name. `Get-DbaService` needed a different mock: unlike the other two it calls `Resolve-DbaNetworkName` with `EnableException` and catches the exception, so a mock returning `$null` makes it stop throwing altogether. Its mock throws instead, and the assertion matches the mock's own text so the test cannot pass without the mock applying.

## Keep only Describe blocks at the top level of five test files

These were the last five files failing the "Has only Describe blocks at the top level" check that `TestTestfiles.Tests.ps1` in the testing-dbatools repo runs over every test file. After this the whole tree passes it.

- `Get-DbaDump` and `New-DbaComputerCertificate` wrapped their integration `Describe` in `if (-not $env:appveyor)`, which is now `-Skip:([bool]$env:appveyor)`.
- `Import-DbaParquet` computed `$hasIntegrationConfig` at the top level. Pester evaluates `-Skip:` during discovery, so the check cannot move into `BeforeAll` and is written out in the `-Skip:` expression instead. The unrelated `$null` guard for `$PSDefaultParameterValues` went with it - no other test file has one, and the integration `Describe` is skipped when `$TestConfig` is missing anyway.
- `Remove-DbaAgentJobSchedule` declared a `MockAgentServer` class, and a class can only be declared at the top level of a file. The mock server is now a string carrying the properties the command reads, which also keeps it bindable to `$PSCmdlet.ShouldProcess` - an added `ToString` on a `PSCustomObject` is not used when PowerShell binds a method argument.
- `Update-DbaInstance` assigned `$exeDir` at the top level; it moved into the `BeforeAll` of the two `Describe` blocks that use it.

## Verification

- Unit tests of all ten changed files pass.
- The `Get-DbaKbUpdate` and `Save-DbaKbUpdate` integration tests run and pass against the live catalog, so the stricter probe does not over-skip.
- A discovery-only Pester run confirms the five restructured files discover, run and skip exactly the same tests as before.
- `TestTestfiles.Tests.ps1 -ExcludeTagFilter Goal`: 0 failures over 723 files.
- `TestTestLayout.ps1` reports the same 82 pre-existing files before and after; none of them are touched here.