### PR TITLE
Stop the test heartbeat from failing the stage when the watchdog is reading it

### DIFF
--- a/tests/appveyor.common.Tests.ps1
+++ b/tests/appveyor.common.Tests.ps1
@@ -34,4 +34,49 @@ Describe $CommandName -Tag UnitTests {
             $result.FullName | Should -Contain (Join-Path $PSScriptRoot "dbatools.Tests.ps1")
         }
     }
+
+    Context "Write-TestHeartbeat" {
+        BeforeAll {
+            $heartbeatTempPath = Join-Path ([System.IO.Path]::GetTempPath()) "dbatools-heartbeat-$(Get-Random)"
+            $null = New-Item -Path $heartbeatTempPath -ItemType Directory
+        }
+
+        AfterAll {
+            Remove-Item -Path $heartbeatTempPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        It "writes the tick count and the label" {
+            $heartbeatFile = Join-Path $heartbeatTempPath "plain-$(Get-Random).txt"
+
+            Write-TestHeartbeat -Path $heartbeatFile -Label "Get-DbaBuild.Tests.ps1"
+
+            $heartbeatParts = (Get-Content -Path $heartbeatFile -TotalCount 1) -split "\|", 2
+            $heartbeatParts[1] | Should -Be "Get-DbaBuild.Tests.ps1"
+            [long]$writtenTicks = 0
+            [System.Int64]::TryParse($heartbeatParts[0], [ref]$writtenTicks) | Should -BeTrue
+            $writtenTicks | Should -BeGreaterThan 0
+        }
+
+        It "writes while the watchdog has the file open for reading" {
+            # This is the regression. Set-Content refuses to share the file with a reader that
+            # already has it open, and the watchdog reads this file every few seconds by design.
+            # The collision surfaces as a terminating error that -ErrorAction SilentlyContinue
+            # does not suppress, so one unlucky poll used to fail the entire test stage.
+            $heartbeatFile = Join-Path $heartbeatTempPath "shared-$(Get-Random).txt"
+            Write-TestHeartbeat -Path $heartbeatFile -Label "First.Tests.ps1"
+
+            $watchdogShare = [System.IO.FileShare]::ReadWrite -bor [System.IO.FileShare]::Delete
+            $watchdogStream = [System.IO.File]::Open($heartbeatFile, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, $watchdogShare)
+            try {
+                { Write-TestHeartbeat -Path $heartbeatFile -Label "Second.Tests.ps1" } | Should -Not -Throw
+
+                # And the removal the runner does once the loop ends has to land too, otherwise
+                # the watchdog keeps judging a stale heartbeat against the summary work
+                Remove-Item -Path $heartbeatFile -Force -ErrorAction SilentlyContinue
+                Test-Path -Path $heartbeatFile | Should -BeFalse
+            } finally {
+                $watchdogStream.Dispose()
+            }
+        }
+    }
 }

--- a/tests/appveyor.common.ps1
+++ b/tests/appveyor.common.ps1
@@ -395,6 +395,35 @@ function Get-FunctionNameFromTestFile($testFilePath) {
     return $leaf.Replace(".Tests.ps1", "")
 }
 
