### PR TITLE
Update-DbaInstance - Un-skip the unit tests, and allow -ForEach when the cases come from BeforeDiscovery

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@
 
 3. **Pester v5.7.1** - Required for running tests
    - Install: `Install-Module Pester -RequiredVersion 5.7.1`
-   - Tests MUST use Pester v5 syntax (no `-ForEach` parameter, strict scoping)
+   - Tests MUST use Pester v5 syntax (strict scoping, `-ForEach` cases built in `BeforeDiscovery`)
 
 ## PR Summary Guidelines
 
@@ -334,8 +334,9 @@ param(
 - ALL setup code in `BeforeAll` blocks
 - ALL cleanup code in `AfterAll` blocks
 - ALL assertions in `It` blocks
-- NO loose code in `Describe` or `Context` blocks
-- NEVER use `-ForEach` parameter
+- ALL discovery-time code in `BeforeDiscovery` blocks
+- NO loose code in `Describe` or `Context` blocks, except computing a value a `-Skip:` needs
+- `-ForEach` ONLY with cases built in `BeforeDiscovery`, never a `foreach` loop around `It`
 
 ### When to Add/Update Tests
 

--- a/.github/prompts/migration.md
+++ b/.github/prompts/migration.md
@@ -25,8 +25,11 @@ param(
 - **All setup code** must be in `BeforeAll` or `BeforeEach` blocks
 - **All cleanup code** must be in `AfterAll` or `AfterEach` blocks
 - **All test assertions** must be in `It` blocks
-- **No loose code** allowed in `Describe` or `Context` blocks
-- **Never use `-ForEach` parameter** on any test blocks
+- **All discovery-time code** must be in a `BeforeDiscovery` block
+- **No loose code** allowed in `Describe` or `Context` blocks, with one exception: computing a value that a `-Skip:` needs
+- **Only use `-ForEach`** with cases built in `BeforeDiscovery`
+
+A v4 file that builds tests with a `foreach` loop around `It` needs particular attention. In v5 the loop runs during discovery and the `It` bodies run afterwards, so the loop variables are gone and every generated test quietly asserts nothing - the test names still look right, which is what makes it hard to spot. Convert those to `-ForEach` with an array of hashtables built in `BeforeDiscovery`, and move every value the body reads into the hashtable.
 
 ```powershell
 # Pester v5 Structure
@@ -118,8 +121,9 @@ Only use script blocks when direct property comparison is not possible.
 - [ ] Added mandatory `#Requires` header
 - [ ] Replaced dynamic command name derivation with static command name
 - [ ] Stripped out old `knownParameters` validation code
-- [ ] Moved all loose code into appropriate `BeforeAll`/`AfterAll` blocks
-- [ ] Removed any `-ForEach` parameters from test blocks
+- [ ] Moved all loose code into appropriate `BeforeAll`/`AfterAll`/`BeforeDiscovery` blocks
+- [ ] Converted every `foreach` loop around `It` into `-ForEach` with cases from `BeforeDiscovery`
+- [ ] Confirmed each converted test still asserts something - run it once with a deliberately wrong expectation
 - [ ] All test assertions properly placed in `It` blocks
 
 **Variable Scoping:**

--- a/bin/prompts/pester.md
+++ b/bin/prompts/pester.md
@@ -29,8 +29,29 @@ Pester v5 enforces strict organization of test code. Follow these rules:
 - **All setup code** must be in `BeforeAll` or `BeforeEach` blocks
 - **All cleanup code** must be in `AfterAll` or `AfterEach` blocks
 - **All test assertions** must be in `It` blocks
-- **No loose code** is allowed in `Describe` or `Context` blocks
-- **Never use the `-ForEach` parameter** on any test blocks
+- **All discovery-time code** must be in a `BeforeDiscovery` block
+- **No loose code** is allowed in `Describe` or `Context` blocks, with one exception: computing a value that a `-Skip:` needs
+- **Only use the `-ForEach` parameter** with cases built in `BeforeDiscovery`
+
+Pester reads a test file twice: it discovers the tests first (block headers, so `-Skip:` and `-ForEach`), then runs them (block bodies). The two do not share variables. `BeforeDiscovery` is the block for discovery-time code, `BeforeAll` for run-time setup.
+
+A `foreach` loop that emits `It` blocks is always wrong: the loop variables no longer exist when the bodies run, so the tests pass while asserting nothing. Use `-ForEach` with an array of hashtables built in `BeforeDiscovery`, and put every value the body needs into the hashtable - Pester turns each key into a variable in the body and expands `<Key>` in the test name.
+
+```powershell
+Describe $CommandName -Tag UnitTests {
+    BeforeDiscovery {
+        $recoveryCases = @(
+            @{ ModelName = "Full"; ExpectedLogReuse = "LogBackup" }
+            @{ ModelName = "Simple"; ExpectedLogReuse = "Nothing" }
+        )
+    }
+
+    It "reports <ExpectedLogReuse> for a database in <ModelName> recovery" -ForEach $recoveryCases {
+        $result.RecoveryModel | Should -Be $ModelName
+        $result.LogReuseWaitStatus | Should -Be $ExpectedLogReuse
+    }
+}
+```
 
 ### Standard Test Structure
 
@@ -248,8 +269,10 @@ Use script blocks only when:
 - [ ] All setup code is in `BeforeAll` or `BeforeEach` blocks
 - [ ] All cleanup code is in `AfterAll` or `AfterEach` blocks
 - [ ] All test assertions are in `It` blocks
-- [ ] No loose code in `Describe` or `Context` blocks
-- [ ] No `-ForEach` parameters used on test blocks
+- [ ] No loose code in `Describe` or `Context` blocks, except computing a `-Skip:` condition
+- [ ] Discovery-time code is in `BeforeDiscovery`, not in `BeforeAll` and not loose
+- [ ] Every `-ForEach` gets its cases from `BeforeDiscovery`, and every value an `It` body uses is a key of the case hashtable
+- [ ] No `foreach` loop emits `It` blocks - use `-ForEach` instead
 
 **Variable Scoping:**
 - [ ] `$global:` used for variables that persist across Pester blocks

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -71,8 +71,9 @@ Pester v5 enforces strict organization of test code. Follow these rules:
 - **All setup code** must be in `BeforeAll` or `BeforeEach` blocks
 - **All cleanup code** must be in `AfterAll` or `AfterEach` blocks
 - **All test assertions** must be in `It` blocks
+- **All discovery-time code** must be in a `BeforeDiscovery` block, see [Discovery Time vs Run Time](#discovery-time-vs-run-time)
 - **No loose code** is allowed in `Describe` or `Context` blocks, with one exception: computing a value that a `-Skip:` needs, see [Skip Conditions](#skip-conditions)
-- **Never use the `-ForEach` parameter** on any test blocks
+- **Only use the `-ForEach` parameter** with cases built in `BeforeDiscovery`, see [Data-Driven Tests](#data-driven-tests)
 
 ### Standard Test Structure
 
@@ -323,6 +324,60 @@ Keep the exception narrow:
 
 Examples in the tree: `Get-DbaKbUpdate.Tests.ps1` and `Save-DbaKbUpdate.Tests.ps1` test whether the Microsoft Update Catalog answers, `New-DbaFirewallRule.Tests.ps1` tests whether the instance uses dynamic ports.
 
+A `BeforeDiscovery` block inside the `Describe` is the tidier home for the same code and is preferred when the `-Skip:` sits on a `Context` or an `It`. It only fails to help when the `-Skip:` sits on the `Describe` itself, because there is no place inside a block to compute a value the block header already needs.
+
+### Discovery Time vs Run Time
+
+Pester reads a test file twice. First it **discovers** the tests: it runs the file top to bottom, evaluates every `Describe`, `Context` and `It` *header*, and builds the tree. Only then does it **run** the tests: the `BeforeAll`, `BeforeEach`, `It` and `AfterAll` *bodies*.
+
+Anything a header needs - `-Skip:`, `-ForEach`, the test name - has to exist at discovery time. Anything a body needs has to exist at run time. The two do not share variables, and this is the single biggest source of confusion left over from Pester v4.
+
+`BeforeDiscovery` is the block for discovery-time code. It keeps that code out of the `Describe` body while still running early enough:
+
+```powershell
+Describe $CommandName -Tag UnitTests {
+    BeforeDiscovery {
+        # Runs during discovery. Its variables are visible to -ForEach and -Skip: on the blocks below.
+        $editions = @("Standard", "Enterprise")
+    }
+
+    BeforeAll {
+        # Runs during the test run. Its variables are visible inside It bodies.
+        $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+    }
+}
+```
+
+### Data-Driven Tests
+
+Use `-ForEach` when the same assertions apply to a list of cases. It is the only correct way to do this - a `foreach` loop that emits `It` blocks looks like it works, but the loop variables are gone by the time the bodies run, so every generated test silently tests nothing. `Update-DbaInstance.Tests.ps1` carried 44 such tests for years.
+
+The rules:
+
+- **Build the cases in `BeforeDiscovery`.** A `BeforeAll` runs after discovery, so `-ForEach` would see an empty array.
+- **Use an array of hashtables.** Pester turns each key into a variable inside the `It` body and expands `<Key>` in the test name. `$_` holds the whole hashtable.
+- **Everything the body needs must be a key.** A variable from `BeforeDiscovery` is not visible inside the body. Scriptblocks survive in a hashtable, so mock bodies can travel this way too.
+- **Name the test from the case**, so a failure identifies itself.
+
+```powershell
+Describe $CommandName -Tag UnitTests {
+    BeforeDiscovery {
+        $recoveryCases = @(
+            @{ ModelName = "Full"; ExpectedLogReuse = "LogBackup" }
+            @{ ModelName = "Simple"; ExpectedLogReuse = "Nothing" }
+        )
+    }
+
+    It "reports <ExpectedLogReuse> for a database in <ModelName> recovery" -ForEach $recoveryCases {
+        $result = Get-DbaDbRecoveryModel -SqlInstance $TestConfig.InstanceSingle -Database $testDbName
+        $result.RecoveryModel | Should -Be $ModelName
+        $result.LogReuseWaitStatus | Should -Be $ExpectedLogReuse
+    }
+}
+```
+
+Do not reach for `-ForEach` when there are two or three cases and the assertions differ between them - separate `It` blocks read better. It earns its place when the case list is long or generated from a table.
+
 ### Array Operations
 
 - Use `$results.Status.Count` for accurate counting in dbatools context
@@ -474,7 +529,9 @@ Describe $CommandName -Tag IntegrationTests {
 - [ ] All cleanup code is in `AfterAll` or `AfterEach` blocks
 - [ ] All test assertions are in `It` blocks
 - [ ] No loose code in `Describe` or `Context` blocks, except computing a `-Skip:` condition
-- [ ] No `-ForEach` parameters used on test blocks
+- [ ] Discovery-time code is in `BeforeDiscovery`, not in `BeforeAll` and not loose
+- [ ] Every `-ForEach` gets its cases from `BeforeDiscovery`, and every value an `It` body uses is a key of the case hashtable
+- [ ] No `foreach` loop emits `It` blocks - use `-ForEach` instead
 
 **Variable Scoping:**
 - [ ] `$global:` used for variables that persist across Pester blocks

--- a/tests/Update-DbaInstance.Tests.ps1
+++ b/tests/Update-DbaInstance.Tests.ps1
@@ -5,9 +5,7 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-# TODO: This test needs a lot of care
-
-Describe -skip $CommandName -Tag UnitTests {
+Describe $CommandName -Tag UnitTests {
     BeforeAll {
         $exeDir = "C:\Temp\dbatools_$CommandName"
 
@@ -94,6 +92,10 @@ Describe -skip $CommandName -Tag UnitTests {
             Mock -CommandName Initialize-CredSSP -ModuleName dbatools -MockWith { }
             # Mock CmObject
             Mock -CommandName Get-DbaCmObject -ModuleName dbatools -MockWith { [PSCustomObject]@{ SystemType = "x64" } }
+            # Mock the connectivity probe. Without this the command really tries to reach a host
+            # called "mock" over WinRM, which takes seconds and only fails by accident. Returning
+            # $false is what the failed connection did anyway, so the CredSSP path is still tested.
+            Mock -CommandName Invoke-Command2 -ModuleName dbatools -MockWith { $false }
         }
         It "should call internal functions using CredSSP" {
             $password = "pwd" | ConvertTo-SecureString -AsPlainText -Force
@@ -158,6 +160,41 @@ Describe -skip $CommandName -Tag UnitTests {
                     }
                 )
             }
+            # The 2008 and 2012 instances reach Test-DbaBuild as well, because Get-SqlInstanceUpdate
+            # calls it whenever only a major version is given. Their answers are pinned here for the
+            # same reason the 2017 one is: so the test does not move when the build reference index
+            # gets a new CU. Until Pester 6 an unmatched -ParameterFilter fell through to the real
+            # command and the call was not counted, which is why this was never needed before.
+            Mock -CommandName Test-DbaBuild -ModuleName dbatools -MockWith {
+                [PSCustomObject]@{
+                    "Build"       = "10.0.5770"
+                    "BuildTarget" = [version]"10.0.6000"
+                    "Compliant"   = $false
+                    "NameLevel"   = "2008"
+                    "SPLevel"     = "SP3"
+                    "SPTarget"    = "SP4"
+                    "CULevel"     = "CU3"
+                    "CUTarget"    = $null
+                    "KBLevel"     = "2648098"
+                    "BuildLevel"  = [version]"10.0.5770"
+                    "MatchType"   = "Exact"
+                }
+            } -ParameterFilter { $Build -eq [version]"10.0.5770" -and $MaxBehind -eq "0CU" }
+            Mock -CommandName Test-DbaBuild -ModuleName dbatools -MockWith {
+                [PSCustomObject]@{
+                    "Build"       = "11.0.5058"
+                    "BuildTarget" = [version]"11.0.7001"
+                    "Compliant"   = $false
+                    "NameLevel"   = "2012"
+                    "SPLevel"     = "SP2"
+                    "SPTarget"    = "SP4"
+                    "CULevel"     = $null
+                    "CUTarget"    = $null
+                    "KBLevel"     = "2958429"
+                    "BuildLevel"  = [version]"11.0.5058"
+                    "MatchType"   = "Exact"
+                }
+            } -ParameterFilter { $Build -eq [version]"11.0.5058" -and $MaxBehind -eq "0CU" }
             #Mock 2017 to think CU12 is the latest patch available
             Mock -CommandName Test-DbaBuild -ModuleName dbatools -MockWith {
                 [PSCustomObject]@{
@@ -211,7 +248,7 @@ Describe -skip $CommandName -Tag UnitTests {
         }
         It "Should mock-upgrade SQL2008\LAB2 to latest SP" {
             $result = Update-DbaInstance -Version 2008 -InstanceName LAB2 -Type ServicePack -Path $exeDir -Restart -EnableException
-            Should -Invoke -CommandName Test-DbaBuild -Exactly 0 -Scope It -ModuleName dbatools
+            Should -Invoke -CommandName Test-DbaBuild -Exactly 1 -Scope It -ModuleName dbatools
             Should -Invoke -CommandName Get-SQLInstanceComponent -Exactly 1 -Scope It -ModuleName dbatools
             Should -Invoke -CommandName Invoke-Program -Exactly 2 -Scope It -ModuleName dbatools
             Should -Invoke -CommandName Restart-Computer -Exactly 1 -Scope It -ModuleName dbatools
@@ -229,7 +266,7 @@ Describe -skip $CommandName -Tag UnitTests {
         }
         It "Should mock-upgrade SQL2008\LAB2 passing extra command line parameters" {
             $result = Update-DbaInstance -Version 2008 -InstanceName LAB2 -Type ServicePack -Path $exeDir -ArgumentList @("/foo", "/bar=foobar") -EnableException
-            Should -Invoke -CommandName Test-DbaBuild -Exactly 0 -Scope It -ModuleName dbatools
+            Should -Invoke -CommandName Test-DbaBuild -Exactly 1 -Scope It -ModuleName dbatools
             Should -Invoke -CommandName Get-SQLInstanceComponent -Exactly 1 -Scope It -ModuleName dbatools
             Should -Invoke -CommandName Invoke-Program -Exactly 1 -Scope It -ModuleName dbatools -ParameterFilter {
                 if ($ArgumentList[0] -like '/x:*' -and $ArgumentList[1] -eq "/quiet") { return $true }
@@ -250,7 +287,7 @@ Describe -skip $CommandName -Tag UnitTests {
         }
         It "Should mock-upgrade two versions to latest SPs" {
             $results = Update-DbaInstance -Version 2008, 2012 -Type ServicePack -Path $exeDir -Restart -EnableException
-            Should -Invoke -CommandName Test-DbaBuild -Exactly 0 -Scope It -ModuleName dbatools
+            Should -Invoke -CommandName Test-DbaBuild -Exactly 2 -Scope It -ModuleName dbatools
             Should -Invoke -CommandName Get-SQLInstanceComponent -Exactly 1 -Scope It -ModuleName dbatools
             Should -Invoke -CommandName Invoke-Program -Exactly 4 -Scope It -ModuleName dbatools
             Should -Invoke -CommandName Restart-Computer -Exactly 2 -Scope It -ModuleName dbatools
@@ -457,7 +494,6 @@ Describe -skip $CommandName -Tag UnitTests {
                     FullComputerName = $ComputerName
                 }
             }
-            $resolvedComputers += $resolvedComputer.FullComputerName
             # Mock invoke-parallel to prevent runspace-based execution
             Mock -CommandName Invoke-Parallel -ModuleName dbatools -MockWith {
                 $InputObject | ForEach-Object -Process $ScriptBlock
@@ -591,184 +627,201 @@ Describe -skip $CommandName -Tag UnitTests {
             }
             Mock -CommandName Get-Item -ModuleName dbatools -MockWith { "c:\mocked" }
         }
-        AfterAll {
+        BeforeDiscovery {
+            # -ForEach is read while Pester discovers the tests, so the table below and the cases
+            # built from it have to exist at discovery time. A BeforeAll would run far too late and
+            # -ForEach would see an empty array.
+            $versions = @{
+                '2005'   = @{
+                    Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
+                                "SqlInstance" = $null
+                                "Build"       = "9.0.1399"
+                                "NameLevel"   = "2005"
+                                "SPLevel"     = "RTM"
+                                "CULevel"     = $null
+                                "KBLevel"     = $null
+                                "BuildLevel"  = [version]'9.0.1399'
+                                "MatchType"   = "Exact"
+                            }
+                        }
+                    }
+                    Versions = @{
+                        'SP1' = 0
+                        'SP2' = 0
+                        'SP4' = 0, 3
+                    }
+                }
+                '2008'   = @{
+                    Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
+                                "SqlInstance" = $null
+                                "Build"       = "10.0.1600"
+                                "NameLevel"   = "2008"
+                                "SPLevel"     = "RTM"
+                                "CULevel"     = $null
+                                "KBLevel"     = $null
+                                "BuildLevel"  = [version]'10.0.1600'
+                                "MatchType"   = "Exact"
+                            }
+                        }
+                    }
+                    Versions = @{
+                        'SP0' = 1, 10
+                        'SP1' = 0, 16
+                        'SP2' = 0, 11
+                        'SP3' = 0, 17
+                        'SP4' = 0
+                    }
+                }
+                '2008R2' = @{
+                    Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
+                                "SqlInstance" = $null
+                                "Build"       = "10.50.1600"
+                                "NameLevel"   = "2008R2"
+                                "SPLevel"     = "RTM"
+                                "CULevel"     = $null
+                                "KBLevel"     = $null
+                                "BuildLevel"  = [version]'10.50.1600'
+                                "MatchType"   = "Exact"
+                            }
+                        }
+                    }
+                    Versions = @{
+                        'SP0' = 1, 14
+                        'SP1' = 0, 13
+                        'SP2' = 0, 13
+                        'SP3' = 0
+                    }
+                }
+                '2012'   = @{
+                    Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
+                                "SqlInstance" = $null
+                                "Build"       = "11.0.2100"
+                                "NameLevel"   = "2012"
+                                "SPLevel"     = "RTM"
+                                "CULevel"     = $null
+                                "KBLevel"     = $null
+                                "BuildLevel"  = [version]'10.0.2100'
+                                "MatchType"   = "Exact"
+                            }
+                        }
+                    }
+                    Versions = @{
+                        'SP0' = 1, 11
+                        'SP1' = 0, 16
+                        'SP2' = 0, 16
+                        'SP3' = 0, 10
+                        'SP4' = 0
+                    }
+                }
+                '2014'   = @{
+                    Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
+                                "SqlInstance" = $null
+                                "Build"       = "12.0.2000"
+                                "NameLevel"   = "2014"
+                                "SPLevel"     = "RTM"
+                                "CULevel"     = $null
+                                "KBLevel"     = $null
+                                "BuildLevel"  = [version]'12.0.2000'
+                                "MatchType"   = "Exact"
+                            }
+                        }
+                    }
+                    Versions = @{
+                        'SP0' = 1, 14
+                        'SP1' = 0, 13
+                        'SP2' = 0, 14
+                        'SP3' = 0
+                    }
+                }
+                '2016'   = @{
+                    Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
+                                "SqlInstance" = $null
+                                "Build"       = "13.0.1601"
+                                "NameLevel"   = "2016"
+                                "SPLevel"     = "RTM"
+                                "CULevel"     = $null
+                                "KBLevel"     = $null
+                                "BuildLevel"  = [version]'13.0.1601'
+                                "MatchType"   = "Exact"
+                            }
+                        }
+                    }
+                    Versions = @{
+                        'SP0' = 1, 9
+                        'SP1' = 0, 12
+                        'SP2' = 0, 4
+                    }
+                }
+                '2017'   = @{
+                    Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
+                                "SqlInstance" = $null
+                                "Build"       = "14.0.1000"
+                                "NameLevel"   = "2017"
+                                "SPLevel"     = "RTM"
+                                "CULevel"     = $null
+                                "KBLevel"     = $null
+                                "BuildLevel"  = [version]'14.0.1000'
+                                "MatchType"   = "Exact"
+                            }
+                        }
+                    }
+                    Versions = @{
+                        'SP0' = 1, 12
+                    }
+                }
+            }
+
+            # One case per SP/CU combination. Everything an It block needs has to travel inside the
+            # hashtable: the loop variables here are gone by the time the It body runs, and the keys
+            # of the hashtable are what Pester turns back into variables in that body.
+            $upgradeCases = @()
+            foreach ($v in $versions.Keys | Sort-Object) {
+                #cycle through every sp and cu defined
+                $upgrades = $versions[$v].Versions
+                foreach ($upgrade in $upgrades.Keys | Sort-Object) {
+                    foreach ($cu in $upgrades[$upgrade]) {
+                        $tLevel = $upgrade
+                        $steps = 0
+                        if ($tLevel -eq 'SP0') { $tLevel = 'RTM' }
+                        else { $steps++ }
+                        if ($cu -gt 0) {
+                            $cuLevel = "$($tLevel)CU$cu"
+                            $steps++
+                        } else {
+                            $cuLevel = $tLevel
+                        }
+                        $upgradeCases += @{
+                            MajorVersion  = $v
+                            TargetLevel   = $tLevel
+                            CuLevel       = $cuLevel
+                            Steps         = $steps
+                            InstalledMock = $versions[$v].Mock
+                        }
+                    }
+                }
+            }
         }
