### PR TITLE
Tests - Recover the tests that a foreach around It never created

### DIFF
--- a/tests/Get-DbaBuild.Tests.ps1
+++ b/tests/Get-DbaBuild.Tests.ps1
@@ -174,45 +174,50 @@ Describe $CommandName -Tag UnitTests {
     }
     # These are groups by major release (aka "Name")
     Context "Properties Check for major releases" {
-        BeforeAll {
-            $OrderedKeys = $OrderedKeys
-            $Groups = $Groups
+        # The groups have to be built here and not in a BeforeAll. -ForEach is read while Pester
+        # discovers the tests, and $OrderedKeys and $Groups were only ever built in the BeforeAll of
+        # a sibling Context, so the foreach that used to stand here ran over nothing and none of the
+        # tests below existed. The "$OrderedKeys = $OrderedKeys" that used to be here was an attempt
+        # to import them into this scope and could never work.
+        # Everything an It block reads has to be a key of the case, so the version list travels with
+        # the release name instead of being looked up again at run time.
+        BeforeDiscovery {
+            $moduleBase = (Get-Module -Name dbatools | Where-Object ModuleBase -NotMatch net).ModuleBase
+            $indexReference = Get-Content "$moduleBase\bin\dbatools-buildref-index.json" -Raw | ConvertFrom-Json
+            $majorReleaseCase = $indexReference.Data |
+                Group-Object -Property { $PSItem.Version.Split(".")[0 .. 1] -join "." } |
+                ForEach-Object { @{ MajorRelease = $PSItem.Name; Versions = $PSItem.Group } }
         }
 
-        foreach ($g in $OrderedKeys) {
-            Context "Properties Check, for major release $g" {
-                BeforeAll {
-                    $Versions = $Groups[$g]
+        Context "Properties Check, for major release <MajorRelease>" -ForEach $majorReleaseCase {
+            It "has the first element with a Name" {
+                $Versions[0].Name | Should -BeLike "20*"
+            }
+            It "No multiple Names around" {
+                ($Versions.Name | Where-Object { $PSItem }).Count | Should -Be 1
+            }
+            It "SP Property is formatted correctly" {
+                $Versions.SP | Where-Object { $PSItem } | Should -Match "^RTM$|^SP[\d]+$|^RC"
+            }
+            It "CU Property is formatted correctly" {
+                $CUMatch = $Versions.CU | Where-Object { $PSItem }
+                if ($CUMatch) {
+                    $CUMatch | Should -Match "^CU[\d]+$"
                 }
-                It "has the first element with a Name" {
-                    $Versions[0].Name | Should -BeLike "20*"
-                }
-                It "No multiple Names around" {
-                    ($Versions.Name | Where-Object { $PSItem }).Count | Should -Be 1
-                }
-                It "SP Property is formatted correctly" {
-                    $Versions.SP | Where-Object { $PSItem } | Should -Match "^RTM$|^SP[\d]+$|^RC"
-                }
-                It "CU Property is formatted correctly" {
-                    $CUMatch = $Versions.CU | Where-Object { $PSItem }
-                    if ($CUMatch) {
-                        $CUMatch | Should -Match "^CU[\d]+$"
-                    }
-                }
-                It "SPs are ordered correctly" {
-                    $SPs = $Versions.SP | Where-Object { $PSItem }
-                    ($SPs | Select-Object -First 1) | Should -BeIn "RTM", "RC"
-                    $ActualSPs = $SPs | Where-Object { $PSItem -match "^SP[\d]+$" }
-                    $OrderedActualSPs = $ActualSPs | Sort-Object
-                    ($ActualSPs -join ",") | Should -Be ($OrderedActualSPs -join ",")
-                }
-                # see https://github.com/dataplat/dbatools/pull/2466
-                It "KBList has only numbers on it" {
-                    $NotNumbers = $Versions.KBList | Where-Object { $PSItem } | Where-Object { $PSItem -notmatch "^[\d]+$" }
-                    if ($NotNumbers.Count -ne 0) {
-                        foreach ($Nn in $NotNumbers) {
-                            $Nn | Should -Be "Composed by integers"
-                        }
+            }
+            It "SPs are ordered correctly" {
+                $SPs = $Versions.SP | Where-Object { $PSItem }
+                ($SPs | Select-Object -First 1) | Should -BeIn "RTM", "RC"
+                $ActualSPs = $SPs | Where-Object { $PSItem -match "^SP[\d]+$" }
+                $OrderedActualSPs = $ActualSPs | Sort-Object
+                ($ActualSPs -join ",") | Should -Be ($OrderedActualSPs -join ",")
+            }
+            # see https://github.com/dataplat/dbatools/pull/2466
+            It "KBList has only numbers on it" {
+                $NotNumbers = $Versions.KBList | Where-Object { $PSItem } | Where-Object { $PSItem -notmatch "^[\d]+$" }
+                if ($NotNumbers.Count -ne 0) {
+                    foreach ($Nn in $NotNumbers) {
+                        $Nn | Should -Be "Composed by integers"
                     }
                 }
             }

--- a/tests/Invoke-DbaDbDbccCheckConstraint.Tests.ps1
+++ b/tests/Invoke-DbaDbDbccCheckConstraint.Tests.ps1
@@ -58,19 +58,24 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     Context "Validate standard output" {
-        BeforeAll {
-            $props = @(
-                "ComputerName",
-                "InstanceName",
-                "SqlInstance",
-                "Database",
-                "Cmd",
-                "Output",
-                "Table",
-                "Constraint",
-                "Where"
+        BeforeDiscovery {
+            # -ForEach is read while Pester discovers the tests, so the list has to be built here.
+            # Built in BeforeAll and consumed by a foreach around the It block, as it was before,
+            # the list is still empty at discovery and not a single one of these tests existed.
+            $expectedProperty = @(
+                @{ PropertyName = "ComputerName" }
+                @{ PropertyName = "InstanceName" }
+                @{ PropertyName = "SqlInstance" }
+                @{ PropertyName = "Database" }
+                @{ PropertyName = "Cmd" }
+                @{ PropertyName = "Output" }
+                @{ PropertyName = "Table" }
+                @{ PropertyName = "Constraint" }
+                @{ PropertyName = "Where" }
             )
+        }
 
+        BeforeAll {
             $splatCheckConstraint = @{
                 SqlInstance = $TestConfig.InstanceSingle
                 Database    = $dbname
@@ -79,11 +84,9 @@ Describe $CommandName -Tag IntegrationTests {
             $result = Invoke-DbaDbDbccCheckConstraint @splatCheckConstraint
         }
 
-        foreach ($prop in $props) {
-            It "Should return property: $prop" {
-                $p = $result[0].PSObject.Properties[$prop]
-                $p.Name | Should -Be $prop
-            }
+        It "Should return property: <PropertyName>" -ForEach $expectedProperty {
+            $p = $result[0].PSObject.Properties[$PropertyName]
+            $p.Name | Should -Be $PropertyName
         }
 
         It "Returns correct results" {

--- a/tests/Set-DbaAgentSchedule.Tests.ps1
+++ b/tests/Set-DbaAgentSchedule.Tests.ps1
@@ -99,9 +99,13 @@ Describe $CommandName -Tag IntegrationTests {
             $renameScheduleResults | Should -Not -BeNullOrEmpty
         }
 
-        foreach ($r in $renameScheduleResults) {
-            It "$($r.name) Should have different name" {
-                $r.name | Should -Not -Be "$($schedules.where({$PSItem.id -eq $r.id}).name)"
+        # The results only exist once the setup has talked to the instance, so there is nothing to
+        # hand to -ForEach at discovery time and the loop has to live inside the It block. Written
+        # as a foreach around the It, as it was before, the loop ran while Pester was still
+        # discovering the tests, $renameScheduleResults was empty and no test was created at all.
+        It "Should have renamed every schedule" {
+            foreach ($r in $renameScheduleResults) {
+                $r.name | Should -Not -Be "$($schedules.where({$PSItem.id -eq $r.id}).name)" -Because "schedule $($r.id) should have been renamed"
             }
         }
     }
@@ -157,12 +161,15 @@ Describe $CommandName -Tag IntegrationTests {
             $staticFrequencyResults | Should -Not -BeNullOrEmpty
         }
 
-        foreach ($r in $staticFrequencyResults) {
-            It "$($r.name) Should have a frequency of OnIdle" {
-                $r.FrequencyTypes | Should -Be "OnIdle"
+        It "Should have a frequency of OnIdle on every schedule" {
+            foreach ($r in $staticFrequencyResults) {
+                $r.FrequencyTypes | Should -Be "OnIdle" -Because "schedule $($r.name) was last set to IdleComputer"
             }
-            It "$($r.name) Should be Enabled" {
-                $r.isEnabled | Should -Be "True"
+        }
+
+        It "Should have every schedule Enabled" {
+            foreach ($r in $staticFrequencyResults) {
+                $r.isEnabled | Should -Be "True" -Because "schedule $($r.name) was last set with Enabled"
             }
         }
     }
@@ -222,12 +229,15 @@ Describe $CommandName -Tag IntegrationTests {
             $calendarFrequencyResults | Should -Not -BeNullOrEmpty
         }
 
-        foreach ($r in $calendarFrequencyResults) {
-            It "$($r.name) Should have a frequency of MonthlyRelative" {
-                $r.FrequencyTypes | Should -Be "MonthlyRelative"
+        It "Should have a frequency of MonthlyRelative on every schedule" {
+            foreach ($r in $calendarFrequencyResults) {
+                $r.FrequencyTypes | Should -Be "MonthlyRelative" -Because "schedule $($r.name) was last set to MonthlyRelative"
             }
-            It "$($r.name) Should have different StartTime" {
-                $r.StartTime | Should -Not -Be "$($schedules.where({$PSItem.id -eq $r.id}).StartTime)"
+        }
+
+        It "Should have a different StartTime on every schedule" {
+            foreach ($r in $calendarFrequencyResults) {
+                $r.StartTime | Should -Not -Be "$($schedules.where({$PSItem.id -eq $r.id}).StartTime)" -Because "schedule $($r.name) was given a new StartTime"
             }
         }
     }
@@ -285,9 +295,9 @@ Describe $CommandName -Tag IntegrationTests {
             $subdayTypeResults | Should -Not -BeNullOrEmpty
         }
 
-        foreach ($r in $subdayTypeResults) {
-            It "$($r.name) Should have different EndDate" {
-                $r.EndDate | Should -Not -Be "$($schedules.where({$PSItem.id -eq $r.id}).EndDate)"
+        It "Should have a different EndDate on every schedule" {
+            foreach ($r in $subdayTypeResults) {
+                $r.EndDate | Should -Not -Be "$($schedules.where({$PSItem.id -eq $r.id}).EndDate)" -Because "schedule $($r.name) was given a new EndDate"
             }
         }
     }
@@ -343,9 +353,9 @@ Describe $CommandName -Tag IntegrationTests {
             $relativeIntervalResults | Should -Not -BeNullOrEmpty
         }
 
-        foreach ($r in $relativeIntervalResults) {
-            It "$($r.name) Should have different EndTime" {
-                $r.EndTime | Should -Not -Be "$($schedules.where({$PSItem.id -eq $r.id}).EndTime)"
+        It "Should have a different EndTime on every schedule" {
+            foreach ($r in $relativeIntervalResults) {
+                $r.EndTime | Should -Not -Be "$($schedules.where({$PSItem.id -eq $r.id}).EndTime)" -Because "schedule $($r.name) was given a new EndTime"
             }
         }
     }


### PR DESCRIPTION
Three test files built their `It` blocks with a `foreach` loop. The loop runs while Pester discovers the tests and the bodies run afterwards, so the loop variables are gone by then. In all three cases the collection the loop walked was built in a `BeforeAll` and was still empty at discovery, so **not one of these tests was ever created**. Nothing failed - the tests simply did not exist, and the report looked healthy the whole time.

| File | tests before | tests after |
|---|---|---|
| Get-DbaBuild | 26 | 92 |
| Set-DbaAgentSchedule | 10 | 17 |
| Invoke-DbaDbDbccCheckConstraint | 2 | 11 |

**Get-DbaBuild** lost its entire "Properties Check for major releases" section, which walked `$OrderedKeys`. That variable was only ever built in the `BeforeAll` of a sibling Context - the `$OrderedKeys = $OrderedKeys` sitting in this one was an attempt to import it and could never work. The grouping moved into `BeforeDiscovery` and the per-release Contexts now come from `-ForEach`. All 11 major releases are covered again.

**Invoke-DbaDbDbccCheckConstraint** lost the per-property checks in "Validate standard output". The property list moved into `BeforeDiscovery` and the `It` uses `-ForEach`.

**Set-DbaAgentSchedule** lost seven assertions across five Contexts. `-ForEach` cannot help here: the results only exist once the setup has talked to the instance, so there is nothing to hand to `-ForEach` at discovery. The loops moved inside the `It` blocks instead, with the schedule name in a `-Because` so a failure still identifies which schedule it was.

## Verification

- All three files pass in full against the lab.
- The recovered assertions are not passing vacuously: mutating two of the Set-DbaAgentSchedule expectations fails exactly those two tests. The pre-existing "Should have Results" in each Context keeps an empty result set from making the internal loops trivially true.
- No change to the layout or structural checks beyond these three files.

Found by a new AST check in the sibling testing repo that flags any loop containing an `It`. Update-DbaInstance had the same defect and is fixed separately in #10482.