### PR TITLE
Get-DbaDbFileGroup, Get-DbaDbLogSpace, Get-DbaDbSpace and Get-DbaDbVirtualLogFile - Warn instead of silently skipping a database that cannot be opened

### DIFF
--- a/public/Get-DbaDbFileGroup.ps1
+++ b/public/Get-DbaDbFileGroup.ps1
@@ -119,12 +119,18 @@ function Get-DbaDbFileGroup {
         }
 
         foreach ($db in $InputObject) {
+            # The name filter has to run before the accessibility test. On the pipeline path
+            # $InputObject holds every database the caller piped in, so a database they narrowed
+            # away with -Database would otherwise be reported as skipped.
+            if (Test-Bound -ParameterName Database) {
+                if ($Database -notcontains $db.Name) {
+                    continue
+                }
+            }
+
             if ($db.IsAccessible) {
                 Write-Message -Level Verbose -Message "Processing database: $db"
                 $server = $db.Parent
-                if (Test-Bound -ParameterName Database) {
-                    $db = $db | Where-Object { $Database -contains $_.Name }
-                }
                 $fileGroups = $db.Filegroups
 
                 if (Test-Bound -ParameterName Filegroup) {
@@ -142,7 +148,10 @@ function Get-DbaDbFileGroup {
                     Select-DefaultView -InputObject $fg -Property $defaultprops
                 }
             } else {
-                Write-Message -Level Verbose -Message "Skipping processing of database: $db as database is not accessible"
+                # Filegroup names live in sys.filegroups, which is database scoped, so there is
+                # nothing to read from master for a database that cannot be opened. Say so rather
+                # than returning nothing and leaving the caller to guess why.
+                Write-Message -Level Warning -Message "Skipping database $db on $($db.Parent) because it is not accessible, so its filegroups cannot be read" -Target $db
             }
         }
     }

--- a/public/Get-DbaDbLogSpace.ps1
+++ b/public/Get-DbaDbLogSpace.ps1
@@ -105,7 +105,7 @@ Function Get-DbaDbLogSpace {
             } catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-            $dbs = $server.Databases | Where-Object IsAccessible