-        $versions = @{
-            '2005'   = @{
-                Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
-                            "SqlInstance" = $null
-                            "Build"       = "9.0.1399"
-                            "NameLevel"   = "2005"
-                            "SPLevel"     = "RTM"
-                            "CULevel"     = $null
-                            "KBLevel"     = $null
-                            "BuildLevel"  = [version]'9.0.1399'
-                            "MatchType"   = "Exact"
-                        }
-                    }
-                }
-                Versions = @{
-                    'SP1' = 0
-                    'SP2' = 0
-                    'SP4' = 0, 3
-                }
-            }
-            '2008'   = @{
-                Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
-                            "SqlInstance" = $null
-                            "Build"       = "10.0.1600"
-                            "NameLevel"   = "2008"
-                            "SPLevel"     = "RTM"
-                            "CULevel"     = $null
-                            "KBLevel"     = $null
-                            "BuildLevel"  = [version]'10.0.1600'
-                            "MatchType"   = "Exact"
-                        }
-                    }
-                }
-                Versions = @{
-                    'SP0' = 1, 10
-                    'SP1' = 0, 16
-                    'SP2' = 0, 11
-                    'SP3' = 0, 17
-                    'SP4' = 0
-                }
-            }
-            '2008R2' = @{
-                Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
-                            "SqlInstance" = $null
-                            "Build"       = "10.50.1600"
-                            "NameLevel"   = "2008R2"
-                            "SPLevel"     = "RTM"
-                            "CULevel"     = $null
-                            "KBLevel"     = $null
-                            "BuildLevel"  = [version]'10.50.1600'
-                            "MatchType"   = "Exact"
-                        }
-                    }
-                }
-                Versions = @{
-                    'SP0' = 1, 14
-                    'SP1' = 0, 13
-                    'SP2' = 0, 13
-                    'SP3' = 0
-                }
-            }
-            '2012'   = @{
-                Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
-                            "SqlInstance" = $null
-                            "Build"       = "11.0.2100"
-                            "NameLevel"   = "2012"
-                            "SPLevel"     = "RTM"
-                            "CULevel"     = $null
-                            "KBLevel"     = $null
-                            "BuildLevel"  = [version]'10.0.2100'
-                            "MatchType"   = "Exact"
-                        }
-                    }
-                }
-                Versions = @{
-                    'SP0' = 1, 11
-                    'SP1' = 0, 16
-                    'SP2' = 0, 16
-                    'SP3' = 0, 10
-                    'SP4' = 0
-                }
-            }
-            '2014'   = @{
-                Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
-                            "SqlInstance" = $null
-                            "Build"       = "12.0.2000"
-                            "NameLevel"   = "2014"
-                            "SPLevel"     = "RTM"
-                            "CULevel"     = $null
-                            "KBLevel"     = $null
-                            "BuildLevel"  = [version]'12.0.2000'
-                            "MatchType"   = "Exact"
-                        }
-                    }
-                }
-                Versions = @{
-                    'SP0' = 1, 14
-                    'SP1' = 0, 13
-                    'SP2' = 0, 14
-                    'SP3' = 0
-                }
-            }
-            '2016'   = @{
-                Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
-                            "SqlInstance" = $null
-                            "Build"       = "13.0.1601"
-                            "NameLevel"   = "2016"
-                            "SPLevel"     = "RTM"
-                            "CULevel"     = $null
-                            "KBLevel"     = $null
-                            "BuildLevel"  = [version]'13.0.1601'
-                            "MatchType"   = "Exact"
-                        }
-                    }
-                }
-                Versions = @{
-                    'SP0' = 1, 9
-                    'SP1' = 0, 12
-                    'SP2' = 0, 4
-                }
-            }
-            '2017'   = @{
-                Mock     = { [PSCustomObject]@{ InstanceName = "LAB"; Version = [PSCustomObject]@{
-                            "SqlInstance" = $null
-                            "Build"       = "14.0.1000"
-                            "NameLevel"   = "2017"
-                            "SPLevel"     = "RTM"
-                            "CULevel"     = $null
-                            "KBLevel"     = $null
-                            "BuildLevel"  = [version]'14.0.1000'
-                            "MatchType"   = "Exact"
-                        }
-                    }
-                }
-                Versions = @{
-                    'SP0' = 1, 12
-                }
-            }
-        }
-        foreach ($v in $versions.Keys | Sort-Object) {
+
+        It "<MajorVersion> to <CuLevel>" -ForEach $upgradeCases {
             #this is our 'currently installed' versions
-            Mock -CommandName Get-SQLInstanceComponent -ModuleName dbatools -MockWith $versions[$v].Mock
-            #cycle through every sp and cu defined
-            $upgrades = $versions[$v].Versions
-            foreach ($upgrade in $upgrades.Keys | Sort-Object) {
-                foreach ($cu in $upgrades[$upgrade]) {
-                    $tLevel = $upgrade
-                    $steps = 0
-                    if ($tLevel -eq 'SP0') { $tLevel = 'RTM' }
-                    else { $steps++ }
-                    if ($cu -gt 0) {
-                        $cuLevel = "$($tLevel)CU$cu"
-                        $steps++
-                    } else {
-                        $cuLevel = $tLevel
-                    }
-                    It "$v to $cuLevel" {
-                        $results = Update-DbaInstance -Version "$v$cuLevel" -Path "mocked" -Restart -EnableException
-                        Should -Invoke -CommandName Get-SQLInstanceComponent -Exactly 1 -Scope It -ModuleName dbatools
-                        Should -Invoke -CommandName Invoke-Program -Exactly ($steps * 2) -Scope It -ModuleName dbatools
-                        Should -Invoke -CommandName Restart-Computer -Exactly $steps -Scope It -ModuleName dbatools
-                        for ($i = 0; $i -lt $steps; $i++) {
-                            $result = $results | Select-Object -First 1 -Skip $i
-                            $result | Should -Not -BeNullOrEmpty
-                            $result.MajorVersion | Should -Be $v
-                            if ($steps -gt 1 -and $i -eq 0) { $result.TargetLevel | Should -Be $tLevel }
-                            else { $result.TargetLevel | Should -Be $cuLevel }
-                            $result.KB | Should -BeGreaterThan 0
-                            $result.Successful | Should -Be $true
-                            $result.Restarted | Should -Be $true
-                            $result.Installer | Should -Be 'c:\mocked\filename.exe'
-                            $result.Notes | Should -BeNullOrEmpty
-                            $result.ExtractPath | Should -BeLike '*\dbatools_KB*Extract_*'
-                        }
-                    }
-                }
+            Mock -CommandName Get-SQLInstanceComponent -ModuleName dbatools -MockWith $InstalledMock
+
+            $results = Update-DbaInstance -Version "$MajorVersion$CuLevel" -Path "mocked" -Restart -EnableException
+            Should -Invoke -CommandName Get-SQLInstanceComponent -Exactly 1 -Scope It -ModuleName dbatools
+            Should -Invoke -CommandName Invoke-Program -Exactly ($Steps * 2) -Scope It -ModuleName dbatools
+            Should -Invoke -CommandName Restart-Computer -Exactly $Steps -Scope It -ModuleName dbatools
+            for ($i = 0; $i -lt $Steps; $i++) {
+                $result = $results | Select-Object -First 1 -Skip $i
+                $result | Should -Not -BeNullOrEmpty
+                $result.MajorVersion | Should -Be $MajorVersion
+                if ($Steps -gt 1 -and $i -eq 0) { $result.TargetLevel | Should -Be $TargetLevel }
+                else { $result.TargetLevel | Should -Be $CuLevel }
+                $result.KB | Should -BeGreaterThan 0
+                $result.Successful | Should -Be $true
+                $result.Restarted | Should -Be $true
+                $result.Installer | Should -Be 'c:\mocked\filename.exe'
+                $result.Notes | Should -BeNullOrEmpty
+                $result.ExtractPath | Should -BeLike '*\dbatools_KB*Extract_*'
             }
         }
     }
@@ -797,31 +850,34 @@ Describe -skip $CommandName -Tag UnitTests {
                 Remove-Item $exeDir -Force -Recurse
             }
         }
