### PR TITLE
Get-DbaUnusedLogin - Match the login name case-sensitively when reading last login time

### DIFF
--- a/public/Get-DbaUnusedLogin.ps1
+++ b/public/Get-DbaUnusedLogin.ps1
@@ -267,7 +267,10 @@ function Get-DbaUnusedLogin {
                     continue
                 }
 
-                $loginTime = $loginTimes | Where-Object login_name -eq $currentLogin.Name | Select-Object -ExpandProperty login_time
+                # -ceq, not -eq: an instance with a case-sensitive server collation can hold both "Bob" and "bob",
+                # and a case-insensitive match returns a row for each. That hands an array to the [DbaDateTime]
+                # cast below, which throws, so the whole instance fails over two logins that differ only in case.
+                $loginTime = $loginTimes | Where-Object { $PSItem.login_name -ceq $currentLogin.Name } | Select-Object -ExpandProperty login_time
                 if ($loginTime) {
                     $lastLogin = [DbaDateTime]$loginTime
                 } else {


### PR DESCRIPTION
Closes the review round on `Get-DbaUnusedLogin`, the command requested in #8477.

### Context

The command itself landed on `development` in 52e19b13c, pushed directly rather than through a pull request, so it never got a review pass and the issue was never linked. This PR carries the one finding from the external review that the pushed version does not already contain.

### Problem

`LastLogin` is read by filtering the `sys.dm_exec_sessions` rows for the current login:

```powershell
$loginTime = $loginTimes | Where-Object login_name -eq $currentLogin.Name | ...
```

`-eq` is case-insensitive. An instance with a case-sensitive server collation can hold both `Bob` and `bob` as separate logins, so that filter returns a row for each. The two-element array is then handed to the `[DbaDateTime]` cast on the next line, which throws:

```
Cannot convert the "System.Object[]" value of type "System.Object[]" to type "Dataplat.Dbatools.Utility.DbaDateTime".
```

The command dies on an otherwise healthy instance because two of its logins differ only in case. Verified both halves locally: the cast does throw on a two-element array, and `-eq` matches 2 rows where `-ceq` matches 1.

### What changed

One line, `-eq` to `-ceq`, plus a comment saying why. The role-membership and SID lookups in the same command already use ordinal comparison, so this brings the third lookup in line with the other two rather than introducing a new convention.

### What deliberately did not change

- **The query itself.** It stays byte-identical to the one in `Get-DbaLogin`, including `login_name` rather than `original_login_name`, so `LastLogin` means the same thing in both commands. Attributing an `EXECUTE AS` session to the original login would be more precise in isolation but would make the two commands disagree.
- **The `-in` filters on `Login` and `ExcludeLogin`.** Those stay case-insensitive, which is how every other dbatools command treats a name the user typed.

### Testing

`Invoke-ManualPester -Path Get-DbaUnusedLogin -TestIntegration` against a real SQL 2022 instance: **19 passed, 0 failed**, unchanged from before the fix.

No test reproduces the case-sensitive condition. Login names follow the server collation, so demonstrating it needs an instance with a case-sensitive server collation; both lab instances are `SQL_Latin1_General_CP1_CI_AS` and cannot hold `Bob` and `bob` at once. Flagging that rather than adding a test that cannot fail for the old behaviour.

### Credit

@ddraillantclark raised #8477 and specified the behaviour; @wsmelton, @ClaudioESSilva and @potatoqualitee settled the name and the property set in that thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
