### PR TITLE
CI - Rename Azure Codex issue trigger

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,15 @@
+# Configuration for actionlint (https://github.com/rhysd/actionlint).
+# Run the linter locally with .github/scripts/Test-ActionlintWorkflows.ps1
+
+# Labels for the self-hosted Azure VMSS runners. Without these, actionlint flags
+# every "runs-on" that targets our own fleet as an unknown runner label.
+self-hosted-runner:
+  labels:
+    - dbatools-modern
+    # ci-azure.yml builds the pool label dynamically from the triggering user so
+    # each maintainer lane keeps its own workers. Keep this list in sync with the
+    # pool expression in ci-azure.yml.
+    - dbatools-pool-potatoqualitee
+    - dbatools-pool-andreasjordan
+    - dbatools-pool-niphlod
+    - dbatools-pool-community

--- a/.github/scripts/Test-ActionlintWorkflows.ps1
+++ b/.github/scripts/Test-ActionlintWorkflows.ps1
@@ -172,8 +172,13 @@ $ignoreArguments = @(
 
 Write-Host "Running actionlint against $($workflowFiles.Count) workflow file(s)"
 
+# -shellcheck= (empty) turns off the shellcheck integration. actionlint shells out to
+# shellcheck when it is on PATH, which it is on the Ubuntu runners but not on a typical
+# Windows dev box, so leaving it on makes the same commit pass locally and fail in CI.
+# It also only reports style nits (mostly SC2086) about the bash embedded in our
+# integration workflows, which is a separate cleanup from linting workflow syntax.
 # -color is disabled so the output stays readable in CI logs and when redirected.
-$output = & $actionlint -no-color -oneline @ignoreArguments @relativeFiles 2>&1
+$output = & $actionlint -no-color -oneline -shellcheck= @ignoreArguments @relativeFiles 2>&1
 $actionlintExitCode = $LASTEXITCODE
 
 if ($output) {

--- a/.github/scripts/Test-ActionlintWorkflows.ps1
+++ b/.github/scripts/Test-ActionlintWorkflows.ps1
@@ -1,0 +1,187 @@
+[CmdletBinding()]
+param(
+    [string]$WorkflowPath = ".github/workflows",
+    [string]$Version = "1.7.12",
+    [string]$ToolPath
+)
+
+$ErrorActionPreference = "Stop"
+
+# Checksums come from the actionlint release page:
+# https://github.com/rhysd/actionlint/releases/download/v<Version>/actionlint_<Version>_checksums.txt
+# Update both $Version and this table together when bumping actionlint.
+$knownChecksums = @{
+    "1.7.12" = @{
+        "darwin_amd64"  = "5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644"
+        "darwin_arm64"  = "aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f"
+        "linux_386"     = "72a44b32c2d032700e6d0c23ca2f540b67519ec68db098ddfcfa96059e61f723"
+        "linux_amd64"   = "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        "linux_arm64"   = "325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6"
+        "linux_armv6"   = "ae4a0a5227578e66f5d00ee02788d5c64fdae1fa6484ab88ceaeee9359c28fa4"
+        "windows_386"   = "cdc8643b2c8dc890c76ad16095da97e75f86572805cc3573cc13f31ea0f19127"
+        "windows_amd64" = "6e7241b51e6817ea6a047693d8e6fed13b31819c9a0dd6c5a726e1592d22f6e9"
+        "windows_arm64" = "cadcf7ea4efe3a68728893813643cebe1185e5b1d4be5b96245f65c9a4d5ea41"
+    }
+}
+
+$resolvedWorkflowPath = Resolve-Path -LiteralPath $WorkflowPath
+$workflowFiles = Get-ChildItem -LiteralPath $resolvedWorkflowPath -Recurse -File |
+    Where-Object { $PSItem.Extension -in ".yml", ".yaml" }
+
+if (-not $workflowFiles) {
+    throw "No GitHub Actions workflow files found under $WorkflowPath"
+}
+
+function Get-ActionlintPlatform {
+    # $IsWindows only exists on PowerShell 6+. Anything older is Windows PowerShell,
+    # which only ever runs on Windows.
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        $osName = "windows"
+    } elseif ($IsWindows) {
+        $osName = "windows"
+    } elseif ($IsMacOS) {
+        $osName = "darwin"
+    } else {
+        $osName = "linux"
+    }
+
+    $architecture = "$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)".ToLowerInvariant()
+
+    switch ($architecture) {
+        "x64" { $archName = "amd64" }
+        "arm64" { $archName = "arm64" }
+        "x86" { $archName = "386" }
+        "arm" { $archName = "armv6" }
+        default { throw "Unsupported processor architecture for actionlint: $architecture" }
+    }
+
+    [pscustomobject]@{
+        Os        = $osName
+        Arch      = $archName
+        Moniker   = "${osName}_${archName}"
+        Extension = if ($osName -eq "windows") { "zip" } else { "tar.gz" }
+        Binary    = if ($osName -eq "windows") { "actionlint.exe" } else { "actionlint" }
+    }
+}
+
+function Install-Actionlint {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Version
+    )
+
+    $platform = Get-ActionlintPlatform
+    $cacheRoot = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "dbatools-actionlint/$Version/$($platform.Moniker)"
+    $binaryPath = Join-Path -Path $cacheRoot -ChildPath $platform.Binary
+
+    if (Test-Path -LiteralPath $binaryPath) {
+        Write-Verbose "Reusing cached actionlint at $binaryPath"
+        return $binaryPath
+    }
+
+    $versionChecksums = $knownChecksums[$Version]
+    if ($versionChecksums) {
+        $expectedChecksum = $versionChecksums[$platform.Moniker]
+    }
+
+    if (-not $expectedChecksum) {
+        throw "No known checksum for actionlint $Version on $($platform.Moniker). Add it to the `$knownChecksums table in this script, copying the value from https://github.com/rhysd/actionlint/releases/download/v$Version/actionlint_${Version}_checksums.txt"
+    }
+
+    $archiveName = "actionlint_${Version}_$($platform.Moniker).$($platform.Extension)"
+    $downloadUri = "https://github.com/rhysd/actionlint/releases/download/v$Version/$archiveName"
+
+    $null = New-Item -Path $cacheRoot -ItemType Directory -Force
+    $archivePath = Join-Path -Path $cacheRoot -ChildPath $archiveName
+
+    Write-Host "Downloading actionlint $Version for $($platform.Moniker)"
+
+    $splatDownload = @{
+        Uri             = $downloadUri
+        OutFile         = $archivePath
+        UseBasicParsing = $true
+        ErrorAction     = "Stop"
+    }
+    Invoke-WebRequest @splatDownload
+
+    $actualChecksum = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash
+    if ($actualChecksum -ne $expectedChecksum) {
+        Remove-Item -LiteralPath $archivePath -Force -ErrorAction SilentlyContinue
+        throw "Checksum mismatch for $archiveName. Expected $expectedChecksum but got $actualChecksum."
+    }
+
+    if ($platform.Extension -eq "zip") {
+        Expand-Archive -LiteralPath $archivePath -DestinationPath $cacheRoot -Force
+    } else {
+        & tar -xzf $archivePath -C $cacheRoot
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to extract $archivePath"
+        }
+    }
+
+    Remove-Item -LiteralPath $archivePath -Force -ErrorAction SilentlyContinue
+
+    if (-not (Test-Path -LiteralPath $binaryPath)) {
+        throw "actionlint binary was not found at $binaryPath after extraction."
+    }
+
+    if ($platform.Os -ne "windows") {
+        & chmod +x $binaryPath
+    }
+
+    $binaryPath
+}
+
+if ($ToolPath) {
+    if (-not (Test-Path -LiteralPath $ToolPath)) {
+        throw "actionlint was not found at $ToolPath"
+    }
+    $actionlint = (Resolve-Path -LiteralPath $ToolPath).Path
+} else {
+    $actionlint = Install-Actionlint -Version $Version
+}
+
+# Wrap in @() so a single workflow file stays an array. Splatting a bare string
+# passes it one character at a time, which makes actionlint try to read "." as a file.
+$relativeFiles = @(
+    foreach ($file in $workflowFiles) {
+        Resolve-Path -LiteralPath $file.FullName -Relative
+    }
+)
+
+# Rules actionlint gets wrong for this repository. Each entry needs a reason so we
+# can retire it once the linter (or the workflow) catches up. These are regular
+# expressions matched against the message text, so "." stands in for the literal
+# double quotes actionlint puts around the offending key.
+$ignoredPatterns = @(
+    # GitHub added "queue" to the concurrency block in May 2026 so a group can hold
+    # up to 100 pending runs. ci-azure.yml relies on it for AppVeyor-style FIFO
+    # lanes. actionlint 1.7.12 predates the key. Drop this once actionlint knows it.
+    "unexpected key .queue. for .concurrency. section",
+    # integration-tests.yml intentionally parks the windows-tests job behind
+    # "if: false" rather than deleting it, so the constant condition is deliberate.
+    "constant expression .false. in condition"
+)
+
+$ignoreArguments = @(
+    foreach ($pattern in $ignoredPatterns) {
+        "-ignore"
+        $pattern
+    }
+)
+
+Write-Host "Running actionlint against $($workflowFiles.Count) workflow file(s)"
+
+# -color is disabled so the output stays readable in CI logs and when redirected.
+$output = & $actionlint -no-color -oneline @ignoreArguments @relativeFiles 2>&1
+$actionlintExitCode = $LASTEXITCODE
+
+if ($output) {
+    $output | ForEach-Object { Write-Host $PSItem }
+}
+
+if ($actionlintExitCode -ne 0) {
+    throw "actionlint reported problems in the GitHub Actions workflows."
+}
+
+Write-Host "All GitHub Actions workflows passed actionlint."

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -13,7 +13,7 @@ jobs:
     if: |
       github.event.issue.pull_request == null &&
       contains(fromJSON('["potatoqualitee","niphlod","andreasjordan"]'), github.actor) &&
