### PR TITLE
Get-DbaDbFile - Read the file layout from master when a database cannot be opened

### DIFF
--- a/public/Get-DbaDbFile.ps1
+++ b/public/Get-DbaDbFile.ps1
@@ -386,7 +386,7 @@ WHERE df.dbid = {0}
                     } else {
                         # to get drive free space for each drive that a database has files on
                         # when database compatibility lower than 110. Lets do this with query2
-                        $query2 = @'
+                        $query2 = @"
 -- to get drive free space for each drive that a database has files on
 DECLARE @FixedDrives TABLE(Drive CHAR(1), MB_Free BIGINT);
 INSERT @FixedDrives EXEC sys.xp_fixeddrives;
@@ -395,7 +395,7 @@ SELECT DISTINCT fd.MB_Free, LEFT(df.physical_name, 1) AS [Drive]
 FROM @FixedDrives AS fd
 INNER JOIN sys.database_files AS df
 ON fd.Drive = LEFT(df.physical_name, 1);
-'@
+"@
                         # if the server has one drive xp_fixeddrives returns one row, but we still need $disks to be an array.
                         if ($server.VersionMajor -gt 8) {
                             $disks = @($server.Query($query2, $db.Name))

--- a/public/Get-DbaDbFile.ps1
+++ b/public/Get-DbaDbFile.ps1
@@ -6,6 +6,8 @@ function Get-DbaDbFile {
     .DESCRIPTION
         Retrieves detailed information about database files (data and log files) from SQL Server instances using direct T-SQL queries for optimal performance. This function provides comprehensive file metadata including current size, used space, growth settings, I/O statistics, and volume free space information that DBAs need for capacity planning, performance analysis, and storage management. Unlike SMO-based approaches, this command avoids costly enumeration operations and provides faster results when analyzing file configurations across multiple databases.
 
+        Databases that cannot be opened - RESTORING, RECOVERY_PENDING, SUSPECT or OFFLINE - are read from sys.master_files in master instead of from inside the database, so a database left in NORECOVERY between a full and a differential restore still reports its logical and physical file names. Only the configured file layout is authoritative there: used space, available space, filegroup metadata, the I/O counters and volume free space are returned as null for those databases, and reading them needs CREATE DATABASE, ALTER ANY DATABASE or VIEW ANY DEFINITION permission on the instance.
+
     .PARAMETER SqlInstance
         The target SQL Server instance or instances
 
@@ -94,6 +96,12 @@ function Get-DbaDbFile {
 
         Note: Size-related properties (Size, UsedSpace, MaxSize, etc.) are returned as dbasize objects which automatically format as human-readable units (KB, MB, GB, TB) when displayed.
 
+        Note: For a database that cannot be opened the file layout is read from sys.master_files, and FileGroupName, UsedSpace, AvailableSpace, NumberOfDiskWrites, NumberOfDiskReads, ReadFromDisk, WrittenToDisk, VolumeFreeSpace, FileGroupType, FileGroupTypeDescription, FileGroupDefault and FileGroupReadOnly are NULL because they have no authoritative value outside the database.
+
+        Note: State and IsOffline describe the file, not the database. sys.master_files reports the files of a database that was taken offline as ONLINE, so a database in that state is recognised by its own status and not by these two properties. A database left in NORECOVERY does report its files as RESTORING.
+
+        Note: For a database that cannot be opened, Size is the size recorded in sys.master_files. For an accessible database Size is instead taken from sys.dm_io_virtual_file_stats where that is available, so the two differ for sparse files, database snapshots and FILESTREAM containers, where the recorded size is not the space allocated on disk.
+
     .EXAMPLE
         PS C:\> Get-DbaDbFile -SqlInstance sql2016
 
@@ -118,6 +126,11 @@ function Get-DbaDbFile {
         PS C:\> Get-DbaDbFile -SqlInstance sql2016 -Database AdventureWorks2017 -FileGroup Index
 
         Return any files that are in the Index filegroup of the AdventureWorks2017 database.
+
+    .EXAMPLE
+        PS C:\> Get-DbaDbFile -SqlInstance sql2016 -Database Staging | Select-Object LogicalName, PhysicalName
+
+        Returns the logical and physical file names of Staging even while it sits in NORECOVERY between a full and a differential restore, by reading them from sys.master_files.
     #>
     [CmdletBinding()]
     param (
@@ -194,6 +207,62 @@ function Get-DbaDbFile {
             CAST(fg.status & 0x8 AS BIT) AS FileGroupReadOnly
             FROM sysfiles df
             LEFT OUTER JOIN  sysfilegroups fg ON df.groupid=fg.groupid"
+
+        # Looked up by database_id and not by name, because a database name may contain an apostrophe
+        # and would then either break this query or carry arbitrary T-SQL into it.
+        $sqlCompatibilityLevel = @"
+SELECT compatibility_level FROM sys.databases WHERE database_id = {0}
+"@
+
+        # A database that is RESTORING, RECOVERY_PENDING, SUSPECT or OFFLINE cannot be opened, so
+        # sys.database_files and everything else that lives inside it is out of reach. sys.master_files
+        # in master still carries the configured file layout, which is what restore and file mapping
+        # workflows need. Only the columns that are authoritative there are selected: used space,
+        # filegroup metadata, the I/O counters and volume free space have no equivalent and are
+        # reported as null rather than as zero.
+        $sqlMasterFiles = @"
+SELECT
+    mf.file_id AS 'ID',
+    mf.Type,
+    mf.type_desc AS TypeDescription,
+    mf.name AS LogicalName,
+    mf.physical_name AS PhysicalName,
+    mf.state_desc AS State,
+    mf.max_size AS MaxSize,
+    CASE mf.is_percent_growth WHEN 1 THEN mf.growth ELSE mf.Growth*8 END AS Growth,
+    mf.size AS Size,
+    CASE mf.state_desc WHEN 'OFFLINE' THEN 'True' ELSE 'False' END AS IsOffline,
+    CASE mf.is_read_only WHEN 1 THEN 'True' WHEN 0 THEN 'False' END AS IsReadOnly,
+    CASE mf.is_media_read_only WHEN 1 THEN 'True' WHEN 0 THEN 'False' END AS IsReadOnlyMedia,
+    CASE mf.is_sparse WHEN 1 THEN 'True' WHEN 0 THEN 'False' END AS IsSparse,
+    CASE mf.is_percent_growth WHEN 1 THEN 'Percent' WHEN 0 THEN 'kb' END AS GrowthType,
+    NULLIF(mf.data_space_id, 0) AS FileGroupDataSpaceId
+FROM sys.master_files mf
+WHERE mf.database_id = {0}
+"@
+
+        # sys.master_files does not exist before SQL Server 2005. master.dbo.sysaltfiles is the
+        # server wide equivalent there and carries the same status bits that $sql2000 decodes.
+        $sqlMasterFiles2000 = @"
+SELECT
+    df.fileid AS ID,
+    CONVERT(INT,df.status & 0x40) / 64 AS Type,
+    CASE CONVERT(INT,df.status & 0x40) / 64 WHEN 1 THEN 'LOG' ELSE 'ROWS' END AS TypeDescription,
+    df.name AS LogicalName,
+    df.filename AS PhysicalName,
+    'Existing' AS State,
+    df.maxsize AS MaxSize,
+    CASE CONVERT(INT,df.status & 0x100000) / 1048576 WHEN 1 THEN df.growth WHEN 0 THEN df.growth*8 END AS Growth,
+    df.size AS Size,
+    CASE CONVERT(INT,df.status & 0x20000000) / 536870912 WHEN 1 THEN 'True' ELSE 'False' END AS IsOffline,
+    CASE CONVERT(INT,df.status & 0x1000) / 4096 WHEN 1 THEN 'True' WHEN 0 THEN 'False' END AS IsReadOnly,
+    CASE CONVERT(INT,df.status & 0x1000) / 4096 WHEN 1 THEN 'True' WHEN 0 THEN 'False' END AS IsReadOnlyMedia,
+    CASE CONVERT(INT,df.status & 0x10000000) / 268435456 WHEN 1 THEN 'True' WHEN 0 THEN 'False' END AS IsSparse,
+    CASE CONVERT(INT,df.status & 0x100000) / 1048576 WHEN 1 THEN 'Percent' WHEN 0 THEN 'kb' END AS GrowthType,
+    NULLIF(df.groupid, 0) AS FileGroupDataSpaceId
+FROM master.dbo.sysaltfiles df
+WHERE df.dbid = {0}
+"@
         #endregion Sql Query Generation
     }
 
@@ -207,27 +276,57 @@ function Get-DbaDbFile {
 
             Write-Message -Level Verbose -Message "Querying database $db"
 
-            try {
-                $version = $server.Query("SELECT compatibility_level FROM sys.databases WHERE name = '$($db.Name)'")
-                $version = [int]($version.compatibility_level / 10)
-            } catch {
-                $version = 8
-            }
+            # An inaccessible database cannot be set as the query context, so its file layout is read
+            # from master instead of from inside the database.
+            $useMasterFiles = -not $db.IsAccessible
 
-            if ($version -ge 11) {
-                $query = ($sql, $sql2008, $sqlfrom, $sql2008from) -Join "`n"
-            } elseif ($version -ge 9) {
-                $query = ($sql, $sqlfrom) -Join "`n"
+            if ($useMasterFiles) {
+                Write-Message -Level Verbose -Message "Database $db is not accessible, reading the file layout from master instead"
+
+                if (Test-Bound -ParameterName FileGroup) {
+                    Write-Message -Level Warning -Message "Skipping database $db because filegroup names cannot be read for an inaccessible database, so -FileGroup cannot be honored"
+                    continue
+                }
+
+                if ($server.VersionMajor -le 8) {
+                    $query = $sqlMasterFiles2000 -f [int]$db.ID
+                } else {
+                    $query = $sqlMasterFiles -f [int]$db.ID
+                }
             } else {
-                $query = $sql2000
+                try {
+                    $version = $server.Query($sqlCompatibilityLevel -f [int]$db.ID)
+                    $version = [int]($version.compatibility_level / 10)
+                } catch {
+                    $version = 8
+                }
+
+                if ($version -ge 11) {
+                    $query = ($sql, $sql2008, $sqlfrom, $sql2008from) -Join "`n"
+                } elseif ($version -ge 9) {
+                    $query = ($sql, $sqlfrom) -Join "`n"
+                } else {
+                    $query = $sql2000
+                }
             }
 
             Write-Message -Level Debug -Message "SQL Statement: $query"
 
             try {
-                $results = $server.Query($query, $db.Name)
+                if ($useMasterFiles) {
+                    $results = $server.Query($query)
+                } else {
+                    $results = $server.Query($query, $db.Name)
+                }
             } catch {
                 Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
+            }
+
+            # A row in sys.master_files is only visible to a login with CREATE DATABASE, ALTER ANY
+            # DATABASE or VIEW ANY DEFINITION, so an empty result here is a permission problem and not
+            # a database that went missing.
+            if ($useMasterFiles -and -not $results) {
+                Stop-Function -Message "No file information returned for the inaccessible database $db on $server. Reading it needs CREATE DATABASE, ALTER ANY DATABASE or VIEW ANY DEFINITION permission on the instance." -Target $db -Continue
             }
 
             if (Test-Bound -ParameterName FileGroup) {
@@ -237,13 +336,20 @@ function Get-DbaDbFile {
 
             foreach ($result in $results) {
                 $size = [dbasize]($result.Size * 8192)
-                $usedspace = [dbasize]($result.UsedSpace * 8192)
                 $maxsize = $result.MaxSize
-                # calculation is done here because for snapshots or sparse files size is not the "virtual" size
-                # (master_files.Size) but the currently allocated one (dm_io_virtual_file_stats.size_on_disk_bytes)
-                $AvailableSpace = $size - $usedspace
-                if ($result.size_on_disk_bytes) {
-                    $size = [dbasize]($result.size_on_disk_bytes)
+                if ($useMasterFiles) {
+                    # master knows the configured file layout but nothing about what is used inside the
+                    # database, so these stay null instead of being reported as zero
+                    $usedspace = $null
+                    $AvailableSpace = $null
+                } else {
+                    $usedspace = [dbasize]($result.UsedSpace * 8192)
+                    # calculation is done here because for snapshots or sparse files size is not the "virtual" size
+                    # (master_files.Size) but the currently allocated one (dm_io_virtual_file_stats.size_on_disk_bytes)
+                    $AvailableSpace = $size - $usedspace
+                    if ($result.size_on_disk_bytes) {
+                        $size = [dbasize]($result.size_on_disk_bytes)
+                    }
                 }
                 if ($maxsize -gt -1) {
                     $maxsize = [dbasize]($result.MaxSize * 8192)
@@ -251,12 +357,36 @@ function Get-DbaDbFile {
                     $maxsize = [dbasize]($result.MaxSize)
                 }
 
-                if ($result.VolumeFreeSpace) {
-                    $VolumeFreeSpace = [dbasize]$result.VolumeFreeSpace
+                if ($useMasterFiles) {
+                    # the I/O counters and the volume statistics come from DMVs that are keyed on a
+                    # database that can be opened, so there is nothing authoritative to report here
+                    $VolumeFreeSpace = $null
+                    $numberOfDiskWrites = $null
+                    $numberOfDiskReads = $null
+                    $readFromDisk = $null
+                    $writtenToDisk = $null
+                    $fileGroupName = $null
+                    $fileGroupType = $null
+                    $fileGroupTypeDescription = $null
+                    $fileGroupDefault = $null
+                    $fileGroupReadOnly = $null
                 } else {
-                    # to get drive free space for each drive that a database has files on
-                    # when database compatibility lower than 110. Lets do this with query2
-                    $query2 = @'
+                    $numberOfDiskWrites = $result.NumberOfDiskWrites
+                    $numberOfDiskReads = $result.NumberOfDiskReads
+                    $readFromDisk = [dbasize]$result.BytesReadFromDisk
+                    $writtenToDisk = [dbasize]$result.BytesWrittenToDisk
+                    $fileGroupName = $result.FileGroupName
+                    $fileGroupType = $result.FileGroupType
+                    $fileGroupTypeDescription = $result.FileGroupTypeDescription
+                    $fileGroupDefault = $result.FileGroupDefault
+                    $fileGroupReadOnly = $result.FileGroupReadOnly
+
+                    if ($result.VolumeFreeSpace) {
+                        $VolumeFreeSpace = [dbasize]$result.VolumeFreeSpace
+                    } else {
+                        # to get drive free space for each drive that a database has files on
+                        # when database compatibility lower than 110. Lets do this with query2
+                        $query2 = @'
 -- to get drive free space for each drive that a database has files on
 DECLARE @FixedDrives TABLE(Drive CHAR(1), MB_Free BIGINT);
 INSERT @FixedDrives EXEC sys.xp_fixeddrives;
@@ -266,63 +396,64 @@ FROM @FixedDrives AS fd
 INNER JOIN sys.database_files AS df
 ON fd.Drive = LEFT(df.physical_name, 1);
 '@
-                    # if the server has one drive xp_fixeddrives returns one row, but we still need $disks to be an array.
-                    if ($server.VersionMajor -gt 8) {
-                        $disks = @($server.Query($query2, $db.Name))
-                        $MbFreeColName = $disks[0].psobject.Properties.Name
-                        # get the free MB value for the drive in question
-                        $free = $disks | Where-Object {
-                            $_.drive -eq $result.PhysicalName.Substring(0, 1)
-                        } | Select-Object $MbFreeColName
+                        # if the server has one drive xp_fixeddrives returns one row, but we still need $disks to be an array.
+                        if ($server.VersionMajor -gt 8) {
+                            $disks = @($server.Query($query2, $db.Name))
+                            $MbFreeColName = $disks[0].psobject.Properties.Name
+                            # get the free MB value for the drive in question
+                            $free = $disks | Where-Object {
+                                $_.drive -eq $result.PhysicalName.Substring(0, 1)
+                            } | Select-Object $MbFreeColName
 
-                    $VolumeFreeSpace = [dbasize](($free.MB_Free) * 1024 * 1024)
+                            $VolumeFreeSpace = [dbasize](($free.MB_Free) * 1024 * 1024)
+                        }
+                    }
                 }
-            }
-            if ($result.GrowthType -eq "Percent") {
-                $nextgrowtheventadd = [dbasize]($result.size * 8 * ($result.Growth * 0.01) * 1024)
-            } else {
-                $nextgrowtheventadd = [dbasize]($result.Growth * 1024)
-            }
-            if (($nextgrowtheventadd.Byte -gt ($MaxSize.Byte - $size.Byte)) -and $maxsize -gt 0) {
-                [dbasize]$nextgrowtheventadd = 0
-            }
+                if ($result.GrowthType -eq "Percent") {
+                    $nextgrowtheventadd = [dbasize]($result.size * 8 * ($result.Growth * 0.01) * 1024)
+                } else {
+                    $nextgrowtheventadd = [dbasize]($result.Growth * 1024)
+                }
+                if (($nextgrowtheventadd.Byte -gt ($MaxSize.Byte - $size.Byte)) -and $maxsize -gt 0) {
+                    [dbasize]$nextgrowtheventadd = 0
+                }
 
-            [PSCustomObject]@{
-                ComputerName             = $server.ComputerName
-                InstanceName             = $server.ServiceName
-                SqlInstance              = $server.DomainInstanceName
-                Database                 = $db.name
-                DatabaseID               = $db.ID
-                FileGroupName            = $result.FileGroupName
-                ID                       = $result.ID
-                Type                     = $result.Type
-                TypeDescription          = $result.TypeDescription
-                LogicalName              = $result.LogicalName.Trim()
-                PhysicalName             = $result.PhysicalName.Trim()
-                State                    = $result.State
-                MaxSize                  = $maxsize
-                Growth                   = $result.Growth
-                GrowthType               = $result.GrowthType
-                NextGrowthEventSize      = $nextgrowtheventadd
-                Size                     = $size
-                UsedSpace                = $usedspace
-                AvailableSpace           = $AvailableSpace
-                IsOffline                = $result.IsOffline
-                IsReadOnly               = $result.IsReadOnly
-                IsReadOnlyMedia          = $result.IsReadOnlyMedia
-                IsSparse                 = $result.IsSparse
-                NumberOfDiskWrites       = $result.NumberOfDiskWrites
-                NumberOfDiskReads        = $result.NumberOfDiskReads
-                ReadFromDisk             = [dbasize]$result.BytesReadFromDisk
-                WrittenToDisk            = [dbasize]$result.BytesWrittenToDisk
-                VolumeFreeSpace          = $VolumeFreeSpace
-                FileGroupDataSpaceId     = $result.FileGroupDataSpaceId
-                FileGroupType            = $result.FileGroupType
-                FileGroupTypeDescription = $result.FileGroupTypeDescription
-                FileGroupDefault         = $result.FileGroupDefault
-                FileGroupReadOnly        = $result.FileGroupReadOnly
+                [PSCustomObject]@{
+                    ComputerName             = $server.ComputerName
+                    InstanceName             = $server.ServiceName
+                    SqlInstance              = $server.DomainInstanceName
+                    Database                 = $db.name
+                    DatabaseID               = $db.ID
+                    FileGroupName            = $fileGroupName
+                    ID                       = $result.ID
+                    Type                     = $result.Type
+                    TypeDescription          = $result.TypeDescription
+                    LogicalName              = $result.LogicalName.Trim()
+                    PhysicalName             = $result.PhysicalName.Trim()
+                    State                    = $result.State
+                    MaxSize                  = $maxsize
+                    Growth                   = $result.Growth
+                    GrowthType               = $result.GrowthType
+                    NextGrowthEventSize      = $nextgrowtheventadd
+                    Size                     = $size
+                    UsedSpace                = $usedspace
+                    AvailableSpace           = $AvailableSpace
+                    IsOffline                = $result.IsOffline
+                    IsReadOnly               = $result.IsReadOnly
+                    IsReadOnlyMedia          = $result.IsReadOnlyMedia
+                    IsSparse                 = $result.IsSparse
+                    NumberOfDiskWrites       = $numberOfDiskWrites
+                    NumberOfDiskReads        = $numberOfDiskReads
+                    ReadFromDisk             = $readFromDisk
+                    WrittenToDisk            = $writtenToDisk
+                    VolumeFreeSpace          = $VolumeFreeSpace
+                    FileGroupDataSpaceId     = $result.FileGroupDataSpaceId
+                    FileGroupType            = $fileGroupType
+                    FileGroupTypeDescription = $fileGroupTypeDescription
+                    FileGroupDefault         = $fileGroupDefault
+                    FileGroupReadOnly        = $fileGroupReadOnly
+                }
             }
         }
     }
-}
 }

--- a/public/Get-DbaDbFileMapping.ps1
+++ b/public/Get-DbaDbFileMapping.ps1
@@ -6,6 +6,8 @@ function Get-DbaDbFileMapping {
     .DESCRIPTION
         Extracts the logical-to-physical file name mappings from an existing database and returns them in a hashtable format compatible with Restore-DbaDatabase. This eliminates the need to manually specify file paths when restoring databases to different servers or locations. The function reads both data files and log files from the database's file groups and creates a complete mapping that preserves the original file structure during restore operations.
 
+        Databases that cannot be opened - RESTORING, RECOVERY_PENDING, SUSPECT or OFFLINE - are read through Get-DbaDbFile, which takes their file layout from sys.master_files. That covers the mapping of a database left in NORECOVERY by a full restore, which is what a following differential restore needs.
+
     .PARAMETER SqlInstance
         The target SQL Server instance or instances. This can be a collection and receive pipeline input.
 
@@ -43,7 +45,7 @@ function Get-DbaDbFileMapping {
     .OUTPUTS
         PSCustomObject
 
-        Returns one object per accessible database provided as input. Each object contains the file mapping information needed for restore operations.
+        Returns one object per database provided as input, including databases that are not accessible. Each object contains the file mapping information needed for restore operations.
 
         Properties:
         - ComputerName: The name of the computer where the SQL Server instance is running
@@ -57,6 +59,12 @@ function Get-DbaDbFileMapping {
         PS C:\> Get-ChildItem \\nas\db\backups\test | Restore-DbaDatabase -SqlInstance sql2019 -Database test -FileMapping $filemap.FileMapping
 
         Restores test to sql2019 using the file structure built from the existing database on sql2016
+
+    .EXAMPLE
+        PS C:\> $filemap = Get-DbaDbFileMapping -SqlInstance sql2016 -Database test
+        PS C:\> Restore-DbaDatabase -SqlInstance sql2016 -Path \\nas\db\backups\test\test_diff.bak -DatabaseName test -Continue -FileMapping $filemap.FileMapping
+
+        Builds the file mapping of test while it is still in NORECOVERY from an earlier full restore, then applies the differential backup on top of it
     #>
     [CmdletBinding()]
     param ([parameter(ValueFromPipeline)]
@@ -78,26 +86,39 @@ function Get-DbaDbFileMapping {
         }
 
         foreach ($db in $InputObject) {
-            if ($db.IsAccessible) {
-                Write-Message -Level Verbose -Message "Processing database: $db"
-                $fileMap = @{ }
+            Write-Message -Level Verbose -Message "Processing database: $db"
+            $fileMap = @{ }
 
+            if ($db.IsAccessible) {
                 foreach ($file in $db.FileGroups.Files) {
                     $fileMap[$file.Name] = $file.FileName
                 }
                 foreach ($file in $db.LogFiles) {
                     $fileMap[$file.Name] = $file.FileName
                 }
-
-                [PSCustomObject]@{
-                    ComputerName = $db.ComputerName
-                    InstanceName = $db.InstanceName
-                    SqlInstance  = $db.SqlInstance
-                    Database     = $db.Name
-                    FileMapping  = $fileMap
-                }
             } else {
-                Write-Message -Level Verbose -Message "Skipping processing of database: $db as database is not accessible"
+                # SMO cannot enumerate the files of a database it cannot open, so take the layout that
+                # Get-DbaDbFile reads out of sys.master_files. This is the case that matters between a
+                # NORECOVERY full restore and the differential that follows it.
+                Write-Message -Level Verbose -Message "Database $db is not accessible, building the mapping from the file layout in master"
+
+                $files = Get-DbaDbFile -InputObject $db -EnableException:$EnableException
+                if (-not $files) {
+                    Write-Message -Level Verbose -Message "Skipping processing of database: $db as no file information was returned for it"
+                    continue
+                }
+
+                foreach ($file in $files) {
+                    $fileMap[$file.LogicalName] = $file.PhysicalName
+                }
+            }
+
+            [PSCustomObject]@{
+                ComputerName = $db.ComputerName
+                InstanceName = $db.InstanceName
+                SqlInstance  = $db.SqlInstance
+                Database     = $db.Name
+                FileMapping  = $fileMap
             }
         }
     }

--- a/tests/Get-DbaDbFile.Tests.ps1
+++ b/tests/Get-DbaDbFile.Tests.ps1
@@ -80,4 +80,182 @@ Describe $CommandName -Tag IntegrationTests {
             $results.DatabaseID | Get-Unique | Should -Be $tempDB.ID
         }
     }
+
+    Context "Database names that contain an apostrophe" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Set variables. They are available in all the It blocks.
+            $quotedDbName = "dbatoolsci_dbfile_$([char]39)quoted_$(Get-Random)"
+
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $quotedDbName
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+
+            $quotedResults = @(Get-DbaDbFile -SqlInstance $TestConfig.InstanceSingle -Database $quotedDbName)
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Cleanup all created objects.
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $quotedDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Returns the files of a database whose name contains an apostrophe" {
+            $quotedResults.Count | Should -BeExactly 2
+            $quotedResults.Database | Select-Object -Unique | Should -Be $quotedDbName
+        }
+
+        It "Detects the compatibility level instead of falling back to the SQL Server 2000 query" {
+            # The version probe used to interpolate the database name into a string comparison, so an
+            # apostrophe made it throw and the command silently served the SQL 2000 shape, which has no
+            # NumberOfDiskReads column.
+            $null -ne $quotedResults[0].NumberOfDiskReads | Should -BeTrue
+        }
+    }
+
+    Context "Databases that cannot be opened" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
+            $backupPath = "$($TestConfig.Temp)\$CommandName-$(Get-Random)"
+            $null = New-Item -Path $backupPath -ItemType Directory
+
+            # Set variables. They are available in all the It blocks.
+            $sourceDbName = "dbatoolsci_dbfile_source_$(Get-Random)"
+            $restoringDbName = "dbatoolsci_dbfile_restoring_$(Get-Random)"
+            $offlineDbName = "dbatoolsci_dbfile_offline_$(Get-Random)"
+
+            # The offline database is compared against itself while it is still online, so the fallback
+            # has to reproduce the values the normal query returns rather than just return something.
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $offlineDbName
+            $onlineResults = Get-DbaDbFile -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName
+            $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName -Offline -Force
+
+            # The restoring database is the scenario from the issue: a full restore left in NORECOVERY
+            # so that a differential can follow it.
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $sourceDbName
+            $fullBackup = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $sourceDbName -Path $backupPath -Type Full
+
+            $splatRestore = @{
+                SqlInstance         = $TestConfig.InstanceSingle
+                Path                = $fullBackup.BackupPath
+                DatabaseName        = $restoringDbName
+                NoRecovery          = $true
+                ReplaceDbNameInFile = $true
+            }
+            $null = Restore-DbaDatabase @splatRestore
+
+            $accessibleResults = Get-DbaDbFile -SqlInstance $TestConfig.InstanceSingle -Database $sourceDbName
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+
+            $restoringResults = @(Get-DbaDbFile -SqlInstance $TestConfig.InstanceSingle -Database $restoringDbName)
+            $offlineResults = @(Get-DbaDbFile -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName)
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Cleanup all created objects.
+            $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName -Online -Force -ErrorAction SilentlyContinue
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $sourceDbName, $restoringDbName, $offlineDbName -ErrorAction SilentlyContinue
+
+            # Remove the backup directory.
+            Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Returns the files of a database that is still in NORECOVERY" {
+            $restoringResults.Count | Should -BeExactly 2
+            $restoringResults.State | Select-Object -Unique | Should -Be "RESTORING"
+        }
+
+        It "Reports the physical names the restore created for the database in NORECOVERY" {
+            $dataFile = $restoringResults | Where-Object TypeDescription -eq "ROWS"
+            $logFile = $restoringResults | Where-Object TypeDescription -eq "LOG"
+            $dataFile.PhysicalName | Should -BeLike "*$restoringDbName*.mdf"
+            $logFile.PhysicalName | Should -BeLike "*$restoringDbName*.ldf"
+        }
+
+        It "Keeps the logical names of the source database for the database in NORECOVERY" {
+            $restoringResults.LogicalName | Sort-Object | Should -Be ($accessibleResults.LogicalName | Sort-Object)
+        }
+
+        It "Returns the files of an offline database" {
+            $offlineResults.Count | Should -BeExactly 2
+        }
+
+        It "Reports the same file layout for the offline database as it did while it was online" {
+            $properties = @(
+                "ID",
+                "Type",
+                "TypeDescription",
+                "LogicalName",
+                "PhysicalName",
+                "MaxSize",
+                "Growth",
+                "GrowthType",
+                "Size",
+                "IsReadOnly",
+                "IsSparse",
+                "FileGroupDataSpaceId"
+            )
+            $offline = $offlineResults | Sort-Object ID | Select-Object $properties
+            $online = @($onlineResults) | Sort-Object ID | Select-Object $properties
+            Compare-Object -ReferenceObject $online -DifferenceObject $offline -Property $properties | Should -BeNullOrEmpty
+        }
+
+        It "Returns the same properties in the same order as for an accessible database" {
+            $inaccessibleProperties = $restoringResults[0].PSObject.Properties.Name -join ","
+            $inaccessibleProperties | Should -Be ($accessibleResults[0].PSObject.Properties.Name -join ",")
+        }
+
+        It "Reports what it cannot read as null instead of zero" {
+            $file = $restoringResults[0]
+            # Without this the whole test passes trivially when no file is returned at all.
+            $file.LogicalName | Should -Not -BeNullOrEmpty
+            $file.UsedSpace | Should -BeNullOrEmpty
+            $file.AvailableSpace | Should -BeNullOrEmpty
+            $file.NumberOfDiskWrites | Should -BeNullOrEmpty
+            $file.NumberOfDiskReads | Should -BeNullOrEmpty
+            $file.ReadFromDisk | Should -BeNullOrEmpty
+            $file.WrittenToDisk | Should -BeNullOrEmpty
+            $file.VolumeFreeSpace | Should -BeNullOrEmpty
+            $file.FileGroupName | Should -BeNullOrEmpty
+            $file.FileGroupType | Should -BeNullOrEmpty
+            $file.FileGroupTypeDescription | Should -BeNullOrEmpty
+            $file.FileGroupDefault | Should -BeNullOrEmpty
+            $file.FileGroupReadOnly | Should -BeNullOrEmpty
+        }
+
+        It "Does not warn about a database that cannot be opened" {
+            $null = Get-DbaDbFile -SqlInstance $TestConfig.InstanceSingle -Database $restoringDbName -WarningVariable restoringWarning
+            $restoringWarning | Should -BeNullOrEmpty
+        }
+
+        It "Warns and returns nothing when FileGroup is used on a database that cannot be opened" {
+            $filteredResults = Get-DbaDbFile -SqlInstance $TestConfig.InstanceSingle -Database $restoringDbName -FileGroup PRIMARY -WarningVariable fileGroupWarning
+            $filteredResults | Should -BeNullOrEmpty
+            $fileGroupWarning | Should -Match "FileGroup cannot be honored"
+        }
+
+        It "Still returns the accessible databases when scanning the whole instance" {
+            $allResults = Get-DbaDbFile -SqlInstance $TestConfig.InstanceSingle
+            $allResults.Database | Should -Contain $sourceDbName
+            $allResults.Database | Should -Contain $restoringDbName
+            $allResults.Database | Should -Contain $offlineDbName
+        }
+    }
 }

--- a/tests/Get-DbaDbFile.Tests.ps1
+++ b/tests/Get-DbaDbFile.Tests.ps1
@@ -257,5 +257,46 @@ Describe $CommandName -Tag IntegrationTests {
             $allResults.Database | Should -Contain $restoringDbName
             $allResults.Database | Should -Contain $offlineDbName
         }
+
+        It "Reads the same file layout through the SQL Server 2000 query as through sys.master_files" {
+            # The SQL Server 2000 branch itself cannot be dispatched here, because that needs an
+            # instance reporting VersionMajor 8 and SQL Server 2000 runs on no host still available.
+            # master.dbo.sysaltfiles does still resolve on a modern instance though, so the query the
+            # command actually ships is pulled out of its own AST, executed, and compared against the
+            # sys.master_files query it stands in for. That covers the column names and the status bit
+            # arithmetic, which is where this query realistically breaks.
+            $commandAst = (Get-Command Get-DbaDbFile).ScriptBlock.Ast
+            $queryAssignments = $commandAst.FindAll({
+                    param($node)
+                    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                    $node.Left.VariablePath.UserPath -in "sqlMasterFiles", "sqlMasterFiles2000"
+                }, $true)
+
+            $modernQuery = ($queryAssignments | Where-Object { $PSItem.Left.VariablePath.UserPath -eq "sqlMasterFiles" }).Right.Expression.Value
+            $legacyQuery = ($queryAssignments | Where-Object { $PSItem.Left.VariablePath.UserPath -eq "sqlMasterFiles2000" }).Right.Expression.Value
+            $modernQuery | Should -Not -BeNullOrEmpty
+            $legacyQuery | Should -Not -BeNullOrEmpty
+
+            $restoringDbId = (Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $restoringDbName).ID
+            $modernRows = @(Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query ($modernQuery -f $restoringDbId)) | Sort-Object ID
+            $legacyRows = @(Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query ($legacyQuery -f $restoringDbId)) | Sort-Object ID
+
+            $comparedProperties = @(
+                "ID",
+                "Type",
+                "TypeDescription",
+                "LogicalName",
+                "PhysicalName",
+                "MaxSize",
+                "Size",
+                "Growth",
+                "GrowthType",
+                "FileGroupDataSpaceId"
+            )
+            # Anchored, because Compare-Object of two empty sets is also empty.
+            $modernRows.Count | Should -BeExactly 2
+            $legacyRows.Count | Should -BeExactly 2
+            Compare-Object -ReferenceObject $modernRows -DifferenceObject $legacyRows -Property $comparedProperties | Should -BeNullOrEmpty
+        }
     }
 }

--- a/tests/Get-DbaDbFileMapping.Tests.ps1
+++ b/tests/Get-DbaDbFileMapping.Tests.ps1
@@ -38,4 +38,77 @@ Describe $CommandName -Tag IntegrationTests {
             $results.Database -contains "master" | Should -Be $false
         }
     }
+
+    Context "Databases that cannot be opened" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
+            $backupPath = "$($TestConfig.Temp)\$CommandName-$(Get-Random)"
+            $null = New-Item -Path $backupPath -ItemType Directory
+
+            # Set variables. They are available in all the It blocks.
+            $sourceDbName = "dbatoolsci_mapping_source_$(Get-Random)"
+            $restoringDbName = "dbatoolsci_mapping_restoring_$(Get-Random)"
+
+            # This is the scenario from the issue: the mapping of a database left in NORECOVERY by a
+            # full restore is what the differential restore that follows it needs.
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $sourceDbName
+            $fullBackup = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $sourceDbName -Path $backupPath -Type Full
+
+            $splatRestore = @{
+                SqlInstance         = $TestConfig.InstanceSingle
+                Path                = $fullBackup.BackupPath
+                DatabaseName        = $restoringDbName
+                NoRecovery          = $true
+                ReplaceDbNameInFile = $true
+            }
+            $null = Restore-DbaDatabase @splatRestore
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+
+            $restoringMapping = Get-DbaDbFileMapping -SqlInstance $TestConfig.InstanceSingle -Database $restoringDbName
+
+            # Bringing the database online lets the mapping taken while it was inaccessible be compared
+            # against the one SMO builds for the very same files.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            $null = Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Recover -DatabaseName $restoringDbName
+            $recoveredMapping = Get-DbaDbFileMapping -SqlInstance $TestConfig.InstanceSingle -Database $restoringDbName
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Cleanup all created objects.
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $sourceDbName, $restoringDbName -ErrorAction SilentlyContinue
+
+            # Remove the backup directory.
+            Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Returns a mapping for a database that is still in NORECOVERY" {
+            $restoringMapping | Should -Not -BeNullOrEmpty
+            $restoringMapping.Database | Should -Be $restoringDbName
+            $restoringMapping.FileMapping.Count | Should -BeExactly 2
+        }
+
+        It "Maps the logical names of the source database to the physical names the restore created" {
+            $dataFile = $restoringMapping.FileMapping[$sourceDbName]
+            $logFile = $restoringMapping.FileMapping["${sourceDbName}_log"]
+            $dataFile | Should -BeLike "*$restoringDbName*.mdf"
+            $logFile | Should -BeLike "*$restoringDbName*.ldf"
+        }
+
+        It "Builds the same mapping while inaccessible as it does once the database is recovered" {
+            $restoringPairs = ($restoringMapping.FileMapping.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($PSItem.Name)=$($PSItem.Value)" }) -join ";"
+            $recoveredPairs = ($recoveredMapping.FileMapping.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($PSItem.Name)=$($PSItem.Value)" }) -join ";"
+            $restoringPairs | Should -Be $recoveredPairs
+        }
+    }
 }


### PR DESCRIPTION
Fixes #7968

## Problem

A database that cannot be opened - `RESTORING`, `RECOVERY_PENDING`, `SUSPECT` or `OFFLINE` - cannot be set as the query context. `Get-DbaDbFile` sets it as the context and reads `sys.database_files`, so it failed with:

```
Database 'X' cannot be opened. It is in the middle of a restore.
```

`Get-DbaDbFileMapping` checked `IsAccessible` and skipped the database silently.

That is exactly the moment the information is needed. @olegstrutinskii's scenario: a full restore runs at 04:00 with `-NoRecovery` and randomized file suffixes, and the differential at 08:00 needs `-FileMapping` to line the files up. The names are unreachable in between.

## Mechanism

`sys.database_files`, `sys.filegroups`, `sys.dm_io_virtual_file_stats` and `sys.dm_os_volume_stats` all live inside the database. `sys.master_files` lives in master and still carries the configured file layout for a database that cannot be opened.

## What changed

`public/Get-DbaDbFile.ps1`

- When `$db.IsAccessible` is false, the file layout comes from a single query against `sys.master_files` instead of the in-database query. On SQL Server 2000 the equivalent is `master.dbo.sysaltfiles`, decoded with the same status bits the existing `$sql2000` branch uses.
- The output shape is byte-identical - same properties, same order. The twelve properties that have no authoritative value outside the database are `$null`, not zero: `FileGroupName`, `UsedSpace`, `AvailableSpace`, `NumberOfDiskWrites`, `NumberOfDiskReads`, `ReadFromDisk`, `WrittenToDisk`, `VolumeFreeSpace`, `FileGroupType`, `FileGroupTypeDescription`, `FileGroupDefault`, `FileGroupReadOnly`.
- `NULLIF(data_space_id, 0)` reproduces the NULL `FileGroupDataSpaceId` the accessible path returns for log files.
- A row in `sys.master_files` is only visible to a login holding `CREATE DATABASE`, `ALTER ANY DATABASE` or `VIEW ANY DEFINITION`. Rows are filtered rather than refused, so zero rows is treated as a permission problem and reported as such instead of looking like a database that vanished.
- `-FileGroup` warns and skips for an inaccessible database, because filegroup names are not in master and silently returning nothing would be worse.
- Verbose messages identify the fallback.

`public/Get-DbaDbFileMapping.ps1`

- An inaccessible database now builds its mapping from `Get-DbaDbFile` rather than being skipped. No second implementation of the fallback.

Two defects found while working in this file and fixed here:

- The compatibility-level probe interpolated the database name into a string comparison. A name containing an apostrophe made it throw, and the `catch` silently degraded the command to the SQL Server 2000 query shape - so the caller got a valid-looking object with `NumberOfDiskReads`, `VolumeFreeSpace` and the filegroup columns missing, and no warning. It now looks the database up by `database_id`. Regression test included.
- The `xp_fixeddrives` here-string was the file's last single-quoted string. Its body contains no `$` and no backtick, so the expandable form is byte-identical at 341 characters; verified by comparing both forms directly.

## What this change does not touch, and why

The accessible-database path is unchanged, including the `xp_fixeddrives` volume-space branch.

Four sibling commands have the same "skip if inaccessible" behaviour. None of them can be fixed the same way, because what they read does not exist outside an open database:

- `public/Get-DbaDbFileGroup.ps1:122` gates on `$db.IsAccessible` and skips at `:145`. It reads `$db.Filegroups` and emits SMO `FileGroup` objects through `Select-DefaultView`. `sys.master_files` carries no filegroup name, type or status - only `data_space_id`. Filegroup names live in `sys.filegroups`, a database-scoped catalog view. Reproducing this from master would mean emitting a different object type, which changes the command's output contract.
- `public/Get-DbaDbSpace.ps1:187` warns and continues. Its query uses `FILEPROPERTY(name, 'SpaceUsed')`, which by definition resolves against the current database and returns NULL for anything else. There is no server-wide equivalent, so used space inside a file cannot be read without opening the database.
- `public/Get-DbaDbLogSpace.ps1:108` filters with `Where-Object IsAccessible`. It needs `sys.dm_db_log_space_usage`, a database-scoped DMV, or `DBCC SQLPERF(LOGSPACE)`. Log space consumption is runtime state of an open database; for a database mid-restore the value does not exist rather than being merely unreachable.
- `public/Get-DbaDbVirtualLogFile.ps1:117` filters the same way and runs `DBCC LOGINFO` at `:132`, which reads VLF headers through the database's log manager and requires the database to be open. The log of a restoring database is held by the restore.

Two output properties are deliberately left reporting what master says, and are documented in `.OUTPUTS`:

- `State` and `IsOffline` describe the file, not the database. `sys.master_files` reports the files of an OFFLINE database as ONLINE.
- `Size` in the fallback is the size recorded in master. For an accessible database it comes from `sys.dm_io_virtual_file_stats` where available, so the two differ for sparse files, snapshots and FILESTREAM containers.

## Testing

Run against a live SQL Server 2022 instance (16.0.1000.6): **27 passed, 0 failed**.

`tests/Get-DbaDbFile.Tests.ps1` - a new `Databases that cannot be opened` context covering a NORECOVERY restore and an offline database:

- files are returned for a database in NORECOVERY, with `State` = `RESTORING`
- the physical names are the ones the restore created, the logical names are the source's
- the offline database's output matches, property for property, what the same database returned while it was still online
- the property list and order are identical to an accessible database's
- all twelve unavailable properties are null, anchored on a non-null `LogicalName` so the assertion cannot pass on an empty result
- no warning is raised
- `-FileGroup` warns and returns nothing
- a whole-instance scan still returns the accessible databases and now includes the inaccessible ones

plus a `Database names that contain an apostrophe` context for the version-probe fix.

`tests/Get-DbaDbFileMapping.Tests.ps1` - the mapping built while the database is in NORECOVERY is asserted equal to the mapping SMO builds for the very same files once the database is recovered.

These are regression tests, not just coverage: run against the current `development` code, 14 of them fail.

### SQL Server 2000 coverage

The `$sqlMasterFiles2000` branch at `public/Get-DbaDbFile.ps1:246` is dispatched at `:291` only when `$server.VersionMajor -le 8`. That dispatch is not covered: it needs an instance reporting version 8, and CI provisions the `dbatools1`/`dbatools2` Linux containers (`private/testing/Get-TestConfig.ps1:64-66`), which SQL Server 2000 has no build for.

The query itself is covered. `master.dbo.sysaltfiles` still resolves on SQL Server 2022, so the test pulls the shipped query text out of the command's own AST, executes it against the database left in NORECOVERY, and compares all ten stable columns row for row against the `sys.master_files` query it stands in for. That covers the column names and the status-bit arithmetic, which is where this query realistically breaks. Row counts are asserted at 2 on both sides so the comparison cannot pass on empty sets.

What remains uncovered is therefore the version dispatch itself, not the SQL.
