### PR TITLE
runner fleet - Size CI runner lanes to queued work and instrument VM lifetimes

### DIFF
--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -103,13 +103,15 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
   queued holds only `WARM_FLOOR` (3) rather than its full five or ten. This is the
   largest single cost lever in the fleet -- July 2026 ran at 14.6% utilization (138.1
   job-hours against 948.9 billed VM-hours), and replaying that month's real job
-  timeline through the policy attributes the waste as 57% hot-idle lanes (what this
-  fixes) and 27% per-VM boot and delete lag (what it cannot).
-- **Boot overhead is a floor that pool sizing cannot reach.** Runners are single-use,
-  so July billed 1,726 VMs for 1,668 jobs -- job count, not pool size, decides how many
-  boots get paid for. At ~9 min of non-job overhead per VM that is ~$106/month no matter
-  how low `WARM_FLOOR` goes. Lowering the floor buys *latency* (how many jobs of a matrix
-  start on an already-booted VM), not boot savings.
+  timeline through the policy attributes the waste as roughly 57% hot-idle lanes (what
+  this fixes) and 27% per-VM boot and delete lag (what it cannot). That split is
+  modelled, not measured; the `FLEETSTAT` lines exist to measure it.
+- **Boot overhead is a floor that pool sizing cannot reach.** Runners are single-use, so
+  July billed 1,726 VMs for 1,668 jobs -- job count, not pool size, decides how many
+  boots get paid for. At an estimated ~9 min of non-job overhead per VM that is roughly
+  $106/month no matter how low `WARM_FLOOR` goes. Lowering the floor buys *latency*, not
+  boot savings -- and only for lanes that are already hot with idle registered VMs, since
+  a cold lane provisions from zero whatever the floor is.
 - Community CI heats a shared lane while live and for 20 minutes after; it is zero
   otherwise. Each maintainer's lane heats independently.
 - Maximum capacity is 35 only when all three maintainers and community are simultaneously

--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -3,9 +3,12 @@
 Replaces AppVeyor with disposable Azure VMs: every job runs on a factory-fresh
 ephemeral VM booted from a golden image with SQL Server preinstalled, registered as a
 single-use GitHub runner, and deleted afterwards. Activity heats four independent