+        # Should -Throw matches with -like, so every expected message needs wildcards. Without them
+        # these assertions can only pass if the command reports nothing but the fragment - which is
+        # never the case here. In Pester 4 the same strings were a substring match and did pass.
         It "fails when a reboot is pending" {
             #override default mock
             Mock -CommandName Test-PendingReboot -MockWith { $true } -ModuleName dbatools
-            { Update-DbaInstance -Version 2008SP3CU7 -Path $exeDir -EnableException } | Should -Throw "Reboot the computer before proceeding"
-            #revert default mock
-            Mock -CommandName Test-PendingReboot -MockWith { $false } -ModuleName dbatools
+            { Update-DbaInstance -Version 2008SP3CU7 -Path $exeDir -EnableException } | Should -Throw "*Reboot the computer before proceeding*"
         }
         It "fails when Version string is incorrect" {
-            { Update-DbaInstance -Version '' -EnableException } | Should -Throw 'Cannot validate argument on parameter ''Version'''
-            { Update-DbaInstance -Version $null -EnableException } | Should -Throw 'Cannot validate argument on parameter ''Version'''
-            { Update-DbaInstance -Version SQL2008-SP3 -EnableException } | Should -Throw 'is an incorrect Version value'
-            { Update-DbaInstance -Version SP2CU -EnableException } | Should -Throw 'is an incorrect Version value'
-            { Update-DbaInstance -Version SPCU2 -EnableException } | Should -Throw 'is an incorrect Version value'
-            { Update-DbaInstance -Version SQLSP2CU2 -EnableException } | Should -Throw 'is an incorrect Version value'
+            # The ? wildcards stand for the quotes PowerShell puts around the parameter name
+            { Update-DbaInstance -Version "" -EnableException } | Should -Throw "*Cannot validate argument on parameter ?Version?*"
+            { Update-DbaInstance -Version $null -EnableException } | Should -Throw "*Cannot validate argument on parameter ?Version?*"
+            { Update-DbaInstance -Version SQL2008-SP3 -EnableException } | Should -Throw "*is an incorrect Version value*"
+            { Update-DbaInstance -Version SP2CU -EnableException } | Should -Throw "*is an incorrect Version value*"
+            { Update-DbaInstance -Version SPCU2 -EnableException } | Should -Throw "*is an incorrect Version value*"
+            { Update-DbaInstance -Version SQLSP2CU2 -EnableException } | Should -Throw "*is an incorrect Version value*"
         }
         It "fails when KB is missing in the folder" {
-            { Update-DbaInstance -Path $exeDir -EnableException } | Should -Throw 'Could not find installer for the SQL2008 update KB'
-            { Update-DbaInstance -Version 2008SP3CU7 -Path $exeDir -EnableException } | Should -Throw 'Could not find installer for the SQL2008 update KB'
+            { Update-DbaInstance -Path $exeDir -EnableException } | Should -Throw "*Could not find installer for the SQL2008 update KB*"
+            { Update-DbaInstance -Version 2008SP3CU7 -Path $exeDir -EnableException } | Should -Throw "*Could not find installer for the SQL2008 update KB*"
         }
         It "fails when SP level is lower than required" {
-            { Update-DbaInstance -Type CumulativeUpdate -Path $exeDir -EnableException } | Should -Throw "Current SP version SQL2008SP2 is not the latest available"
+            { Update-DbaInstance -Type CumulativeUpdate -Path $exeDir -EnableException } | Should -Throw "*Current SP version SQL2008SP2 is not the latest available*"
         }
         It "fails when repository is not available" {
-            { Update-DbaInstance -Version 2008SP3CU7 -Path .\NonExistingFolder -EnableException } | Should -Throw "Cannot find path"
-            { Update-DbaInstance -Version 2008SP3CU7 -EnableException } | Should -Throw "Path is required"
+            # An absolute path, so the test does not depend on the working directory of the runner
+            { Update-DbaInstance -Version 2008SP3CU7 -Path "$exeDir\NonExistingFolder" -EnableException } | Should -Throw "*Cannot find path*"
+            { Update-DbaInstance -Version 2008SP3CU7 -EnableException } | Should -Throw "*Path is required*"
         }
         It "fails when update execution has failed" {
             #Mock Get-Item and Get-ChildItem with a dummy file
@@ -833,7 +889,7 @@ Describe -skip $CommandName -Tag UnitTests {
             Mock -CommandName Get-Item -ModuleName dbatools -MockWith { "c:\mocked" }
             #override default mock
             Mock -CommandName Invoke-Program -MockWith { [PSCustomObject]@{ Successful = $false; ExitCode = 12345 } } -ModuleName dbatools
-            { Update-DbaInstance -Version 2008SP3 -EnableException -Path "mocked" } | Should -Throw 'failed with exit code 12345'
+            { Update-DbaInstance -Version 2008SP3 -EnableException -Path "mocked" } | Should -Throw "*failed with exit code 12345*"
             $result = Update-DbaInstance -Version 2008SP3 -Path "mocked" -WarningVariable warVar 3>$null
             $result | Should -Not -BeNullOrEmpty
             $result.MajorVersion | Should -Be 2008
@@ -845,8 +901,6 @@ Describe -skip $CommandName -Tag UnitTests {
             $result.Notes | Should -BeLike '*failed with exit code 12345*'
             $result.ExtractPath | Should -BeLike '*\dbatools_KB*Extract_*'
             $warVar | Should -BeLike '*failed with exit code 12345*'
-            #revert default mock
-            Mock -CommandName Invoke-Program -MockWith { [PSCustomObject]@{ Successful = $true } } -ModuleName dbatools
         }
     }
 }


