### PR TITLE
Tests - Make the assertions that could never fail actually assert

### DIFF
--- a/tests/Export-DbaDbRole.Tests.ps1
+++ b/tests/Export-DbaDbRole.Tests.ps1
@@ -49,19 +49,20 @@ Describe $CommandName -Tag IntegrationTests {
         $user1 = "dbatoolsci_exportdbadbrole_user1$random"
         $dbRole = "dbatoolsci_SpExecute$random"
 
-        try {
-            $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
-            $null = $server.Query("CREATE DATABASE [$dbname1]")
-            $null = $server.Query("CREATE LOGIN [$login1] WITH PASSWORD = 'GoodPass1234!'")
-            $server.Databases[$dbname1].ExecuteNonQuery("CREATE USER [$user1] FOR LOGIN [$login1]")
+        $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+        $null = $server.Query("CREATE DATABASE [$dbname1]")
+        $null = $server.Query("CREATE LOGIN [$login1] WITH PASSWORD = 'GoodPass1234!'")
+        $server.Databases[$dbname1].ExecuteNonQuery("CREATE USER [$user1] FOR LOGIN [$login1]")
 
-            $server.Databases[$dbname1].ExecuteNonQuery("ALTER ROLE [$dbRole] ADD MEMBER [$user1]")
-            $server.Databases[$dbname1].ExecuteNonQuery("GRANT SELECT ON SCHEMA::dbo to [$dbRole]")
-            $server.Databases[$dbname1].ExecuteNonQuery("GRANT EXECUTE ON SCHEMA::dbo to [$dbRole]")
-            $server.Databases[$dbname1].ExecuteNonQuery("GRANT VIEW DEFINITION ON SCHEMA::dbo to [$dbRole]")
-        } catch {
-            # Ignore setup errors for now
-        }
+        # The role itself was never created, so the ALTER ROLE below always threw and the catch
+        # that used to wrap this whole block swallowed it. None of the objects the tests look for
+        # existed, and the tests passed regardless because their assertions were never piped to
+        # Should. The catch is gone as well, so a broken setup now fails the test loudly.
+        $server.Databases[$dbname1].ExecuteNonQuery("CREATE ROLE [$dbRole]")
+        $server.Databases[$dbname1].ExecuteNonQuery("ALTER ROLE [$dbRole] ADD MEMBER [$user1]")
+        $server.Databases[$dbname1].ExecuteNonQuery("GRANT SELECT ON SCHEMA::dbo to [$dbRole]")
+        $server.Databases[$dbname1].ExecuteNonQuery("GRANT EXECUTE ON SCHEMA::dbo to [$dbRole]")
+        $server.Databases[$dbname1].ExecuteNonQuery("GRANT VIEW DEFINITION ON SCHEMA::dbo to [$dbRole]")
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
@@ -100,6 +101,11 @@ Describe $CommandName -Tag IntegrationTests {
             $role = Get-DbaDbRole -SqlInstance $TestConfig.InstanceSingle -Database $dbname1 -Role $dbRole
             $null = $role | Export-DbaDbRole -FilePath $outputFile1
             $results = $role | Export-DbaDbRole -Passthru
+
+            # Role membership is only scripted when it is asked for, so the membership test below
+            # needs its own export. It used to assert against the default output, where the ALTER
+            # ROLE line can never appear.
+            $resultsWithMember = $role | Export-DbaDbRole -Passthru -IncludeRoleMember
         }
 
         It "Exports results to one sql file" {
@@ -111,27 +117,31 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "should include the defined BatchSeparator" {
-            $results -match "GO"
+            ($results -join [Environment]::NewLine) | Should -Match "GO"
         }
 
         It "should include the role" {
-            $results -match "CREATE ROLE [$dbRole]"
+            ($results -join [Environment]::NewLine) | Should -Match ([regex]::Escape("CREATE ROLE [$dbRole]"))
         }
 
         It "should include GRANT EXECUTE ON SCHEMA" {
-            $results -match "GRANT EXECUTE ON SCHEMA::[dbo] TO [$dbRole];"
+            ($results -join [Environment]::NewLine) | Should -Match ([regex]::Escape("GRANT EXECUTE ON SCHEMA::[dbo] TO [$dbRole];"))
         }
 
         It "should include GRANT SELECT ON SCHEMA" {
-            $results -match "GRANT SELECT ON SCHEMA::[dbo] TO [$dbRole];"
+            ($results -join [Environment]::NewLine) | Should -Match ([regex]::Escape("GRANT SELECT ON SCHEMA::[dbo] TO [$dbRole];"))
         }
 
         It "should include GRANT VIEW DEFINITION ON SCHEMA" {
-            $results -match "GRANT VIEW DEFINITION ON SCHEMA::[dbo] TO [$dbRole];"
+            ($results -join [Environment]::NewLine) | Should -Match ([regex]::Escape("GRANT VIEW DEFINITION ON SCHEMA::[dbo] TO [$dbRole];"))
         }
 
-        It "should include ALTER ROLE ADD MEMBER" {
-            $results -match "ALTER ROLE [$dbRole] ADD MEMBER [$user1];"
+        It "should not include ALTER ROLE ADD MEMBER without IncludeRoleMember" {
+            ($results -join [Environment]::NewLine) | Should -Not -Match ([regex]::Escape("ALTER ROLE [$dbRole] ADD MEMBER [$user1];"))
+        }
+
+        It "should include ALTER ROLE ADD MEMBER with IncludeRoleMember" {
+            ($resultsWithMember -join [Environment]::NewLine) | Should -Match ([regex]::Escape("ALTER ROLE [$dbRole] ADD MEMBER [$user1];"))
         }
     }
 }

--- a/tests/Export-DbaScript.Tests.ps1
+++ b/tests/Export-DbaScript.Tests.ps1
@@ -84,23 +84,27 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "Should export some text matching create table" {
             $results = Get-DbaDbTable -SqlInstance $TestConfig.InstanceSingle -Database msdb | Select-Object -First 1 | Export-DbaScript -Passthru
-            $results -match "CREATE TABLE"
+            ($results -join [Environment]::NewLine) | Should -Match "CREATE TABLE"
         }
 
         It "Should include BatchSeparator based on the Formatting.BatchSeparator configuration" {
             $results = Get-DbaDbTable -SqlInstance $TestConfig.InstanceSingle -Database msdb | Select-Object -First 1 | Export-DbaScript -Passthru
-            $results -match "(Get-DbatoolsConfigValue -FullName 'Formatting.BatchSeparator')"
+            # This used to look for the literal text "(Get-DbatoolsConfigValue -FullName ...)". The
+            # subexpression marker was missing, so it searched the script for the name of the command
+            # instead of for the separator the command is configured to emit.
+            $batchSeparator = Get-DbatoolsConfigValue -FullName "Formatting.BatchSeparator"
+            ($results -join [Environment]::NewLine) | Should -Match ([regex]::Escape($batchSeparator))
         }
 
         It "Should include the defined BatchSeparator" {
             $results = Get-DbaDbTable -SqlInstance $TestConfig.InstanceSingle -Database msdb | Select-Object -First 1 | Export-DbaScript -Passthru -BatchSeparator "MakeItSo"
-            $results -match "MakeItSo"
+            ($results -join [Environment]::NewLine) | Should -Match "MakeItSo"
         }
 
         It "Should not accept non-SMO objects" {
             $null = Get-DbaDbTable -SqlInstance $TestConfig.InstanceSingle -Database msdb | Select-Object -First 1 | Export-DbaScript -Passthru -BatchSeparator "MakeItSo"
             $null = [PSCustomObject]@{ Invalid = $true } | Export-DbaScript -WarningVariable invalid -WarningAction SilentlyContinue
-            $invalid -match "not a SQL Management Object"
+            $invalid | Should -Match "not a SQL Management Object"
         }
 
         It "Should not append when using NoPrefix (#7455)" {

--- a/tests/Get-DbaDbccSessionBuffer.Tests.ps1
+++ b/tests/Get-DbaDbccSessionBuffer.Tests.ps1
@@ -44,7 +44,10 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     Context "Validate standard output for all databases" {
-        BeforeAll {
+        BeforeDiscovery {
+            # -ForEach is read while Pester discovers the tests. Built in the BeforeAll below, as
+            # they were before, these two lists were still empty at discovery and neither of the
+            # property tests existed at all.
             $propsInputBuffer = @(
                 "ComputerName",
                 "InstanceName",
@@ -62,6 +65,9 @@ Describe $CommandName -Tag IntegrationTests {
                 "Buffer",
                 "HexBuffer"
             )
+        }
+
+        BeforeAll {
             $resultInputBuffer = Get-DbaDbccSessionBuffer -SqlInstance $TestConfig.InstanceSingle -Operation InputBuffer -All
             $resultOutputBuffer = Get-DbaDbccSessionBuffer -SqlInstance $TestConfig.InstanceSingle -Operation OutputBuffer -All
         }

--- a/tests/Get-DbaKbUpdate.Tests.ps1
+++ b/tests/Get-DbaKbUpdate.Tests.ps1
@@ -84,15 +84,15 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Querying the Microsoft Update Catalog" -Skip:(-not $catalogReachable) {
         It "successfully connects and parses link and title" {
             $results = Get-DbaKbUpdate -Name KB4057119
-            $results.Link -match "download.windowsupdate.com"
-            $results.Title -match "Cumulative Update"
+            $results.Link | Should -Match "download.windowsupdate.com"
+            $results.Title | Should -Match "Cumulative Update"
             $results.KBLevel | Should -Be 4057119
         }
 
         It "test with the -Simple param" {
             $results = Get-DbaKbUpdate -Name KB4577194 -Simple
-            $results.Link -match "download.windowsupdate.com"
-            $results.Title -match "Cumulative Update"
+            $results.Link | Should -Match "download.windowsupdate.com"
+            $results.Title | Should -Match "Cumulative Update"
             $results.KBLevel | Should -Be 4577194
         }
 
@@ -102,8 +102,8 @@ Describe $CommandName -Tag IntegrationTests {
 
             $results = Get-DbaKbUpdate -Name KB4564903
             $results.KBLevel | Should -Be 4564903
-            $results.Link -match "download.windowsupdate.com"
-            $results.Title -match "Cumulative Update"
+            $results.Link | Should -Match "download.windowsupdate.com"
+            $results.Title | Should -Match "Cumulative Update"
         }
 
         It "Call with multiple KBs" {
@@ -124,15 +124,15 @@ Describe $CommandName -Tag IntegrationTests {
         It "Call without specific language" {
             $results = Get-DbaKbUpdate -Name KB5003279
             $results.KBLevel | Should -Be 5003279
-            $results.Classification -match "Service Packs"
-            $results.Link -match "-enu_"
+            $results.Classification | Should -Match "Service Packs"
+            $results.Link | Should -Match "-enu_"
         }
 
         It "Call with specific language" {
             $results = Get-DbaKbUpdate -Name KB5003279 -Language ja
             $results.KBLevel | Should -Be 5003279
-            $results.Classification -match "Service Packs"
-            $results.Link -match "-jpn_"
+            $results.Classification | Should -Match "Service Packs"
+            $results.Link | Should -Match "-jpn_"
         }
     }
 }

--- a/tests/Get-DbaSpConfigure.Tests.ps1
+++ b/tests/Get-DbaSpConfigure.Tests.ps1
@@ -28,11 +28,18 @@ Describe $CommandName -Tag IntegrationTests {
             $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
             $configs = $server.Query("sp_configure")
             $remoteQueryTimeout = $configs | Where-Object name -match "remote query timeout"
+
+            # sp_configure only lists the basic options unless "show advanced options" is turned on,
+            # which is 25 rows against the 86 the command returns. sys.configurations lists them all
+            # without changing the configuration of the instance, so it is the comparable set.
+            # The sp_configure result is kept for the test below, which reads its config_value and
+            # run_value columns.
+            $allConfigs = $server.Query("SELECT name FROM sys.configurations")
         }
 
         It "returns equal to results of the straight T-SQL query" {
             $results = Get-DbaSpConfigure -SqlInstance $TestConfig.InstanceSingle
-            $results.count -eq $configs.count
+            $results.Count | Should -Be $allConfigs.Count
         }
 
         It "returns two results" {
@@ -42,7 +49,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "returns two results less than all data" {
             $results = Get-DbaSpConfigure -SqlInstance $TestConfig.InstanceSingle -ExcludeName "remote query timeout (s)", AllowUpdates
-            $results.Count -eq $configs.count - 2
+            $results.Count | Should -Be ($allConfigs.Count - 2)
         }
 
         It "matches the output of sp_configure" {

--- a/tests/Get-SqlDefaultSpConfigure.Tests.ps1
+++ b/tests/Get-SqlDefaultSpConfigure.Tests.ps1
@@ -20,36 +20,34 @@ Describe $CommandName -Tag UnitTests {
 
 Describe $CommandName -Tag IntegrationTests {
     Context "Try all versions of SQL" {
+        BeforeDiscovery {
+            # -ForEach is read while Pester discovers the tests, so the case list holds data only.
+            # It used to be built in the BeforeAll below by calling the function under test, which
+            # meant it was still empty at discovery and neither of these tests existed at all.
+            # The function is dot sourced in BeforeAll and called inside the It, which runs later.
+            $versionCase = @(
+                @{ Version = 8; VersionName = "2000" }
+                @{ Version = 9; VersionName = "2005" }
+                @{ Version = 10; VersionName = "2008/2008R2" }
+                @{ Version = 11; VersionName = "2012" }
+                @{ Version = 12; VersionName = "2014" }
+                @{ Version = 13; VersionName = "2016" }
+                @{ Version = 14; VersionName = "2017" }
+            )
+        }
+
         BeforeAll {
             . "$PSScriptRoot\..\private\functions\Get-SqlDefaultSPConfigure.ps1"
-            $versionName = @{
-                8  = "2000"
-                9  = "2005"
-                10 = "2008/2008R2"
-                11 = "2012"
-                12 = "2014"
-                13 = "2016"
-                14 = "2017"
-                15 = "2019"
-                16 = "2022"
-            }
-            $allResults = @()
-            foreach ($version in 8..14) {
-                $results = Get-SqlDefaultSPConfigure -SqlVersion $version
-                $allResults += [PSCustomObject]@{
-                    Version     = $version
-                    VersionName = $versionName.Item($version)
-                    Results     = $results
-                }
-            }
         }
 
-        It "Should return results for <VersionName>" -ForEach $allResults {
-            $Results | Should -Not -BeNullOrEmpty
+        It "Should return results for <VersionName>" -ForEach $versionCase {
+            $results = Get-SqlDefaultSPConfigure -SqlVersion $Version
+            $results | Should -Not -BeNullOrEmpty
         }
 
-        It "Should return 'System.Management.Automation.PSCustomObject' object for <VersionName>" -ForEach $allResults {
-            $Results.GetType().fullname | Should -Be "System.Management.Automation.PSCustomObject"
+        It "Should return 'System.Management.Automation.PSCustomObject' object for <VersionName>" -ForEach $versionCase {
+            $results = Get-SqlDefaultSPConfigure -SqlVersion $Version
+            $results.GetType().fullname | Should -Be "System.Management.Automation.PSCustomObject"
         }
     }
 }

--- a/tests/New-DbaDiagnosticAdsNotebook.Tests.ps1
+++ b/tests/New-DbaDiagnosticAdsNotebook.Tests.ps1
@@ -41,7 +41,7 @@ Describe $CommandName -Tag IntegrationTests {
         It "Returns a file that includes specific phrases" {
             $results = New-DbaDiagnosticAdsNotebook -TargetVersion 2017 -Path $testNotebookFile -IncludeDatabaseSpecific
             $results | Should -Not -BeNullOrEmpty
-            ($results | Get-Content) -contains "information for current instance"
+            ($results | Get-Content -Raw) | Should -Match "information for current instance"
         }
     }
 }

--- a/tests/Save-DbaKbUpdate.Tests.ps1
+++ b/tests/Save-DbaKbUpdate.Tests.ps1
@@ -84,12 +84,12 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Downloading from the Microsoft Update Catalog" -Skip:(-not $catalogReachable) {
         It "downloads a small update" {
             $results = Save-DbaKbUpdate -Name KB2992080 -Architecture All -Path $tempPath
-            $results.Name -match "aspnet"
+            $results.Name | Should -Match "aspnet"
         }
 
         It "supports piping" {
             $results = Get-DbaKbUpdate -Name KB2992080 | Select-Object -First 1 | Save-DbaKbUpdate -Architecture All -Path $tempPath
-            $results.Name -match "aspnet"
+            $results.Name | Should -Match "aspnet"
         }
 
         It "Download multiple updates" {

--- a/tests/Set-DbaDbIdentity.Tests.ps1
+++ b/tests/Set-DbaDbIdentity.Tests.ps1
@@ -99,8 +99,14 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     Context "Validate standard output" {
-        BeforeAll {
+        BeforeDiscovery {
+            # -ForEach is read while Pester discovers the tests. Built in the BeforeAll below, as it
+            # was before, this list was still empty at discovery and not one of the property tests
+            # existed at all.
             $props = "ComputerName", "InstanceName", "SqlInstance", "Database", "Table", "Cmd", "IdentityValue", "ColumnValue", "Output"
+        }
+
+        BeforeAll {
             $result = Set-DbaDbIdentity -SqlInstance $TestConfig.InstanceSingle -Database $dbname -Table $tableName1, $tableName2
         }
 


### PR DESCRIPTION
Twenty-five statements across six test files computed a comparison inside an `It` and threw the result away - lines like `$results -match "CREATE TABLE"` with no `Should`. They read like assertions, they ran, and they could not fail. Three more files handed `-ForEach` a case list built in a `BeforeAll`, which is still empty at discovery, so those tests were never created at all.

Piping the comparisons to `Should` turned four of them red. **Every one was a real defect that had been invisible.**

## What was actually broken

**Export-DbaDbRole never created the role.** The setup ran `ALTER ROLE ... ADD MEMBER` with no `CREATE ROLE` first, so it threw, and a `catch { # Ignore setup errors for now }` swallowed it. The database had no role, no grants, no membership, and `Export-DbaDbRole -Passthru` returned `$null`. Six assertions were checking `$null` against expected SQL and reporting success. Added the missing `CREATE ROLE` and removed the catch, so a broken setup now fails loudly.

**Export-DbaDbRole also expected membership it never asked for.** The default output cannot contain `ALTER ROLE ... ADD MEMBER` - that needs `-IncludeRoleMember`. Split into two tests: the default output must *not* contain it, the `-IncludeRoleMember` output must. That switch had no coverage at all before.

**Export-DbaScript searched for the name of a command.** The assertion was `$results -match "(Get-DbatoolsConfigValue -FullName 'Formatting.BatchSeparator')"` - the subexpression marker was missing, so it looked for that literal text in the SQL script rather than for the separator the command emits.

**Get-DbaSpConfigure compared against the wrong set.** It checked its result count against `sp_configure`, which lists only the 25 basic options unless *show advanced options* is on. The command returns all 86. Now compared against `sys.configurations`, which lists them all without changing the configuration of the instance. The `sp_configure` result is still used by the test that reads its `config_value` and `run_value` columns.

## Two mechanical points

`Export-DbaScript` and `Export-DbaDbRole` return the script as a **string array**, so the text is joined before matching - piping the array asserts against a single element. And the bracketed SQL identifiers (`[dbo]`, `[$dbRole]`) are regex character classes, so they are matched with `[regex]::Escape`.

## Tests recovered

| File | before | after |
|---|---|---|
| Get-DbaDbccSessionBuffer | 3 | 18 |
| Set-DbaDbIdentity | 2 | 14 |
| Get-SqlDefaultSpConfigure | 1 | 15 |
| Export-DbaDbRole | 11 | 12 |

The three `-ForEach` case lists moved into `BeforeDiscovery`. In `Get-SqlDefaultSpConfigure` the list was built by calling the function under test, which cannot happen at discovery, so the cases are plain data now and the function is called inside the `It`.

## Verification

All nine files pass against the lab. The two AST checks that found this - discarded comparison inside an `It`, and `-ForEach` cases not from `BeforeDiscovery` - are now hard checks in the testing repo, and the whole tree passes them with 0 failures.

One thing left alone deliberately: `Get-SqlDefaultSpConfigure` tests SQL versions 8 to 14, while its version map also lists 15 (2019) and 16 (2022). That gap predates this change and I did not widen the scope, but it is probably worth closing.