### PR TITLE
Tests - Recover two skipped tests and give the rest a reason for being skipped

### DIFF
--- a/tests/Get-DbaWindowsLog.Tests.ps1
+++ b/tests/Get-DbaWindowsLog.Tests.ps1
@@ -25,7 +25,9 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
-    # Skip IntegrationTests because the command is very unstable and should be reviewed.
+    # These were skipped as "very unstable and should be reviewed". Reviewed on 2026-08-01: five
+    # consecutive runs against the lab were all green, so they run again. If the instability comes
+    # back, skip them once more but record what actually failed, not only that it is unstable.
 
     Context "Command returns proper info" {
         It "returns results" {

--- a/tests/Get-DbaWindowsLog.Tests.ps1
+++ b/tests/Get-DbaWindowsLog.Tests.ps1
@@ -24,7 +24,7 @@ Describe $CommandName -Tag UnitTests {
     }
 }
 
-Describe $CommandName -Tag IntegrationTests -Skip {
+Describe $CommandName -Tag IntegrationTests {
     # Skip IntegrationTests because the command is very unstable and should be reviewed.
 
     Context "Command returns proper info" {

--- a/tests/Invoke-DbaWhoIsActive.Tests.ps1
+++ b/tests/Invoke-DbaWhoIsActive.Tests.ps1
@@ -90,7 +90,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
             # No test for results as we don't expect any running queries
         }
 
-        It "Should execute with ShowSleepingSpids" -Skip {
+        It "Should execute with ShowSleepingSpids" {
             # Skip It because it warns: Failed during execution | Name cannot begin with the ' ' character, hexadecimal value 0x20. Line 5372, position 60.
             # TODO: The command runs correct in an interactive session and only fails if executed by pester
 

--- a/tests/Invoke-DbaWhoIsActive.Tests.ps1
+++ b/tests/Invoke-DbaWhoIsActive.Tests.ps1
@@ -91,8 +91,10 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
         }
 
         It "Should execute with ShowSleepingSpids" {
-            # Skip It because it warns: Failed during execution | Name cannot begin with the ' ' character, hexadecimal value 0x20. Line 5372, position 60.
-            # TODO: The command runs correct in an interactive session and only fails if executed by pester
+            # This was skipped because it warned "Failed during execution | Name cannot begin with
+            # the ' ' character, hexadecimal value 0x20" when Pester ran it, though not in an
+            # interactive session. Re-checked on 2026-08-01: five consecutive runs were all green,
+            # so it runs again. If the warning returns, the $WarnVar assertion below will catch it.
 
             $resultsSleeping = Invoke-DbaWhoIsActive -SqlInstance $TestConfig.InstanceSingle -ShowSleepingSpids 2
             $WarnVar | Should -BeNullOrEmpty

--- a/tests/Measure-DbatoolsImport.Tests.ps1
+++ b/tests/Measure-DbatoolsImport.Tests.ps1
@@ -7,6 +7,9 @@ param(
 
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
+        # Skipped: Measure-DbatoolsImport takes no parameters, so the standard parameter validation
+        # test has nothing to compare against and fails on a null DifferenceObject.
+        # TestTestLayout.ps1 exempts this file for the same reason.
         It -Skip "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters

--- a/tests/New-DbaScriptingOption.Tests.ps1
+++ b/tests/New-DbaScriptingOption.Tests.ps1
@@ -7,6 +7,9 @@ param(
 
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
+        # Skipped: New-DbaScriptingOption takes no parameters, so the standard parameter validation
+        # test has nothing to compare against and fails on a null DifferenceObject.
+        # TestTestLayout.ps1 exempts this file for the same reason.
         It -Skip "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters

--- a/tests/Test-DbaDbOwner.Tests.ps1
+++ b/tests/Test-DbaDbOwner.Tests.ps1
@@ -27,6 +27,10 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     InModuleScope 'dbatools' {
         Context "Connects to SQL Server" {
+            # Skipped: these mock Connect-SQLInstance, which no longer exists in the module - it was
+            # renamed to Connect-DbaInstance long ago. Un-skipping fails on every one of them with
+            # "Could not find Command Connect-SQLInstance", so reviving them means rewriting the
+            # mocks against the current API, not just removing the -Skip.
             It -Skip "Should not throw" {
                 Mock Connect-SQLInstance -MockWith {
                     [object]@{
@@ -51,6 +55,10 @@ Describe $CommandName -Tag IntegrationTests {
                     Test-DbaDbOwner -SqlInstance 'SQLServerName'
                 } | Should -Not -Throw
             } #It
+            # Skipped: these mock Connect-SQLInstance, which no longer exists in the module - it was
+            # renamed to Connect-DbaInstance long ago. Un-skipping fails on every one of them with
+            # "Could not find Command Connect-SQLInstance", so reviving them means rewriting the
+            # mocks against the current API, not just removing the -Skip.
             It -Skip "Should not return if no wrong owner for default" {
                 Mock Connect-SQLInstance -MockWith {
                     [object]@{
@@ -75,6 +83,10 @@ Describe $CommandName -Tag IntegrationTests {
                     Test-DbaDbOwner -SqlInstance 'SQLServerName'
                 } | Should -Not -Throw
             } #It
+            # Skipped: these mock Connect-SQLInstance, which no longer exists in the module - it was
+            # renamed to Connect-DbaInstance long ago. Un-skipping fails on every one of them with
+            # "Could not find Command Connect-SQLInstance", so reviving them means rewriting the
+            # mocks against the current API, not just removing the -Skip.
             It -Skip "Should return wrong owner information for one database with no owner specified" {
                 Mock Connect-SQLInstance -MockWith {
                     [object]@{
@@ -103,6 +115,10 @@ Describe $CommandName -Tag IntegrationTests {
                 $Result[0].TargetOwner | Should -Be 'sa';
                 $Result[0].OwnerMatch | Should -Be $False
             } # it
+            # Skipped: these mock Connect-SQLInstance, which no longer exists in the module - it was
+            # renamed to Connect-DbaInstance long ago. Un-skipping fails on every one of them with
+            # "Could not find Command Connect-SQLInstance", so reviving them means rewriting the
+            # mocks against the current API, not just removing the -Skip.
             It -Skip "Should return information for one database with correct owner with detail parameter" {
                 Mock Connect-SQLInstance -MockWith {
                     [object]@{
@@ -131,6 +147,10 @@ Describe $CommandName -Tag IntegrationTests {
                 $Result.TargetOwner | Should -Be 'sa';
                 $Result.OwnerMatch | Should -Be $True
             } # it
+            # Skipped: these mock Connect-SQLInstance, which no longer exists in the module - it was
+            # renamed to Connect-DbaInstance long ago. Un-skipping fails on every one of them with
+            # "Could not find Command Connect-SQLInstance", so reviving them means rewriting the
+            # mocks against the current API, not just removing the -Skip.
             It -Skip "Should return wrong owner information for one database with no owner specified and multiple databases" {
                 Mock Connect-SQLInstance -MockWith {
                     [object]@{
@@ -164,6 +184,10 @@ Describe $CommandName -Tag IntegrationTests {
                 $Result[0].TargetOwner | Should -Be 'sa';
                 $Result[0].OwnerMatch | Should -Be $False
             } # it
+            # Skipped: these mock Connect-SQLInstance, which no longer exists in the module - it was
+            # renamed to Connect-DbaInstance long ago. Un-skipping fails on every one of them with
+            # "Could not find Command Connect-SQLInstance", so reviving them means rewriting the
+            # mocks against the current API, not just removing the -Skip.
             It -Skip "Should return wrong owner information for two databases with no owner specified and multiple databases" {
                 Mock Connect-SQLInstance -MockWith {
                     [object]@{
@@ -204,6 +228,10 @@ Describe $CommandName -Tag IntegrationTests {
                 $Result[1].OwnerMatch | Should -Be $False
             } # it
 
+            # Skipped: these mock Connect-SQLInstance, which no longer exists in the module - it was
+            # renamed to Connect-DbaInstance long ago. Un-skipping fails on every one of them with
+            # "Could not find Command Connect-SQLInstance", so reviving them means rewriting the
+            # mocks against the current API, not just removing the -Skip.
             It -Skip "Should call Stop-Function one time if Target Login does not exist on Server" {
                 Mock Connect-SQLInstance -MockWith {
                     [object]@{
@@ -239,6 +267,10 @@ Describe $CommandName -Tag IntegrationTests {
                 }
                 Should -Invoke @assertMockParams
             } # it
+            # Skipped: these mock Connect-SQLInstance, which no longer exists in the module - it was
+            # renamed to Connect-DbaInstance long ago. Un-skipping fails on every one of them with
+            # "Could not find Command Connect-SQLInstance", so reviving them means rewriting the
+            # mocks against the current API, not just removing the -Skip.
             It -Skip "Returns all information with detailed for correct and incorrect owner" {
                 Mock Connect-SQLInstance -MockWith {
                     [object]@{

--- a/tests/Test-DbaDiskSpeed.Tests.ps1
+++ b/tests/Test-DbaDiskSpeed.Tests.ps1
@@ -225,7 +225,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Separate test to run against a Linux-hosted SQL instance.
         # To run this test ensure you have specified the InstanceLinux values for a Linux-hosted SQL instance in the Get-TestConfig
-        It "aggregate by file and check column names returned on a Linux instance" -Skip {
+        It "aggregate by file and check column names returned on a Linux instance" -Skip:(-not $TestConfig.InstanceLinux) {
             # check returned columns
             [object[]]$expectedColumnArray = "ComputerName", "InstanceName", "SqlInstance", "Database", "SizeGB", "FileName", "FileID", "FileType", "DiskLocation", "Reads", "AverageReadStall", "ReadPerformance", "Writes", "AverageWriteStall", "WritePerformance", "Avg Overall Latency", "Avg Bytes/Read", "Avg Bytes/Write", "Avg Bytes/Transfer"
 
@@ -265,7 +265,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Separate test to run against a Linux-hosted SQL instance.
         # To run this test ensure you have specified the InstanceLinux values for a Linux-hosted SQL instance in the Get-TestConfig
-        It "aggregate by database and check column names returned on a Linux instance" -Skip {
+        It "aggregate by database and check column names returned on a Linux instance" -Skip:(-not $TestConfig.InstanceLinux) {
             # check returned columns
             [object[]]$expectedColumnArray = "ComputerName", "InstanceName", "SqlInstance", "Database", "DiskLocation", "Reads", "AverageReadStall", "ReadPerformance", "Writes", "AverageWriteStall", "WritePerformance", "Avg Overall Latency", "Avg Bytes/Read", "Avg Bytes/Write", "Avg Bytes/Transfer"
 
@@ -305,7 +305,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Separate test to run against a Linux-hosted SQL instance.
         # To run this test ensure you have specified the InstanceLinux values for a Linux-hosted SQL instance in the Get-TestConfig
-        It "aggregate by disk and check column names returned on a Linux instance" -Skip {
+        It "aggregate by disk and check column names returned on a Linux instance" -Skip:(-not $TestConfig.InstanceLinux) {
             # check returned columns
             [object[]]$expectedColumnArray = "ComputerName", "InstanceName", "SqlInstance", "DiskLocation", "Reads", "AverageReadStall", "ReadPerformance", "Writes", "AverageWriteStall", "WritePerformance", "Avg Overall Latency", "Avg Bytes/Read", "Avg Bytes/Write", "Avg Bytes/Transfer"
 


### PR DESCRIPTION
34 test blocks across 17 files are switched off with a bare `-Skip`. Nothing makes them visible afterwards, so there is no way to tell an intentional skip from an abandoned one. I un-skipped every one that could be run safely and recorded what actually happened.

## Recovered - the skip is removed

| File | Block |
|---|---|
| Get-DbaWindowsLog | the whole integration Describe |
| Invoke-DbaWhoIsActive | "Should execute with ShowSleepingSpids" |

Both were skipped for being **unstable**, not obsolete - one green run does not refute that, so I ran each five consecutive times. All green. The comment on each now says what was skipped, why, that it was re-checked and when, and what to do if the problem returns.

## Turned into a real condition

Three tests in `Test-DbaDiskSpeed` need a Linux-hosted instance. That is a condition, not a permanent state - and the **fourth** Linux test in the same file already writes it as `-Skip:(-not $TestConfig.InstanceLinux)`. The other three now match, so they will run on a lab that has one.

## Given a reason, still skipped

**Test-DbaDbOwner, 8 tests.** They mock `Connect-SQLInstance`, which no longer exists in the module - it was renamed to `Connect-DbaInstance`. Every one fails with `Could not find Command Connect-SQLInstance` when un-skipped. Reviving them means rewriting the mocks against the current API, not removing a `-Skip`. That is now written on each of them. This is effectively a command with no unit coverage.

**Measure-DbatoolsImport and New-DbaScriptingOption.** Both commands take no parameters, so the standard parameter-validation test has nothing to compare against and fails on a null `DifferenceObject`. `TestTestLayout.ps1` already exempts both files for exactly that reason; now the test says so too.

## Left alone

These fail when un-skipped and each needs a decision rather than a sweep:

| File | Blocks | Reason recorded in the file | What happens when un-skipped |
|---|---|---|---|
| Restore-DbaDatabase | 4 | none on 3 of them | not run - restores databases, too invasive to try casually |
| Get-DbaDatabase | 6 | "Skip UnitTests because they need refactoring" | fail |
| Get-DbaDbMirror | 3 | "Skip IntegrationTests because Mirroring need additional setup" | fail - attempts real mirroring |
| Invoke-DbaDbPiiScan | 9 | none | 5 pass, 4 fail on missing known-names and patterns files |
| Set-DbaDbState | 4 | the command does not write the warning the test expects | fail |
| Set-DbaLogin | 2 | one is `Context -Skip "???"` marked `# TODO: Fix later` | its tests are not even discovered |
| New-DbaDbMailAccount | 2 | needs a configured mail server | not run |
| Set-DbaAgentServer | 1 | `RegCreateKeyEx() returned error 5` | not run |
| Get-DbaDbSharePoint | 1 | "Skip IntegrationTests because they need to be tested first" | fail |
| Stop-DbaAgentJob | 1 | none | fail |
| Update-DbaInstance | 1 | none | the integration Describe, a WhatIf smoke test |

`Invoke-DbaDbPiiScan` is the most promising: 5 of its 9 would pass if the fixture files were available.

Only five blocks have no reason recorded anywhere - three in Restore-DbaDatabase, one in Stop-DbaAgentJob and the Update-DbaInstance integration Describe.

## One thing you should know

Finding this out meant running previously-skipped tests against the lab, and `Get-DbaDbMirror` attempted real mirroring. It left two mirroring endpoints on SQL03\SQL2022 and SQL03\SQL2025 and two backup files in the temp share. I removed all four and `TestEnvironment.Tests.ps1` is back to clean.

That file said `# Skip IntegrationTests because Mirroring need additional setup` **inside** the Describe, one line below the `-Skip`. My inventory only looked at the lines above each block, so I did not see it - the same oversight that left the two stale comments this PR now fixes. Reading it would have told me to leave that file alone, as I did with `Restore-DbaDatabase`.

## Verification

All six changed files pass with the environment check enabled: Get-DbaWindowsLog 2/2, Invoke-DbaWhoIsActive 12/12, Test-DbaDiskSpeed 12 passed and 4 correctly skipped, Test-DbaDbOwner 2 passed and 8 skipped, and the two no-parameter files skip as before.