-      contains(github.event.comment.body, '@codex')
+      contains(github.event.comment.body, 'azure-codex')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/github-actions-security.yml
+++ b/.github/workflows/github-actions-security.yml
@@ -3,7 +3,9 @@ name: GitHub Actions Security
 on:
   pull_request:
     paths:
+      - ".github/actionlint.yaml"
       - ".github/dependabot.yml"
+      - ".github/scripts/Test-ActionlintWorkflows.ps1"
       - ".github/scripts/Test-GitHubActionsPins.ps1"
       - ".github/workflows/**"
   push:
@@ -12,7 +14,9 @@ on:
     tags-ignore:
       - "**"
     paths:
+      - ".github/actionlint.yaml"
       - ".github/dependabot.yml"
+      - ".github/scripts/Test-ActionlintWorkflows.ps1"
       - ".github/scripts/Test-GitHubActionsPins.ps1"
       - ".github/workflows/**"
   workflow_dispatch:
@@ -36,3 +40,15 @@ jobs:
       - name: Verify action refs
         shell: pwsh
         run: ./.github/scripts/Test-GitHubActionsPins.ps1
+
+  actionlint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run actionlint
+        shell: pwsh
+        run: ./.github/scripts/Test-ActionlintWorkflows.ps1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,7 @@ A few notes:
 - If actionlint reports something that is intentional in our workflows, add it to `$ignoredPatterns` in the script **with a comment explaining why**, rather than reshaping the workflow to satisfy the linter.
 - To bump actionlint, update `$Version` and the matching `$knownChecksums` entry together. The checksums come from that release's `checksums.txt`.
 - Already have actionlint installed? Skip the download with `-ToolPath`.
