### PR TITLE
CI - Kill a wedged test file fast instead of burning the 90 minute job timeout

### DIFF
--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -459,7 +459,7 @@ if (-not $Finalize) {
                 $CoverFiles = Get-CoverageIndications -Path $f -ModuleBase $ModuleBase
                 $pester5Config.CodeCoverage.Enabled = $true
                 $pester5Config.CodeCoverage.Path = $CoverFiles
-                $pester5Config.CodeCoverage.OutputFormat = 'JaCoCo'
+                $pester5Config.CodeCoverage.OutputFormat = "JaCoCo"
                 $pester5Config.CodeCoverage.OutputPath = "$ModuleBase\Pester5Coverage$PSVersion$Counter.xml"
             }
 
@@ -501,7 +501,7 @@ if (-not $Finalize) {
                     if ($trialNo -le 3) {
                         Write-Host -Object "appveyor.pester: Test failed with $($PesterRun.FailedCount) failed tests. Retrying (attempt $trialNo of 3)..." -ForegroundColor Yellow
                         # Restarting all used instances to avoid state issues
-                        $null = Get-DbaService -Type Engine | Where-Object State -eq 'Running' | Restart-DbaService -Force -Confirm:$false
+                        $null = Get-DbaService -Type Engine | Where-Object State -eq "Running" | Restart-DbaService -Force -Confirm:$false
                         Start-Sleep -Seconds 10
                     } else {
                         Write-Host -Object "appveyor.pester: Test failed with $($PesterRun.FailedCount) failed tests. No more retries left." -ForegroundColor Red
@@ -515,7 +515,7 @@ if (-not $Finalize) {
                         Outcome       = "Failed"
                         FailedCount   = $PesterRun.FailedCount
                         Duration      = $PesterRun.Duration.TotalMilliseconds
-                        PesterVersion = '5'
+                        PesterVersion = "5"
                     }
                 } else {
                     Update-AppveyorTest -Name $appvTestName -Framework NUnit -FileName $f.FullName -Outcome "Passed" -Duration $PesterRun.Duration.TotalMilliseconds
@@ -526,7 +526,7 @@ if (-not $Finalize) {
                         Attempt       = $trialNo
                         Outcome       = "Passed"
                         Duration      = $PesterRun.Duration.TotalMilliseconds
-                        PesterVersion = '5'
+                        PesterVersion = "5"
                     }
                     break
                 }

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -400,84 +400,156 @@ if (-not $Finalize) {
         TestRuns = @()
     }
 
-    $TestConfig = Get-TestConfig
-    $Counter = 0
-    foreach ($f in $AllTestsWithinScenario) {
-        $Counter += 1
+    # A native call that blocks with no timeout (certreq, SMO ManagedComputer/WMI, WinRM) wedges
+    # this process for good, because nothing running inside it can interrupt a blocked thread.
+    # Without a guard the run stays silent until the 90 minute job timeout and never says which
+    # file was stuck. The watchdog runs out of process, so it can name the file and kill this one.
+    # The PID keeps two runs that share a workspace from clobbering the same heartbeat
+    $heartbeatPath = "$ModuleBase\pester-heartbeat-$PID.txt"
+    $splatRemoveHeartbeat = @{
+        Path        = $heartbeatPath
+        Force       = $true
+        ErrorAction = "SilentlyContinue"
+    }
+    Remove-Item @splatRemoveHeartbeat
 
-        $pester5Config = New-PesterConfiguration
-        $pester5Config.Run.Path = $f.FullName
-        $pester5config.Run.PassThru = $true
-        $pester5config.Output.Verbosity = "None"
-
-        #opt-in
-        if ($IncludeCoverage) {
-            $CoverFiles = Get-CoverageIndications -Path $f -ModuleBase $ModuleBase
-            $pester5Config.CodeCoverage.Enabled = $true
-            $pester5Config.CodeCoverage.Path = $CoverFiles
-            $pester5Config.CodeCoverage.OutputFormat = 'JaCoCo'
-            $pester5Config.CodeCoverage.OutputPath = "$ModuleBase\Pester5Coverage$PSVersion$Counter.xml"
+    # A bad value here would either disable the guard or kill every test on sight, so it is
+    # rejected now rather than discovered once the suite is already running
+    $testFileTimeoutMinutes = 15
+    if ($env:DBATOOLS_TEST_FILE_TIMEOUT_MINUTES) {
+        [int]$parsedTimeoutMinutes = 0
+        if (-not [System.Int32]::TryParse($env:DBATOOLS_TEST_FILE_TIMEOUT_MINUTES, [ref]$parsedTimeoutMinutes)) {
+            throw "DBATOOLS_TEST_FILE_TIMEOUT_MINUTES is not a number: $env:DBATOOLS_TEST_FILE_TIMEOUT_MINUTES"
         }
+        if ($parsedTimeoutMinutes -lt 1 -or $parsedTimeoutMinutes -gt 1440) {
+            throw "DBATOOLS_TEST_FILE_TIMEOUT_MINUTES must be between 1 and 1440, got $parsedTimeoutMinutes"
+        }
+        $testFileTimeoutMinutes = $parsedTimeoutMinutes
+    }
 
-        $trialNo = 1
-        while ($trialNo -le 3) {
-            if ($trialNo -eq 1) {
-                $appvTestName = $f.Name
-            } else {
-                $appvTestName = "$($f.Name), attempt #$trialNo"
+    $splatWatchdog = @{
+        FilePath     = "powershell.exe"
+        ArgumentList = @(
+            "-NoProfile"
+            "-NonInteractive"
+            "-ExecutionPolicy", "Bypass"
+            "-File", "`"$ModuleBase\tests\appveyor.watchdog.ps1`""
+            "-ParentProcessId", $PID
+            "-HeartbeatPath", "`"$heartbeatPath`""
+            "-TimeoutMinutes", $testFileTimeoutMinutes
+        )
+        NoNewWindow  = $true
+        PassThru     = $true
+    }
+    $watchdogProcess = Start-Process @splatWatchdog
+
+    try {
+        $TestConfig = Get-TestConfig
+        $Counter = 0
+        foreach ($f in $AllTestsWithinScenario) {
+            $Counter += 1
+
+            $pester5Config = New-PesterConfiguration
+            $pester5Config.Run.Path = $f.FullName
+            $pester5config.Run.PassThru = $true
+            $pester5config.Output.Verbosity = "None"
+
+            #opt-in
+            if ($IncludeCoverage) {
+                $CoverFiles = Get-CoverageIndications -Path $f -ModuleBase $ModuleBase
+                $pester5Config.CodeCoverage.Enabled = $true
+                $pester5Config.CodeCoverage.Path = $CoverFiles
+                $pester5Config.CodeCoverage.OutputFormat = 'JaCoCo'
+                $pester5Config.CodeCoverage.OutputPath = "$ModuleBase\Pester5Coverage$PSVersion$Counter.xml"
             }
-            Write-Host -Object "Running $($f.FullName) ..." -ForegroundColor Cyan -NoNewLine
-            Add-AppveyorTest -Name $appvTestName -Framework NUnit -FileName $f.FullName -Outcome Running
-            $PesterRun = Invoke-Pester -Configuration $pester5config
-            Write-Host -Object "`rCompleted $($f.FullName) in $([int]$PesterRun.Duration.TotalMilliseconds)ms" -ForegroundColor Cyan
-            $PesterRun | Export-Clixml -Path "$ModuleBase\Pester5Results$PSVersion$Counter.xml"
 
-            # Export failure summary for easier retrieval
-            Export-TestFailureSummary -TestFile $f -PesterRun $PesterRun -Counter $Counter -ModuleBase $ModuleBase
-
-            if ($PesterRun.FailedCount -gt 0) {
-                $trialno += 1
-
-                # Create detailed error message for AppVeyor with comprehensive extraction
-                $failedTestsList = $PesterRun.Tests | Where-Object { $PSItem.Passed -eq $false } | ForEach-Object {
-                    $path = $PSItem.Path -join " > "
-                    $errorInfo = Get-ComprehensiveErrorMessage -TestResult $PSItem -DebugMode:$DebugErrorExtraction
-                    "$path > $($PSItem.Name): $($errorInfo.ErrorMessage)"
-                }
-                $errorMessageDetail = $failedTestsList -join " | "
-
-                if ($trialNo -le 3) {
-                    Write-Host -Object "appveyor.pester: Test failed with $($PesterRun.FailedCount) failed tests. Retrying (attempt $trialNo of 3)..." -ForegroundColor Yellow
-                    # Restarting all used instances to avoid state issues
-                    $null = Get-DbaService -Type Engine | Where-Object State -eq 'Running' | Restart-DbaService -Force -Confirm:$false
-                    Start-Sleep -Seconds 10
+            $trialNo = 1
+            while ($trialNo -le 3) {
+                if ($trialNo -eq 1) {
+                    $appvTestName = $f.Name
                 } else {
-                    Write-Host -Object "appveyor.pester: Test failed with $($PesterRun.FailedCount) failed tests. No more retries left." -ForegroundColor Red
-                    Update-AppveyorTest -Name $appvTestName -Framework NUnit -FileName $f.FullName -Outcome "Failed" -Duration $PesterRun.Duration.TotalMilliseconds -ErrorMessage $errorMessageDetail
+                    $appvTestName = "$($f.Name), attempt #$trialNo"
                 }
+                Write-Host -Object "Running $($f.FullName) ..." -ForegroundColor Cyan -NoNewLine
+                Add-AppveyorTest -Name $appvTestName -Framework NUnit -FileName $f.FullName -Outcome Running
+                # Tell the watchdog what is running now, so a wedge is reported against the right file.
+                # Written per attempt, so a retry gets its own budget rather than sharing the first one.
+                $splatHeartbeat = @{
+                    Path        = $heartbeatPath
+                    Value       = "$((Get-Date).Ticks)|$appvTestName"
+                    ErrorAction = "SilentlyContinue"
+                }
+                Set-Content @splatHeartbeat
+                $PesterRun = Invoke-Pester -Configuration $pester5config
+                Write-Host -Object "`rCompleted $($f.FullName) in $([int]$PesterRun.Duration.TotalMilliseconds)ms" -ForegroundColor Cyan
+                $PesterRun | Export-Clixml -Path "$ModuleBase\Pester5Results$PSVersion$Counter.xml"
 
-                # Add to summary
-                $allTestsSummary.TestRuns += @{
-                    TestFile      = $f.Name
-                    Attempt       = $trialNo
-                    Outcome       = "Failed"
-                    FailedCount   = $PesterRun.FailedCount
-                    Duration      = $PesterRun.Duration.TotalMilliseconds
-                    PesterVersion = '5'
-                }
-            } else {
-                Update-AppveyorTest -Name $appvTestName -Framework NUnit -FileName $f.FullName -Outcome "Passed" -Duration $PesterRun.Duration.TotalMilliseconds
+                # Export failure summary for easier retrieval
+                Export-TestFailureSummary -TestFile $f -PesterRun $PesterRun -Counter $Counter -ModuleBase $ModuleBase
 
-                # Add to summary
-                $allTestsSummary.TestRuns += @{
-                    TestFile      = $f.Name
-                    Attempt       = $trialNo
-                    Outcome       = "Passed"
-                    Duration      = $PesterRun.Duration.TotalMilliseconds
-                    PesterVersion = '5'
+                if ($PesterRun.FailedCount -gt 0) {
+                    $trialno += 1
+
+                    # Create detailed error message for AppVeyor with comprehensive extraction
+                    $failedTestsList = $PesterRun.Tests | Where-Object { $PSItem.Passed -eq $false } | ForEach-Object {
+                        $path = $PSItem.Path -join " > "
+                        $errorInfo = Get-ComprehensiveErrorMessage -TestResult $PSItem -DebugMode:$DebugErrorExtraction
+                        "$path > $($PSItem.Name): $($errorInfo.ErrorMessage)"
+                    }
+                    $errorMessageDetail = $failedTestsList -join " | "
+
+                    if ($trialNo -le 3) {
+                        Write-Host -Object "appveyor.pester: Test failed with $($PesterRun.FailedCount) failed tests. Retrying (attempt $trialNo of 3)..." -ForegroundColor Yellow
+                        # Restarting all used instances to avoid state issues
+                        $null = Get-DbaService -Type Engine | Where-Object State -eq 'Running' | Restart-DbaService -Force -Confirm:$false
+                        Start-Sleep -Seconds 10
+                    } else {
+                        Write-Host -Object "appveyor.pester: Test failed with $($PesterRun.FailedCount) failed tests. No more retries left." -ForegroundColor Red
+                        Update-AppveyorTest -Name $appvTestName -Framework NUnit -FileName $f.FullName -Outcome "Failed" -Duration $PesterRun.Duration.TotalMilliseconds -ErrorMessage $errorMessageDetail
+                    }
+
+                    # Add to summary
+                    $allTestsSummary.TestRuns += @{
+                        TestFile      = $f.Name
+                        Attempt       = $trialNo
+                        Outcome       = "Failed"
+                        FailedCount   = $PesterRun.FailedCount
+                        Duration      = $PesterRun.Duration.TotalMilliseconds
+                        PesterVersion = '5'
+                    }
+                } else {
+                    Update-AppveyorTest -Name $appvTestName -Framework NUnit -FileName $f.FullName -Outcome "Passed" -Duration $PesterRun.Duration.TotalMilliseconds
+
+                    # Add to summary
+                    $allTestsSummary.TestRuns += @{
+                        TestFile      = $f.Name
+                        Attempt       = $trialNo
+                        Outcome       = "Passed"
+                        Duration      = $PesterRun.Duration.TotalMilliseconds
+                        PesterVersion = '5'
+                    }
+                    break
                 }
-                break
             }
+        }
+    } finally {
+        # Removing the heartbeat first puts the watchdog back to idle, so the summary and log
+        # work below is never mistaken for a wedged test file. This runs even when the loop
+        # throws, so a failed run can never leave a live watchdog aimed at a later stage.
+        $splatRemoveHeartbeatAfter = @{
+            Path        = $heartbeatPath
+            Force       = $true
+            ErrorAction = "SilentlyContinue"
+        }
+        Remove-Item @splatRemoveHeartbeatAfter
+
+        if ($watchdogProcess -and -not $watchdogProcess.HasExited) {
+            $splatStopWatchdog = @{
+                Id          = $watchdogProcess.Id
+                Force       = $true
+                ErrorAction = "SilentlyContinue"
+            }
+            Stop-Process @splatStopWatchdog
         }
     }
 

--- a/tests/appveyor.watchdog.Tests.ps1
+++ b/tests/appveyor.watchdog.Tests.ps1
@@ -1,0 +1,211 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName = "dbatools",
+    $CommandName = "appveyor.watchdog",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    # The watchdog drives real processes, so these tests need a powershell.exe to sacrifice.
+    # $IsWindows does not exist on 5.1, where it evaluates to $null and would skip the whole
+    # block on the very platform this runs on, so the platform is read a way that is correct
+    # on both editions.
+    $onWindows = $PSVersionTable.Platform -ne "Unix"
+
+    Context "Watching a wedged run" -Skip:(-not $onWindows) {
+        BeforeAll {
+            $watchdogScript = Join-Path $PSScriptRoot "appveyor.watchdog.ps1"
+            $watchdogTempPath = Join-Path ([System.IO.Path]::GetTempPath()) "dbatools-watchdog-$(Get-Random)"
+            $null = New-Item -Path $watchdogTempPath -ItemType Directory
+
+            # A sleeper stands in for a wedged test process. Both variants live in script files so
+            # nothing has to survive a round trip through nested command line quoting.
+            $sleeperScript = Join-Path $watchdogTempPath "sleeper.ps1"
+            Set-Content -Path $sleeperScript -Value "Start-Sleep -Seconds 600"
+
+            $sleeperWithChildScript = Join-Path $watchdogTempPath "sleeper-with-child.ps1"
+            $childLauncher = "Start-Process powershell.exe -ArgumentList `"-NoProfile`", `"-File`", `"$sleeperScript`" -WindowStyle Hidden"
+            Set-Content -Path $sleeperWithChildScript -Value @($childLauncher, "Start-Sleep -Seconds 600")
+
+            # Everything this suite starts is tracked so a failed assertion cannot leak a runaway
+            # process onto the build agent
+            $script:startedProcessIds = @()
+
+            function New-SacrificialProcess {
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+                param(
+                    [switch]$WithChild
+                )
+
+                if ($WithChild) {
+                    $sacrificeScript = $sleeperWithChildScript
+                } else {
+                    $sacrificeScript = $sleeperScript
+                }
+
+                $splatSacrifice = @{
+                    FilePath     = "powershell.exe"
+                    ArgumentList = @("-NoProfile", "-NonInteractive", "-File", "`"$sacrificeScript`"")
+                    PassThru     = $true
+                    WindowStyle  = "Hidden"
+                }
+                $sacrifice = Start-Process @splatSacrifice
+                $script:startedProcessIds += $sacrifice.Id
+                return $sacrifice
+            }
+
+            function Start-TestWatchdog {
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+                param(
+                    [int]$TargetProcessId,
+                    [string]$HeartbeatFile,
+                    [int]$TimeoutMinutes = 1,
+                    [int]$PollSeconds = 1
+                )
+
+                $splatWatchdogRun = @{
+                    FilePath     = "powershell.exe"
+                    ArgumentList = @(
+                        "-NoProfile"
+                        "-NonInteractive"
+                        "-ExecutionPolicy", "Bypass"
+                        "-File", "`"$watchdogScript`""
+                        "-ParentProcessId", $TargetProcessId
+                        "-HeartbeatPath", "`"$HeartbeatFile`""
+                        "-TimeoutMinutes", $TimeoutMinutes
+                        "-PollSeconds", $PollSeconds
+                    )
+                    PassThru     = $true
+                    WindowStyle  = "Hidden"
+                }
+                $watchdog = Start-Process @splatWatchdogRun
+                $script:startedProcessIds += $watchdog.Id
+                return $watchdog
+            }
+
+            function Test-ProcessRunning {
+                param(
+                    [int]$ProcessId
+                )
+
+                return [bool](Get-Process -Id $ProcessId -ErrorAction SilentlyContinue)
+            }
+
+            function Wait-ForProcessExit {
+                param(
+                    [int]$ProcessId,
+                    [int]$TimeoutSeconds = 30
+                )
+
+                $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+                while ((Get-Date) -lt $deadline) {
+                    if (-not (Test-ProcessRunning -ProcessId $ProcessId)) {
+                        return $true
+                    }
+                    Start-Sleep -Milliseconds 250
+                }
+                return $false
+            }
+
+            function New-HeartbeatFile {
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+                param(
+                    [int]$AgeMinutes,
+                    [string]$Label = "Wedged.Tests.ps1"
+                )
+
+                $heartbeatFile = Join-Path $watchdogTempPath "heartbeat-$(Get-Random).txt"
+                $heartbeatTicks = ((Get-Date).AddMinutes(-$AgeMinutes)).Ticks
+                Set-Content -Path $heartbeatFile -Value "$heartbeatTicks|$Label"
+                return $heartbeatFile
+            }
+        }
+
+        AfterAll {
+            foreach ($startedProcessId in $script:startedProcessIds) {
+                $splatCleanup = @{
+                    Id          = $startedProcessId
+                    Force       = $true
+                    ErrorAction = "SilentlyContinue"
+                }
+                Stop-Process @splatCleanup
+            }
+            Remove-Item -Path $watchdogTempPath -Recurse -ErrorAction SilentlyContinue
+        }
+
+        It "kills the watched process when a heartbeat goes stale" {
+            $sacrifice = New-SacrificialProcess
+            $heartbeatFile = New-HeartbeatFile -AgeMinutes 60
+
+            $null = Start-TestWatchdog -TargetProcessId $sacrifice.Id -HeartbeatFile $heartbeatFile
+
+            Wait-ForProcessExit -ProcessId $sacrifice.Id | Should -BeTrue
+        }
+
+        It "kills the processes the watched run left behind" {
+            $sacrifice = New-SacrificialProcess -WithChild
+            Start-Sleep -Seconds 3
+            $childIds = @(Get-CimInstance -ClassName Win32_Process -Filter "ParentProcessId = $($sacrifice.Id)" | Where-Object Name -eq "powershell.exe" | Select-Object -ExpandProperty ProcessId)
+            $childIds.Count | Should -BeGreaterThan 0
+            $script:startedProcessIds += $childIds
+
+            $heartbeatFile = New-HeartbeatFile -AgeMinutes 60
+            $null = Start-TestWatchdog -TargetProcessId $sacrifice.Id -HeartbeatFile $heartbeatFile
+
+            Wait-ForProcessExit -ProcessId $sacrifice.Id | Should -BeTrue
+            Wait-ForProcessExit -ProcessId $childIds[0] | Should -BeTrue
+        }
+
+        It "leaves the watched process alone while the heartbeat is fresh" {
+            $sacrifice = New-SacrificialProcess
+            $heartbeatFile = New-HeartbeatFile -AgeMinutes 0
+
+            $null = Start-TestWatchdog -TargetProcessId $sacrifice.Id -HeartbeatFile $heartbeatFile
+            Start-Sleep -Seconds 8
+
+            Test-ProcessRunning -ProcessId $sacrifice.Id | Should -BeTrue
+        }
+
+        It "leaves the watched process alone when there is no heartbeat at all" {
+            $sacrifice = New-SacrificialProcess
+            $missingHeartbeat = Join-Path $watchdogTempPath "absent-$(Get-Random).txt"
+
+            $null = Start-TestWatchdog -TargetProcessId $sacrifice.Id -HeartbeatFile $missingHeartbeat
+            Start-Sleep -Seconds 8
+
+            Test-ProcessRunning -ProcessId $sacrifice.Id | Should -BeTrue
+        }
+
+        It "stops itself once the watched process is gone" {
+            $sacrifice = New-SacrificialProcess
+            $heartbeatFile = New-HeartbeatFile -AgeMinutes 0
+
+            $watchdog = Start-TestWatchdog -TargetProcessId $sacrifice.Id -HeartbeatFile $heartbeatFile
+            Stop-Process -Id $sacrifice.Id -Force
+
+            Wait-ForProcessExit -ProcessId $watchdog.Id | Should -BeTrue
+        }
+
+        It "refuses to watch a process that is not running, so a reused PID is never killed" {
+            $sacrifice = New-SacrificialProcess
+            $deadProcessId = $sacrifice.Id
+            Stop-Process -Id $deadProcessId -Force
+            $null = Wait-ForProcessExit -ProcessId $deadProcessId
+
+            $heartbeatFile = New-HeartbeatFile -AgeMinutes 60
+            $watchdog = Start-TestWatchdog -TargetProcessId $deadProcessId -HeartbeatFile $heartbeatFile
+
+            Wait-ForProcessExit -ProcessId $watchdog.Id -TimeoutSeconds 20 | Should -BeTrue
+        }
+
+        It "rejects a timeout outside the supported range" {
+            $sacrifice = New-SacrificialProcess
+            $heartbeatFile = New-HeartbeatFile -AgeMinutes 0
+
+            $watchdog = Start-TestWatchdog -TargetProcessId $sacrifice.Id -HeartbeatFile $heartbeatFile -TimeoutMinutes 0
+
+            $watchdog.WaitForExit(20000) | Should -BeTrue
+            $watchdog.ExitCode | Should -Not -Be 0
+        }
+    }
+}

--- a/tests/appveyor.watchdog.ps1
+++ b/tests/appveyor.watchdog.ps1
@@ -1,0 +1,255 @@
+#Requires -Version 3
+<#
+    .SYNOPSIS
+        Fails a wedged CI test run fast instead of letting it burn the whole job timeout.
+
+    .DESCRIPTION
+        Some of the calls the test suite makes cannot be cancelled once they block. A native
+        process invoked without a timeout (certreq), an SMO ManagedComputer WMI call, or a
+        WinRM operation can all wedge the thread that runs Invoke-Pester. Nothing inside that
+        process can recover: PowerShell.Stop only sets a flag that is checked between pipeline
+        commands, and Thread.Abort does not interrupt blocking unmanaged code. The run then sits
+        silent until the 90 minute job timeout kills it, with no indication of which test file
+        was responsible.
+
+        This watchdog runs out of process, so it stays responsive while the test process is
+        stuck. appveyor.pester.ps1 writes the file it is about to run into a heartbeat file.
+        When a heartbeat gets older than the timeout, the watchdog names the offending file,
+        lists the processes that usually cause this, and then kills the test process so the job
+        fails in minutes rather than in an hour and a half.
+
+        The heartbeat file is removed by the runner between the test loop and the summary work,
+        so a missing heartbeat means "not running a test" and never triggers a kill.
+
+        Two ordering rules matter here. The test process is killed before any descendant is
+        enumerated, because enumeration needs WMI and WMI is one of the things that can be
+        wedged: a watchdog that queried first could hang on exactly the fault it exists to
+        catch. And the watchdog kills processes individually rather than with taskkill /T,
+        because it is itself a child of the test process and a tree kill could take it out
+        before the wedged process died.
+
+    .PARAMETER ParentProcessId
+        Process ID of the PowerShell process running the test loop.
+
+    .PARAMETER HeartbeatPath
+        File the test loop writes before each test file, as "<ticks>|<label>".
+
+    .PARAMETER TimeoutMinutes
+        How long a single test file may run before it is treated as wedged.
+
+    .PARAMETER PollSeconds
+        How often to check the heartbeat.
+
+    .PARAMETER CimTimeoutSeconds
+        Bound on the WMI query used to find leftover child processes after the kill.
+
+    .NOTES
+        Tags: CI, Testing
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2026 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .EXAMPLE
+        PS C:\> .\appveyor.watchdog.ps1 -ParentProcessId 1234 -HeartbeatPath C:\github\dbatools\pester-heartbeat-1234.txt
+
+        Watches process 1234 and kills it when a single test file runs longer than the default timeout.
+#>
+param(
+    [Parameter(Mandatory)]
+    [ValidateRange(1, 2147483647)]
+    [int]$ParentProcessId,
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$HeartbeatPath,
+    [ValidateRange(1, 1440)]
+    [int]$TimeoutMinutes = 15,
+    [ValidateRange(1, 300)]
+    [int]$PollSeconds = 15,
+    [ValidateRange(5, 120)]
+    [int]$CimTimeoutSeconds = 20
+)
+
+$ErrorActionPreference = "Continue"
+
+function Write-WatchdogLine {
+    param(
+        [string]$Message
+    )
+
+    # Console is used directly rather than Write-Host because this process is started with
+    # -NoNewWindow to share the parent console, and its output has to reach the CI log even
+    # though nothing is reading this pipeline.
+    [Console]::Out.WriteLine($Message)
+    [Console]::Out.Flush()
+}
+
+function Get-ParentIdentity {
+    <#
+        Returns the start time of the watched process, or $null when it is gone. A PID on its
+        own is not an identity: Windows reuses PIDs, so an abnormally exited parent could be
+        replaced by an unrelated process that we would then kill. The creation time pins it.
+    #>
+    param(
+        [int]$ProcessId
+    )
+
+    $process = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+    if (-not $process) {
+        return $null
+    }
+
+    try {
+        return $process.StartTime
+    } catch {
+        # A PID we cannot read the start time for is not one we are willing to kill
+        return $null
+    }
+}
+
+function Get-DescendantProcessId {
+    <#
+        Best effort, and deliberately bounded. This is the only WMI call in the watchdog and it
+        runs after the kill, so a wedged WMI provider costs a leftover child rather than the
+        whole safety net.
+    #>
+    param(
+        [int]$ProcessId,
+        [int]$OperationTimeoutSeconds
+    )
+
+    $splatChildQuery = @{
+        ClassName           = "Win32_Process"
+        Filter              = "ParentProcessId = $ProcessId"
+        OperationTimeoutSec = $OperationTimeoutSeconds
+        ErrorAction         = "SilentlyContinue"
+    }
+    $children = Get-CimInstance @splatChildQuery
+
+    foreach ($child in $children) {
+        # Never report our own PID, we have to outlive the processes we are killing
+        if ($child.ProcessId -eq $PID) {
+            continue
+        }
+        $child.ProcessId
+        Get-DescendantProcessId -ProcessId $child.ProcessId -OperationTimeoutSeconds $OperationTimeoutSeconds
+    }
+}
+
+$parentIdentity = Get-ParentIdentity -ProcessId $ParentProcessId
+if (-not $parentIdentity) {
+    Write-WatchdogLine -Message "appveyor.watchdog: pid $ParentProcessId is not running, nothing to watch"
+    return
+}
+
+Write-WatchdogLine -Message "appveyor.watchdog: watching pid $ParentProcessId, per-file limit $TimeoutMinutes minutes"
+
+while ($true) {
+    Start-Sleep -Seconds $PollSeconds
+
+    # The run finished normally, or the PID now belongs to an unrelated process
+    $currentIdentity = Get-ParentIdentity -ProcessId $ParentProcessId
+    if ($currentIdentity -ne $parentIdentity) {
+        Write-WatchdogLine -Message "appveyor.watchdog: pid $ParentProcessId exited, stopping"
+        return
+    }
+
+    # No heartbeat means the runner is not inside a test file right now
+    if (-not (Test-Path -Path $HeartbeatPath)) {
+        continue
+    }
+
+    $splatHeartbeat = @{
+        Path        = $HeartbeatPath
+        TotalCount  = 1
+        ErrorAction = "Stop"
+    }
+    try {
+        $heartbeat = Get-Content @splatHeartbeat
+    } catch {
+        # The runner rewrites this file before every test, so a read collision just means retry
+        continue
+    }
+
+    if (-not $heartbeat) {
+        continue
+    }
+
+    $heartbeatParts = $heartbeat -split "\|", 2
+    if ($heartbeatParts.Count -ne 2) {
+        continue
+    }
+
+    [long]$startedTicks = 0
+    if (-not [System.Int64]::TryParse($heartbeatParts[0], [ref]$startedTicks)) {
+        continue
+    }
+    if ($startedTicks -le 0) {
+        continue
+    }
+
+    $startedAt = New-Object -TypeName System.DateTime -ArgumentList $startedTicks
+    $elapsed = (Get-Date) - $startedAt
+    if ($elapsed.TotalMinutes -lt $TimeoutMinutes) {
+        continue
+    }
+
+    # GitHub only parses a workflow command at the start of a line, so this annotation
+    # is written without the usual prefix
+    Write-WatchdogLine -Message "::error::Test file $($heartbeatParts[1]) has run for $([int]$elapsed.TotalMinutes) minutes (limit $TimeoutMinutes). Killing the run."
+    Write-WatchdogLine -Message "appveyor.watchdog: a native call most likely wedged with no timeout (certreq, SMO ManagedComputer/WMI, or WinRM)."
+
+    # Record the usual suspects before the kill removes the evidence. Get-Process is used
+    # rather than a WMI query so this diagnostic cannot hang.
+    $suspects = Get-Process -Name "certreq", "certutil", "WmiPrvSE", "wsmprovhost" -ErrorAction SilentlyContinue
+    foreach ($suspect in $suspects) {
+        try {
+            $suspectStartTime = $suspect.StartTime.ToString("HH:mm:ss")
+            $startedText = "started $suspectStartTime"
+        } catch {
+            # Protected processes do not expose StartTime, the name and PID are still worth logging
+            $startedText = "start time not readable"
+        }
+        Write-WatchdogLine -Message "appveyor.watchdog: suspect process $($suspect.Name) (pid $($suspect.Id)), $startedText"
+    }
+
+    # Re-check identity immediately before the kill, so a parent that exited during the
+    # diagnostics above cannot be confused with a recycled PID
+    if ((Get-ParentIdentity -ProcessId $ParentProcessId) -ne $parentIdentity) {
+        Write-WatchdogLine -Message "appveyor.watchdog: pid $ParentProcessId exited before the kill, stopping"
+        return
+    }
+
+    # Kill the test process first. This is the action that has to happen, and it needs nothing
+    # but the PID, so it cannot be blocked by the fault we are reacting to.
+    Write-WatchdogLine -Message "appveyor.watchdog: killing test process pid $ParentProcessId"
+    $splatStopParent = @{
+        Id          = $ParentProcessId
+        Force       = $true
+        ErrorAction = "SilentlyContinue"
+    }
+    Stop-Process @splatStopParent
+
+    # Then clean up whatever it left behind. Win32_Process still reports ParentProcessId for a
+    # dead parent, so this works after the kill. If WMI is the thing that is wedged, the bounded
+    # query gives up and we simply leave the orphans to the ephemeral runner.
+    try {
+        $descendantIds = @(Get-DescendantProcessId -ProcessId $ParentProcessId -OperationTimeoutSeconds $CimTimeoutSeconds)
+    } catch {
+        $descendantIds = @()
+        Write-WatchdogLine -Message "appveyor.watchdog: could not enumerate leftover children. $($PSItem.Exception.Message)"
+    }
+
+    foreach ($descendantId in $descendantIds) {
+        Write-WatchdogLine -Message "appveyor.watchdog: killing leftover child pid $descendantId"
+        $splatStopDescendant = @{
+            Id          = $descendantId
+            Force       = $true
+            ErrorAction = "SilentlyContinue"
+        }
+        Stop-Process @splatStopDescendant
+    }
+
+    return
+}


### PR DESCRIPTION
## Problem

[PR #10478](https://github.com/dataplat/dbatools/pull/10478) failed on `ci-azure / test (SINGLE, 2/5, sql2022)` after hitting the 90 minute job timeout. Attempt 1 sat inside `tests/Test-DbaNetworkCertificate.Tests.ps1` for 87 minutes producing no output. Attempt 2 ran the same SHA on a different ephemeral runner and finished that same file in 10.2 seconds, so this was infrastructure, not the PR.

The costly part is not that it happened, it is how it failed. The job burned 90 minutes and the log gave no indication of which file was responsible — that took manual timestamp arithmetic across the raw log to work out.

## Why the hang cannot be timed out in process

Several calls the suite makes cannot be cancelled once they block:

- `certreq` invoked as a native process with no timeout
- SMO `Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer`, which is synchronous DCOM/WMI with no timeout and no `CancellationToken`
- WinRM operations

`Invoke-Command2` short-circuits for localhost (`if (-not $ComputerName.IsLocalHost)` gates the PSSession), so these run in process on the main thread. Once that thread is blocked in unmanaged code, `PowerShell.Stop()` only sets a flag that is checked between pipeline commands, and `Thread.Abort()` does not interrupt blocking unmanaged code (and does not exist on .NET Core). Ctrl+C does nothing. Process isolation is the only reliable bound.

Running each test file in its own child process was considered and rejected: it would need a full dbatools import per file, and a shard runs ~148 files.

## What this does

`tests/appveyor.watchdog.ps1` is started once by `tests/appveyor.pester.ps1` and runs out of process, so it stays responsive while the test process is stuck. The runner writes the file it is about to run into a heartbeat file before each attempt. When a heartbeat goes stale the watchdog:

1. emits `::error::Test file <name> has run for N minutes` so GitHub annotates the run with the culprit
2. logs the usual suspect processes (`certreq`, `certutil`, `WmiPrvSE`, `wsmprovhost`) with start times, via `Get-Process` rather than WMI so the diagnostic itself cannot hang
3. kills the test process, then its leftover children

Two ordering details matter. The test process is killed **before** descendants are enumerated, because enumeration needs WMI and WMI is one of the things that can be wedged — a watchdog that queried first could hang on exactly the fault it exists to catch (the query is also bounded with `-OperationTimeoutSec`). And processes are killed individually rather than with `taskkill /T`, because the watchdog is itself a child of the test process and a tree kill could take it out first.

A missing heartbeat means "not running a test" and never triggers a kill, so the summary and artifact work after the loop is unaffected. Identity is `Process.StartTime`, not the PID alone, so a recycled PID is never killed. The heartbeat path includes `$PID` so two runs sharing a workspace cannot clobber each other, and teardown is in a `finally` so the watchdog is stopped even when the loop throws.

## Choosing 15 minutes

Measured rather than guessed. Across 296 files in two shards the slowest legitimate file is `Restore-DbaDatabase.Tests.ps1` at 355,659 ms (5.9 minutes); the next slowest is 39.9 s, and the default-scenario maximum across 217 files is 62.8 s. 15 minutes is 2.5x headroom over the real worst case. Override with `DBATOOLS_TEST_FILE_TIMEOUT_MINUTES` (validated 1-1440, throws on a non-numeric or out-of-range value).

Net effect: a wedge fails in ~15 minutes with the offending file named, instead of 90 minutes with nothing to go on.

## Testing

`tests/appveyor.watchdog.Tests.ps1` adds 7 unit tests covering stale heartbeat kills, leftover children killed, fresh heartbeat leaves the process alone, absent heartbeat leaves the process alone, self-stop when the watched process exits, refusal to watch a non-running PID, and rejection of an out-of-range timeout.

- 10 tests pass / 0 fail (7 new + 3 existing `appveyor.common`), 24 s, 0 leaked processes
- `Import-Module dbatools.psd1 -Force` clean (2.8.4, 732 commands)
- PSScriptAnalyzer: 0 findings on both new files, and an identical before/after profile on `appveyor.pester.ps1`
- `git diff -w` confirms the `try`/`finally` wrap reindented the existing loop without changing any logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
