### PR TITLE
Tests - Standardise the last four parameter validation tests

### DIFF
--- a/tests/Get-DbaInstanceList.Tests.ps1
+++ b/tests/Get-DbaInstanceList.Tests.ps1
@@ -9,6 +9,10 @@ Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            # $TestConfig.CommonParameters is a HashSet, which Compare-Object treats as a single
+            # object. Every other test file gets away with the bare property because the "+= @()"
+            # on the next line converts it to an array first. This command has no parameters of
+            # its own, so there is no "+=" and the conversion has to happen here.
             $expectedParameters = @($TestConfig.CommonParameters)
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }

--- a/tests/Get-ObjectNameParts.Tests.ps1
+++ b/tests/Get-ObjectNameParts.Tests.ps1
@@ -5,8 +5,6 @@ param(
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-. "$PSScriptRoot\..\private\functions\Get-ObjectNameParts.ps1"
-
 Describe $CommandName -Tag UnitTests {
     Context 'Parameter validation' {
         BeforeAll {

--- a/tests/Import-DbaParquet.Tests.ps1
+++ b/tests/Import-DbaParquet.Tests.ps1
@@ -9,7 +9,8 @@ Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
-            $expectedParameters = @(
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "Path",
                 "SqlInstance",
                 "SqlCredential",
@@ -35,7 +36,7 @@ Describe $CommandName -Tag UnitTests {
                 "StaticColumns",
                 "EnableException"
             )
-            ($expectedParameters | Where-Object { $PSItem -notin $hasParameters }) | Should -BeNullOrEmpty
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
 
         It "Should not have any CSV-only parameters" {

--- a/tests/Install-DbaParquet.Tests.ps1
+++ b/tests/Install-DbaParquet.Tests.ps1
@@ -9,14 +9,15 @@ Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
-            $expectedParameters = @(
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "Path",
                 "Version",
                 "LocalFile",
                 "Force",
                 "EnableException"
             )
-            ($expectedParameters | Where-Object { $PSItem -notin $hasParameters }) | Should -BeNullOrEmpty
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Invoke-ManagedComputerCommand.Tests.ps1
+++ b/tests/Invoke-ManagedComputerCommand.Tests.ps1
@@ -8,10 +8,10 @@ param(
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {
-            # This is a private command, so we have to ask the module for it.
-            # We must not do this inside of InModuleScope, because $TestConfig is not available there.
-            $commandInfo = & (Get-Module dbatools) { Get-Command -Name Invoke-ManagedComputerCommand }
-            $hasParameters = $commandInfo.Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            # This is a private command, but a checkout has no dbatools.dat, so the psm1 exports
+            # every function and plain Get-Command finds it. What still matters is that this stays
+            # outside InModuleScope, where $TestConfig would not be readable in CI.
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
                 "ComputerName",

--- a/tests/Test-DbaLsnChain.Tests.ps1
+++ b/tests/Test-DbaLsnChain.Tests.ps1
@@ -8,12 +8,7 @@ param(
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {
-            # Test-DbaLsnChain is private, so Get-Command cannot see it from here. Reaching into the
-            # module for just that one call keeps the rest of the test outside InModuleScope, where
-            # $TestConfig is readable - inside it the lookup chains to global only, so $TestConfig
-            # comes back empty in CI and every common parameter is reported as unexpected. That is
-            # also why the common parameters used to be written out by hand here.
-            $hasParameters = (& (Get-Module dbatools) { Get-Command -Name Test-DbaLsnChain }).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
                 "FilteredRestoreFiles",

--- a/tests/Test-DbaLsnChain.Tests.ps1
+++ b/tests/Test-DbaLsnChain.Tests.ps1
@@ -6,32 +6,21 @@ param(
 )
 
 Describe $CommandName -Tag UnitTests {
-    InModuleScope dbatools {
-        Context "Parameter validation" {
-            It "Should have the expected parameters" {
-                $hasParameters = (Get-Command "Test-DbaLsnChain").Parameters.Values.Name | Where-Object {
-                    $PSItem -notin @(
-                        "Verbose",
-                        "Debug",
-                        "ErrorAction",
-                        "WarningAction",
-                        "InformationAction",
-                        "ProgressAction",
-                        "ErrorVariable",
-                        "WarningVariable",
-                        "InformationVariable",
-                        "OutVariable",
-                        "OutBuffer",
-                        "PipelineVariable"
-                    )
-                }
-                $expectedParameters = @(
-                    "FilteredRestoreFiles",
-                    "Continue",
-                    "EnableException"
-                )
-                Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
-            }
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            # Test-DbaLsnChain is private, so Get-Command cannot see it from here. Reaching into the
+            # module for just that one call keeps the rest of the test outside InModuleScope, where
+            # $TestConfig is readable - inside it the lookup chains to global only, so $TestConfig
+            # comes back empty in CI and every common parameter is reported as unexpected. That is
+            # also why the common parameters used to be written out by hand here.
+            $hasParameters = (& (Get-Module dbatools) { Get-Command -Name Test-DbaLsnChain }).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "FilteredRestoreFiles",
+                "Continue",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Test-PSRemoting.Tests.ps1
+++ b/tests/Test-PSRemoting.Tests.ps1
@@ -4,7 +4,6 @@ param(
     $CommandName = "Test-PSRemoting",
     $PSDefaultParameterValues = $TestConfig.Defaults
 )
-. "$PSScriptRoot\..\private\functions\Test-PSRemoting.ps1"
 
 Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {


### PR DESCRIPTION
Four parameter validation tests that deviate from the standard shape, found while reviewing the test layout. **Only four of the ten deviations the layout check reported were defects.** The other six were legitimate patterns the check did not allow for, so I relaxed the check rather than reshape working files.

## The four that were wrong

**Import-DbaParquet and Install-DbaParquet asserted in one direction only.** They built the expected list without `$TestConfig.CommonParameters` and finished with

```powershell
($expectedParameters | Where-Object { $PSItem -notin $hasParameters }) | Should -BeNullOrEmpty
```

That proves the expected parameters exist. A parameter **added** to the command by mistake would pass. Both now use the standard `Compare-Object` form, which is exact in both directions. Their lists already match the commands, so nothing else had to change.

**Test-DbaLsnChain wrapped its whole Describe in `InModuleScope` and wrote out the twelve common parameters by hand.** Reading `$TestConfig` inside `InModuleScope` is the thing that passes locally and fails in CI, and the hand-written list was presumably the workaround for it.

It now uses the same plain form as every other parameter validation test:

```powershell
$hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
$expectedParameters = $TestConfig.CommonParameters
```

There is no need to reach into the module for a private command. A checkout has no `dbatools.dat`, so the psm1 takes the `Export-ModuleMember -Function *` branch and exports **all 870 functions** against the 717 in the manifest - private ones included. Both the lab harness and `tests\appveyor.pester.ps1` import the psm1 from the checkout, so that holds in CI too. **Thirteen of the sixteen tests for private functions already call plain `Get-Command`** and pass.

The part that matters is unchanged: the Context stays outside `InModuleScope`, so `$TestConfig` is read from a scope where it is visible in CI.

**Get-DbaInstanceList keeps its `@()` wrapper, and now says why.** This one is worth knowing generally:

> `$TestConfig.CommonParameters` is a **`HashSet[string]`**, and `Compare-Object` treats a HashSet as a single object. Every test file gets away with the bare property only because the `+= @(...)` on the next line converts it to an array first. `Get-DbaInstanceList` has no parameters of its own, so there is no `+=`.

I removed the `@()` to make the file match the standard shape, and the test failed with all twelve common parameters reported as unexpected. That is how I found it. Restored, with the reason in a comment.

This probably belongs in `tests/CLAUDE.md` as well, now that #10485 has made it the single source. Say the word and I will add it here or in a follow-up.

## The six that were fine

Left alone; the check in the testing repo now allows them:

- **Four files put a second `It` in the Parameter validation Context** (Find-DbaAgentJob, Set-DbaAgentSchedule, Sync-DbaLoginPassword, Test-DbaKerberos) - testing a wildcard attribute, a mandatory parameter, a parameter set, an alias. Exactly where those belong. The check required the Context to end after the first test.
- **Two files put a comment between the Describe and the Context** (Remove-DbaReplArticle, Remove-DbaReplPublication) explaining the `-Skip:` on the Describe - which is what the guide asks for.

## Three more tests for private functions, cleaned up the same way

- **Invoke-ManagedComputerCommand** asked the module for the command with `& (Get-Module dbatools) { Get-Command -Name ... }`. Now plain `Get-Command $CommandName`. The comment keeps the part that does matter: this has to stay outside `InModuleScope`.
- **Test-PSRemoting and Get-ObjectNameParts** dot-sourced the private function file at the top of the test. Besides being unnecessary, it meant anything called from test scope ran the **dot-sourced copy rather than the one in the loaded module**. Identical today because both come from the same checkout, so nothing changed, but it would have hidden a difference if they ever diverged.

With those gone, no test file dot-sources at the top level and none reaches into the module for `Get-Command`, so the tolerances both layout checks carried for those two patterns are removed as well. All sixteen tests for private functions pass.

## Result

`TestTestLayout.ps1` no longer reports any of these ten files.

What it still reports is the 75 files whose `$ModuleName` is not aligned in the param block. That was #10487, which has been closed as unwanted, so those stay as they are. This PR is independent of it.

All four changed files pass, and so do all sixteen tests for private functions.
