### PR TITLE
CI - Cancel superseded ci-azure runs so the newest head owns the lane (do Get-DbaBuild)

### DIFF
--- a/.github/workflows/ci-azure-supersede.yml
+++ b/.github/workflows/ci-azure-supersede.yml
@@ -1,0 +1,64 @@
+# AppVeyor-style rolling builds for the Azure lanes. ci-azure serializes each pool
+# owner's runs in FIFO order (queue: max) and never cancels a superseded run, so a PR
+# that gets three pushes in half an hour grinds the lane through two dead SHAs before
+# reaching the one that matters. This workflow runs on GitHub-hosted compute OUTSIDE
+# the lane, so it fires the moment a new head lands: it cancels every active ci-azure
+# run for the same branch that is not testing the current head SHA. The paths-ignore
+# list mirrors ci-azure's — a docs-only push gets no new ci-azure run, so cancelling
+# its predecessor would leave the PR with no Azure checks at all.
+name: ci-azure-supersede
+run-name: "supersede stale ci-azure runs for ${{ github.head_ref }}"
+
+on:
+  pull_request:
+    branches:
+      - development
+    paths-ignore:
+      - "**/*.md"
+      - ".github/FUNDING.yml"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - ".aider/**"
+      - ".devcontainer/**"
+      - ".vscode/**"
+      - "en-us/**"
+
+permissions:
+  actions: write
+
+concurrency:
+  group: ci-azure-supersede-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  supersede:
+    # Fork PRs get a read-only token that cannot cancel runs; their lanes keep FIFO.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Cancel ci-azure runs superseded by this head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.head_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          stale=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/ci-azure.yml/runs" \
+            -f branch="$HEAD_BRANCH" -f per_page=50 \
+            --jq '.workflow_runs[]
+              | select(.status == "queued" or .status == "in_progress" or .status == "pending" or .status == "waiting" or .status == "requested")
+              | select(.head_sha != env.HEAD_SHA)
+              | .id')
+          if [ -z "$stale" ]; then
+            echo "No superseded ci-azure runs for $HEAD_BRANCH."
+            exit 0
+          fi
+          for id in $stale; do
+            if gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${id}/cancel" > /dev/null 2>&1; then
+              echo "Cancelled superseded run ${id}."
+            else
+              echo "::warning::Could not cancel run ${id}; it may have just completed."
+            fi
+          done


### PR DESCRIPTION
## The problem

The Azure pool lanes serialize per owner (`queue: max`, FIFO, no `cancel-in-progress`) — fine for human push cadence, but the Codex issue agent now pushes to PR branches every few minutes. Nothing cancels a superseded run, so today the potatoqualitee lane spent 14:19–14:36 testing a SHA that was already three commits stale, while the actual head of #10495 sat `pending` with zero jobs — invisible in the PR's checks, so the merge box read "All checks have passed" without the suite of record.

## The fix

A tiny GitHub-hosted workflow that runs **outside the lane** on every PR push and cancels any active ci-azure run for the same branch that isn't testing the current head SHA. AppVeyor-style rolling builds, with the FIFO lane semantics left untouched.

- Zero `uses:` — pure `gh api` run steps, nothing to pin
- Mirrors ci-azure's `paths-ignore`, so a docs-only push doesn't cancel the run whose results still describe the head's code
- Fork PRs are skipped (read-only token can't cancel anyway); community lanes keep plain FIFO

🤖 Generated with [Claude Code](https://claude.com/claude-code)