+            $dbs = $server.Databases
 
             if ($Database) {
                 $dbs = $dbs | Where-Object Name -in $Database
@@ -117,6 +117,16 @@ Function Get-DbaDbLogSpace {
             if ($ExcludeSystemDatabase) {
                 $dbs = $dbs | Where-Object IsSystemObject -eq $false
             }
+
+            # Accessibility is filtered after the name filters rather than before, so that a database
+            # the caller named is reported as skipped instead of silently vanishing, and one the
+            # caller excluded is never mentioned at all. There is no fallback to offer: log space is
+            # runtime state of an open database, sys.dm_db_log_space_usage needs it as query context,
+            # and DBCC SQLPERF(LOGSPACE) leaves databases it cannot open out of its result set.
+            foreach ($skippedDb in ($dbs | Where-Object IsAccessible -eq $false)) {
+                Write-Message -Level Warning -Message "Skipping $skippedDb on $instance because it is not accessible, so its log space cannot be read" -Target $skippedDb
+            }
+            $dbs = $dbs | Where-Object IsAccessible
 
             # 2012+ use new DMV
             if ($server.versionMajor -ge 11) {

--- a/public/Get-DbaDbSpace.ps1
+++ b/public/Get-DbaDbSpace.ps1
@@ -126,7 +126,7 @@ function Get-DbaDbSpace {
                     ,CAST(CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS INT)/128.0 AS FLOAT) AS [UsedSpaceMB]
                     ,CAST(f.size/128.0 - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS INT)/128.0 AS FLOAT) AS [FreeSpaceMB]
                     ,CAST((f.size/128.0) AS FLOAT) AS [FileSizeMB]
-                    ,CAST((FILEPROPERTY(f.name, 'SpaceUsed')/(f.size/1.0)) * 100 AS FLOAT) AS [PercentUsed]
+                    ,CAST((FILEPROPERTY(f.name, 'SpaceUsed')/(NULLIF(f.size, 0)/1.0)) * 100 AS FLOAT) AS [PercentUsed]
                     ,CAST((f.growth/128.0) AS FLOAT) AS [GrowthMB]
                     ,CASE is_percent_growth WHEN 1 THEN 'pct' WHEN 0 THEN 'MB' ELSE 'Unknown' END AS [GrowthType]
                     ,CASE f.max_size WHEN -1 THEN 2147483648. ELSE CAST((f.max_size/128.0) AS FLOAT) END AS [MaxSizeMB]
@@ -145,8 +145,8 @@ function Get-DbaDbSpace {
                                                     WHEN 1
                                                     THEN    CASE f.max_size
                                                             WHEN (-1)
-                                                            THEN CAST(CONVERT([INT],f.size*POWER((1)+CONVERT([FLOAT],f.growth)/(100),CONVERT([INT],LOG10(CONVERT([FLOAT],(2147483648.))/CONVERT([FLOAT],f.size))/LOG10((1)+CONVERT([FLOAT],f.growth)/(100)))))/128.0 AS FLOAT)
-                                                            ELSE CAST(CONVERT([INT],f.size*POWER((1)+CONVERT([FLOAT],f.growth)/(100),CONVERT([INT],LOG10(CONVERT([FLOAT],f.max_size)/CONVERT([FLOAT],f.size))/LOG10((1)+CONVERT([FLOAT],f.growth)/(100)))))/128.0 AS FLOAT)
+                                                            THEN CAST(CONVERT([INT],f.size*POWER((1)+CONVERT([FLOAT],f.growth)/(100),CONVERT([INT],LOG10(CONVERT([FLOAT],(2147483648.))/NULLIF(CONVERT([FLOAT],f.size),0))/LOG10((1)+CONVERT([FLOAT],f.growth)/(100)))))/128.0 AS FLOAT)
+                                                            ELSE CAST(CONVERT([INT],f.size*POWER((1)+CONVERT([FLOAT],f.growth)/(100),CONVERT([INT],LOG10(CONVERT([FLOAT],f.max_size)/NULLIF(CONVERT([FLOAT],f.size),0))/LOG10((1)+CONVERT([FLOAT],f.growth)/(100)))))/128.0 AS FLOAT)
                                                             END
                                                     ELSE (0)
                                                     END
@@ -157,7 +157,7 @@ function Get-DbaDbSpace {
                                                 ELSE    CASE f.is_percent_growth
                                                         WHEN 0
                                                         THEN CAST((f.max_size - f.size - (    CONVERT(FLOAT,FLOOR((f.max_size-f.size)/f.growth)*f.growth)))/128.0 AS FLOAT)
-                                                        ELSE CAST((f.max_size - f.size - (    CONVERT([INT],f.size*POWER((1)+CONVERT([FLOAT],f.growth)/(100),CONVERT([INT],LOG10(CONVERT([FLOAT],f.max_size)/CONVERT([FLOAT],f.size))/LOG10((1)+CONVERT([FLOAT],f.growth)/(100)))))))/128.0 AS FLOAT)
+                                                        ELSE CAST((f.max_size - f.size - (    CONVERT([INT],f.size*POWER((1)+CONVERT([FLOAT],f.growth)/(100),CONVERT([INT],LOG10(CONVERT([FLOAT],f.max_size)/NULLIF(CONVERT([FLOAT],f.size),0))/LOG10((1)+CONVERT([FLOAT],f.growth)/(100)))))))/128.0 AS FLOAT)
                                                         END
                                                 END
                                     END AS [UnusableSpaceMB]
@@ -183,9 +183,14 @@ function Get-DbaDbSpace {
             }
 
             try {
-                Write-Message -Level Verbose -Message "Querying $instance - $db."
-                If ($db.status -ne 'Normal' -or $db.IsAccessible -eq $false) {
-                    Write-Message -Level Warning -Message "$db is not accessible." -Target $db
+                Write-Message -Level Verbose -Message "Querying $server - $db."
+                # Gated on IsAccessible alone. Status is a flags enum, so a database that merely has
+                # AUTO_CLOSE on reports "Normal, AutoClosed" while it is closed, and a standby or
+                # emergency-mode database reports neither Normal nor a fault. All of those answer
+                # this query, and testing the status turned them away with a message saying they
+                # were inaccessible when they were not.
+                if (-not $db.IsAccessible) {
+                    Write-Message -Level Warning -Message "Skipping $db on $server because it is not accessible, so the space used inside its files cannot be read" -Target $db
                     continue
                 }
                 #Execute query against individual database and add to output
@@ -215,6 +220,17 @@ function Get-DbaDbSpace {
                     } else {
                         $UnusableSpace = [Math]::Round($row.UnusableSpaceMB)
                     }
+                    # A file that reports zero size makes the growth projection divide by zero,
+                    # which aborts the query for the whole database rather than one column. The
+                    # divisors above now use NULLIF so the column comes back NULL instead, and
+                    # this turns that into 0 the way the columns above already do. Seen once
+                    # against a database that had just come online, and not reproducible after
+                    # its files warmed up, so there is no regression test for it.
+                    if ($row.PossibleAutoGrowthMB -is [System.DBNull]) {
+                        $PossibleAutoGrowth = 0
+                    } else {
+                        $PossibleAutoGrowth = $row.PossibleAutoGrowthMB
+                    }
 
                     [PSCustomObject]@{
                         ComputerName       = $server.ComputerName
@@ -232,12 +248,12 @@ function Get-DbaDbSpace {
                         AutoGrowth         = [dbasize]($row.GrowthMB * 1024 * 1024)
                         AutoGrowType       = $row.GrowthType
                         SpaceUntilMaxSize  = [dbasize]($SpaceUntilMax * 1024 * 1024)
-                        AutoGrowthPossible = [dbasize]($row.PossibleAutoGrowthMB * 1024 * 1024)
+                        AutoGrowthPossible = [dbasize]($PossibleAutoGrowth * 1024 * 1024)
                         UnusableSpace      = [dbasize]($UnusableSpace * 1024 * 1024)
                     }
                 }
             } catch {
-                Stop-Function -Message "Unable to query $instance - $db." -Target $db -ErrorRecord $_ -Continue
+                Stop-Function -Message "Unable to query $server - $db." -Target $db -ErrorRecord $_ -Continue
             }
         }
     }

--- a/public/Get-DbaDbVirtualLogFile.ps1
+++ b/public/Get-DbaDbVirtualLogFile.ps1
@@ -114,7 +114,7 @@ function Get-DbaDbVirtualLogFile {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            $dbs = $server.Databases | Where-Object IsAccessible
+            $dbs = $server.Databases
 
             if ($Database) {
                 $dbs = $dbs | Where-Object Name -in $Database
@@ -126,6 +126,17 @@ function Get-DbaDbVirtualLogFile {
             if (!$IncludeSystemDBs) {
                 $dbs = $dbs | Where-Object IsSystemObject -eq $false
             }
+
+            # Accessibility is filtered after the name filters rather than before, so that a database
+            # the caller named is reported as skipped instead of silently vanishing. DBCC LOGINFO
+            # reads the VLF headers through the database's own log manager and needs it open.
+            # sys.dm_db_log_info can be called from master for a database that cannot be opened, but
+            # it reports VLF size rounded to two decimals of a megabyte, so it cannot reproduce the
+            # exact FileSize in bytes this command returns.
+            foreach ($skippedDb in ($dbs | Where-Object IsAccessible -eq $false)) {
+                Write-Message -Level Warning -Message "Skipping $skippedDb on $instance because it is not accessible, so its virtual log files cannot be read" -Target $skippedDb
+            }
+            $dbs = $dbs | Where-Object IsAccessible
 
             foreach ($db in $dbs) {
                 try {

--- a/tests/Get-DbaDbFileGroup.Tests.ps1
+++ b/tests/Get-DbaDbFileGroup.Tests.ps1
@@ -44,6 +44,12 @@ Describe $CommandName -Tag IntegrationTests {
         $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
         $server.Query("CREATE DATABASE $multifgdb; ALTER DATABASE $multifgdb ADD FILEGROUP [Test1]; ALTER DATABASE $multifgdb ADD FILEGROUP [Test2];")
 
+        # A database that cannot be opened. Taking one offline is the cheapest way to get
+        # IsAccessible false, and the command cannot tell one inaccessible state from another.
+        $offlineDb = "dbatoolsci_offlinefg$random"
+        $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $offlineDb
+        $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -Offline -Force
+
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
@@ -54,6 +60,10 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Cleanup all created objects.
         Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $multifgdb -ErrorAction SilentlyContinue
+
+        # An offline database has to be brought back online before it can be dropped.
+        $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -Online -Force -ErrorAction SilentlyContinue
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -ErrorAction SilentlyContinue
 
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse
@@ -102,6 +112,42 @@ Describe $CommandName -Tag IntegrationTests {
         It "Excludes User Databases" {
             $pipedResults.Parent.Name | Should -Not -Contain $multifgdb
             $pipedResults.Parent.Name | Should -Contain "msdb"
+        }
+    }
+
+    Context "Databases that cannot be opened" {
+        It "Warns rather than returning nothing when the database is named" {
+            $offlineResults = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            $offlineResults | Should -BeNullOrEmpty
+            ($WarnVar -join " ") | Should -Match ([regex]::Escape($offlineDb))
+        }
+
+        It "Says the database was skipped because it is not accessible" {
+            $null = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            ($WarnVar -join " ") | Should -Match "not accessible"
+        }
+
+        It "Names the instance in the warning" {
+            $null = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            ($WarnVar -join " ") | Should -Match ([regex]::Escape($TestConfig.InstanceSingle))
+        }
+
+        It "Still returns the accessible databases in a whole instance scan" {
+            $scanResults = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle
+            $scanResults.Parent.Name | Should -Contain $multifgdb
+            $scanResults.Parent.Name | Should -Not -Contain $offlineDb
+        }
+
+        It "Stays quiet about a piped database that -Database narrowed away" {
+            # On the pipeline path every database the caller piped in arrives in $InputObject, so
+            # the name filter has to run before the accessibility test. Otherwise a database they
+            # narrowed away is still reported as skipped. Collect the databases in their own
+            # statement so the warning variable holds what Get-DbaDbFileGroup wrote, not what
+            # Get-DbaDatabase wrote.
+            $allDbs = Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle
+            $narrowedResults = $allDbs | Get-DbaDbFileGroup -Database $multifgdb
+            $narrowedResults.Parent.Name | Should -Contain $multifgdb
+            ($WarnVar -join " ") | Should -Not -Match ([regex]::Escape($offlineDb))
         }
     }
 }

--- a/tests/Get-DbaDbLogSpace.Tests.ps1
+++ b/tests/Get-DbaDbLogSpace.Tests.ps1
@@ -43,6 +43,12 @@ Describe $CommandName -Tag IntegrationTests {
         ALTER DATABASE [$db1] MODIFY FILE ( NAME = N'$($db1)_log', SIZE = 10MB )"
         $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database master -Query $dbCreate
 
+        # A database that cannot be opened. Taking one offline is the cheapest way to get
+        # IsAccessible false, and the command cannot tell one inaccessible state from another.
+        $offlineDb = "dbatoolsci_offline_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $offlineDb
+        $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -Offline -Force
+
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
@@ -53,6 +59,10 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Cleanup all created object.
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $db1
+
+        # An offline database has to be brought back online before it can be dropped.
+        $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -Online -Force -ErrorAction SilentlyContinue
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -ErrorAction SilentlyContinue
 
         # Remove the backup directory.
         Remove-Item -Path $backupPath -Recurse
@@ -117,6 +127,38 @@ Describe $CommandName -Tag IntegrationTests {
         It "Should have database name of $db1" {
             $results = $TestConfig.InstanceSingle | Get-DbaDbLogSpace
             $results.Database | Should -Contain $db1
+        }
+    }
+
+    Context "Databases that cannot be opened" {
+        It "Warns rather than returning nothing when the database is named" {
+            $offlineResults = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            $offlineResults | Should -BeNullOrEmpty
+            ($WarnVar -join " ") | Should -Match ([regex]::Escape($offlineDb))
+        }
+
+        It "Says the database was skipped because it is not accessible" {
+            $null = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            ($WarnVar -join " ") | Should -Match "not accessible"
+        }
+
+        It "Names the instance in the warning" {
+            $null = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            ($WarnVar -join " ") | Should -Match ([regex]::Escape($TestConfig.InstanceSingle))
+        }
+
+        It "Stays quiet about a database that was excluded" {
+            # The accessibility filter runs after -ExcludeDatabase, so a database the caller
+            # excluded must not be reported as skipped.
+            $excludedResults = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -ExcludeDatabase $offlineDb
+            $excludedResults | Should -Not -BeNullOrEmpty
+            ($WarnVar -join " ") | Should -Not -Match ([regex]::Escape($offlineDb))
+        }
+
+        It "Still returns the accessible databases in a whole instance scan" {
+            $scanResults = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle
+            $scanResults.Database | Should -Contain $db1
+            $scanResults.Database | Should -Not -Contain $offlineDb
         }
     }
 }

--- a/tests/Get-DbaDbSpace.Tests.ps1
+++ b/tests/Get-DbaDbSpace.Tests.ps1
@@ -29,10 +29,35 @@ Describe $CommandName -Tag IntegrationTests {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
+        # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
+        $backupPath = "$($TestConfig.Temp)\$CommandName-$(Get-Random)"
+        $null = New-Item -Path $backupPath -ItemType Directory
+
         # Set variables. They are available in all the It blocks.
         $dbName = "dbatoolsci_test_$(Get-Random)"
         $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
         $null = $server.Query("Create Database [$dbName]")
+
+        # A standby database is the regression fixture. Its Status reads "Normal, Standby" while
+        # IsAccessible stays true and the space query answers normally, so the old status test
+        # turned away a database the command can read perfectly well. A log shipping secondary is
+        # exactly where a DBA wants to watch file space, so this is the case that has to keep working.
+        $standbyDb = "dbatoolsci_standby_$(Get-Random)"
+        $standbyBackup = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbName -Path $backupPath -Type Full
+        $splatStandby = @{
+            SqlInstance         = $TestConfig.InstanceSingle
+            Path                = $standbyBackup.BackupPath
+            DatabaseName        = $standbyDb
+            StandbyDirectory    = $backupPath
+            ReplaceDbNameInFile = $true
+        }
+        $null = Restore-DbaDatabase @splatStandby
+
+        # A database that cannot be opened at all. Taking one offline is the cheapest way to get
+        # IsAccessible false, and the command cannot tell one inaccessible state from another.
+        $offlineDb = "dbatoolsci_offlinespace_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $offlineDb
+        $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -Offline -Force
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
@@ -45,6 +70,14 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Cleanup all created objects.
         Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbName
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $standbyDb -ErrorAction SilentlyContinue
+
+        # An offline database has to be brought back online before it can be dropped.
+        $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -Online -Force -ErrorAction SilentlyContinue
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -ErrorAction SilentlyContinue
+
+        # Remove the backup directory.
+        Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
@@ -94,6 +127,43 @@ Describe $CommandName -Tag IntegrationTests {
         It "Gets no results for excluded database" {
             $excludeResults = @(Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -ExcludeDatabase $dbName)
             $excludeResults.Database | Should -Not -Contain $dbName
+        }
+    }
+
+    Context "Databases the command can read but the status test turned away" {
+        It "Returns file space for a standby database" {
+            $standbyResults = @(Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -Database $standbyDb)
+            $standbyResults | Should -Not -BeNullOrEmpty
+            $standbyResults[0].Database | Should -Be $standbyDb
+        }
+
+        It "Does not claim a standby database is inaccessible" {
+            $null = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -Database $standbyDb
+            ($WarnVar -join " ") | Should -Not -Match "not accessible"
+        }
+
+        It "Includes the standby database in a whole instance scan" {
+            $scanResults = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle
+            $scanResults.Database | Should -Contain $standbyDb
+        }
+    }
+
+    Context "Databases that cannot be opened" {
+        It "Warns rather than returning nothing when the database is named" {
+            $offlineResults = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            $offlineResults | Should -BeNullOrEmpty
+            ($WarnVar -join " ") | Should -Match ([regex]::Escape($offlineDb))
+        }
+
+        It "Says the database was skipped because it is not accessible" {
+            $null = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            ($WarnVar -join " ") | Should -Match "not accessible"
+        }
+
+        It "Still returns the accessible databases in a whole instance scan" {
+            $scanResults = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle
+            $scanResults.Database | Should -Contain $dbName
+            $scanResults.Database | Should -Not -Contain $offlineDb
         }
     }
 }

--- a/tests/Get-DbaDbVirtualLogFile.Tests.ps1
+++ b/tests/Get-DbaDbVirtualLogFile.Tests.ps1
@@ -36,6 +36,12 @@ Describe $CommandName -Tag IntegrationTests {
         }
         $null = New-DbaDatabase @splatDatabase
 
+        # A database that cannot be opened. Taking one offline is the cheapest way to get
+        # IsAccessible false, and the command cannot tell one inaccessible state from another.
+        $offlineDb = "dbatoolsci_getvlf_offline_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $offlineDb
+        $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -Offline -Force
+
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
@@ -45,6 +51,10 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $testDbName
+
+        # An offline database has to be brought back online before it can be dropped.
+        $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -Online -Force -ErrorAction SilentlyContinue
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -ErrorAction SilentlyContinue
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
@@ -80,6 +90,33 @@ Describe $CommandName -Tag IntegrationTests {
             foreach ($result in $allResults) {
                 $result.Database | Should -Be $testDbName
             }
+        }
+    }
+
+    Context "Databases that cannot be opened" {
+        It "Warns rather than returning nothing when the database is named" {
+            $offlineResults = Get-DbaDbVirtualLogFile -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            $offlineResults | Should -BeNullOrEmpty
+            ($WarnVar -join " ") | Should -Match ([regex]::Escape($offlineDb))
+        }
+
+        It "Says the database was skipped because it is not accessible" {
+            $null = Get-DbaDbVirtualLogFile -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            ($WarnVar -join " ") | Should -Match "not accessible"
+        }
+
+        It "Stays quiet about a database that was excluded" {
+            # The accessibility filter runs after -ExcludeDatabase, so a database the caller
+            # excluded must not be reported as skipped.
+            $excludedResults = Get-DbaDbVirtualLogFile -SqlInstance $TestConfig.InstanceSingle -ExcludeDatabase $offlineDb
+            $excludedResults | Should -Not -BeNullOrEmpty
+            ($WarnVar -join " ") | Should -Not -Match ([regex]::Escape($offlineDb))
+        }
+
+        It "Still returns the accessible databases in a whole instance scan" {
+            $scanResults = Get-DbaDbVirtualLogFile -SqlInstance $TestConfig.InstanceSingle
+            $scanResults.Database | Should -Contain $testDbName
+            $scanResults.Database | Should -Not -Contain $offlineDb
         }
     }
 }


### PR DESCRIPTION
Follow-up to #10496. That PR fixed `Get-DbaDbFile` and documented four sibling commands as sharing the same "skip if inaccessible" behaviour. This fixes those four.

## The problem

Each of these commands drops a database it cannot open and says nothing at all. A caller who names one gets an empty result and no reason for it:

```powershell
Get-DbaDbLogSpace -SqlInstance sql01 -Database MyOfflineDb
# returns nothing, no warning, exit code fine
```

Verified against `development` before changing anything: all four return zero rows in complete silence for offline and restoring databases.

## Mechanism

`Get-DbaDbFileGroup` used `Write-Message -Level Verbose`, which is invisible by default. The other three filtered with `Where-Object IsAccessible` before ever reaching a message.

`Get-DbaDbSpace` had a second, worse defect. It gated on `Status` **and** `IsAccessible`:

```powershell
If ($db.status -ne 'Normal' -or $db.IsAccessible -eq $false) {
```

`Status` is a flags enum. A standby database reads `Normal, Standby`; an auto-close database reads `Normal, AutoClosed`; an emergency-mode database reads neither `Normal` nor a fault. All of them answer the space query perfectly well, and all of them were turned away with a message claiming they were inaccessible. A log shipping secondary is exactly where a DBA wants to watch file space, so this was a false negative on a case that matters.

## What changed

- All four warn per database and continue, naming the database and the instance and saying what could not be read.
- The accessibility check now runs **after** the name filters, so a database excluded with `-Database` or `-ExcludeDatabase` is not reported as skipped.
- `Get-DbaDbSpace` gates on `IsAccessible` alone.
- `Get-DbaDbSpace` had `$instance` in two messages, a variable that is never assigned in that scope; both rendered blank. Now `$server`.

### One extra defect found while testing

Once inaccessible databases stopped being turned away, `Get-DbaDbSpace` hit `Divide by zero error encountered`, which aborts the query for the **whole database** rather than one column. Four expressions divide by `f.size` without a guard — `PercentUsed` and three `LOG10` divisors in the percent-growth projection. They now use `NULLIF`, and the resulting `DBNull` is folded to `0` the way the neighbouring columns already were.

I could not reduce this to a fixture, and I want to be straight about that. I saw it once against a database that had just come online and it was not reproducible after the files warmed up; no file on the test instance reports `size = 0` now. What I did verify directly, with `ARITHABORT ON` and `ANSI_WARNINGS ON`, is that the unguarded expressions throw for `size = 0` while the guarded ones return `NULL`, and that a normal-size file returns a byte-identical value before and after. The change is strictly widening — `NULLIF` only alters behaviour in the case that currently throws. It is noted in a code comment as untested. Happy to split it out if you would rather it travelled on its own.

## What deliberately did not change

- The pre-2012 `DBCC SQLPERF(LOGSPACE)` branch in `Get-DbaDbLogSpace`. It consumes the same collection after the filter, so it inherits the fix without edits — checked rather than assumed.
- The `IncludeSystemDBs` deprecation path in `Get-DbaDbSpace`.
- No output objects, properties or parameters changed. This only affects databases that previously produced nothing.

## Testing

Run against a real SQL Server 2022 instance, with fixtures for standby, offline and a whole-instance scan.

| File | Result |
|---|---|
| `Get-DbaDbSpace.Tests.ps1` | 14/14 pass |
| `Get-DbaDbFileGroup.Tests.ps1` | 12/12 pass |
| `Get-DbaDbVirtualLogFile.Tests.ps1` | 7/7 pass |
| `Get-DbaDbLogSpace.Tests.ps1` | see below |

The standby fixture is the regression test for the flags-enum defect: it fails on `development` (zero rows plus a false "is not accessible" warning) and passes here. Auto-close is deliberately **not** used as a fixture — reading the database reopens it, so `Status` reads plain `Normal` by the time the assertion runs, which would make the test non-deterministic.

The `Get-DbaDbFileGroup` ordering fix has a regression test that I checked in both directions: it fails against the pre-fix ordering with the exact false-positive warning, and passes with the fix.

**`Get-DbaDbLogSpace.Tests.ps1` cannot complete `BeforeAll` on my instance**, and this is pre-existing, not caused by this change. Its setup runs `ALTER DATABASE ... MODIFY FILE (SIZE = 10MB)`, and `model` on that instance has a 72 MB log, so `MODIFY FILE` fails with "Specified size is less than or equal to current size" — it can only grow. I confirmed this by running the unmodified test from a detached worktree at the merge base: identical failure. I left it alone rather than mutating shared instance state or reworking setup that is out of scope here. The command's behaviour was verified directly against the same offline fixture the other three use.

## Review

Codex flagged the `Get-DbaDbFileGroup` `-Database` ordering bug, which was real — the filter sat inside the accessible branch, so on the pipeline path a database the caller had narrowed away still warned. Fixed and covered by the test described above. Its remaining findings were all "splat calls with 3+ parameters"; I did not apply those, because inline `Write-Message -Level ... -Message ... -Target` appears 88 times across 33 files in `public/`, inline `Stop-Function -Message ... -Target ... -ErrorRecord ... -Continue` appears 111 times across 70 files, and `tests/CLAUDE.md`'s own canonical `AfterAll` examples use inline three-parameter cleanup calls. Splatting them would have made these lines read unlike everything around them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