### PR DESCRIPTION
Two commits: the first makes `tests/Update-DbaInstance.Tests.ps1` run again, the second changes the test guides to permit the syntax it needed.

## Why the file was skipped

The unit test `Describe` has carried `-skip` and a `# TODO: This test needs a lot of care` since d81b4fe53, *"Fix tests that needed extra care after migration to pester 5"*. Removing the skip gives **15 passed, 53 failed**. All 53 come from three defects, none of them about the command:

**1. Forty-four tests had empty bodies.** A `foreach` loop emitted the `It` blocks during discovery. The names interpolated fine, so the test report looked healthy, but `$v`, `$cuLevel` and `$steps` were gone by the time the bodies ran - every one of them called `Update-DbaInstance -Version ""` and died on parameter validation. The `Mock` inside the same loop was registered during discovery and applied to nothing.

**2. Seven `Should -Throw` assertions could never match.** `-ExpectedMessage` compares with `-like` and none of them had wildcards, e.g. `Should -Throw "Cannot find path"` against `Cannot find path '...' because it does not exist.` They were a substring match in Pester 4.

**3. Three tests asserted something the command does not do.** `Should -Invoke Test-DbaBuild -Exactly 0`, but [Get-SqlInstanceUpdate.ps1:109](../blob/development/private/functions/Get-SqlInstanceUpdate.ps1#L109) calls it whenever only a major version is given, which is exactly what those tests do. Until Pester 6 an unmatched `-ParameterFilter` fell through to the real command and the call was not counted, so the wrong expectation was invisible.

## Result

**69 tests, 68 pass**, 1 is the still-skipped integration `Describe`. Runtime ~35s.

The recovered tests are not passing vacuously: mutating a single expectation inside the `-ForEach` block fails exactly 44 of them.

Also fixed while in there: the "testing proper Authorization" Context made a real WinRM call to a host literally named `mock` (the connectivity probe at [Update-DbaInstance.ps1:523](../blob/development/public/Update-DbaInstance.ps1#L523) was unmocked, two tests took ~3s each and passed only because the connection failed); "fails when repository is not available" used a relative path so its message depended on the runner's working directory; and a dead `$resolvedComputers` assignment, an empty `AfterAll` and two "revert default mock" lines are gone.

The integration `Describe` is deliberately untouched. It is still `-Skip`, and since it mocks away reboot, elevation and update discovery it is a `-WhatIf` smoke test rather than an integration test - that deserves its own decision.

## The guide change

The guides banned `-ForEach` outright. That ban came out of the Pester 4 to 5 migration, but it removed the only correct way to write data-driven tests while leaving the wrong way fully compliant - a `foreach` loop around `It` passes every style rule, looks right in the report, and asserts nothing.

The missing piece was `BeforeDiscovery`. With the cases built there, `-ForEach` is safe and the discovery-time code stops being loose as well. `tests/CLAUDE.md` now has a "Discovery Time vs Run Time" section explaining Pester's two passes and a "Data-Driven Tests" section with the rules:

- build the cases in `BeforeDiscovery`, never `BeforeAll`
- use an array of hashtables, so keys become variables and `<Key>` expands in the name
- every value the body reads must be a key - a `BeforeDiscovery` variable is not visible in the body
- prefer separate `It` blocks when there are only two or three cases

`bin/prompts/pester.md`, `.github/prompts/migration.md` and `.github/copilot-instructions.md` carry the same rules and are updated to match.

The same commit documents the **existing** exception to the no-loose-code rule - a value that a `-Skip:` needs may be computed in the `Describe` block - in the three guides that did not have it yet. `tests/CLAUDE.md` already did. It also notes that `BeforeDiscovery` is the tidier home for that computation whenever the `-Skip:` is not on the `Describe` itself.

## Verification

- `Invoke-DbatoolsTest.ps1 Update-DbaInstance -Tag UnitTests`: 69 total, 68 passed, 0 failed.
- Mutation check on the `-ForEach` assertions: 44 failures, one per case.
- `TestTestfiles.Tests.ps1 -ExcludeTagFilter Goal`: 0 failures over 723 files.
- `TestTestLayout.ps1`: the same 82 pre-existing files as before the change.