-AppVeyor-style lanes: ten runners each for `potatoqualitee`, `andreasjordan`, and
-`niphlod`, plus five shared community runners. Maintainer lanes cool after one hour;
-community cools 20 minutes after CI finishes. With no activity, capacity is zero.
+AppVeyor-style lanes: `potatoqualitee`, `andreasjordan`, `niphlod`, and a shared
+community lane. A hot lane is sized to the jobs actually queued or running in it --
+up to ten for a maintainer, five for community -- and holds a small warm floor
+(`WARM_FLOOR`, currently 3) while it is hot but has nothing pending. Maintainer lanes
+cool after one hour; community cools 20 minutes after CI finishes. With no activity,
+capacity is zero.
 
 ```
 GitHub (public repo)                          Azure (eastus)
@@ -26,10 +29,10 @@ GitHub (public repo)                          Azure (eastus)
 | Runner execution | **interactive autologon session** as local admin `appveyor` (AppVeyor parity: BITS transfers, `$env:USERNAME`, `C:\Users\appveyor\Documents\DbatoolsExport`); bootstrap registers the ephemeral runner, arms autologon + a logon task, reboots |
 | Instance parity knobs | firewall off, `LocalAccountTokenFilterPolicy=1`, pagefile setting on D:, `@@SERVERNAME` repaired per job (all NSG-shielded) |
 | Harness | untouched `tests/appveyor.*.ps1` via `tests/gha.shim.ps1` (`APPVEYOR=True` drives Get-TestConfig) |
-| Scaling controls | Maintainer lanes heat to ten for one hour after eligible activity or while CI is live; community heats to five while CI is live and for 20 minutes after; `MAX_RUNNERS=35` is the hard VMSS ceiling |
+| Scaling controls | Eligible activity or a live run makes a lane hot for one hour (community: while CI is live and 20 minutes after). A hot lane is then sized to its pending job count, capped at ten (community five), falling back to `WARM_FLOOR` (3) when nothing is pending. Demand never heats a cold lane. `MAX_RUNNERS=35` is the hard VMSS ceiling |
 | CI markers | `(do <cmd>)` selects CI tests (the existing campaign convention); `[do ci]` activates the runner pool. They are compatible and unrelated. |
 | Build queue | Workflow concurrency uses `queue: max`: one matrix build per lane consumes that lane's workers while later builds wait FIFO, matching AppVeyor account concurrency |
-| Pool sizes | `potatoqualitee`, `andreasjordan`, and `niphlod` receive ten dedicated workers each; non-maintainers share five |
+| Pool sizes | `potatoqualitee`, `andreasjordan`, and `niphlod` each cap at ten dedicated workers; non-maintainers share five. These are ceilings, not fixed sizes -- a lane only reaches them when that many jobs are actually pending |
 | Outbound | Instance public IPs are the fleet's egress -- the subnet has no NAT gateway, no load balancer and no route table, and `defaultOutboundAccess` is unset, so implicit egress is not something to rely on. ~$8.31/mo and scales to zero with the fleet; a NAT gateway bills 24/7 against a fleet that is at zero capacity most of the day. Do not remove the IPs as a cost measure. |
 | Azure auth | OIDC only — Entra app `dbatools-ci-github`, federated for the default branch, custom role `dbatools-ci-operator` scoped to RG `dbatools-ci` |
 | Runner registration | `CI_RUNNER_PAT` secret mints single-use tokens; tokens are never stored on VMs |
@@ -76,8 +79,10 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
 1. Push/PR triggers `ci-azure.yml`; ordinary `potatoqualitee` pushes stop on a
    GitHub-hosted authorization job unless the head commit contains `[do ci]`. Eligible
    builds wait in the actor's FIFO lane, then queue on its pool-specific runner label.
-2. `runner-reconcile.yml` reacts to the requested CI run, raises that logical pool to
-   five or ten workers (total cap `MAX_RUNNERS=35`), tags each Flexible VMSS instance
+2. `runner-reconcile.yml` reacts to the requested CI run, sizes that logical pool to the
+   jobs pending in it (cap five or ten per lane, `MAX_RUNNERS=35` overall; the matrix is
+   not created until the `authorize` gate clears, so the first pass estimates a full
+   pool and the next replaces it with the real count), tags each Flexible VMSS instance
    with its pool, and registers an ephemeral runner on every new instance via
    `az vm run-command` + `bootstrap-runner.ps1` (which then reboots the VM into the
    appveyor autologon session where run.cmd picks up the job). `runner-scale-up.yml`
@@ -94,17 +99,29 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
 - Budget `dbatools-ci-budget`: $600/month on RG `dbatools-ci`, email at 50/80/100%.
 - Dead-runner cleanup: reconcile deletes never-registered and offline instances;
   healthy online hot-pool runners are not evicted merely because of age.
-- Community CI heats a five-runner shared lane while live and for 20 minutes after; it
-  is zero otherwise. Each maintainer independently heats ten dedicated runners.
-- Maximum capacity is 35 only when all three maintainers and community are active together;
-  otherwise the VMSS scales to the sum of the active lanes, including zero.
+- Lanes are sized to pending jobs, not to a flat pool size: a hot lane with nothing
+  queued holds only `WARM_FLOOR` (3) rather than its full five or ten. This is the
+  largest single cost lever in the fleet -- July 2026 ran at 14.6% utilization (138.1
+  job-hours against 948.9 billed VM-hours) precisely because lanes sat hot and idle.
+- Community CI heats a shared lane while live and for 20 minutes after; it is zero
+  otherwise. Each maintainer's lane heats independently.
+- Maximum capacity is 35 only when all three maintainers and community are simultaneously
+  saturated with pending jobs; otherwise the VMSS scales to the sum of the active lanes,
+  including zero.
+- Reconcile reaps orphaned NICs and instance public IPs every pass (snapshot at the start,
+  delete only what was orphaned then and still is), so IP-hours track VM-hours instead of
+  outliving them.
 - Weekly month-to-date spend lands on the "CI cost tracker" issue (Mondays).
 - Ephemeral OS disks cost nothing; the only storage bill is the gallery replicas.
 - Dead man's switch (last ditch): Azure Automation account `dbatools-ci-janitor`
   runs the `Remove-RunawayRunner` runbook every 6 hours, entirely independent
-  of GitHub Actions (source: `janitor-runbook.ps1`, deployed manually). It always
-  preserves the desired 0/5/10/15/20/25/30/35-runner total. Excess runners older than 1h
-  are deleted; if GitHub is unreachable, conservative age caps apply to all capacity.
+  of GitHub Actions (source: `janitor-runbook.ps1`, deployed manually). It preserves a
+  full ten-runner matrix for each lane with a **live** ci-azure run and `WARM_FLOOR` (3)
+  for each lane that is merely hot, because a live lane may have ten jobs executing and
+  the anonymous GitHub API cannot see per-runner `busy` state. Excess runners older than
+  4h are deleted -- VM age runs from creation, and 45m to register plus 60m hot-idle plus
+  a 90m job timeout is ~3.25h of legitimate life, so a tighter cap would kill busy VMs.
+  If GitHub is unreachable, conservative age caps apply to all capacity.
   ps3smoke VMs past 2h and orphaned CI NICs/public IPs
   die in every mode. Its managed identity holds
   only the `dbatools-ci-operator` role on RG `dbatools-ci` -- no storage, no

--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -109,7 +109,8 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
   Lowering `WARM_FLOOR` buys *latency*, not boot savings -- and only for lanes already hot
   with idle registered VMs, since a cold lane provisions from zero whatever the floor is.
   How that 28 minutes splits between idle waiting and boot is not yet measured; the
-  `FLEETSTAT` lines (`bootMin`, `rebootMin`, `ageMin`) exist to settle it.
+  `FLEETSTAT` lines (`bootMin`, `onlineObservedMin`, `ageMin`) exist to settle it.
+  `onlineObservedMin` is an upper bound sampled by reconcile, not an exact reboot timer.
 - Community CI heats a shared lane while live and for 20 minutes after; it is zero
   otherwise. Each maintainer's lane heats independently.
 - Maximum capacity is 35 only when all three maintainers and community are simultaneously
@@ -129,7 +130,8 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
   4h are deleted -- VM age runs from creation, and 45m to register plus 60m hot-idle plus
   a 90m job timeout is ~3.25h of legitimate life, so a tighter cap would kill busy VMs.
   If GitHub is unreachable, conservative age caps apply to all capacity.
-  ps3smoke VMs past 2h and orphaned CI NICs/public IPs
+  ps3smoke VMs past 2h and orphaned CI NICs/public IPs older than a 15-minute
+  provisioning grace period
   die in every mode. Its managed identity holds
   only the `dbatools-ci-operator` role on RG `dbatools-ci` -- no storage, no
   other resource groups. There is no all-day baseline; the switch caps runaway cost.

--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -102,16 +102,14 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
 - Lanes are sized to pending jobs, not to a flat pool size: a hot lane with nothing
   queued holds only `WARM_FLOOR` (3) rather than its full five or ten. This is the
   largest single cost lever in the fleet -- July 2026 ran at 14.6% utilization (138.1
-  job-hours against 948.9 billed VM-hours), and replaying that month's real job
-  timeline through the policy attributes the waste as roughly 57% hot-idle lanes (what
-  this fixes) and 27% per-VM boot and delete lag (what it cannot). That split is
-  modelled, not measured; the `FLEETSTAT` lines exist to measure it.
-- **Boot overhead is a floor that pool sizing cannot reach.** Runners are single-use, so
-  July billed 1,726 VMs for 1,668 jobs -- job count, not pool size, decides how many
-  boots get paid for. At an estimated ~9 min of non-job overhead per VM that is roughly
-  $106/month no matter how low `WARM_FLOOR` goes. Lowering the floor buys *latency*, not
-  boot savings -- and only for lanes that are already hot with idle registered VMs, since
-  a cold lane provisions from zero whatever the floor is.
+  job-hours against 948.9 billed VM-hours), almost all of it lanes sitting hot and idle.
+- **Per-VM overhead is a floor that pool sizing cannot reach.** Runners are single-use, so
+  July billed 1,726 VMs for 1,668 jobs -- job count, not pool size, decides how many boots
+  get paid for, and 28 of an average VM's 33 billed minutes were not job execution.
+  Lowering `WARM_FLOOR` buys *latency*, not boot savings -- and only for lanes already hot
+  with idle registered VMs, since a cold lane provisions from zero whatever the floor is.
+  How that 28 minutes splits between idle waiting and boot is not yet measured; the
+  `FLEETSTAT` lines (`bootMin`, `rebootMin`, `ageMin`) exist to settle it.
 - Community CI heats a shared lane while live and for 20 minutes after; it is zero
   otherwise. Each maintainer's lane heats independently.
 - Maximum capacity is 35 only when all three maintainers and community are simultaneously

--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -102,7 +102,14 @@ pwsh .github/runners/infra.ps1 -ImageId <gallery image id>
 - Lanes are sized to pending jobs, not to a flat pool size: a hot lane with nothing
   queued holds only `WARM_FLOOR` (3) rather than its full five or ten. This is the
   largest single cost lever in the fleet -- July 2026 ran at 14.6% utilization (138.1
-  job-hours against 948.9 billed VM-hours) precisely because lanes sat hot and idle.
+  job-hours against 948.9 billed VM-hours), and replaying that month's real job
+  timeline through the policy attributes the waste as 57% hot-idle lanes (what this
+  fixes) and 27% per-VM boot and delete lag (what it cannot).
+- **Boot overhead is a floor that pool sizing cannot reach.** Runners are single-use,
+  so July billed 1,726 VMs for 1,668 jobs -- job count, not pool size, decides how many
+  boots get paid for. At ~9 min of non-job overhead per VM that is ~$106/month no matter
+  how low `WARM_FLOOR` goes. Lowering the floor buys *latency* (how many jobs of a matrix
+  start on an already-booted VM), not boot savings.
 - Community CI heats a shared lane while live and for 20 minutes after; it is zero
   otherwise. Each maintainer's lane heats independently.
 - Maximum capacity is 35 only when all three maintainers and community are simultaneously

--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -30,6 +30,7 @@ GitHub (public repo)                          Azure (eastus)
 | CI markers | `(do <cmd>)` selects CI tests (the existing campaign convention); `[do ci]` activates the runner pool. They are compatible and unrelated. |
 | Build queue | Workflow concurrency uses `queue: max`: one matrix build per lane consumes that lane's workers while later builds wait FIFO, matching AppVeyor account concurrency |
 | Pool sizes | `potatoqualitee`, `andreasjordan`, and `niphlod` receive ten dedicated workers each; non-maintainers share five |
+| Outbound | Instance public IPs are the fleet's egress -- the subnet has no NAT gateway, no load balancer and no route table, and `defaultOutboundAccess` is unset, so implicit egress is not something to rely on. ~$8.31/mo and scales to zero with the fleet; a NAT gateway bills 24/7 against a fleet that is at zero capacity most of the day. Do not remove the IPs as a cost measure. |
 | Azure auth | OIDC only — Entra app `dbatools-ci-github`, federated for the default branch, custom role `dbatools-ci-operator` scoped to RG `dbatools-ci` |
 | Runner registration | `CI_RUNNER_PAT` secret mints single-use tokens; tokens are never stored on VMs |
 

--- a/.github/runners/janitor-runbook.ps1
+++ b/.github/runners/janitor-runbook.ps1
@@ -14,9 +14,13 @@
       - STALE (no eligible activity, checked through anonymous GitHub APIs):
         no runner capacity is preserved; runners older than 1 hour
         are deleted.
-      - ACTIVE: ten runners are preserved for each active maintainer and five
-        while community CI is live or within its 20-minute grace period; excess
-        runners older than 1 hour die.
+      - ACTIVE: ten runners are preserved for each maintainer with a LIVE
+        ci-azure run (a full matrix may be executing right now) and the warm
+        floor for each maintainer that is merely hot -- recent activity, no run
+        yet. Community is five while its CI is live, the warm floor within the
+        20-minute grace period. Excess runners older than 4 hours die: VM age
+        runs from creation, so 45m to register + 60m hot-idle + a 90m job
+        timeout is ~3.25h of legitimate life, and a tighter cap kills busy VMs.
       - GITHUB UNREACHABLE: we cannot know activity, so conservative age caps
         apply to all capacity -- 3 hours on nights and weekends, 13 hours on
         weekday daytime (06-17 UTC).
@@ -47,12 +51,16 @@ $communityGraceMinutes = 20
 $ciMarker = "[do ci]"
 $communityPoolSize = 5
 $maintainerPoolSize = 10
+# Mirrors WARM_FLOOR in runner-reconcile.yml -- kept aligned by a test in
+# tests/runner-policy.Tests.ps1. Held only for lanes that are hot but have no live run.
+$warmFloor = 3
 $utcNow = (Get-Date).ToUniversalTime()
 
 # ---- recent pool activity (anonymous API, public repo) -------------------------
 $mode = "github-unreachable"
 $lastActivityAgeHours = $null
 $activeMaintainers = @( )
+$liveMaintainers = @( )
 $communityActive = $false
 
 function Invoke-GitHubGet {
@@ -144,6 +152,9 @@ try {
                 Test-JanitorMaintainerEvent -ActivityEvent $PSItem -Maintainer $maintainer -Cutoff $maintainerCutoff
             }).Count -gt 0
         $liveCi = @($liveRuns | Where-Object { (Get-JanitorRunActor -Run $PSItem) -eq $maintainer }).Count -gt 0
+        if ($liveCi) {
+            $liveMaintainers += $maintainer
+        }
         if ($recentActivity -or $liveCi) {
             $activeMaintainers += $maintainer
         }
@@ -176,15 +187,26 @@ try {
     Write-Warning "GitHub activity check failed ($($PSItem.Exception.Message)) -- falling back to age caps"
 }
 
-$desiredPoolSize = ($activeMaintainers.Count * $maintainerPoolSize)
-if ($communityActive) {
+# A lane with a live ci-azure run may have ten jobs executing right now, so it keeps a
+# full matrix's worth of capacity. A lane that is merely hot -- a recent push, no run
+# yet -- has nothing executing, so the warm floor is enough. This is the closest thing
+# to a busy check the anonymous GitHub API can answer.
+$idleHotMaintainers = @($activeMaintainers | Where-Object { $PSItem -notin $liveMaintainers })
+$desiredPoolSize = ($liveMaintainers.Count * $maintainerPoolSize) + ($idleHotMaintainers.Count * $warmFloor)
+if ($communityLive) {
     $desiredPoolSize += $communityPoolSize
+} elseif ($communityActive) {
+    $desiredPoolSize += $warmFloor
 }
 
 switch ($mode) {
     "active" {
-        $runnerMaxHours = 1
-        Write-Output "mode=active: maintainers=[$($activeMaintainers -join ', ')] community=$communityActive -- preserving $desiredPoolSize runners; excess runners past ${runnerMaxHours}h die"
+        # 4h clears the worst legitimate VM lifetime: 45m to register (:403-404) + 60m
+        # hot-idle (BOOST_HOURS) + 90m job timeout (ci-azure.yml) = ~3.25h. Age is
+        # measured from VM creation, not from job start, so a cap merely above the job
+        # timeout would delete VMs mid-job.
+        $runnerMaxHours = 4
+        Write-Output "mode=active: maintainers=[$($activeMaintainers -join ", ")] live=[$($liveMaintainers -join ", ")] community=$communityActive -- preserving $desiredPoolSize runners; excess runners past ${runnerMaxHours}h die"
     }
     "stale" {
         $runnerMaxHours = 1

--- a/.github/runners/janitor-runbook.ps1
+++ b/.github/runners/janitor-runbook.ps1
@@ -54,6 +54,7 @@ $maintainerPoolSize = 10
 # Mirrors WARM_FLOOR in runner-reconcile.yml -- kept aligned by a test in
 # tests/runner-policy.Tests.ps1. Held only for lanes that are hot but have no live run.
 $warmFloor = 3
+$orphanGraceMinutes = 15
 $utcNow = (Get-Date).ToUniversalTime()
 
 # ---- recent pool activity (anonymous API, public repo) -------------------------
@@ -189,14 +190,24 @@ try {
 
 # A lane with a live ci-azure run may have ten jobs executing right now, so it keeps a
 # full matrix's worth of capacity. A lane that is merely hot -- a recent push, no run
-# yet -- has nothing executing, so the warm floor is enough. This is the closest thing
-# to a busy check the anonymous GitHub API can answer.
+# yet -- has nothing executing, so the warm floor is enough. Protection stays per lane;
+# preserving only the fleet-wide total can keep another lane's newer VMs instead.
 $idleHotMaintainers = @($activeMaintainers | Where-Object { $PSItem -notin $liveMaintainers })
-$desiredPoolSize = ($liveMaintainers.Count * $maintainerPoolSize) + ($idleHotMaintainers.Count * $warmFloor)
+$desiredPools = @{ }
+foreach ($maintainer in $liveMaintainers) {
+    $desiredPools[$maintainer] = $maintainerPoolSize
+}
+foreach ($maintainer in $idleHotMaintainers) {
+    $desiredPools[$maintainer] = $warmFloor
+}
 if ($communityLive) {
-    $desiredPoolSize += $communityPoolSize
+    $desiredPools["community"] = $communityPoolSize
 } elseif ($communityActive) {
-    $desiredPoolSize += $warmFloor
+    $desiredPools["community"] = $warmFloor
+}
+$desiredPoolSize = ($desiredPools.Values | Measure-Object -Sum).Sum
+if ($null -eq $desiredPoolSize) {
+    $desiredPoolSize = 0
 }
 
 switch ($mode) {
@@ -230,12 +241,19 @@ switch ($mode) {
 
 $deleted = 0
 $vms = Get-AzVM -ResourceGroupName $rg
-$protectedRunners = @(
-    $vms |
-        Where-Object Name -Like "dbatools-runners_*" |
-        Sort-Object TimeCreated -Descending |
-        Select-Object -First $desiredPoolSize -ExpandProperty Name
-)
+$protectedRunners = @()
+foreach ($pool in $desiredPools.Keys) {
+    $protectedRunners += @(
+        $vms |
+            Where-Object {
+                $PSItem.Name -like "dbatools-runners_*" -and
+                $PSItem.Tags -and
+                [string]$PSItem.Tags.runnerPool -eq $pool
+            } |
+            Sort-Object TimeCreated -Descending |
+            Select-Object -First $desiredPools[$pool] -ExpandProperty Name
+    )
+}
 Write-Output "found $(@($vms).Count) VM(s) in $rg"
 foreach ($vm in $vms) {
     $cap = $null
@@ -268,13 +286,41 @@ foreach ($vm in $vms) {
     }
 }
 
-# orphaned NICs and public IPs survive a workflow that died between VM delete
-# and network teardown; unattached ones matching CI naming are always garbage
+# Orphaned NICs and public IPs survive a workflow that died between VM delete and
+# network teardown. A newly provisioning VM can also leave its networking unattached
+# briefly, so only matching resources older than the grace period are garbage.
+function Test-JanitorOrphanOldEnough {
+    param([Parameter(Mandatory)]$Resource)
+
+    if (-not $Resource.Id) {
+        Write-Warning "preserving orphan candidate $($Resource.Name); resource ID is unavailable"
+        return $false
+    }
+    try {
+        $splatResource = @{
+            ResourceId       = $Resource.Id
+            ExpandProperties = $true
+            ErrorAction      = "Stop"
+        }
+        $resourceDetails = Get-AzResource @splatResource
+    } catch {
+        Write-Warning "preserving orphan candidate $($Resource.Name); creation time lookup failed: $($PSItem.Exception.Message)"
+        return $false
+    }
+    if (-not $resourceDetails.CreatedTime) {
+        Write-Warning "preserving orphan candidate $($Resource.Name); creation time is unavailable"
+        return $false
+    }
+    $ageMinutes = ($utcNow - ([datetime]$resourceDetails.CreatedTime).ToUniversalTime()).TotalMinutes
+    return $ageMinutes -ge $orphanGraceMinutes
+}
+
 foreach ($nic in Get-AzNetworkInterface -ResourceGroupName $rg) {
     if ($nic.VirtualMachine) {
         continue
     }
-    if ($nic.Name -like "ps3smoke*" -or $nic.Name -like "*Nic-*") {
+    if (($nic.Name -like "ps3smoke*" -or $nic.Name -like "*Nic-*") -and
+        (Test-JanitorOrphanOldEnough -Resource $nic)) {
         Write-Warning "orphaned NIC $($nic.Name) -- deleting"
         $null = Remove-AzNetworkInterface -ResourceGroupName $rg -Name $nic.Name -Force
         $deleted++
@@ -284,7 +330,8 @@ foreach ($pip in Get-AzPublicIpAddress -ResourceGroupName $rg) {
     if ($pip.IpConfiguration) {
         continue
     }
-    if ($pip.Name -like "ps3smoke*" -or $pip.Name -like "instancepublicip-*") {
+    if (($pip.Name -like "ps3smoke*" -or $pip.Name -like "instancepublicip-*") -and
+        (Test-JanitorOrphanOldEnough -Resource $pip)) {
         Write-Warning "orphaned public IP $($pip.Name) -- deleting"
         $null = Remove-AzPublicIpAddress -ResourceGroupName $rg -Name $pip.Name -Force
         $deleted++

--- a/.github/runners/reconcile-runner-fleet.ps1
+++ b/.github/runners/reconcile-runner-fleet.ps1
@@ -192,6 +192,35 @@ function Set-VmRegisteredAt {
     ) -Operation "stamp $VmName registration time"
 }
 
+function Set-VmOnlineAt {
+    param($State, $Vms)
+    # Records when a runner first shows online, i.e. when the VM finished rebooting into
+    # the autologon session and the listener came up. registeredAt alone cannot separate
+    # the reboot from hot-idle waiting: the span from registration to the job's start is
+    # reboot PLUS however long GitHub left the runner sitting idle, and for a warm-floor
+    # VM the idle part dominates. Stamping the online transition splits the two.
+    #
+    # The controller does this rather than the VM because runner VMs hold no Azure
+    # identity and must not gain one. Resolution is therefore the reconcile interval.
+    foreach ($vm in $Vms) {
+        if (-not $vm.tags -or -not $vm.tags.registeredAt -or $vm.tags.onlineAt) {
+            continue
+        }
+        $runner = Get-RunnerForVm -State $State -VmName $vm.name
+        if (-not $runner -or $runner.status -ne "online") {
+            continue
+        }
+        $vmId = Invoke-AzJson -Arguments @(
+            "vm", "show", "--resource-group", $resourceGroup, "--name", $vm.name, "--query", "id"
+        ) -Operation "read resource ID for $($vm.name)"
+        $stamp = [DateTimeOffset]::UtcNow.ToString("o")
+        $null = Invoke-NativeText -Tool "az" -Arguments @(
+            "tag", "update", "--resource-id", $vmId, "--operation", "Merge",
+            "--tags", "onlineAt=$stamp", "--only-show-errors", "--output", "none"
+        ) -Operation "stamp $($vm.name) online time"
+    }
+}
+
 function Remove-FleetVm {
     param($State, $Vm, [string]$Reason)
     if (-not $deletedVms.Add($Vm.name)) {
@@ -222,14 +251,23 @@ function Remove-FleetVm {
         "vm", "delete", "--resource-group", $resourceGroup, "--name", $Vm.name,
         "--yes", "--only-show-errors", "--output", "none"
     ) -Operation "delete VM $($Vm.name)"
+    # bootMin is creation to runner registration; rebootMin is registration to the
+    # listener coming up after the reboot -- the span Task 4 actually removes. Keep them
+    # separate: their sum is the VM's unavoidable overhead, while everything between the
+    # listener and the job start is hot-idle waiting, which is Task 2's target instead.
     $bootMin = "unknown"
+    $rebootMin = "unknown"
     if ($Vm.tags -and $Vm.tags.registeredAt) {
         $registered = [DateTimeOffset]::Parse([string]$Vm.tags.registeredAt)
         $created = [DateTimeOffset]::Parse([string]$Vm.created)
         $bootMin = [int]($registered - $created).TotalMinutes
+        if ($Vm.tags.onlineAt) {
+            $online = [DateTimeOffset]::Parse([string]$Vm.tags.onlineAt)
+            $rebootMin = [int]($online - $registered).TotalMinutes
+        }
     }
     $servedJob = ($null -ne $Vm.tags) -and ($null -ne $Vm.tags.registeredAt) -and (-not $runner)
-    Write-Host "FLEETSTAT vm=$($Vm.name) pool=$(Get-VmPool -Vm $Vm) createdAt=$($Vm.created) ageMin=$(Get-VmAgeMinutes -Vm $Vm) bootMin=$bootMin servedJob=$servedJob reason=$Reason"
+    Write-Host "FLEETSTAT vm=$($Vm.name) pool=$(Get-VmPool -Vm $Vm) createdAt=$($Vm.created) ageMin=$(Get-VmAgeMinutes -Vm $Vm) bootMin=$bootMin rebootMin=$rebootMin servedJob=$servedJob reason=$Reason"
 }
 
 function Get-OrphanedNetworking {
@@ -514,6 +552,7 @@ try {
     $state = Get-FleetState
     Register-PoolVms -State $state -Desired $desired
     $state = Get-FleetState
+    Set-VmOnlineAt -State $state -Vms $state.Vms
 
     # Remove dead runners and trim pools whose hot window has ended.
     foreach ($vm in $state.Vms) {
@@ -581,6 +620,7 @@ try {
     $state = Get-FleetState
     Register-PoolVms -State $state -Desired $desired
     $state = Get-FleetState
+    Set-VmOnlineAt -State $state -Vms $state.Vms
     foreach ($pool in $desired.Keys) {
         $poolVms = @($state.Vms | Where-Object { (Get-VmPool -Vm $PSItem) -eq $pool })
         $poolRunners = @($state.Runners | Where-Object { (Get-RunnerPool -Runner $PSItem) -eq $pool })

--- a/.github/runners/reconcile-runner-fleet.ps1
+++ b/.github/runners/reconcile-runner-fleet.ps1
@@ -232,6 +232,61 @@ function Remove-FleetVm {
     Write-Host "FLEETSTAT vm=$($Vm.name) pool=$(Get-VmPool -Vm $Vm) createdAt=$($Vm.created) ageMin=$(Get-VmAgeMinutes -Vm $Vm) bootMin=$bootMin servedJob=$servedJob reason=$Reason"
 }
 
+function Get-OrphanedNetworking {
+    # Unattached NICs and instance public IPs matching the CI naming convention. The
+    # filters mirror the janitor's own patterns (janitor-runbook.ps1:255, :265) so both
+    # sweepers agree on what counts as garbage.
+    #
+    # Here-strings because JMESPath needs both single quotes (its string-literal form --
+    # double quotes there mean identifier quoting, not a literal) and literal backticks
+    # around null. A bare null parses as an identifier rather than the null literal; it
+    # happens to evaluate correctly, but only by accident, and the next person to edit
+    # the filter should not have to rediscover that.
+    $nicQuery = @'
+[?virtualMachine==`null` && contains(name, 'Nic-')].name
+'@
+    $pipQuery = @'
+[?ipConfiguration==`null` && starts_with(name, 'instancepublicip-')].name
+'@
+    $nics = @(Invoke-AzJson -Arguments @(
+            "network", "nic", "list", "--resource-group", $resourceGroup,
+            "--query", $nicQuery
+        ) -Operation "list orphaned NICs")
+    $pips = @(Invoke-AzJson -Arguments @(
+            "network", "public-ip", "list", "--resource-group", $resourceGroup,
+            "--query", $pipQuery
+        ) -Operation "list orphaned public IPs")
+    [pscustomobject]@{ Nics = $nics; Pips = $pips }
+}
+
+function Remove-OrphanedNetworking {
+    param($Snapshot)
+    # The VM delete leaves its NIC and instance public IP behind; the 6-hourly janitor
+    # was the only thing reaping them, and they bill the whole time. July: 1661 IP-hours
+    # against 949 VM-hours.
+    #
+    # Only resources orphaned BOTH at the start of this run and now are deleted. A NIC
+    # created by this run's vmss scale reads virtualMachine==null for a moment before
+    # its VM attaches, and deleting it would break that VM's creation.
+    $current = Get-OrphanedNetworking
+    $staleNics = @($current.Nics | Where-Object { $PSItem -in $Snapshot.Nics })
+    $stalePips = @($current.Pips | Where-Object { $PSItem -in $Snapshot.Pips })
+    foreach ($nicName in $staleNics) {
+        $null = Invoke-NativeText -Tool "az" -Arguments @(
+            "network", "nic", "delete", "--resource-group", $resourceGroup,
+            "--name", $nicName, "--only-show-errors", "--output", "none"
+        ) -Operation "delete orphaned NIC $nicName"
+    }
+    # NICs first: a public IP still bound to a NIC cannot be deleted.
+    foreach ($pipName in $stalePips) {
+        $null = Invoke-NativeText -Tool "az" -Arguments @(
+            "network", "public-ip", "delete", "--resource-group", $resourceGroup,
+            "--name", $pipName, "--only-show-errors", "--output", "none"
+        ) -Operation "delete orphaned public IP $pipName"
+    }
+    Write-Host "reaped orphans: nics=$($staleNics.Count) pips=$($stalePips.Count)"
+}
+
 function Get-PoolJobDemand {
     param([object[]]$WorkflowRuns)
     # I/O only -- the transform lives in runner-policy.ps1, where it is unit tested.
@@ -434,6 +489,7 @@ function Register-PoolVms {
 
 try {
     $demand = Get-RunnerDemand
+    $orphanSnapshot = Get-OrphanedNetworking
     if ($demand.Dispatch) {
         Invoke-MarkedCiDispatch -Request $demand.Dispatch
     }
@@ -532,6 +588,8 @@ try {
         $busy = @($poolRunners | Where-Object busy).Count
         Write-Host "pool=$pool desired=$($desired[$pool]) vms=$($poolVms.Count) online=$online busy=$busy"
     }
+
+    Remove-OrphanedNetworking -Snapshot $orphanSnapshot
 } catch [TransientFleetException] {
     Write-Warning "$($PSItem.Exception.Message) No further fleet changes will be attempted; a job-completion nudge or scheduled reconcile will retry."
     exit 0

--- a/.github/runners/reconcile-runner-fleet.ps1
+++ b/.github/runners/reconcile-runner-fleet.ps1
@@ -28,6 +28,7 @@ $maintainerCount = if ($env:BOOST_COUNT) { [int]$env:BOOST_COUNT } else { 10 }
 $maintainerWindowMinutes = if ($env:BOOST_HOURS) { [int]$env:BOOST_HOURS * 60 } else { 60 }
 $communityGraceMinutes = if ($env:COMMUNITY_GRACE_MINUTES) { [int]$env:COMMUNITY_GRACE_MINUTES } else { 20 }
 $maxRunners = if ($env:MAX_RUNNERS) { [int]$env:MAX_RUNNERS } else { 35 }
+$warmFloor = if ($env:WARM_FLOOR) { [int]$env:WARM_FLOOR } else { 0 }
 $maintainers = @($env:BOOST_USERS -split "\s+" | Where-Object { $PSItem })
 $optInPushUsers = @($env:OPT_IN_PUSH_USERS -split "\s+" | Where-Object { $PSItem })
 $ciMarker = if ($env:CI_MARKER) { $env:CI_MARKER } else { "[do ci]" }
@@ -231,6 +232,38 @@ function Remove-FleetVm {
     Write-Host "FLEETSTAT vm=$($Vm.name) pool=$(Get-VmPool -Vm $Vm) createdAt=$($Vm.created) ageMin=$(Get-VmAgeMinutes -Vm $Vm) bootMin=$bootMin servedJob=$servedJob reason=$Reason"
 }
 
+function Get-PoolJobDemand {
+    param([object[]]$WorkflowRuns)
+    # I/O only -- the transform lives in runner-policy.ps1, where it is unit tested.
+    # Only live runs are probed: completed runs have no pending jobs, and the live set
+    # is normally zero to two runs, so this adds one cheap API call per run.
+    $jobs = @()
+    foreach ($run in @($WorkflowRuns | Where-Object { [string]$PSItem.status -ne "completed" })) {
+        $jobResponse = Invoke-GhJson -Arguments @(
+            "repos/$repo/actions/runs/$($run.id)/jobs?per_page=100"
+        ) -Operation "read jobs for run $($run.id)"
+        $jobs += @($jobResponse.jobs)
+    }
+    $demand = Get-PoolJobDemandFromJobs -Jobs $jobs -PoolLabelPrefix $poolLabelPrefix
+    # A run can be live before its matrix exists. Measured 2026-08-01: ci-azure's ten
+    # matrix jobs are created only once the `needs: authorize` gate clears, so at the
+    # workflow_run:requested tick that starts this reconcile the jobs API shows only the
+    # ubuntu-hosted authorize job, which carries no pool label. Sizing to zero there
+    # would make every build wait a full reconcile interval for its first VM, so an
+    # eligible live run with no visible pool jobs yet reports full-pool demand; the next
+    # pass replaces the estimate with the real count.
+    foreach ($run in @($WorkflowRuns | Where-Object { [string]$PSItem.status -ne "completed" })) {
+        $pool = Get-CiRunActor -Run $run
+        if ($pool -notin $maintainers) {
+            $pool = "community"
+        }
+        if (-not $demand.ContainsKey($pool)) {
+            $demand[$pool] = $maintainerCount
+        }
+    }
+    $demand
+}
+
 function Get-RunnerDemand {
     $events = @(Invoke-GhJson -Arguments @("repos/$repo/events?per_page=100") -Operation "read repository activity")
     $runResponse = Invoke-GhJson -Arguments @(
@@ -238,6 +271,8 @@ function Get-RunnerDemand {
     ) -Operation "read CI build queue"
     $workflowRuns = @($runResponse.workflow_runs)
     $now = [DateTimeOffset]::UtcNow
+    $poolJobDemand = Get-PoolJobDemand -WorkflowRuns $workflowRuns
+    Write-Host "pending jobs: $(($poolJobDemand.GetEnumerator() | ForEach-Object { "$($PSItem.Key)=$($PSItem.Value)" }) -join ", ")"
     $splatPolicy = @{
         Events                  = $events
         WorkflowRuns            = $workflowRuns
@@ -252,6 +287,8 @@ function Get-RunnerDemand {
         Now                     = $now
         DirectTriggerActor      = [string]$env:BOOST_TRIGGER
         DirectTriggerMessage    = [string]$env:BOOST_MESSAGE
+        PoolJobDemand           = $poolJobDemand
+        WarmFloor               = $warmFloor
     }
     $desired = Get-DesiredRunnerPools @splatPolicy
 

--- a/.github/runners/reconcile-runner-fleet.ps1
+++ b/.github/runners/reconcile-runner-fleet.ps1
@@ -177,47 +177,52 @@ function Set-VmPool {
     Write-Host "assigned $VmName to pool $Pool"
 }
 
+function Set-VmTimestampTag {
+    param(
+        [string]$VmName,
+        [string]$TagName
+    )
+    $vmId = Invoke-AzJson -Arguments @(
+        "vm", "show", "--resource-group", $resourceGroup, "--name", $VmName, "--query", "id"
+    ) -Operation "read resource ID for $VmName"
+    $stamp = [DateTimeOffset]::UtcNow.ToString("o")
+    $splatTag = @{
+        Tool      = "az"
+        Arguments = @(
+            "tag", "update", "--resource-id", $vmId, "--operation", "Merge",
+            "--tags", "$TagName=$stamp", "--only-show-errors", "--output", "none"
+        )
+        Operation = "stamp $VmName $TagName"
+    }
+    $null = Invoke-NativeText @splatTag
+}
+
 function Set-VmRegisteredAt {
     param([string]$VmName)
     # Records when bootstrap finished registering the runner. Paired with the VM's
     # creation time in Remove-FleetVm, this separates boot overhead from hot-idle
     # time -- the two are indistinguishable in Azure cost data alone.
-    $vmId = Invoke-AzJson -Arguments @(
-        "vm", "show", "--resource-group", $resourceGroup, "--name", $VmName, "--query", "id"
-    ) -Operation "read resource ID for $VmName"
-    $stamp = [DateTimeOffset]::UtcNow.ToString("o")
-    $null = Invoke-NativeText -Tool "az" -Arguments @(
-        "tag", "update", "--resource-id", $vmId, "--operation", "Merge",
-        "--tags", "registeredAt=$stamp", "--only-show-errors", "--output", "none"
-    ) -Operation "stamp $VmName registration time"
+    Set-VmTimestampTag -VmName $VmName -TagName "registeredAt"
 }
 
-function Set-VmOnlineAt {
+function Set-VmOnlineObservedAt {
     param($State, $Vms)
-    # Records when a runner first shows online, i.e. when the VM finished rebooting into
-    # the autologon session and the listener came up. registeredAt alone cannot separate
-    # the reboot from hot-idle waiting: the span from registration to the job's start is
-    # reboot PLUS however long GitHub left the runner sitting idle, and for a warm-floor
-    # VM the idle part dominates. Stamping the online transition splits the two.
+    # Records when the controller first observes a runner online. This is an upper bound
+    # on listener startup, not its exact timestamp: observation is delayed by up to the
+    # five-minute reconcile interval. It still separates startup from longer hot-idle
+    # waiting without granting the runner an Azure identity.
     #
     # The controller does this rather than the VM because runner VMs hold no Azure
     # identity and must not gain one. Resolution is therefore the reconcile interval.
     foreach ($vm in $Vms) {
-        if (-not $vm.tags -or -not $vm.tags.registeredAt -or $vm.tags.onlineAt) {
+        if (-not $vm.tags -or -not $vm.tags.registeredAt -or $vm.tags.onlineObservedAt) {
             continue
         }
         $runner = Get-RunnerForVm -State $State -VmName $vm.name
         if (-not $runner -or $runner.status -ne "online") {
             continue
         }
-        $vmId = Invoke-AzJson -Arguments @(
-            "vm", "show", "--resource-group", $resourceGroup, "--name", $vm.name, "--query", "id"
-        ) -Operation "read resource ID for $($vm.name)"
-        $stamp = [DateTimeOffset]::UtcNow.ToString("o")
-        $null = Invoke-NativeText -Tool "az" -Arguments @(
-            "tag", "update", "--resource-id", $vmId, "--operation", "Merge",
-            "--tags", "onlineAt=$stamp", "--only-show-errors", "--output", "none"
-        ) -Operation "stamp $($vm.name) online time"
+        Set-VmTimestampTag -VmName $vm.name -TagName "onlineObservedAt"
     }
 }
 
@@ -251,23 +256,22 @@ function Remove-FleetVm {
         "vm", "delete", "--resource-group", $resourceGroup, "--name", $Vm.name,
         "--yes", "--only-show-errors", "--output", "none"
     ) -Operation "delete VM $($Vm.name)"
-    # bootMin is creation to runner registration; rebootMin is registration to the
-    # listener coming up after the reboot -- the span Task 4 actually removes. Keep them
-    # separate: their sum is the VM's unavoidable overhead, while everything between the
-    # listener and the job start is hot-idle waiting, which is Task 2's target instead.
+    # bootMin is creation to runner registration. onlineObservedMin is registration to
+    # the controller's first online observation, so it is a reconcile-resolution upper
+    # bound on listener startup rather than an exact reboot duration.
     $bootMin = "unknown"
-    $rebootMin = "unknown"
+    $onlineObservedMin = "unknown"
     if ($Vm.tags -and $Vm.tags.registeredAt) {
         $registered = [DateTimeOffset]::Parse([string]$Vm.tags.registeredAt)
         $created = [DateTimeOffset]::Parse([string]$Vm.created)
         $bootMin = [int]($registered - $created).TotalMinutes
-        if ($Vm.tags.onlineAt) {
-            $online = [DateTimeOffset]::Parse([string]$Vm.tags.onlineAt)
-            $rebootMin = [int]($online - $registered).TotalMinutes
+        if ($Vm.tags.onlineObservedAt) {
+            $onlineObserved = [DateTimeOffset]::Parse([string]$Vm.tags.onlineObservedAt)
+            $onlineObservedMin = [int]($onlineObserved - $registered).TotalMinutes
         }
     }
     $servedJob = ($null -ne $Vm.tags) -and ($null -ne $Vm.tags.registeredAt) -and (-not $runner)
-    Write-Host "FLEETSTAT vm=$($Vm.name) pool=$(Get-VmPool -Vm $Vm) createdAt=$($Vm.created) ageMin=$(Get-VmAgeMinutes -Vm $Vm) bootMin=$bootMin rebootMin=$rebootMin servedJob=$servedJob reason=$Reason"
+    Write-Host "FLEETSTAT vm=$($Vm.name) pool=$(Get-VmPool -Vm $Vm) createdAt=$($Vm.created) ageMin=$(Get-VmAgeMinutes -Vm $Vm) bootMin=$bootMin onlineObservedMin=$onlineObservedMin servedJob=$servedJob reason=$Reason"
 }
 
 function Get-OrphanedNetworking {
@@ -275,17 +279,10 @@ function Get-OrphanedNetworking {
     # filters mirror the janitor's own patterns (janitor-runbook.ps1:255, :265) so both
     # sweepers agree on what counts as garbage.
     #
-    # Here-strings because JMESPath needs both single quotes (its string-literal form --
-    # double quotes there mean identifier quoting, not a literal) and literal backticks
-    # around null. A bare null parses as an identifier rather than the null literal; it
-    # happens to evaluate correctly, but only by accident, and the next person to edit
-    # the filter should not have to rediscover that.
-    $nicQuery = @'
-[?virtualMachine==`null` && contains(name, 'Nic-')].name
-'@
-    $pipQuery = @'
-[?ipConfiguration==`null` && starts_with(name, 'instancepublicip-')].name
-'@
+    # JMESPath needs single quotes for string literals and literal backticks around null.
+    # PowerShell therefore escapes each query backtick by doubling it in the string.
+    $nicQuery = "[?virtualMachine==``null`` && contains(name, 'Nic-')].name"
+    $pipQuery = "[?ipConfiguration==``null`` && starts_with(name, 'instancepublicip-')].name"
     $nics = @(Invoke-AzJson -Arguments @(
             "network", "nic", "list", "--resource-group", $resourceGroup,
             "--query", $nicQuery
@@ -294,7 +291,10 @@ function Get-OrphanedNetworking {
             "network", "public-ip", "list", "--resource-group", $resourceGroup,
             "--query", $pipQuery
         ) -Operation "list orphaned public IPs")
-    [pscustomobject]@{ Nics = $nics; Pips = $pips }
+    [pscustomobject]@{
+        Nics = $nics
+        Pips = $pips
+    }
 }
 
 function Remove-OrphanedNetworking {
@@ -310,51 +310,62 @@ function Remove-OrphanedNetworking {
     $staleNics = @($current.Nics | Where-Object { $PSItem -in $Snapshot.Nics })
     $stalePips = @($current.Pips | Where-Object { $PSItem -in $Snapshot.Pips })
     foreach ($nicName in $staleNics) {
-        $null = Invoke-NativeText -Tool "az" -Arguments @(
-            "network", "nic", "delete", "--resource-group", $resourceGroup,
-            "--name", $nicName, "--only-show-errors", "--output", "none"
-        ) -Operation "delete orphaned NIC $nicName"
+        $splatDeleteNic = @{
+            Tool      = "az"
+            Arguments = @(
+                "network", "nic", "delete", "--resource-group", $resourceGroup,
+                "--name", $nicName, "--only-show-errors", "--output", "none"
+            )
+            Operation = "delete orphaned NIC $nicName"
+        }
+        $null = Invoke-NativeText @splatDeleteNic
     }
     # NICs first: a public IP still bound to a NIC cannot be deleted.
     foreach ($pipName in $stalePips) {
-        $null = Invoke-NativeText -Tool "az" -Arguments @(
-            "network", "public-ip", "delete", "--resource-group", $resourceGroup,
-            "--name", $pipName, "--only-show-errors", "--output", "none"
-        ) -Operation "delete orphaned public IP $pipName"
+        $splatDeletePip = @{
+            Tool      = "az"
+            Arguments = @(
+                "network", "public-ip", "delete", "--resource-group", $resourceGroup,
+                "--name", $pipName, "--only-show-errors", "--output", "none"
+            )
+            Operation = "delete orphaned public IP $pipName"
+        }
+        $null = Invoke-NativeText @splatDeletePip
     }
     Write-Host "reaped orphans: nics=$($staleNics.Count) pips=$($stalePips.Count)"
 }
 
 function Get-PoolJobDemand {
     param([object[]]$WorkflowRuns)
-    # I/O only -- the transform lives in runner-policy.ps1, where it is unit tested.
-    # Only live runs are probed: completed runs have no pending jobs, and the live set
-    # is normally zero to two runs, so this adds one cheap API call per run.
-    $jobs = @()
-    foreach ($run in @($WorkflowRuns | Where-Object { [string]$PSItem.status -ne "completed" })) {
+    # I/O only -- eligibility, matrix-state detection and the demand transform live in
+    # runner-policy.ps1, where they are unit tested. Rejected runs are filtered before
+    # I/O so an unmarked push cannot spend an API call or inflate an already-hot lane.
+    $eligibleLiveRuns = @($WorkflowRuns | Where-Object {
+            $splatEligibility = @{
+                Run            = $PSItem
+                OptInPushUsers = $optInPushUsers
+                Marker         = $ciMarker
+            }
+            [string]$PSItem.status -ne "completed" -and (Test-CiRunEligible @splatEligibility)
+        })
+    $jobsByRun = @{ }
+    foreach ($run in $eligibleLiveRuns) {
         $jobResponse = Invoke-GhJson -Arguments @(
             "repos/$repo/actions/runs/$($run.id)/jobs?per_page=100"
         ) -Operation "read jobs for run $($run.id)"
-        $jobs += @($jobResponse.jobs)
+        $jobsByRun[[string]$run.id] = @($jobResponse.jobs)
     }
-    $demand = Get-PoolJobDemandFromJobs -Jobs $jobs -PoolLabelPrefix $poolLabelPrefix
-    # A run can be live before its matrix exists. Measured 2026-08-01: ci-azure's ten
-    # matrix jobs are created only once the `needs: authorize` gate clears, so at the
-    # workflow_run:requested tick that starts this reconcile the jobs API shows only the
-    # ubuntu-hosted authorize job, which carries no pool label. Sizing to zero there
-    # would make every build wait a full reconcile interval for its first VM, so an
-    # eligible live run with no visible pool jobs yet reports full-pool demand; the next
-    # pass replaces the estimate with the real count.
-    foreach ($run in @($WorkflowRuns | Where-Object { [string]$PSItem.status -ne "completed" })) {
-        $pool = Get-CiRunActor -Run $run
-        if ($pool -notin $maintainers) {
-            $pool = "community"
-        }
-        if (-not $demand.ContainsKey($pool)) {
-            $demand[$pool] = $maintainerCount
-        }
+
+    $splatDemand = @{
+        WorkflowRuns    = $eligibleLiveRuns
+        JobsByRun       = $jobsByRun
+        Maintainers     = $maintainers
+        OptInPushUsers  = $optInPushUsers
+        Marker          = $ciMarker
+        MaintainerCount = $maintainerCount
+        CommunityCount  = $communityCount
     }
-    $demand
+    Get-PoolJobDemandFromRuns @splatDemand
 }
 
 function Get-RunnerDemand {
@@ -552,7 +563,7 @@ try {
     $state = Get-FleetState
     Register-PoolVms -State $state -Desired $desired
     $state = Get-FleetState
-    Set-VmOnlineAt -State $state -Vms $state.Vms
+    Set-VmOnlineObservedAt -State $state -Vms $state.Vms
 
     # Remove dead runners and trim pools whose hot window has ended.
     foreach ($vm in $state.Vms) {
@@ -620,7 +631,7 @@ try {
     $state = Get-FleetState
     Register-PoolVms -State $state -Desired $desired
     $state = Get-FleetState
-    Set-VmOnlineAt -State $state -Vms $state.Vms
+    Set-VmOnlineObservedAt -State $state -Vms $state.Vms
     foreach ($pool in $desired.Keys) {
         $poolVms = @($state.Vms | Where-Object { (Get-VmPool -Vm $PSItem) -eq $pool })
         $poolRunners = @($state.Runners | Where-Object { (Get-RunnerPool -Runner $PSItem) -eq $pool })

--- a/.github/runners/reconcile-runner-fleet.ps1
+++ b/.github/runners/reconcile-runner-fleet.ps1
@@ -176,6 +176,21 @@ function Set-VmPool {
     Write-Host "assigned $VmName to pool $Pool"
 }
 
+function Set-VmRegisteredAt {
+    param([string]$VmName)
+    # Records when bootstrap finished registering the runner. Paired with the VM's
+    # creation time in Remove-FleetVm, this separates boot overhead from hot-idle
+    # time -- the two are indistinguishable in Azure cost data alone.
+    $vmId = Invoke-AzJson -Arguments @(
+        "vm", "show", "--resource-group", $resourceGroup, "--name", $VmName, "--query", "id"
+    ) -Operation "read resource ID for $VmName"
+    $stamp = [DateTimeOffset]::UtcNow.ToString("o")
+    $null = Invoke-NativeText -Tool "az" -Arguments @(
+        "tag", "update", "--resource-id", $vmId, "--operation", "Merge",
+        "--tags", "registeredAt=$stamp", "--only-show-errors", "--output", "none"
+    ) -Operation "stamp $VmName registration time"
+}
+
 function Remove-FleetVm {
     param($State, $Vm, [string]$Reason)
     if (-not $deletedVms.Add($Vm.name)) {
@@ -206,6 +221,14 @@ function Remove-FleetVm {
         "vm", "delete", "--resource-group", $resourceGroup, "--name", $Vm.name,
         "--yes", "--only-show-errors", "--output", "none"
     ) -Operation "delete VM $($Vm.name)"
+    $bootMin = "unknown"
+    if ($Vm.tags -and $Vm.tags.registeredAt) {
+        $registered = [DateTimeOffset]::Parse([string]$Vm.tags.registeredAt)
+        $created = [DateTimeOffset]::Parse([string]$Vm.created)
+        $bootMin = [int]($registered - $created).TotalMinutes
+    }
+    $servedJob = ($null -ne $Vm.tags) -and ($null -ne $Vm.tags.registeredAt) -and (-not $runner)
+    Write-Host "FLEETSTAT vm=$($Vm.name) pool=$(Get-VmPool -Vm $Vm) createdAt=$($Vm.created) ageMin=$(Get-VmAgeMinutes -Vm $Vm) bootMin=$bootMin servedJob=$servedJob reason=$Reason"
 }
 
 function Get-RunnerDemand {
@@ -357,6 +380,14 @@ function Register-PoolVms {
             continue
         }
         Write-Host (($result.Output -split "`r?`n" | Select-Object -Last 3) -join [Environment]::NewLine)
+        # Only the first successful registration is stamped. Register-PoolVms re-probes
+        # any VM whose runner is still offline (:309), and bootstrap short-circuits with
+        # "runner already configured" (:33-36) -- which is also exit 0. Re-stamping there
+        # would overwrite the real registration time for exactly the VMs still inside the
+        # boot window, i.e. the whole population bootMin is meant to measure.
+        if ($result.Output -notmatch "already configured" -and $result.Output -notmatch "SPENT-VM") {
+            Set-VmRegisteredAt -VmName $result.VmName
+        }
         if ($result.Output -match "SPENT-VM") {
             $vm = @($State.Vms | Where-Object name -EQ $result.VmName | Select-Object -First 1)[0]
             Remove-FleetVm -State $State -Vm $vm -Reason "ephemeral runner already served a job"

--- a/.github/runners/reconcile-runner-fleet.ps1
+++ b/.github/runners/reconcile-runner-fleet.ps1
@@ -511,7 +511,7 @@ function Register-PoolVms {
         }
         Write-Host (($result.Output -split "`r?`n" | Select-Object -Last 3) -join [Environment]::NewLine)
         # Only the first successful registration is stamped. Register-PoolVms re-probes
-        # any VM whose runner is still offline (:309), and bootstrap short-circuits with
+        # any VM whose runner is still offline (:462), and bootstrap short-circuits with
         # "runner already configured" (:33-36) -- which is also exit 0. Re-stamping there
         # would overwrite the real registration time for exactly the VMs still inside the
         # boot window, i.e. the whole population bootMin is meant to measure.

--- a/.github/runners/runner-policy.ps1
+++ b/.github/runners/runner-policy.ps1
@@ -151,6 +151,69 @@ function Get-PoolJobDemandFromJobs {
     $demand
 }
 
+function Get-PoolJobDemandFromRuns {
+    [CmdletBinding()]
+    param(
+        [object[]]$WorkflowRuns = @(),
+        [hashtable]$JobsByRun = @{ },
+        [Parameter(Mandatory)]
+        [string[]]$Maintainers,
+        [Parameter(Mandatory)]
+        [string[]]$OptInPushUsers,
+        [Parameter(Mandatory)]
+        [string]$Marker,
+        [Parameter(Mandatory)]
+        [int]$MaintainerCount,
+        [Parameter(Mandatory)]
+        [int]$CommunityCount,
+        [string]$PoolLabelPrefix = "dbatools-pool-"
+    )
+
+    $demand = @{ }
+    $eligibleLiveRuns = @($WorkflowRuns | Where-Object {
+            $splatEligibility = @{
+                Run            = $PSItem
+                OptInPushUsers = $OptInPushUsers
+                Marker         = $Marker
+            }
+            [string]$PSItem.status -ne "completed" -and (Test-CiRunEligible @splatEligibility)
+        })
+    foreach ($run in $eligibleLiveRuns) {
+        $runId = [string]$run.id
+        $jobs = @()
+        if ($JobsByRun.ContainsKey($runId)) {
+            $jobs = @($JobsByRun[$runId])
+        }
+        $fleetJobs = @($jobs | Where-Object {
+                @($PSItem.labels | Where-Object { $PSItem -like "$PoolLabelPrefix*" }).Count -gt 0
+            })
+        if (-not $fleetJobs) {
+            # The authorization job exists before the fleet matrix. Estimate one full
+            # pool for that short gap; once any fleet-labelled job exists, even a
+            # completed one, the real pending count replaces the estimate.
+            $pool = Get-CiRunActor -Run $run
+            $poolSize = $MaintainerCount
+            if ($pool -notin $Maintainers) {
+                $pool = "community"
+                $poolSize = $CommunityCount
+            }
+            if (-not $demand.ContainsKey($pool) -or $demand[$pool] -lt $poolSize) {
+                $demand[$pool] = $poolSize
+            }
+            continue
+        }
+
+        $runDemand = Get-PoolJobDemandFromJobs -Jobs $fleetJobs -PoolLabelPrefix $PoolLabelPrefix
+        foreach ($pool in $runDemand.Keys) {
+            if (-not $demand.ContainsKey($pool)) {
+                $demand[$pool] = 0
+            }
+            $demand[$pool] += $runDemand[$pool]
+        }
+    }
+    $demand
+}
+
 function Get-DesiredRunnerPools {
     [CmdletBinding()]
     param(

--- a/.github/runners/runner-policy.ps1
+++ b/.github/runners/runner-policy.ps1
@@ -119,6 +119,38 @@ function Test-MaintainerActivityEvent {
     return Test-CiMarker -Message $message -Marker $Marker
 }
 
+function Get-PoolJobDemandFromJobs {
+    param(
+        [object[]]$Jobs = @(),
+        [string]$PoolLabelPrefix = "dbatools-pool-"
+    )
+    # Demand is read from each job's own dbatools-pool-* label rather than from the
+    # run's actor. That is exact: it counts only jobs that actually queue against this
+    # fleet (ci-azure.yml's authorize job runs on ubuntu-latest and carries no pool
+    # label), and it already honours the [pool:...] display-title override, because
+    # the workflow resolved inputs.pool_user into runs-on before the job was created.
+    #
+    # Anything not "completed" needs a runner, so the filter is negative rather than a
+    # whitelist -- GitHub has added job statuses (waiting, pending, requested) since
+    # this fleet was written and will add more.
+    $demand = @{ }
+    foreach ($job in $Jobs) {
+        if ([string]$job.status -eq "completed") {
+            continue
+        }
+        $poolLabel = @($job.labels | Where-Object { $PSItem -like "$PoolLabelPrefix*" } | Select-Object -First 1)
+        if (-not $poolLabel) {
+            continue
+        }
+        $pool = ([string]$poolLabel[0]).Substring($PoolLabelPrefix.Length)
+        if (-not $demand.ContainsKey($pool)) {
+            $demand[$pool] = 0
+        }
+        $demand[$pool] += 1
+    }
+    $demand
+}
+
 function Get-DesiredRunnerPools {
     [CmdletBinding()]
     param(
@@ -145,7 +177,10 @@ function Get-DesiredRunnerPools {
         [AllowEmptyString()]
         [string]$DirectTriggerActor = "",
         [AllowEmptyString()]
-        [string]$DirectTriggerMessage = ""
+        [string]$DirectTriggerMessage = "",
+        [hashtable]$PoolJobDemand = @{ },
+        [ValidateRange(0, 35)]
+        [int]$WarmFloor = 0
     )
 
     $maintainerCutoff = $Now.AddMinutes(-$MaintainerWindowMinutes)
@@ -165,10 +200,19 @@ function Get-DesiredRunnerPools {
         if ($directTrigger -and $maintainer -in $OptInPushUsers) {
             $directTrigger = Test-CiMarker -Message $DirectTriggerMessage -Marker $Marker
         }
-        $desired[$maintainer] = if ($recentActivity -or $liveCi -or $directTrigger) {
-            $MaintainerCount
-        } else {
+        # Demand sizes a hot lane; it never heats a cold one. A community PR must not
+        # be able to size a maintainer lane by reporting jobs against it.
+        $hot = $recentActivity -or $liveCi -or $directTrigger
+        $pending = 0
+        if ($PoolJobDemand.ContainsKey($maintainer)) {
+            $pending = [int]$PoolJobDemand[$maintainer]
+        }
+        $desired[$maintainer] = if (-not $hot) {
             0
+        } elseif ($pending -gt 0) {
+            [math]::Min($MaintainerCount, $pending)
+        } else {
+            [math]::Min($MaintainerCount, $WarmFloor)
         }
     }
 
@@ -181,10 +225,17 @@ function Get-DesiredRunnerPools {
             [DateTimeOffset]::Parse([string]$PSItem.updated_at) -gt $communityCutoff
         }).Count -gt 0
     $directCommunityTrigger = $DirectTriggerActor -and $DirectTriggerActor -notin $Maintainers
-    $desired["community"] = if ($communityLive -or $communityRecentlyCompleted -or $directCommunityTrigger) {
-        $CommunityCount
-    } else {
+    $communityHot = $communityLive -or $communityRecentlyCompleted -or $directCommunityTrigger
+    $communityPending = 0
+    if ($PoolJobDemand.ContainsKey("community")) {
+        $communityPending = [int]$PoolJobDemand["community"]
+    }
+    $desired["community"] = if (-not $communityHot) {
         0
+    } elseif ($communityPending -gt 0) {
+        [math]::Min($CommunityCount, $communityPending)
+    } else {
+        [math]::Min($CommunityCount, $WarmFloor)
     }
 
     $total = ($desired.Values | Measure-Object -Sum).Sum

--- a/.github/runners/tests/janitor-runbook.Tests.ps1
+++ b/.github/runners/tests/janitor-runbook.Tests.ps1
@@ -1,0 +1,167 @@
+BeforeAll {
+    $script:JanitorPath = (Resolve-Path "$PSScriptRoot/../janitor-runbook.ps1").Path
+    $script:Now = (Get-Date).ToUniversalTime()
+}
+
+Describe "janitor runner protection" {
+    BeforeEach {
+        $script:RemovedVms = @()
+        $script:RemovedNics = @()
+        $script:RemovedPips = @()
+        $script:Events = @()
+        $script:Runs = @()
+        $script:Vms = @()
+        $script:Nics = @()
+        $script:Pips = @()
+        $script:ResourceCreatedAt = @{ }
+
+        function Connect-AzAccount {
+            param([switch]$Identity, [string]$WarningAction)
+        }
+
+        function Invoke-RestMethod {
+            param(
+                [string]$Uri,
+                [hashtable]$Headers,
+                [int]$TimeoutSec
+            )
+            if ($Uri -like "*/events?*") {
+                return $script:Events
+            }
+            [pscustomobject]@{ workflow_runs = $script:Runs }
+        }
+
+        function Get-AzVM {
+            param([string]$ResourceGroupName)
+            $script:Vms
+        }
+
+        function Remove-AzVM {
+            param(
+                [string]$ResourceGroupName,
+                [string]$Name,
+                [switch]$Force
+            )
+            $script:RemovedVms += $Name
+        }
+
+        function Get-AzNetworkInterface {
+            param([string]$ResourceGroupName)
+            $script:Nics
+        }
+
+        function Remove-AzNetworkInterface {
+            param(
+                [string]$ResourceGroupName,
+                [string]$Name,
+                [switch]$Force
+            )
+            $script:RemovedNics += $Name
+        }
+
+        function Get-AzPublicIpAddress {
+            param([string]$ResourceGroupName)
+            $script:Pips
+        }
+
+        function Get-AzVmss {
+            param(
+                [string]$ResourceGroupName,
+                [string]$VMScaleSetName,
+                [string]$ErrorAction
+            )
+        }
+
+        function Remove-AzPublicIpAddress {
+            param(
+                [string]$ResourceGroupName,
+                [string]$Name,
+                [switch]$Force
+            )
+            $script:RemovedPips += $Name
+        }
+
+        function Get-AzResource {
+            param(
+                [string]$ResourceId,
+                [switch]$ExpandProperties,
+                [string]$ErrorAction
+            )
+            [pscustomobject]@{ CreatedTime = $script:ResourceCreatedAt[$ResourceId] }
+        }
+    }
+
+    It "protects the active lane instead of the newest runners from another lane" {
+        $script:Runs = @(
+            [pscustomobject]@{
+                actor         = [pscustomobject]@{ login = "andreasjordan" }
+                display_title = "ci-azure"
+                event         = "pull_request"
+                status        = "in_progress"
+                updated_at    = $script:Now.ToString("o")
+            }
+        )
+        $andreasVms = @(1..10 | ForEach-Object {
+                [pscustomobject]@{
+                    Name        = "dbatools-runners_andreas-$PSItem"
+                    TimeCreated = $script:Now.AddHours(-6)
+                    Tags        = @{ runnerPool = "andreasjordan" }
+                }
+            })
+        $niphVms = @(1..10 | ForEach-Object {
+                [pscustomobject]@{
+                    Name        = "dbatools-runners_niph-$PSItem"
+                    TimeCreated = $script:Now.AddHours(-5)
+                    Tags        = @{ runnerPool = "niphlod" }
+                }
+            })
+        $script:Vms = @($andreasVms + $niphVms)
+
+        . $script:JanitorPath | Out-Null
+
+        @($script:RemovedVms | Where-Object { $PSItem -like "*andreas*" }).Count | Should -Be 0
+        @($script:RemovedVms | Where-Object { $PSItem -like "*niph*" }).Count | Should -Be 10
+    }
+
+    It "deletes only orphaned networking older than the provisioning grace period" {
+        $oldNicId = "/subscriptions/test/resourceGroups/dbatools-ci/providers/Microsoft.Network/networkInterfaces/old-Nic-1"
+        $youngNicId = "/subscriptions/test/resourceGroups/dbatools-ci/providers/Microsoft.Network/networkInterfaces/young-Nic-1"
+        $oldPipId = "/subscriptions/test/resourceGroups/dbatools-ci/providers/Microsoft.Network/publicIPAddresses/instancepublicip-old"
+        $youngPipId = "/subscriptions/test/resourceGroups/dbatools-ci/providers/Microsoft.Network/publicIPAddresses/instancepublicip-young"
+        $script:Nics = @(
+            [pscustomobject]@{
+                Name           = "old-Nic-1"
+                Id             = $oldNicId
+                VirtualMachine = $null
+            }
+            [pscustomobject]@{
+                Name           = "young-Nic-1"
+                Id             = $youngNicId
+                VirtualMachine = $null
+            }
+        )
+        $script:Pips = @(
+            [pscustomobject]@{
+                Name            = "instancepublicip-old"
+                Id              = $oldPipId
+                IpConfiguration = $null
+            }
+            [pscustomobject]@{
+                Name            = "instancepublicip-young"
+                Id              = $youngPipId
+                IpConfiguration = $null
+            }
+        )
+        $script:ResourceCreatedAt = @{
+            $oldNicId   = $script:Now.AddMinutes(-30)
+            $youngNicId = $script:Now.AddMinutes(-2)
+            $oldPipId   = $script:Now.AddMinutes(-30)
+            $youngPipId = $script:Now.AddMinutes(-2)
+        }
+
+        . $script:JanitorPath | Out-Null
+
+        $script:RemovedNics | Should -Be @("old-Nic-1")
+        $script:RemovedPips | Should -Be @("instancepublicip-old")
+    }
+}

--- a/.github/runners/tests/runner-policy.Tests.ps1
+++ b/.github/runners/tests/runner-policy.Tests.ps1
@@ -81,7 +81,9 @@ BeforeAll {
             [object[]]$WorkflowRuns = @(),
             [string]$DirectTriggerActor = "",
             [string]$DirectTriggerMessage = "",
-            [int]$MaxRunners = 35
+            [int]$MaxRunners = 35,
+            [hashtable]$PoolJobDemand = @{ },
+            [int]$WarmFloor = 10
         )
 
         $splatPolicy = @{
@@ -98,6 +100,8 @@ BeforeAll {
             Now                     = $script:Now
             DirectTriggerActor      = $DirectTriggerActor
             DirectTriggerMessage    = $DirectTriggerMessage
+            PoolJobDemand           = $PoolJobDemand
+            WarmFloor               = $WarmFloor
         }
         Get-DesiredRunnerPools @splatPolicy
     }
@@ -246,6 +250,127 @@ Describe "Get-DesiredRunnerPools" {
         )
         $run = New-CiRun -Actor "contributor" -Status "in_progress" -UpdatedAt $script:Now
         { Invoke-TestPolicy -Events $events -WorkflowRuns @($run) -MaxRunners 34 } | Should -Throw "*MAX_RUNNERS*"
+    }
+}
+
+Describe "Get-DesiredRunnerPools demand-driven sizing" {
+    It "sizes a maintainer lane to the pending job count" {
+        $run = New-CiRun -Actor "andreasjordan" -Status "in_progress" -UpdatedAt $script:Now
+        $splatDemand = @{
+            WorkflowRuns  = @($run)
+            PoolJobDemand = @{ andreasjordan = 3 }
+            WarmFloor     = 0
+        }
+        $result = Invoke-TestPolicy @splatDemand
+        $result.andreasjordan | Should -Be 3
+    }
+
+    It "caps pending job demand at the maintainer pool size" {
+        $run = New-CiRun -Actor "andreasjordan" -Status "in_progress" -UpdatedAt $script:Now
+        $splatDemand = @{
+            WorkflowRuns  = @($run)
+            PoolJobDemand = @{ andreasjordan = 25 }
+            WarmFloor     = 0
+        }
+        $result = Invoke-TestPolicy @splatDemand
+        $result.andreasjordan | Should -Be 10
+    }
+
+    It "holds a hot lane at the warm floor when nothing is pending" {
+        $event = New-PushEvent -Actor "andreasjordan" -CreatedAt $script:Now.AddMinutes(-5)
+        $splatDemand = @{
+            Events        = @($event)
+            PoolJobDemand = @{ }
+            WarmFloor     = 2
+        }
+        $result = Invoke-TestPolicy @splatDemand
+        $result.andreasjordan | Should -Be 2
+    }
+
+    It "drops a hot lane to zero when the warm floor is zero and nothing is pending" {
+        $event = New-PushEvent -Actor "andreasjordan" -CreatedAt $script:Now.AddMinutes(-5)
+        $splatDemand = @{
+            Events        = @($event)
+            PoolJobDemand = @{ }
+            WarmFloor     = 0
+        }
+        $result = Invoke-TestPolicy @splatDemand
+        $result.andreasjordan | Should -Be 0
+    }
+
+    It "sizes the community lane to pending jobs and caps at five" {
+        $run = New-CiRun -Actor "outsider" -Status "in_progress" -UpdatedAt $script:Now
+        $splatDemand = @{
+            WorkflowRuns  = @($run)
+            PoolJobDemand = @{ community = 9 }
+            WarmFloor     = 0
+        }
+        $result = Invoke-TestPolicy @splatDemand
+        $result.community | Should -Be 5
+    }
+
+    It "leaves a cold lane at zero even when demand is reported" {
+        $splatDemand = @{
+            PoolJobDemand = @{ niphlod = 4 }
+            WarmFloor     = 3
+        }
+        $result = Invoke-TestPolicy @splatDemand
+        $result.niphlod | Should -Be 0
+    }
+}
+
+Describe "Get-PoolJobDemandFromJobs" {
+    BeforeAll {
+        # Defined in BeforeAll, not the Describe body: Pester 5 runs the Describe body
+        # during discovery, so a function declared there does not exist when the It
+        # blocks execute. This matches the helper idiom in the top-level BeforeAll.
+        function New-TestJob {
+            param(
+                [string]$Status = "queued",
+                [string[]]$Labels = @("self-hosted", "dbatools-modern", "dbatools-pool-andreasjordan")
+            )
+            [pscustomobject]@{ status = $Status; labels = $Labels }
+        }
+    }
+
+    It "counts pending jobs per pool label" {
+        $jobs = @((New-TestJob), (New-TestJob), (New-TestJob -Status "in_progress"))
+        $result = Get-PoolJobDemandFromJobs -Jobs $jobs
+        $result.andreasjordan | Should -Be 3
+    }
+
+    It "ignores completed jobs" {
+        $jobs = @((New-TestJob -Status "completed"), (New-TestJob))
+        $result = Get-PoolJobDemandFromJobs -Jobs $jobs
+        $result.andreasjordan | Should -Be 1
+    }
+
+    It "ignores jobs with no pool label" {
+        $jobs = @((New-TestJob -Labels @("ubuntu-latest")), (New-TestJob))
+        $result = Get-PoolJobDemandFromJobs -Jobs $jobs
+        $result.andreasjordan | Should -Be 1
+        $result.Keys.Count | Should -Be 1
+    }
+
+    It "counts job statuses it has never seen as pending" {
+        $jobs = @((New-TestJob -Status "waiting"), (New-TestJob -Status "some_future_status"))
+        $result = Get-PoolJobDemandFromJobs -Jobs $jobs
+        $result.andreasjordan | Should -Be 2
+    }
+
+    It "separates pools within one job list" {
+        $jobs = @(
+            (New-TestJob),
+            (New-TestJob -Labels @("self-hosted", "dbatools-pool-community"))
+        )
+        $result = Get-PoolJobDemandFromJobs -Jobs $jobs
+        $result.andreasjordan | Should -Be 1
+        $result.community | Should -Be 1
+    }
+
+    It "returns an empty hashtable for no jobs" {
+        $result = Get-PoolJobDemandFromJobs -Jobs @()
+        $result.Keys.Count | Should -Be 0
     }
 }
 

--- a/.github/runners/tests/runner-policy.Tests.ps1
+++ b/.github/runners/tests/runner-policy.Tests.ps1
@@ -52,6 +52,7 @@ BeforeAll {
 
     function New-CiRun {
         param(
+            [int]$Id = 1,
             [Parameter(Mandatory)]
             [string]$Actor,
             [Parameter(Mandatory)]
@@ -65,6 +66,7 @@ BeforeAll {
         )
 
         [pscustomobject]@{
+            id          = $Id
             actor       = [pscustomobject]@{ login = $Actor }
             event       = $TriggerEvent
             status      = $Status
@@ -329,7 +331,10 @@ Describe "Get-PoolJobDemandFromJobs" {
                 [string]$Status = "queued",
                 [string[]]$Labels = @("self-hosted", "dbatools-modern", "dbatools-pool-andreasjordan")
             )
-            [pscustomobject]@{ status = $Status; labels = $Labels }
+            [pscustomobject]@{
+                status = $Status
+                labels = $Labels
+            }
         }
     }
 
@@ -371,6 +376,94 @@ Describe "Get-PoolJobDemandFromJobs" {
     It "returns an empty hashtable for no jobs" {
         $result = Get-PoolJobDemandFromJobs -Jobs @()
         $result.Keys.Count | Should -Be 0
+    }
+}
+
+Describe "Get-PoolJobDemandFromRuns" {
+    BeforeAll {
+        function New-RunJob {
+            param(
+                [string]$Status = "queued",
+                [string[]]$Labels = @("self-hosted", "dbatools-modern", "dbatools-pool-potatoqualitee")
+            )
+            [pscustomobject]@{
+                status = $Status
+                labels = $Labels
+            }
+        }
+    }
+
+    It "ignores an ineligible live run before its matrix is created" {
+        $splatRun = @{
+            Id           = 41
+            Actor        = "potatoqualitee"
+            Status       = "in_progress"
+            UpdatedAt    = $script:Now
+            TriggerEvent = "push"
+        }
+        $run = New-CiRun @splatRun
+        $jobsByRun = @{ "41" = @((New-RunJob -Labels @("ubuntu-latest"))) }
+        $splatDemand = @{
+            WorkflowRuns    = @($run)
+            JobsByRun       = $jobsByRun
+            Maintainers     = $script:Maintainers
+            OptInPushUsers  = $script:OptInPushUsers
+            Marker          = "[do ci]"
+            MaintainerCount = 10
+            CommunityCount  = 5
+        }
+
+        $result = Get-PoolJobDemandFromRuns @splatDemand
+
+        $result.Keys.Count | Should -Be 0
+    }
+
+    It "returns no demand after an eligible run's fleet matrix has completed" {
+        $splatRun = @{
+            Id        = 42
+            Actor     = "potatoqualitee"
+            Status    = "in_progress"
+            UpdatedAt = $script:Now
+        }
+        $run = New-CiRun @splatRun
+        $jobsByRun = @{ "42" = @((New-RunJob -Status "completed")) }
+        $splatDemand = @{
+            WorkflowRuns    = @($run)
+            JobsByRun       = $jobsByRun
+            Maintainers     = $script:Maintainers
+            OptInPushUsers  = $script:OptInPushUsers
+            Marker          = "[do ci]"
+            MaintainerCount = 10
+            CommunityCount  = 5
+        }
+
+        $result = Get-PoolJobDemandFromRuns @splatDemand
+
+        $result.Keys.Count | Should -Be 0
+    }
+
+    It "estimates a full pool only before an eligible run's fleet matrix exists" {
+        $splatRun = @{
+            Id        = 43
+            Actor     = "potatoqualitee"
+            Status    = "in_progress"
+            UpdatedAt = $script:Now
+        }
+        $run = New-CiRun @splatRun
+        $jobsByRun = @{ "43" = @((New-RunJob -Labels @("ubuntu-latest"))) }
+        $splatDemand = @{
+            WorkflowRuns    = @($run)
+            JobsByRun       = $jobsByRun
+            Maintainers     = $script:Maintainers
+            OptInPushUsers  = $script:OptInPushUsers
+            Marker          = "[do ci]"
+            MaintainerCount = 10
+            CommunityCount  = 5
+        }
+
+        $result = Get-PoolJobDemandFromRuns @splatDemand
+
+        $result.potatoqualitee | Should -Be 10
     }
 }
 

--- a/.github/runners/tests/runner-policy.Tests.ps1
+++ b/.github/runners/tests/runner-policy.Tests.ps1
@@ -454,6 +454,16 @@ Describe "Runner workflow policy wiring" {
         $script:Janitor | Should -Match 'MAX_RUNNERS is 35'
     }
 
+    It "keeps the janitor warm floor aligned with the reconcile workflow" {
+        # Explicit -match, not Should -Match: Pester's assertion does not publish
+        # $Matches into the test scope, so capturing the captured group needs the
+        # operator itself. Each -match overwrites $Matches, hence the interleaving.
+        ($script:ReconcileWorkflow -match "WARM_FLOOR: (\d+)") | Should -BeTrue
+        $workflowFloor = [int]$Matches[1]
+        ($script:Janitor -match "\`$warmFloor = (\d+)") | Should -BeTrue
+        [int]$Matches[1] | Should -Be $workflowFloor
+    }
+
     It "documents that targeting and activation markers are unrelated" {
         $script:Readme | Should -Match '\(do <cmd>\).*\[do ci\].*compatible and unrelated'
     }

--- a/.github/workflows/runner-reconcile.yml
+++ b/.github/workflows/runner-reconcile.yml
@@ -1,12 +1,21 @@
 # The single VMSS fleet controller. CI requests, per-job completion nudges, maintainer
 # pushes, and the five-minute safety tick all reconcile the same desired state.
 #
-# AppVeyor-style pool policy:
-#   - potatoqualitee: 10 dedicated workers for one hour after a PR or [do ci]
-#   - andreasjordan:  10 dedicated workers for one hour after activity
-#   - niphlod:         10 dedicated workers for one hour after activity
-#   - community:       5 shared workers while CI is live and for 20 minutes after
+# AppVeyor-style pool policy. Activity makes a lane HOT; the lane is then SIZED to the
+# jobs actually pending in it, so a hot-but-idle lane costs WARM_FLOOR, not a full pool.
+# Demand never heats a cold lane -- a community PR cannot size a maintainer's.
+#   - potatoqualitee: hot for one hour after a PR or [do ci], up to 10 dedicated workers
+#   - andreasjordan:  hot for one hour after activity,        up to 10 dedicated workers
+#   - niphlod:        hot for one hour after activity,        up to 10 dedicated workers
+#   - community:      hot while CI is live and 20 minutes after, up to 5 shared workers
+#   - hot lane, nothing pending: WARM_FLOOR workers
 #   - no activity or queued work: zero workers
+#
+# ci-azure's matrix jobs are not created until the `needs: authorize` gate clears, so on
+# the workflow_run:requested tick the jobs API shows only the ubuntu-hosted authorize
+# job. The controller estimates a full pool for a live run with no visible pool jobs and
+# corrects it on the next pass; without that, every build would wait a reconcile
+# interval for its first VM.
 #
 # Each Flexible VMSS instance stores its pool in the runnerPool Azure tag and the
 # matching GitHub runner label. Ephemeral agents take one job, unregister, and the

--- a/.github/workflows/runner-reconcile.yml
+++ b/.github/workflows/runner-reconcile.yml
@@ -67,6 +67,7 @@ jobs:
       BOOST_USERS: potatoqualitee andreasjordan niphlod
       BOOST_COUNT: 10
       BOOST_HOURS: 1
+      WARM_FLOOR: 3
       OPT_IN_PUSH_USERS: potatoqualitee
       CI_MARKER: "[do ci]"
       BOOST_TRIGGER: ${{ inputs.boost_user }}


### PR DESCRIPTION
Cuts the Azure CI bill by sizing runner lanes to the jobs actually queued in them, and adds the instrumentation needed to decide the remaining levers on measurement instead of estimate.

Implements Tasks 1, 2, 5, and 6 of the CI cost reduction plan. Task 3 (Spot) remains blocked by quota. Task 4 (double boot) is intentionally not included here; the owner decision is now settled in favor of removing the interactive runner, and that service-mode conversion belongs in the next focused PR.

## What changes

**Demand-driven pool sizing (the cost lever).** `Get-DesiredRunnerPools` no longer returns a flat pool size the moment a lane goes hot. A hot lane is sized to its pending job count, capped at ten for a maintainer and five for community, falling back to `WARM_FLOOR` (3) when it is hot with nothing queued. Demand never heats a cold lane, so a community PR cannot size a maintainer's. `MAX_RUNNERS=35` remains a hard ceiling.

July 2026 ran at **14.6% utilization** — 138.1 job-hours against 948.9 billed VM-hours — so lanes sitting hot and idle are where the money went.

**Lifecycle instrumentation.** `Remove-FleetVm` emits a `FLEETSTAT` line per deleted VM (`createdAt`, `ageMin`, `bootMin`, `onlineObservedMin`, `servedJob`), and `Set-VmOnlineObservedAt` stamps when reconcile first sees the runner online. `onlineObservedMin` is explicitly an upper bound with up to one reconcile interval of sampling delay, not an exact reboot duration.

**Orphaned NIC/IP reaping.** Reconcile snapshots orphans at the start of a pass and deletes only what was orphaned then and still is. The independent Azure janitor now also requires a resource to be at least 15 minutes old, so temporarily unattached networking for a provisioning VM is preserved.

**Janitor alignment.** The dead man's switch preserves a full matrix for lanes with a *live* run and `WARM_FLOOR` for merely-hot lanes. Protection is applied per `runnerPool` tag rather than by preserving the newest fleet-wide total, and executable tests cover both lane isolation and orphan age.

## Testing

- `.github/runners/tests`: **50/50 passing** across `runner-policy.Tests.ps1` and `janitor-runbook.Tests.ps1`.
- Run-aware demand tests prove that ineligible runs cannot inflate a hot lane, a completed fleet matrix does not trigger the pre-matrix fallback, and only a genuinely not-yet-created matrix estimates a full pool.
- Janitor behavior tests execute the real runbook policy against controlled Azure/GitHub boundary fixtures and cover per-lane protection plus the 15-minute orphan grace period.
- The policy files stay pure and unit-tested; Azure/GitHub I/O stays in the controller/runbook boundary.

**This PR's own CI run does not exercise the change.** `runner-reconcile.yml` triggers only on `schedule`, `workflow_run`, and `workflow_dispatch`, all of which execute the default-branch copy of the workflow. There is no `pull_request` trigger — by design, since the fleet controller holds the Azure credential. The fleet that served this PR therefore ran `development`'s policy. The new sizing logic goes live on merge, not here, so reviewers should not expect this PR's CI timings to demonstrate it.

## Field data: what a job actually waits for

Queue wait (job created → job started) across this PR's ten-job matrix and eight peer runs from the same day, all under the current policy:

| Run | Jobs | Wait avg | Wait max | Exec avg |
|---|---|---|---|---|
| this PR | 10 | 12.2m | 12.3m | 8.4m |
| tepp-lazy-async-cache | 10 | 16.7m | 24.2m | 0.6m |
| rename-miscased-test-files | 10 | 11.9m | 25.9m | 8.5m |
| standardise-param-valid | 10 | 13.2m | 29.6m | 8.9m |
| document-recover-skipped | 10 | 11.3m | 29.3m | 10.2m |
| FRK-certs | 10 | 13.6m | 13.7m | 8.8m |
| fix-throw-and-mock | 10 | 19.6m | 40.6m | 8.9m |
| align-test-header | 10 | 12.8m | 28.2m | 9.5m |

Two conclusions:

1. **A job waits ~12 minutes for a VM and then runs ~8.5 minutes of tests.** The fleet spends longer producing a runner than using it. This is independent corroboration of the July figure of 28 non-job minutes per billed VM, measured a different way. Combined with the owner decision to drop interactive execution, **Task 4 (reconfigure the runner as a Windows service and eliminate the second boot) is the next lever**.
2. **It prices Task 4 Step 9.** That step proposes `WARM_FLOOR: 0` once cold start is cheap. Cold start is *not* cheap today — it costs ~12 minutes of queue wait — so `WARM_FLOOR: 0` must not ship before the double-boot fix, or it converts cost savings straight into latency on every lane's first job.

Run wall-clock is deliberately excluded from the table: it is dominated by how many test files each PR's `(do …)` marker selected and by `queue: max` FIFO waiting, so it measures which PR edited more tests, not fleet behaviour.

## What is NOT here

- **Task 3 (Spot)** — blocked. Measured Spot quota on this subscription is **3 vCPUs** against 140 needed. Adding Spot arguments to `infra.ps1` at that quota would break any VMSS rebuild, and `infra.ps1` is the fleet's repair tool.

  The quota request path is now open but the grant is not yet made. The `Microsoft.Quota` resource provider was `NotRegistered` on the subscription, which fails every Quota API call with `MissingRegistrationForResourceProvider` — a `429 RequestThrottled` on the PUT had been masking that 400. The provider is now registered and the API confirms the limit is 3. Worth flagging for whoever picks this up: the subscription is a **Microsoft Azure Sponsorship** offer, and those routinely decline automated quota increases and route to a support ticket, with Spot among the most commonly refused. If the grant is refused, Task 3 stays blocked permanently and the savings have to come from Tasks 1, 2, 5, 6 and eventually 4.
- **Task 4 (double boot)** — not included in this PR, but no longer blocked on an owner decision. Interactive execution was troubleshooting residue, not a requirement to preserve. The follow-up should configure the Windows runner as a service under a system account, remove autologon/the logon task/the bootstrap reboot, and canary BITS, loopback SMB, WMI/WinRM, SQL service changes, the effective Windows identity, and the system-profile Documents path.

## Expected effect

Modelling puts the shipped `WARM_FLOOR: 3` at **$182 or $240/month all-in** against a measured $399.79 baseline, depending on which of two unvalidated assumptions you accept — these are two scenarios, not a bracket around the truth. A per-VM lifecycle replay was built to adjudicate them and failed (it reproduced the desired-capacity envelope it was meant to test, 27% under the real bill), so the figures stay labelled as modelled. `FLEETSTAT` adds field evidence, with `onlineObservedMin` explicitly treated as an observation upper bound.

The conclusion that survives either scenario: **Spot is required, not optional** — even the optimistic scenario at `WARM_FLOOR: 1` lands above the target.

## Note on CI cost

Opening this PR spends ~$2.05: `Test-CiRunEligible` returns true unconditionally for `pull_request`, so a PR heats the author's lane and runs the full ten-job matrix regardless of commit markers. Every commit here uses `(do none)` and touches only `.github/runners/**` and `.github/workflows/runner-*.yml`, so pushing straight to `development` would have been free. Raised deliberately, at request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
