### PR TITLE
CI - Fix the two things stopping @claude from doing work

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,8 +44,12 @@ jobs:
           # subprocess under bubblewrap with secrets (OAuth token, GITHUB_TOKEN, cloud
           # creds) scrubbed from its environment. The CLI refuses to start if bubblewrap
           # is missing, so install it on the runner before invoking the action.
+          # socat is the second half of the pair: it relays sandboxed network traffic
+          # through the sandbox proxy. Without it every Bash command that touches the
+          # network (gh, git push) dies on sandbox init. Neither package ships in the
+          # ubuntu-latest image. Ref: https://code.claude.com/docs/en/sandboxing
           sudo apt-get update
-          sudo apt-get install -y bubblewrap
+          sudo apt-get install -y bubblewrap socat
           # Ubuntu 24.04 (ubuntu-latest) blocks unprivileged user namespaces via AppArmor,
           # which bubblewrap needs. Rather than globally disabling the kernel restriction
           # (kernel.apparmor_restrict_unprivileged_userns), load a dedicated AppArmor profile

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,8 +38,12 @@ jobs:
           # subprocess under bubblewrap with secrets (OAuth token, GITHUB_TOKEN, cloud
           # creds) scrubbed from its environment. The CLI refuses to start if bubblewrap
           # is missing, so install it on the runner before invoking the action.
+          # socat is the second half of the pair: it relays sandboxed network traffic
+          # through the sandbox proxy. Without it every Bash command that touches the
+          # network (gh, git push) dies on sandbox init. Neither package ships in the
+          # ubuntu-latest image. Ref: https://code.claude.com/docs/en/sandboxing
           sudo apt-get update
-          sudo apt-get install -y bubblewrap
+          sudo apt-get install -y bubblewrap socat
           # Ubuntu 24.04 (ubuntu-latest) blocks unprivileged user namespaces via AppArmor,
           # which bubblewrap needs. Rather than globally disabling the kernel restriction
           # (kernel.apparmor_restrict_unprivileged_userns), load a dedicated AppArmor profile

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -77,11 +77,13 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Keep public-triggered Claude runs read-only. Use a maintainer-run
-          # local session or a separate protected workflow for code-writing tasks.
+          # The job-level if: gates this workflow to named maintainers, so Claude is
+          # trusted to change code here. Edit and Write are what let it act on that:
+          # the action already grants git add/commit/rm/push, so without them Claude
+          # could commit but never author, and burned a whole run finding that out.
           claude_args: >-
             --max-turns 100
-            --allowedTools "Read,Glob,Grep,Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh run view:*)"
+            --allowedTools "Read,Glob,Grep,Edit,Write,Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh run view:*)"
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
Two independent problems, both found while chasing why `@claude` could not apply a parameter rename on #10463.

## 1. socat was missing, so the sandbox never started

`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` makes the CLI run every Bash subprocess under the sandbox. On Linux that sandbox needs [two packages](https://code.claude.com/docs/en/sandboxing), not one:

> On Linux and WSL2, the sandbox relies on two packages: `bubblewrap` — the unprivileged sandboxing tool that enforces filesystem isolation — and `socat` — the relay used to route network traffic through the sandbox proxy.

Both workflows installed only `bubblewrap`, and neither package ships in the `ubuntu-latest` image, so every Bash command that touches the network (`gh`, `git push`) died on sandbox init. Fixed in both workflows.

## 2. Edit and Write were never granted

The resolved `allowedTools` in [run 30710969030](https://github.com/dataplat/dbatools/actions/runs/30710969030) contained no `Edit` and no `Write`, which is what `permission_denials_count: 4` was — Claude trying to edit and being refused by policy.

The stale comment described these as "public-triggered" runs, but the job-level `if:` gates the workflow to three named maintainers. And the action already grants `git add`, `git commit`, `git rm` and `git-push.sh`. So the configuration was half-open: Claude could commit and push but never author. It burned a full run deriving the exact diff, then failed at the last step with nothing to commit.

`claude-code-review.yml` stays read-only — it only posts a review comment.

## Note on the push path

`permissions:` is left alone. The action mints its own GitHub App token, which is separate from `GITHUB_TOKEN`, so `contents: read` should not block the push. That path has never actually run in CI here, though — the only `claude`-authored commits on #10463 came from local maintainer sessions. If the first push from a CI run fails, `contents: write` is the lever.

This needs to land on `development` before it takes effect: `issue_comment` triggers always load the workflow from the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)