+function Write-TestHeartbeat {
+    <#
+        Records the test file the runner is about to run, for appveyor.watchdog.ps1 to read.
+
+        Written by hand rather than with Set-Content because the provider's writer refuses to
+        share the file with a reader that already has it open, and the watchdog reads this file
+        every few seconds by design. That collision surfaces as a TERMINATING error which
+        -ErrorAction SilentlyContinue does not suppress, so it used to fail the whole test
+        stage rather than skip one heartbeat. FileShare.ReadWrite lets the two coexist.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+    param(
+        [string]$Path,
+        [string]$Label
+    )
+
+    $heartbeatStream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite)
+    try {
+        $heartbeatWriter = New-Object -TypeName System.IO.StreamWriter -ArgumentList $heartbeatStream
+        try {
+            $heartbeatWriter.WriteLine("$((Get-Date).Ticks)|$Label")
+        } finally {
+            $heartbeatWriter.Dispose()
+        }
+    } finally {
+        $heartbeatStream.Dispose()
+    }
+}
+
 function Show-DependencyTree {
     # helper function to show the dependency tree for easier debugging
     param (

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -474,12 +474,13 @@ if (-not $Finalize) {
                 Add-AppveyorTest -Name $appvTestName -Framework NUnit -FileName $f.FullName -Outcome Running
                 # Tell the watchdog what is running now, so a wedge is reported against the right file.
                 # Written per attempt, so a retry gets its own budget rather than sharing the first one.
-                $splatHeartbeat = @{
-                    Path        = $heartbeatPath
-                    Value       = "$((Get-Date).Ticks)|$appvTestName"
-                    ErrorAction = "SilentlyContinue"
+                # Caught rather than left to throw, because a missed heartbeat only costs a
+                # little watchdog accuracy while an unhandled throw here fails the whole stage
+                try {
+                    Write-TestHeartbeat -Path $heartbeatPath -Label $appvTestName
+                } catch {
+                    Write-Host -Object "appveyor.pester: could not write the heartbeat. $($PSItem.Exception.Message)" -ForegroundColor Yellow
                 }
-                Set-Content @splatHeartbeat
                 $PesterRun = Invoke-Pester -Configuration $pester5config
                 Write-Host -Object "`rCompleted $($f.FullName) in $([int]$PesterRun.Duration.TotalMilliseconds)ms" -ForegroundColor Cyan
                 $PesterRun | Export-Clixml -Path "$ModuleBase\Pester5Results$PSVersion$Counter.xml"

--- a/tests/appveyor.watchdog.Tests.ps1
+++ b/tests/appveyor.watchdog.Tests.ps1
@@ -198,6 +198,22 @@ Describe $CommandName -Tag UnitTests {
             Wait-ForProcessExit -ProcessId $watchdog.Id -TimeoutSeconds 20 | Should -BeTrue
         }
 
+        It "still reads a heartbeat the runner is holding open" {
+            # The runner keeps a write handle on this file while it records the next test, so a
+            # watchdog that asked for exclusive access would go blind exactly when a run is
+            # active and would never notice the wedge it exists to catch
+            $sacrifice = New-SacrificialProcess
+            $heartbeatFile = New-HeartbeatFile -AgeMinutes 60
+
+            $heldStream = [System.IO.File]::Open($heartbeatFile, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite)
+            try {
+                $null = Start-TestWatchdog -TargetProcessId $sacrifice.Id -HeartbeatFile $heartbeatFile
+                Wait-ForProcessExit -ProcessId $sacrifice.Id | Should -BeTrue
+            } finally {
+                $heldStream.Dispose()
+            }
+        }
+
         It "rejects a timeout outside the supported range" {
             $sacrifice = New-SacrificialProcess
             $heartbeatFile = New-HeartbeatFile -AgeMinutes 0

--- a/tests/appveyor.watchdog.ps1
+++ b/tests/appveyor.watchdog.ps1
@@ -160,13 +160,25 @@ while ($true) {
         continue
     }
 
-    $splatHeartbeat = @{
-        Path        = $HeartbeatPath
-        TotalCount  = 1
-        ErrorAction = "Stop"
-    }
+    # Opened by hand rather than with Get-Content so the sharing mode is stated here instead of
+    # being whatever the provider happens to pick. Delete is the part that matters: the runner
+    # removes this file before its summary work, and a removal that lands while we hold the
+    # file fails silently, which would leave this watchdog judging a stale heartbeat against
+    # whatever runs next. ReadWrite keeps the runner's own rewrites from being denied.
+    $heartbeatShare = [System.IO.FileShare]::ReadWrite -bor [System.IO.FileShare]::Delete
+    $heartbeat = $null
     try {
-        $heartbeat = Get-Content @splatHeartbeat
+        $heartbeatStream = [System.IO.File]::Open($HeartbeatPath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, $heartbeatShare)
+        try {
+            $heartbeatReader = New-Object -TypeName System.IO.StreamReader -ArgumentList $heartbeatStream
+            try {
+                $heartbeat = $heartbeatReader.ReadLine()
+            } finally {
+                $heartbeatReader.Dispose()
+            }
+        } finally {
+            $heartbeatStream.Dispose()
+        }
     } catch {
         # The runner rewrites this file before every test, so a read collision just means retry
         continue


### PR DESCRIPTION
## The failure

```
Error: stage threw: The process cannot access the file
'C:\github\dbatools\pester-heartbeat-5236.txt' because it is being used by another process.
===== stage FAILED: tests\appveyor.pester.ps1 (279s) =====
```

## Root cause

`Set-Content` refuses to share a file with a reader that already has it open, and
`appveyor.watchdog.ps1` reads the heartbeat every few seconds by design. That collision
throws a **terminating** error, which `-ErrorAction SilentlyContinue` does not suppress, so
`Invoke-GhaStage` catches it and exits 1. Nothing to do with the test that happened to be
running when it fired.

## The fix

- The heartbeat write moves into `Write-TestHeartbeat` in `tests/appveyor.common.ps1`,
  opened with `FileShare.ReadWrite` so the watchdog's read cannot deny it. It is wrapped at
  the call site too, because a missed heartbeat costs a little watchdog accuracy while an
  unhandled throw costs the run.
- `appveyor.watchdog.ps1` now opens its read explicitly with `ReadWrite` plus `Delete`. Without
  `Delete`, the `Remove-Item` the runner does before its summary work fails silently during an
  overlap, leaving a stale heartbeat pointed at whatever runs next.

## Verification

- New regression test in `appveyor.common.Tests.ps1` holds a watchdog-shaped read handle and
  asserts the write and the removal both land. It **fails with the old `Set-Content`**,
  reproducing the exact CI message, and passes now.
- New test in `appveyor.watchdog.Tests.ps1` starts the real watchdog against a heartbeat the
  runner is holding open for writing, and asserts it still detects the wedge.
- 13/13 pass across both files. A 5-second race of the two shapes against a live concurrent
  reader: old = 8575 write failures and 50/50 delete failures; new = 0 and 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)