+- The shellcheck integration is turned off. actionlint runs shellcheck against the bash embedded in `run:` steps whenever shellcheck is on `PATH`, which is true on the Ubuntu runners but not on a typical Windows dev box, so leaving it on meant the same commit passed locally and failed in CI. Cleaning up those findings (mostly SC2086 in the integration workflows) is worth doing on its own.
 
 ## Pester 🧪
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,23 @@ We 💘 OTBS with this project. Contributors will find an easier experience with
 
 **We do have a Pester test that will validate the format of the file in any Pull Request.**
 
+## GitHub Actions Workflows ⚙️
+
+If your pull request touches anything under `.github/workflows`, check it locally before you push:
+
+```powershell
+./.github/scripts/Test-ActionlintWorkflows.ps1
+```
+
+This downloads [actionlint](https://github.com/rhysd/actionlint) for your platform (verifying it against a pinned SHA256 checksum, then caching it under your temp directory) and lints every workflow file. The same script runs in the **GitHub Actions Security** workflow, alongside `Test-GitHubActionsPins.ps1`, which enforces that every `uses:` reference is pinned to a full 40-character commit SHA.
+
+A few notes:
+
+- Custom self-hosted runner labels live in `.github/actionlint.yaml`. Add new ones there or actionlint will flag the `runs-on:` that uses them.
+- If actionlint reports something that is intentional in our workflows, add it to `$ignoredPatterns` in the script **with a comment explaining why**, rather than reshaping the workflow to satisfy the linter.
+- To bump actionlint, update `$Version` and the matching `$knownChecksums` entry together. The checksums come from that release's `checksums.txt`.
+- Already have actionlint installed? Skip the download with `-ToolPath`.
+
 ## Pester 🧪
 
 Our project uses [Pester](https://pester.dev) for our testing framework. Appveyor runs a matrix of environments that test against various versions of SQL Server. We do have some commands that cannot be tested easily but the majority we use Pester to ensure the code behaves properly. Appveyor runs these tests for each-and-every commit in our repository.


### PR DESCRIPTION
## Summary

- change the restricted Azure-backed issue agent trigger from `@codex` to the bare token `azure-codex`
- leave the official Codex integration and issue-only/allowlist restrictions unchanged

## Usage

Comment `azure-codex please do this` on an ordinary issue from an allowlisted maintainer account.

## Verification

- trigger assertions confirm the bare token is accepted and the custom `@codex` match is absent
- `git diff --check` passes