### PR TITLE
Run the VMSS runner fleet from an Azure Function instead of a five-minute Actions cron

### DIFF
--- a/.github/runners/ci-trigger.txt
+++ b/.github/runners/ci-trigger.txt
@@ -1,2 +1,2 @@
 ci-azure validation trigger
-run: 6 (FULL SUITE, final config: interactive runners, all parity fixes)
+run: 7 (post-cutover: prove Azure-controller registration end to end)

--- a/.github/runners/controller-infra.ps1
+++ b/.github/runners/controller-infra.ps1
@@ -399,14 +399,38 @@ if ($tickBlockers) {
     $settings += "AzureWebJobs.SafetyTick.Disabled=0"
 }
 
-$splatSettingsArgs = @(
-    "functionapp", "config", "appsettings", "set",
-    "--name", $FunctionAppName,
-    "--resource-group", $ResourceGroup,
-    "--subscription", $SubscriptionId,
-    "--settings"
-) + $settings + @("--output", "none")
-az @splatSettingsArgs --only-show-errors
+# Handed to az in a file rather than on the command line. az is az.cmd on Windows, so
+# every argument is re-parsed by cmd.exe, and a Key Vault reference contains parentheses,
+# which cmd reads as grouping -- it rejects the whole line with "was unexpected at this
+# time". Nothing caught it for two runs because the references only appear once the
+# secrets exist, and the exit code was never read. Microsoft's own guidance for these
+# commands is the same: use a file on Windows to avoid the escaping.
+$settingsPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "dbatools-fleet-settings-$([System.Guid]::NewGuid().ToString("N")).json"
+$settingsForFile = foreach ($setting in $settings) {
+    # Split once: values carry their own = signs, in connection strings and SecretUris alike
+    $settingParts = $setting -split "=", 2
+    [pscustomobject]@{
+        name  = $settingParts[0]
+        value = $settingParts[1]
+    }
+}
+try {
+    [System.IO.File]::WriteAllText($settingsPath, (ConvertTo-Json -InputObject @($settingsForFile)))
+    $splatSettingsArgs = @(
+        "functionapp", "config", "appsettings", "set",
+        "--name", $FunctionAppName,
+        "--resource-group", $ResourceGroup,
+        "--subscription", $SubscriptionId,
+        "--settings", "@$settingsPath",
+        "--output", "none"
+    )
+    az @splatSettingsArgs --only-show-errors
+    if ($LASTEXITCODE -ne 0) {
+        throw "could not write the app settings to $FunctionAppName"
+    }
+} finally {
+    Remove-Item -Path $settingsPath -Force -ErrorAction SilentlyContinue
+}
 
 $splatHostArgs = @(
     "functionapp", "show",

--- a/.github/runners/controller-infra.ps1
+++ b/.github/runners/controller-infra.ps1
@@ -1,0 +1,371 @@
+<#
+.SYNOPSIS
+    Provisions (idempotently) the Azure-native fleet controller that replaces the
+    GitHub-Actions-hosted reconcile workflow.
+
+.DESCRIPTION
+    Creates everything the Function App controller needs, safe to rerun any time:
+
+      - Storage account dbatoolsfleetsa (Functions host storage + the fleet-nudge queue)
+      - Log Analytics workspace + Application Insights (structured pass logs, alerts)
+      - Key Vault dbatools-fleet-kv (RBAC mode) holding the GitHub App private key and
+        the webhook secret -- the two values the controller cannot run without
+      - Function App dbatools-fleet-controller on Flex Consumption (FC1, PowerShell 7.6)
+        with a system-assigned identity, capped at one instance so reconcile passes
+        serialize the way the old runner-fleet concurrency group did
+      - Role assignments for that identity: dbatools-ci-operator on the RG (the same
+        least-privilege role the OIDC app and the janitor already hold) and Key Vault
+        Secrets User on the vault
+      - App settings, including Key Vault references once the secrets exist
+
+    Order of operations: run this first so the Function App exists, hand the operator the
+    GitHub App checklist in .github/runners/README.md, then rerun with -GitHubAppId and
+    -GitHubInstallationId to finish the wiring. Both runs are safe.
+
+    This script touches only the NEW controller resources. It never modifies the VMSS,
+    the janitor, the OIDC app, or anything the existing fleet path depends on.
+
+.PARAMETER GitHubAppId
+    App ID of the dbatools-fleet-controller GitHub App. Supply on the second run.
+
+.PARAMETER GitHubInstallationId
+    Installation ID of that App on dataplat/dbatools. Supply on the second run.
+
+.PARAMETER DryRun
+    Value for the controller's DRY_RUN app setting. Defaults to true: the controller
+    computes and logs every decision but performs no Azure or GitHub mutation.
+
+.NOTES
+    Author: the dbatools team + Claude
+    Requires: az CLI logged in with Owner rights on the subscription.
+
+.EXAMPLE
+    ./.github/runners/controller-infra.ps1
+
+    First run. Creates all resources; the GitHub App can then point at the webhook.
+
+.EXAMPLE
+    ./.github/runners/controller-infra.ps1 -GitHubAppId 1234567 -GitHubInstallationId 87654321
+
+    Second run, after the App exists and its secrets are in Key Vault. Completes the
+    app settings so the controller can authenticate.
+#>
+param(
+    [string]$SubscriptionId = "fda988ac-f308-440e-ad06-ad1c3f026218",
+    [string]$ResourceGroup = "dbatools-ci",
+    [string]$Location = "eastus",
+    [string]$FunctionAppName = "dbatools-fleet-controller",
+    [string]$StorageAccount = "dbatoolsfleetsa",
+    [string]$KeyVaultName = "dbatools-fleet-kv",
+    [string]$InsightsName = "dbatools-fleet-insights",
+    [string]$WorkspaceName = "dbatools-fleet-logs",
+    [string]$QueueName = "fleet-nudge",
+    [string]$Repo = "dataplat/dbatools",
+    [string]$VmssName = "dbatools-runners",
+    [string]$GitHubAppId,
+    [string]$GitHubInstallationId,
+    [ValidateSet("true", "false")]
+    [string]$DryRun = "true"
+)
+
+$ErrorActionPreference = "Stop"
+# Built-in role: Key Vault Secrets User. Referenced by ID because the display name is
+# localized in some tenants and az matches it literally.
+$keyVaultSecretsUserRoleId = "4633458b-17de-408a-b874-0445c86b69e6"
+$keyVaultSecretsOfficerRoleId = "b86a8fe4-44ce-4948-aee5-eccb2c155cd7"
+$operatorRoleId = "c1ff6fe2-a25f-415b-bfb8-852a9c81cbfc"
+$rgScope = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup"
+
+Write-Host "== storage account $StorageAccount" -ForegroundColor Cyan
+$storageExists = az storage account show --name $StorageAccount --resource-group $ResourceGroup --subscription $SubscriptionId --only-show-errors 2>$null
+if (-not $storageExists) {
+    $splatStorageArgs = @(
+        "storage", "account", "create",
+        "--name", $StorageAccount,
+        "--resource-group", $ResourceGroup,
+        "--location", $Location,
+        "--sku", "Standard_LRS",
+        "--min-tls-version", "TLS1_2",
+        "--allow-blob-public-access", "false",
+        "--subscription", $SubscriptionId,
+        "--output", "none"
+    )
+    az @splatStorageArgs --only-show-errors
+}
+
+Write-Host "== queue $QueueName" -ForegroundColor Cyan
+$splatKeyArgs = @(
+    "storage", "account", "keys", "list",
+    "--account-name", $StorageAccount,
+    "--resource-group", $ResourceGroup,
+    "--subscription", $SubscriptionId,
+    "--query", "[0].value",
+    "--output", "tsv"
+)
+$storageKey = az @splatKeyArgs --only-show-errors
+$splatQueueArgs = @(
+    "storage", "queue", "create",
+    "--name", $QueueName,
+    "--account-name", $StorageAccount,
+    "--account-key", $storageKey,
+    "--output", "none"
+)
+az @splatQueueArgs --only-show-errors
+
+Write-Host "== Log Analytics workspace $WorkspaceName" -ForegroundColor Cyan
+$splatWorkspaceArgs = @(
+    "monitor", "log-analytics", "workspace", "create",
+    "--resource-group", $ResourceGroup,
+    "--workspace-name", $WorkspaceName,
+    "--location", $Location,
+    "--subscription", $SubscriptionId,
+    "--query", "id",
+    "--output", "tsv"
+)
+$workspaceId = az @splatWorkspaceArgs --only-show-errors
+
+Write-Host "== Application Insights $InsightsName" -ForegroundColor Cyan
+# Deliberately ARM rather than `az monitor app-insights component create`: that command
+# lives in the application-insights CLI extension, which is not installed by default and
+# was found corrupt on a maintainer workstation. The PUT is idempotent.
+$insightsUri = "https://management.azure.com$rgScope/providers/Microsoft.Insights/components/$InsightsName" + "?api-version=2020-02-02"
+$insightsJson = @"
+{
+  "location": "$Location",
+  "kind": "web",
+  "properties": {
+    "Application_Type": "web",
+    "WorkspaceResourceId": "$workspaceId",
+    "IngestionMode": "LogAnalytics"
+  }
+}
+"@
+$insightsPath = Join-Path ([System.IO.Path]::GetTempPath()) "dbatools-fleet-insights.json"
+Set-Content -Path $insightsPath -Value $insightsJson
+$null = az rest --method put --uri $insightsUri --body "@$insightsPath" --only-show-errors
+Remove-Item -Path $insightsPath -Force
+$splatConnectionArgs = @(
+    "rest", "--method", "get",
+    "--uri", $insightsUri,
+    "--query", "properties.ConnectionString",
+    "--output", "tsv"
+)
+$insightsConnection = az @splatConnectionArgs --only-show-errors
+if (-not $insightsConnection) {
+    throw "Application Insights $InsightsName has no connection string"
+}
+
+Write-Host "== Key Vault $KeyVaultName (RBAC authorization)" -ForegroundColor Cyan
+$vaultExists = az keyvault show --name $KeyVaultName --resource-group $ResourceGroup --subscription $SubscriptionId --only-show-errors 2>$null
+if (-not $vaultExists) {
+    $splatVaultArgs = @(
+        "keyvault", "create",
+        "--name", $KeyVaultName,
+        "--resource-group", $ResourceGroup,
+        "--location", $Location,
+        "--enable-rbac-authorization", "true",
+        "--subscription", $SubscriptionId,
+        "--output", "none"
+    )
+    az @splatVaultArgs --only-show-errors
+}
+
+Write-Host "== Function App $FunctionAppName (Flex Consumption, PowerShell 7.6)" -ForegroundColor Cyan
+$functionExists = az functionapp show --name $FunctionAppName --resource-group $ResourceGroup --subscription $SubscriptionId --only-show-errors 2>$null
+if (-not $functionExists) {
+    # maximum-instance-count 1 is the serialization guarantee. It replaces the
+    # runner-fleet concurrency group, so two reconcile passes can never race.
+    $splatFunctionArgs = @(
+        "functionapp", "create",
+        "--name", $FunctionAppName,
+        "--resource-group", $ResourceGroup,
+        "--flexconsumption-location", $Location,
+        "--runtime", "powershell",
+        "--runtime-version", "7.6",
+        "--instance-memory", "2048",
+        "--maximum-instance-count", "1",
+        "--storage-account", $StorageAccount,
+        "--disable-app-insights", "true",
+        "--assign-identity", "[system]",
+        "--subscription", $SubscriptionId,
+        "--output", "none"
+    )
+    az @splatFunctionArgs --only-show-errors
+}
+
+$splatIdentityArgs = @(
+    "functionapp", "identity", "show",
+    "--name", $FunctionAppName,
+    "--resource-group", $ResourceGroup,
+    "--subscription", $SubscriptionId,
+    "--query", "principalId",
+    "--output", "tsv"
+)
+$principalId = az @splatIdentityArgs --only-show-errors
+if (-not $principalId) {
+    throw "Function App $FunctionAppName has no system-assigned identity"
+}
+Write-Host "   identity principalId = $principalId"
+
+Write-Host "== role assignments" -ForegroundColor Cyan
+$vaultScope = "$rgScope/providers/Microsoft.KeyVault/vaults/$KeyVaultName"
+$assignments = @(
+    @{
+        Principal = $principalId
+        Type      = "ServicePrincipal"
+        Role      = $operatorRoleId
+        Scope     = $rgScope
+        Label     = "controller identity: dbatools-ci-operator on $ResourceGroup"
+    },
+    @{
+        Principal = $principalId
+        Type      = "ServicePrincipal"
+        Role      = $keyVaultSecretsUserRoleId
+        Scope     = $vaultScope
+        Label     = "controller identity: Key Vault Secrets User on $KeyVaultName"
+    }
+)
+
+# The vault is RBAC-authorized, and subscription Owner carries no data-plane rights, so
+# the human who has to put the App private key in the vault needs an explicit grant.
+#
+# Graph is queried with a token minted for THIS subscription rather than through
+# `az ad signed-in-user show`. That command follows the CLI's default subscription, and
+# on a workstation whose default lives in another tenant it returns a guest object ID
+# that this directory has never heard of -- the role assignment then fails with
+# PrincipalNotFound naming an ID that looks perfectly valid.
+$graphToken = az account get-access-token --subscription $SubscriptionId --resource "https://graph.microsoft.com" --query accessToken --output tsv --only-show-errors
+$signedInUserId = $null
+if ($graphToken) {
+    $splatGraph = @{
+        Uri        = "https://graph.microsoft.com/v1.0/me"
+        Headers    = @{ Authorization = "Bearer $graphToken" }
+        TimeoutSec = 30
+    }
+    $signedInUserId = (Invoke-RestMethod @splatGraph).id
+}
+if ($signedInUserId) {
+    $assignments += @{
+        Principal = $signedInUserId
+        Type      = "User"
+        Role      = $keyVaultSecretsOfficerRoleId
+        Scope     = $vaultScope
+        Label     = "operator: Key Vault Secrets Officer on $KeyVaultName"
+    }
+} else {
+    Write-Warning "could not resolve the signed-in user; grant yourself Key Vault Secrets Officer on $KeyVaultName before setting secrets"
+}
+
+foreach ($assignment in $assignments) {
+    # Filtered client-side rather than with --assignee: that flag makes az resolve the
+    # principal through Graph, which fails for a managed identity the CLI's default
+    # tenant cannot see even though the assignment itself is pure ARM.
+    $splatExistingArgs = @(
+        "role", "assignment", "list",
+        "--scope", $assignment.Scope,
+        "--subscription", $SubscriptionId,
+        "--query", "[].{principal:principalId,role:roleDefinitionId}",
+        "--output", "tsv"
+    )
+    $existingRows = @(az @splatExistingArgs --only-show-errors)
+    $existing = @($existingRows | Where-Object { $PSItem -match [regex]::Escape($assignment.Principal) -and $PSItem -match [regex]::Escape($assignment.Role) })
+    if ($existing) {
+        Write-Host "   have $($assignment.Label)"
+        continue
+    }
+    $splatAssignArgs = @(
+        "role", "assignment", "create",
+        "--assignee-object-id", $assignment.Principal,
+        "--assignee-principal-type", $assignment.Type,
+        "--role", $assignment.Role,
+        "--scope", $assignment.Scope,
+        "--subscription", $SubscriptionId,
+        "--output", "none"
+    )
+    az @splatAssignArgs --only-show-errors
+    if ($LASTEXITCODE -ne 0) {
+        throw "role assignment failed -- $($assignment.Label)"
+    }
+    Write-Host "   added $($assignment.Label)"
+}
+
+Write-Host "== app settings" -ForegroundColor Cyan
+# Deliberately no pool policy numbers here. Those live in controller/fleet-config.psd1,
+# where the mirror tests can read them; an app setting of the same name overrides one at
+# runtime and is the emergency lever, so setting any of them up front would quietly
+# disconnect the committed file from the running fleet.
+$settings = @(
+    "REPO=$Repo",
+    "RG=$ResourceGroup",
+    "VMSS=$VmssName",
+    "SUBSCRIPTION_ID=$SubscriptionId",
+    "FLEET_QUEUE=$QueueName",
+    "DRY_RUN=$DryRun",
+    "APPLICATIONINSIGHTS_CONNECTION_STRING=$insightsConnection",
+    # A reconcile pass runs for minutes. The HTTP webhook must still answer inside
+    # GitHub's 10 second delivery timeout while one is running, so worker concurrency
+    # stays above one even though the instance count does not.
+    "PSWorkerInProcConcurrencyUpperBound=10"
+)
+if ($GitHubAppId) {
+    $settings += "GITHUB_APP_ID=$GitHubAppId"
+}
+if ($GitHubInstallationId) {
+    $settings += "GITHUB_INSTALLATION_ID=$GitHubInstallationId"
+}
+
+# Key Vault references are wired only once the secrets exist. Pointing a reference at a
+# missing secret leaves the literal @Microsoft.KeyVault(...) string in the environment,
+# which fails HMAC validation silently rather than loudly.
+$settingBySecret = @{
+    "github-app-private-key" = "GITHUB_APP_PRIVATE_KEY"
+    "github-webhook-secret"  = "GITHUB_WEBHOOK_SECRET"
+}
+foreach ($secretName in @("github-app-private-key", "github-webhook-secret")) {
+    $splatSecretArgs = @(
+        "keyvault", "secret", "show",
+        "--vault-name", $KeyVaultName,
+        "--name", $secretName,
+        "--subscription", $SubscriptionId,
+        "--query", "id",
+        "--output", "tsv"
+    )
+    $secretId = az @splatSecretArgs --only-show-errors 2>$null
+    if (-not $secretId) {
+        Write-Warning "secret $secretName is not in $KeyVaultName yet; $($settingBySecret[$secretName]) left unset. Rerun after the GitHub App exists."
+        continue
+    }
+    # Version-less SecretUri so a rotated secret is picked up without a redeploy.
+    $secretUri = $secretId -replace "/[^/]+$", ""
+    $settings += "$($settingBySecret[$secretName])=@Microsoft.KeyVault(SecretUri=$secretUri/)"
+}
+
+$splatSettingsArgs = @(
+    "functionapp", "config", "appsettings", "set",
+    "--name", $FunctionAppName,
+    "--resource-group", $ResourceGroup,
+    "--subscription", $SubscriptionId,
+    "--settings"
+) + $settings + @("--output", "none")
+az @splatSettingsArgs --only-show-errors
+
+$splatHostArgs = @(
+    "functionapp", "show",
+    "--name", $FunctionAppName,
+    "--resource-group", $ResourceGroup,
+    "--subscription", $SubscriptionId,
+    # az 2.80 returns the ARM-shaped body for Flex apps, older builds flatten it
+    "--query", "properties.defaultHostName || defaultHostName",
+    "--output", "tsv"
+)
+$hostName = az @splatHostArgs --only-show-errors
+
+Write-Host ""
+Write-Host "== done" -ForegroundColor Green
+Write-Host "Function App : https://$hostName"
+Write-Host "Identity     : $principalId"
+Write-Host "Key Vault    : $KeyVaultName"
+Write-Host "Nudge queue  : $QueueName on $StorageAccount"
+Write-Host ""
+Write-Host "Next: pwsh .github/runners/deploy-controller.ps1"
+Write-Host "Then: pwsh .github/runners/deploy-controller.ps1 -ShowWebhookUrl  (the URL the GitHub App posts to)"

--- a/.github/runners/controller-infra.ps1
+++ b/.github/runners/controller-infra.ps1
@@ -101,23 +101,15 @@ if (-not $storageExists) {
 }
 
 Write-Host "== queue $QueueName" -ForegroundColor Cyan
-$splatKeyArgs = @(
-    "storage", "account", "keys", "list",
-    "--account-name", $StorageAccount,
-    "--resource-group", $ResourceGroup,
-    "--subscription", $SubscriptionId,
-    "--query", "[0].value",
-    "--output", "tsv"
-)
-$storageKey = az @splatKeyArgs --only-show-errors
-$splatQueueArgs = @(
-    "storage", "queue", "create",
-    "--name", $QueueName,
-    "--account-name", $StorageAccount,
-    "--account-key", $storageKey,
-    "--output", "none"
-)
-az @splatQueueArgs --only-show-errors
+# Created through ARM rather than `az storage queue create`, which wants either the account
+# master key or a data-plane role the operator's Owner rights do not imply. Handing the key
+# to the CLI would put it in this process's argv, where anything that can list processes can
+# read it. The control-plane PUT needs no key at all and is idempotent.
+$queueUri = "https://management.azure.com$rgScope/providers/Microsoft.Storage/storageAccounts/$StorageAccount/queueServices/default/queues/$QueueName" + "?api-version=2023-05-01"
+$null = az rest --method put --uri $queueUri --body "{}" --only-show-errors
+if ($LASTEXITCODE -ne 0) {
+    throw "could not create queue $QueueName on $StorageAccount"
+}
 
 Write-Host "== Log Analytics workspace $WorkspaceName" -ForegroundColor Cyan
 $splatWorkspaceArgs = @(
@@ -147,10 +139,15 @@ $insightsJson = @"
   }
 }
 "@
-$insightsPath = Join-Path ([System.IO.Path]::GetTempPath()) "dbatools-fleet-insights.json"
-Set-Content -Path $insightsPath -Value $insightsJson
-$null = az rest --method put --uri $insightsUri --body "@$insightsPath" --only-show-errors
-Remove-Item -Path $insightsPath -Force
+# Unique per run and removed in finally: a fixed name in the shared temp directory is one
+# a concurrent run clobbers and anyone can pre-create as a link to somewhere else
+$insightsPath = Join-Path ([System.IO.Path]::GetTempPath()) "dbatools-fleet-insights-$([System.Guid]::NewGuid().ToString("N")).json"
+try {
+    Set-Content -Path $insightsPath -Value $insightsJson
+    $null = az rest --method put --uri $insightsUri --body "@$insightsPath" --only-show-errors
+} finally {
+    Remove-Item -Path $insightsPath -Force -ErrorAction SilentlyContinue
+}
 $splatConnectionArgs = @(
     "rest", "--method", "get",
     "--uri", $insightsUri,
@@ -328,18 +325,6 @@ if ($GitHubInstallationId) {
     $settings += "GITHUB_INSTALLATION_ID=$GitHubInstallationId"
 }
 
-# Until the GitHub App exists there is nothing for a reconcile to authenticate with, and
-# the timer is the one trigger that fires without being asked: every five minutes it
-# would enqueue a pass that fails initialization, burns its five dequeues and lands in
-# the poison queue. Hold it off until the credentials are here, and release it once they
-# are, so re-running this script always leaves the tick in the state the app can support.
-if ($GitHubAppId -and $GitHubInstallationId) {
-    $settings += "AzureWebJobs.SafetyTick.Disabled=0"
-} else {
-    Write-Warning "no GitHub App yet -- disabling the safety tick so it cannot poison the queue"
-    $settings += "AzureWebJobs.SafetyTick.Disabled=1"
-}
-
 # Key Vault references are wired only once the secrets exist. Pointing a reference at a
 # missing secret leaves the literal @Microsoft.KeyVault(...) string in the environment,
 # which fails HMAC validation silently rather than loudly.
@@ -347,6 +332,7 @@ $settingBySecret = @{
     "github-app-private-key" = "GITHUB_APP_PRIVATE_KEY"
     "github-webhook-secret"  = "GITHUB_WEBHOOK_SECRET"
 }
+$wiredSecrets = @()
 foreach ($secretName in @("github-app-private-key", "github-webhook-secret")) {
     $splatSecretArgs = @(
         "keyvault", "secret", "show",
@@ -364,6 +350,29 @@ foreach ($secretName in @("github-app-private-key", "github-webhook-secret")) {
     # Version-less SecretUri so a rotated secret is picked up without a redeploy.
     $secretUri = $secretId -replace "/[^/]+$", ""
     $settings += "$($settingBySecret[$secretName])=@Microsoft.KeyVault(SecretUri=$secretUri/)"
+    $wiredSecrets += $secretName
+}
+
+# The timer is the one trigger that fires without being asked, so it is the one that can
+# poison the queue unattended: every five minutes it would enqueue a pass that fails
+# initialization, burn its five dequeues and give up. The test is every credential
+# Initialize-FleetContext demands, not just the two IDs -- an App ID with its private key
+# still sitting outside Key Vault fails exactly the same way, which is how this gate read
+# before. Re-running this script therefore always leaves the tick in the state the app
+# can actually support.
+$tickBlockers = @()
+if (-not $GitHubAppId) {
+    $tickBlockers += "GitHubAppId"
+}
+if (-not $GitHubInstallationId) {
+    $tickBlockers += "GitHubInstallationId"
+}
+$tickBlockers += @($settingBySecret.Keys | Where-Object { $PSItem -notin $wiredSecrets } | Sort-Object)
+if ($tickBlockers) {
+    Write-Warning "safety tick stays disabled so it cannot poison the queue -- still missing: $($tickBlockers -join ", ")"
+    $settings += "AzureWebJobs.SafetyTick.Disabled=1"
+} else {
+    $settings += "AzureWebJobs.SafetyTick.Disabled=0"
 }
 
 $splatSettingsArgs = @(

--- a/.github/runners/controller-infra.ps1
+++ b/.github/runners/controller-infra.ps1
@@ -74,6 +74,13 @@ $ErrorActionPreference = "Stop"
 $keyVaultSecretsUserRoleId = "4633458b-17de-408a-b874-0445c86b69e6"
 $keyVaultSecretsOfficerRoleId = "b86a8fe4-44ce-4948-aee5-eccb2c155cd7"
 $operatorRoleId = "c1ff6fe2-a25f-415b-bfb8-852a9c81cbfc"
+# Built-in role: Cost Management Reader. dbatools-ci-operator carries no cost actions, so
+# without this the weekly spend report gets a 403 and posts "unavailable" forever. The
+# GitHub Actions identity never needed it declared here because it happens to hold the
+# same role at subscription scope; the controller identity holds nothing but the two
+# below, so the grant has to be explicit -- and resource-group scope is enough, because
+# the query itself is scoped to the resource group.
+$costManagementReaderRoleId = "72fafb9e-0641-4937-9268-a91bfd8191a3"
 $rgScope = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup"
 
 Write-Host "== storage account $StorageAccount" -ForegroundColor Cyan
@@ -223,6 +230,13 @@ $assignments = @(
         Role      = $keyVaultSecretsUserRoleId
         Scope     = $vaultScope
         Label     = "controller identity: Key Vault Secrets User on $KeyVaultName"
+    },
+    @{
+        Principal = $principalId
+        Type      = "ServicePrincipal"
+        Role      = $costManagementReaderRoleId
+        Scope     = $rgScope
+        Label     = "controller identity: Cost Management Reader on $ResourceGroup"
     }
 )
 
@@ -312,6 +326,18 @@ if ($GitHubAppId) {
 }
 if ($GitHubInstallationId) {
     $settings += "GITHUB_INSTALLATION_ID=$GitHubInstallationId"
+}
+
+# Until the GitHub App exists there is nothing for a reconcile to authenticate with, and
+# the timer is the one trigger that fires without being asked: every five minutes it
+# would enqueue a pass that fails initialization, burns its five dequeues and lands in
+# the poison queue. Hold it off until the credentials are here, and release it once they
+# are, so re-running this script always leaves the tick in the state the app can support.
+if ($GitHubAppId -and $GitHubInstallationId) {
+    $settings += "AzureWebJobs.SafetyTick.Disabled=0"
+} else {
+    Write-Warning "no GitHub App yet -- disabling the safety tick so it cannot poison the queue"
+    $settings += "AzureWebJobs.SafetyTick.Disabled=1"
 }
 
 # Key Vault references are wired only once the secrets exist. Pointing a reference at a

--- a/.github/runners/controller-infra.ps1
+++ b/.github/runners/controller-infra.ps1
@@ -318,11 +318,35 @@ $settings = @(
     # stays above one even though the instance count does not.
     "PSWorkerInProcConcurrencyUpperBound=10"
 )
+
+# What the app already carries. `appsettings set` only touches the names it is given, so a
+# rerun without -GitHubAppId leaves a previously wired ID in place -- and the safety tick
+# below has to judge the app's real state, not just this invocation's parameters, or a
+# routine rerun would switch off a tick that was working fine.
+$splatExistingArgs = @(
+    "functionapp", "config", "appsettings", "list",
+    "--name", $FunctionAppName,
+    "--resource-group", $ResourceGroup,
+    "--subscription", $SubscriptionId,
+    "--output", "json"
+)
+$existingJson = az @splatExistingArgs --only-show-errors 2>$null
+$existingSettings = @{ }
+if ($existingJson) {
+    foreach ($existing in ($existingJson | ConvertFrom-Json)) {
+        $existingSettings[[string]$existing.name] = [string]$existing.value
+    }
+}
+
 if ($GitHubAppId) {
     $settings += "GITHUB_APP_ID=$GitHubAppId"
+} else {
+    $GitHubAppId = $existingSettings["GITHUB_APP_ID"]
 }
 if ($GitHubInstallationId) {
     $settings += "GITHUB_INSTALLATION_ID=$GitHubInstallationId"
+} else {
+    $GitHubInstallationId = $existingSettings["GITHUB_INSTALLATION_ID"]
 }
 
 # Key Vault references are wired only once the secrets exist. Pointing a reference at a

--- a/.github/runners/controller/GithubWebhook/function.json
+++ b/.github/runners/controller/GithubWebhook/function.json
@@ -1,0 +1,26 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "Request",
+      "methods": [
+        "post"
+      ],
+      "route": "github-webhook"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "Response"
+    },
+    {
+      "type": "queue",
+      "direction": "out",
+      "name": "Nudge",
+      "queueName": "%FLEET_QUEUE%",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}

--- a/.github/runners/controller/GithubWebhook/run.ps1
+++ b/.github/runners/controller/GithubWebhook/run.ps1
@@ -1,0 +1,91 @@
+# Ack-then-queue. GitHub gives a webhook 10 seconds to answer and never redelivers a
+# failed one, so this validates the signature, drops a nudge on the queue and returns.
+# A reconcile pass takes minutes; it must not happen on this thread.
+
+param($Request, $TriggerMetadata)
+
+$secret = $env:GITHUB_WEBHOOK_SECRET
+if (-not $secret) {
+    # Write-Warning, not Write-Error: an errored invocation is marked Failed and the
+    # host answers with a bare 500, throwing away the response below. The status code
+    # is the alert signal; the body is what tells whoever reads GitHub's delivery log
+    # which setting is missing.
+    Write-Warning "GITHUB_WEBHOOK_SECRET is not set; refusing to accept unverifiable deliveries"
+    $splatUnconfigured = @{
+        Name  = "Response"
+        Value = [HttpResponseContext]@{
+            StatusCode = [System.Net.HttpStatusCode]::InternalServerError
+            Body       = "webhook secret not configured"
+        }
+    }
+    Push-OutputBinding @splatUnconfigured
+    return
+}
+
+$rawBody = [string]$Request.RawBody
+$splatSignature = @{
+    Body      = $rawBody
+    Signature = [string]$Request.Headers["x-hub-signature-256"]
+    Secret    = $secret
+}
+if (-not (Test-GitHubWebhookSignature @splatSignature)) {
+    # Deliberately before the payload is parsed or logged: an unverified body is
+    # attacker-controlled and gets no further than this.
+    $splatUnauthorized = @{
+        Name  = "Response"
+        Value = [HttpResponseContext]@{
+            StatusCode = [System.Net.HttpStatusCode]::Unauthorized
+            Body       = "invalid signature"
+        }
+    }
+    Push-OutputBinding @splatUnauthorized
+    return
+}
+
+$eventName = [string]$Request.Headers["x-github-event"]
+$deliveryId = [string]$Request.Headers["x-github-delivery"]
+if ($eventName -eq "ping") {
+    $splatPing = @{
+        Name  = "Response"
+        Value = [HttpResponseContext]@{
+            StatusCode = [System.Net.HttpStatusCode]::OK
+            Body       = "pong"
+        }
+    }
+    Push-OutputBinding @splatPing
+    return
+}
+
+$config = Get-FleetConfig
+$splatNudge = @{
+    EventName   = $eventName
+    Payload     = ($rawBody | ConvertFrom-Json -Depth 20)
+    BoostUsers  = @([string]$config["BOOST_USERS"] -split "\s+" | Where-Object { $PSItem })
+    RunnerLabel = [string]$config["RUNNER_LABEL"]
+    CiWorkflow  = [string]$config["CI_WORKFLOW"]
+}
+$nudge = Get-FleetNudge @splatNudge
+if (-not $nudge) {
+    Write-Host "ignored $eventName delivery $deliveryId"
+    $splatIgnored = @{
+        Name  = "Response"
+        Value = [HttpResponseContext]@{
+            StatusCode = [System.Net.HttpStatusCode]::Accepted
+            Body       = "ignored"
+        }
+    }
+    Push-OutputBinding @splatIgnored
+    return
+}
+
+$nudge["delivery"] = $deliveryId
+Push-OutputBinding -Name Nudge -Value ($nudge | ConvertTo-Json -Compress -Depth 6)
+Write-Host "queued $($nudge["reason"]) from delivery $deliveryId"
+$splatQueued = @{
+    Name  = "Response"
+    Value = [HttpResponseContext]@{
+        StatusCode = [System.Net.HttpStatusCode]::Accepted
+        Body       = "queued"
+    }
+}
+Push-OutputBinding @splatQueued

--- a/.github/runners/controller/Modules/FleetCore/FleetCore.psm1
+++ b/.github/runners/controller/Modules/FleetCore/FleetCore.psm1
@@ -120,6 +120,15 @@ function Initialize-FleetContext {
         throw "Missing required fleet settings: $($missingSettings -join ", ")"
     }
 
+    # Fails closed, and refuses anything but the two words. A missing or misspelled DRY_RUN
+    # would otherwise read as "not dry" and let a controller that was only supposed to be
+    # shadowing delete real runners. In the old workflow this arrived from a dispatch input
+    # that could not be absent; here it is an app setting one typo away from armed.
+    $dryRunSetting = [string]$env:DRY_RUN
+    if ($dryRunSetting -notin @("true", "false")) {
+        throw "DRY_RUN must be exactly `"true`" or `"false`"; got `"$dryRunSetting`""
+    }
+
     $bootstrapPath = Resolve-FleetFile -Name "bootstrap-runner.ps1"
 
     $script:Fleet = @{
@@ -140,7 +149,7 @@ function Initialize-FleetContext {
         OptInPushUsers          = @([string]$config["OPT_IN_PUSH_USERS"] -split "\s+" | Where-Object { $PSItem })
         CiMarker                = [string]$config["CI_MARKER"]
         BootstrapPath           = $bootstrapPath
-        DryRun                  = $env:DRY_RUN -eq "true"
+        DryRun                  = $dryRunSetting -eq "true"
         DeletedVms              = New-Object -TypeName "System.Collections.Generic.HashSet[string]" -ArgumentList ([System.StringComparer]::OrdinalIgnoreCase)
         ArmToken                = $null
         ArmTokenExpiry          = [DateTimeOffset]::MinValue
@@ -230,7 +239,7 @@ function Get-ArmToken {
     $expiry = [DateTimeOffset]::UtcNow.AddMinutes(45)
     if ($response.expires_on) {
         $expiresOn = [string]$response.expires_on
-        $parsedSeconds = 0
+        [long]$parsedSeconds = 0
         if ([long]::TryParse($expiresOn, [ref]$parsedSeconds)) {
             $expiry = [DateTimeOffset]::FromUnixTimeSeconds($parsedSeconds)
         } else {
@@ -694,9 +703,9 @@ function Get-OrphanedNetworking {
         Path      = "/subscriptions/$($script:Fleet.SubscriptionId)/resourceGroups/$($script:Fleet.ResourceGroup)/providers/Microsoft.Network/networkInterfaces?api-version=2024-05-01"
         Operation = "list orphaned NICs"
     }
-    $nicResponse = Invoke-ArmJson @splatNics
+    $nicResponse = @(Invoke-ArmList @splatNics)
     $nics = @(
-        $nicResponse.value |
+        $nicResponse |
             Where-Object { -not $PSItem.properties.virtualMachine -and [string]$PSItem.name -like "*Nic-*" } |
             ForEach-Object { [string]$PSItem.name }
     )
@@ -704,9 +713,9 @@ function Get-OrphanedNetworking {
         Path      = "/subscriptions/$($script:Fleet.SubscriptionId)/resourceGroups/$($script:Fleet.ResourceGroup)/providers/Microsoft.Network/publicIPAddresses?api-version=2024-05-01"
         Operation = "list orphaned public IPs"
     }
-    $pipResponse = Invoke-ArmJson @splatPips
+    $pipResponse = @(Invoke-ArmList @splatPips)
     $pips = @(
-        $pipResponse.value |
+        $pipResponse |
             Where-Object { -not $PSItem.properties.ipConfiguration -and [string]$PSItem.name -like "instancepublicip-*" } |
             ForEach-Object { [string]$PSItem.name }
     )
@@ -809,9 +818,9 @@ function Confirm-DirectTrigger {
     # A webhook body is a hint about where to look, never the fact itself. The HMAC
     # proves a delivery is authentic but not that it is current, so a captured delivery
     # replayed later would otherwise heat a pool or dispatch an old commit. Asking
-    # GitHub for the ref's head settles both: a replay names a SHA that is no longer
-    # the head and gets dropped, and the sha, message and actor handed downstream come
-    # from the API response rather than from the request body.
+    # GitHub for the ref's head settles that: a replay names a SHA that is no longer
+    # the head and gets dropped, and the sha and message handed downstream come from
+    # the API response rather than from the request body.
     $branch = $Ref -replace "^refs/heads/", ""
     # Conservative because this value reaches a REST path. Real branch names here are
     # well inside it, and anything stranger is dropped rather than escaped. The explicit
@@ -835,15 +844,19 @@ function Confirm-DirectTrigger {
         Write-Host "trigger hint for $branch is stale (head is $([string]$head.sha)); converging from repository activity instead"
         return $empty
     }
+    # The actor stays the one the signed delivery named. What the HMAC could not prove was
+    # freshness, and the sha check above settles that; who pushed was never in doubt, because
+    # the body is GitHub's own statement of it. head.author.login is a different person --
+    # the commit AUTHOR -- whenever someone pushes work they did not write, and the
+    # maintainer and opt-in lists are about the pusher. Attributing to the author would both
+    # miss a maintainer pushing a contributor's commit and hand a maintainer lane to anyone
+    # who pushes a maintainer-authored one.
     $headAuthor = [string]$head.author.login
     if ($headAuthor -and $headAuthor -ne $Actor) {
-        Write-Host "trigger hint actor $Actor does not match commit author $headAuthor; using the commit author"
-    }
-    if (-not $headAuthor) {
-        $headAuthor = $Actor
+        Write-Host "trigger $Sha was authored by $headAuthor and pushed by $Actor; attributing to the pusher"
     }
     [pscustomobject]@{
-        Actor   = $headAuthor
+        Actor   = $Actor
         Message = [string]$head.commit.message
         Sha     = [string]$head.sha
         Ref     = $Ref
@@ -910,7 +923,7 @@ function Get-RunnerDemand {
     $desired = Get-DesiredRunnerPools @splatPolicy
 
     $total = ($desired.Values | Measure-Object -Sum).Sum
-    Write-Host "desired pools: $(($desired.GetEnumerator() | ForEach-Object { "$($PSItem.Key)=$($PSItem.Value)" }) -join ', ') total=$total"
+    Write-Host "desired pools: $(($desired.GetEnumerator() | ForEach-Object { "$($PSItem.Key)=$($PSItem.Value)" }) -join ", ") total=$total"
     $splatDispatch = @{
         Events               = $events
         WorkflowRuns         = $workflowRuns

--- a/.github/runners/controller/Modules/FleetCore/FleetCore.psm1
+++ b/.github/runners/controller/Modules/FleetCore/FleetCore.psm1
@@ -355,6 +355,34 @@ function Invoke-ArmJson {
     $response.Content | ConvertFrom-Json -Depth 20
 }
 
+function Invoke-ArmList {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$Operation
+    )
+
+    # ARM list operations paginate at the service's discretion, and reading only the
+    # first page silently shrinks the fleet inventory -- VMs past the boundary would
+    # never be counted or reaped. The az CLI followed nextLink for us; raw REST does
+    # not, so every list call in this module has to come through here.
+    $next = $Path
+    while ($next) {
+        $splatPage = @{
+            Path      = $next
+            Operation = $Operation
+        }
+        $page = Invoke-ArmJson @splatPage
+        if (-not $page) {
+            break
+        }
+        $page.value
+        $next = [string]$page.nextLink
+    }
+}
+
 function Get-ResponseHeader {
     [CmdletBinding()]
     param(
@@ -498,9 +526,9 @@ function Get-FleetState {
         Path      = "/subscriptions/$($script:Fleet.SubscriptionId)/resourceGroups/$($script:Fleet.ResourceGroup)/providers/Microsoft.Compute/virtualMachines?api-version=2024-07-01"
         Operation = "list Azure runner VMs"
     }
-    $vmResponse = Invoke-ArmJson @splatVms
+    $vmResponse = @(Invoke-ArmList @splatVms)
     $vms = @(
-        $vmResponse.value |
+        $vmResponse |
             Where-Object { [string]$PSItem.name -like "$($script:Fleet.Vmss)_*" } |
             ForEach-Object {
                 [pscustomobject]@{
@@ -762,17 +790,91 @@ function Get-PoolJobDemand {
     Get-PoolJobDemandFromRuns @splatDemand
 }
 
+function Confirm-DirectTrigger {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()]
+        [string]$Actor = "",
+        [AllowEmptyString()]
+        [string]$Sha = "",
+        [AllowEmptyString()]
+        [string]$Ref = ""
+    )
+
+    $empty = [pscustomobject]@{ Actor = ""; Message = ""; Sha = ""; Ref = "" }
+    if (-not $Actor -or -not $Sha -or -not $Ref) {
+        return $empty
+    }
+
+    # A webhook body is a hint about where to look, never the fact itself. The HMAC
+    # proves a delivery is authentic but not that it is current, so a captured delivery
+    # replayed later would otherwise heat a pool or dispatch an old commit. Asking
+    # GitHub for the ref's head settles both: a replay names a SHA that is no longer
+    # the head and gets dropped, and the sha, message and actor handed downstream come
+    # from the API response rather than from the request body.
+    $branch = $Ref -replace "^refs/heads/", ""
+    # Conservative because this value reaches a REST path. Real branch names here are
+    # well inside it, and anything stranger is dropped rather than escaped. The explicit
+    # ".." check is the point of the whole test: a plain character class still admits
+    # refs/heads/../../etc, which .NET collapses into a request to a different endpoint.
+    if ($branch -notmatch "^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$" -or $branch -match "\.\.") {
+        Write-Warning "Trigger ref $Ref is not a plain branch name; converging from repository activity instead"
+        return $empty
+    }
+    $splatHead = @{
+        Path      = "repos/$($script:Fleet.Repo)/commits/$branch"
+        Operation = "corroborate the trigger commit on $branch"
+    }
+    try {
+        $head = Invoke-GhJson @splatHead
+    } catch {
+        Write-Warning "Could not corroborate the trigger on $branch; converging from repository activity instead. $($PSItem.Exception.Message)"
+        return $empty
+    }
+    if ([string]$head.sha -ne $Sha) {
+        Write-Host "trigger hint for $branch is stale (head is $([string]$head.sha)); converging from repository activity instead"
+        return $empty
+    }
+    $headAuthor = [string]$head.author.login
+    if ($headAuthor -and $headAuthor -ne $Actor) {
+        Write-Host "trigger hint actor $Actor does not match commit author $headAuthor; using the commit author"
+    }
+    if (-not $headAuthor) {
+        $headAuthor = $Actor
+    }
+    [pscustomobject]@{
+        Actor   = $headAuthor
+        Message = [string]$head.commit.message
+        Sha     = [string]$head.sha
+        Ref     = $Ref
+    }
+}
+
 function Get-RunnerDemand {
     param(
         [AllowEmptyString()]
         [string]$DirectTriggerActor = "",
         [AllowEmptyString()]
-        [string]$DirectTriggerMessage = "",
-        [AllowEmptyString()]
         [string]$DirectTriggerSha = "",
         [AllowEmptyString()]
         [string]$DirectTriggerRef = ""
     )
+
+    # No DirectTriggerMessage parameter on purpose: the marker test downstream decides
+    # whether CI runs, so the message it reads has to be the one GitHub holds, not the
+    # one the caller was handed.
+    $DirectTriggerMessage = ""
+
+    $splatConfirm = @{
+        Actor = $DirectTriggerActor
+        Sha   = $DirectTriggerSha
+        Ref   = $DirectTriggerRef
+    }
+    $trigger = Confirm-DirectTrigger @splatConfirm
+    $DirectTriggerActor = $trigger.Actor
+    $DirectTriggerMessage = $trigger.Message
+    $DirectTriggerSha = $trigger.Sha
+    $DirectTriggerRef = $trigger.Ref
 
     $splatEvents = @{
         Path      = "repos/$($script:Fleet.Repo)/events?per_page=100"
@@ -991,14 +1093,20 @@ function Register-PoolVms {
     $runCommandDefinition = ${function:Invoke-VmRunCommand}.ToString()
     $results = $tasks | ForEach-Object -Parallel {
         ${function:Invoke-VmRunCommand} = $using:runCommandDefinition
+        # Bind the task to its own name before the try. Inside catch, $PSItem is the
+        # ErrorRecord, not the pipeline item, so reading $PSItem.VmName there yields
+        # $null -- which silently strips the identity off every failed registration
+        # and, on SPENT-VM, hands Remove-FleetVm a null VM. The CLI original had no
+        # try/catch (it read $LASTEXITCODE) and so never hit this.
+        $task = $PSItem
         $parameters = @(
-            @{ name = "Token"; value = $PSItem.Token },
-            @{ name = "RunnerName"; value = $PSItem.VmName },
-            @{ name = "Labels"; value = $PSItem.Labels }
+            @{ name = "Token"; value = $task.Token },
+            @{ name = "RunnerName"; value = $task.VmName },
+            @{ name = "Labels"; value = $task.Labels }
         )
         $splatRunCommand = @{
             ArmToken     = $using:armToken
-            VmResourceId = $PSItem.Vm.id
+            VmResourceId = $task.Vm.id
             ScriptLines  = $using:bootstrapLines
             Parameters   = $parameters
         }
@@ -1006,20 +1114,20 @@ function Register-PoolVms {
         foreach ($attempt in 1..3) {
             try {
                 $outputText = Invoke-VmRunCommand @splatRunCommand
-                $result = [pscustomobject]@{ VmName = $PSItem.VmName; Vm = $PSItem.Vm; Succeeded = $true; Output = $outputText }
+                $result = [pscustomobject]@{ VmName = $task.VmName; Vm = $task.Vm; Succeeded = $true; Output = $outputText }
                 break
             } catch {
                 $outputText = $PSItem.Exception.Message
                 # A bootstrap that reports SPENT-VM has done its job even if the
                 # transport around it stumbled; the caller still needs to see it.
                 if ($outputText -match "SPENT-VM") {
-                    $result = [pscustomobject]@{ VmName = $PSItem.VmName; Vm = $PSItem.Vm; Succeeded = $true; Output = $outputText }
+                    $result = [pscustomobject]@{ VmName = $task.VmName; Vm = $task.Vm; Succeeded = $true; Output = $outputText }
                     break
                 }
                 if ($attempt -lt 3) {
                     Start-Sleep -Seconds (3 * $attempt)
                 } else {
-                    $result = [pscustomobject]@{ VmName = $PSItem.VmName; Vm = $PSItem.Vm; Succeeded = $false; Output = $outputText }
+                    $result = [pscustomobject]@{ VmName = $task.VmName; Vm = $task.Vm; Succeeded = $false; Output = $outputText }
                 }
             }
         }
@@ -1086,12 +1194,18 @@ function Invoke-FleetReconcile {
         Write-Host "DRY_RUN is on: decisions are logged, nothing is mutated"
     }
 
+    if ($DirectTriggerActor -or $DirectTriggerSha) {
+        # Logged as the hint it is. The message is deliberately not passed on; the
+        # reconcile re-reads it from GitHub so a stale or replayed delivery cannot
+        # carry its own marker text into the dispatch decision.
+        Write-Host "trigger hint: actor=$DirectTriggerActor ref=$DirectTriggerRef sha=$DirectTriggerSha message=$($DirectTriggerMessage -replace "`r?`n", " ")"
+    }
+
     try {
         $splatDemand = @{
-            DirectTriggerActor   = $DirectTriggerActor
-            DirectTriggerMessage = $DirectTriggerMessage
-            DirectTriggerSha     = $DirectTriggerSha
-            DirectTriggerRef     = $DirectTriggerRef
+            DirectTriggerActor = $DirectTriggerActor
+            DirectTriggerSha   = $DirectTriggerSha
+            DirectTriggerRef   = $DirectTriggerRef
         }
         $demand = Get-RunnerDemand @splatDemand
         $orphanSnapshot = Get-OrphanedNetworking

--- a/.github/runners/controller/Modules/FleetCore/FleetCore.psm1
+++ b/.github/runners/controller/Modules/FleetCore/FleetCore.psm1
@@ -1,0 +1,1359 @@
+<#
+.SYNOPSIS
+    Reconciles the AppVeyor-style GitHub Actions worker pools on the Azure VMSS.
+
+.DESCRIPTION
+    Maintains four logical pools on one Flexible VMSS. Individual VMs retain their
+    pool assignment in the runnerPool tag and register with a matching GitHub runner
+    label. Runner agents are ephemeral; a VM is deleted after its single job and its
+    pool slot is replaced from the golden image.
+
+    External control-plane calls are retried three times. Exhausted control-plane
+    failures throw TransientFleetException so the pass can bail out green without
+    making scaling decisions from incomplete state. Logic errors still fail normally.
+
+    This is the port of reconcile-runner-fleet.ps1 from the gh/az CLIs to raw REST so
+    it can run inside an Azure Function, which has neither binary. The pool logic is
+    unchanged and still lives in runner-policy.ps1, dot-sourced beside this file by
+    deploy-controller.ps1.
+
+.NOTES
+    Author: the dbatools team + Claude
+#>
+
+class TransientFleetException : System.Exception {
+    TransientFleetException([string]$message) : base($message) { }
+}
+
+$script:Fleet = $null
+
+function Resolve-FleetFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    # Deployed, deploy-controller.ps1 stages everything beside this module. In the repo
+    # the same files stay at .github/runners/ and .github/runners/controller/, where the
+    # mirror tests and runner-scale-up.yml expect them. Searching both layouts is what
+    # lets the tests import this module straight from a checkout with no staging step.
+    $roots = @(
+        $PSScriptRoot,
+        (Join-Path -Path $PSScriptRoot -ChildPath "../.."),
+        (Join-Path -Path $PSScriptRoot -ChildPath "../../..")
+    )
+    foreach ($root in $roots) {
+        $candidate = Join-Path -Path $root -ChildPath $Name
+        if (Test-Path -Path $candidate) {
+            return (Resolve-Path -Path $candidate).Path
+        }
+    }
+    throw "Cannot find $Name beside FleetCore or in the repo layout above it"
+}
+
+. (Resolve-FleetFile -Name "runner-policy.ps1")
+
+function New-TransientFleetException {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Message
+    )
+
+    New-Object -TypeName TransientFleetException -ArgumentList $Message
+}
+
+function Get-FleetSetting {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Config,
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    # An app setting of the same name wins over the committed default. That is the
+    # emergency lever -- change one number in the portal, no redeploy, no PR.
+    $override = [Environment]::GetEnvironmentVariable($Name)
+    if ($override) {
+        return $override
+    }
+    $Config[$Name]
+}
+
+function Get-FleetConfig {
+    [CmdletBinding()]
+    param(
+        [string]$ConfigPath
+    )
+
+    if (-not $ConfigPath) {
+        $ConfigPath = Resolve-FleetFile -Name "fleet-config.psd1"
+    }
+    $config = Import-PowerShellDataFile -Path $ConfigPath
+    $resolved = @{ }
+    foreach ($key in $config.Keys) {
+        $resolved[$key] = Get-FleetSetting -Config $config -Name $key
+    }
+    $resolved
+}
+
+function Initialize-FleetContext {
+    [CmdletBinding()]
+    param(
+        [string]$ConfigPath
+    )
+
+    $config = Get-FleetConfig -ConfigPath $ConfigPath
+    $requiredSettings = @(
+        "REPO",
+        "RG",
+        "VMSS",
+        "SUBSCRIPTION_ID",
+        "GITHUB_APP_ID",
+        "GITHUB_INSTALLATION_ID",
+        "GITHUB_APP_PRIVATE_KEY"
+    )
+    $missingSettings = @($requiredSettings | Where-Object { -not [Environment]::GetEnvironmentVariable($PSItem) })
+    if ($missingSettings) {
+        throw "Missing required fleet settings: $($missingSettings -join ", ")"
+    }
+
+    $bootstrapPath = Resolve-FleetFile -Name "bootstrap-runner.ps1"
+
+    $script:Fleet = @{
+        Repo                    = $env:REPO
+        ResourceGroup           = $env:RG
+        Vmss                    = $env:VMSS
+        SubscriptionId          = $env:SUBSCRIPTION_ID
+        RunnerLabel             = [string]$config["RUNNER_LABEL"]
+        PoolLabelPrefix         = [string]$config["POOL_LABEL_PREFIX"]
+        CiWorkflow              = [string]$config["CI_WORKFLOW"]
+        CommunityCount          = [int]$config["COMMUNITY_COUNT"]
+        MaintainerCount         = [int]$config["BOOST_COUNT"]
+        MaintainerWindowMinutes = [int]$config["BOOST_HOURS"] * 60
+        CommunityGraceMinutes   = [int]$config["COMMUNITY_GRACE_MINUTES"]
+        MaxRunners              = [int]$config["MAX_RUNNERS"]
+        WarmFloor               = [int]$config["WARM_FLOOR"]
+        Maintainers             = @([string]$config["BOOST_USERS"] -split "\s+" | Where-Object { $PSItem })
+        OptInPushUsers          = @([string]$config["OPT_IN_PUSH_USERS"] -split "\s+" | Where-Object { $PSItem })
+        CiMarker                = [string]$config["CI_MARKER"]
+        BootstrapPath           = $bootstrapPath
+        DryRun                  = $env:DRY_RUN -eq "true"
+        DeletedVms              = New-Object -TypeName "System.Collections.Generic.HashSet[string]" -ArgumentList ([System.StringComparer]::OrdinalIgnoreCase)
+        ArmToken                = $null
+        ArmTokenExpiry          = [DateTimeOffset]::MinValue
+        GitHubToken             = $null
+    }
+    $script:Fleet
+}
+
+function Test-FleetDryRun {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Decision
+    )
+
+    if (-not $script:Fleet.DryRun) {
+        return $false
+    }
+    Write-Host "DECISION $Decision"
+    $true
+}
+
+function Invoke-WithRetry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Operation,
+        [Parameter(Mandatory)]
+        [scriptblock]$Action
+    )
+
+    foreach ($attempt in 1..3) {
+        try {
+            return & $Action
+        } catch {
+            if ($attempt -eq 3) {
+                throw (New-TransientFleetException -Message "$Operation failed after 3 attempts. $($PSItem.Exception.Message)")
+            }
+            Write-Warning "$Operation attempt $attempt of 3 failed; retrying. $($PSItem.Exception.Message)"
+            Start-Sleep -Seconds (3 * $attempt)
+        }
+    }
+}
+
+function Get-HttpErrorText {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $ErrorRecord
+    )
+
+    # The retry wrapper's message is what Remove-FleetVm pattern-matches on to spot a
+    # runner that took a job mid-delete, so the response body has to survive into it.
+    # Invoke-RestMethod keeps the body in ErrorDetails, not in the exception message.
+    $detail = [string]$ErrorRecord.ErrorDetails.Message
+    if ($detail) {
+        return "$($ErrorRecord.Exception.Message) $detail"
+    }
+    [string]$ErrorRecord.Exception.Message
+}
+
+function Get-ArmToken {
+    [CmdletBinding()]
+    param()
+
+    if ($script:Fleet.ArmToken -and [DateTimeOffset]::UtcNow -lt $script:Fleet.ArmTokenExpiry) {
+        return $script:Fleet.ArmToken
+    }
+    # Straight to the managed identity endpoint rather than Connect-AzAccount: Flex
+    # Consumption caps app init at 30 seconds and has no managed dependencies, so
+    # importing Az.Accounts would be both slow and an extra thing to ship. Token
+    # strings are also safe to hand to ForEach-Object -Parallel; an Az context is not.
+    $endpoint = $env:IDENTITY_ENDPOINT
+    $identityHeader = $env:IDENTITY_HEADER
+    if (-not $endpoint -or -not $identityHeader) {
+        throw "No managed identity endpoint; the Function App needs a system-assigned identity"
+    }
+    $splatToken = @{
+        Uri        = "$($endpoint)?resource=https://management.azure.com/&api-version=2019-08-01"
+        Headers    = @{ "X-IDENTITY-HEADER" = $identityHeader }
+        TimeoutSec = 30
+    }
+    $response = Invoke-WithRetry -Operation "acquire ARM token" -Action {
+        Invoke-RestMethod @splatToken
+    }
+    $script:Fleet.ArmToken = $response.access_token
+    $expiry = [DateTimeOffset]::UtcNow.AddMinutes(45)
+    if ($response.expires_on) {
+        $expiresOn = [string]$response.expires_on
+        $parsedSeconds = 0
+        if ([long]::TryParse($expiresOn, [ref]$parsedSeconds)) {
+            $expiry = [DateTimeOffset]::FromUnixTimeSeconds($parsedSeconds)
+        } else {
+            $expiry = [DateTimeOffset]::Parse($expiresOn)
+        }
+    }
+    $script:Fleet.ArmTokenExpiry = $expiry.AddMinutes(-5)
+    $script:Fleet.ArmToken
+}
+
+function Get-GitHubToken {
+    [CmdletBinding()]
+    param()
+
+    if (-not $script:Fleet.GitHubToken) {
+        $splatInstallation = @{
+            AppId          = $env:GITHUB_APP_ID
+            InstallationId = $env:GITHUB_INSTALLATION_ID
+            PrivateKeyPem  = $env:GITHUB_APP_PRIVATE_KEY
+        }
+        $script:Fleet.GitHubToken = Invoke-WithRetry -Operation "mint GitHub installation token" -Action {
+            Get-GitHubInstallationToken @splatInstallation
+        }
+    }
+    $script:Fleet.GitHubToken
+}
+
+function Invoke-GhJson {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [string]$Method = "Get",
+        $Body,
+        [Parameter(Mandatory)]
+        [string]$Operation
+    )
+
+    $uri = $Path
+    if ($uri -notmatch "^https://") {
+        $uri = "https://api.github.com/$($Path.TrimStart("/"))"
+    }
+    $splatRequest = @{
+        Method     = $Method
+        Uri        = $uri
+        Headers    = @{
+            Accept                 = "application/vnd.github+json"
+            Authorization          = "Bearer $(Get-GitHubToken)"
+            "X-GitHub-Api-Version" = "2022-11-28"
+            "User-Agent"           = "dbatools-fleet-controller"
+        }
+        TimeoutSec = 60
+    }
+    if ($null -ne $Body) {
+        $splatRequest["Body"] = ($Body | ConvertTo-Json -Depth 6)
+        $splatRequest["ContentType"] = "application/json"
+    }
+    Invoke-WithRetry -Operation $Operation -Action {
+        try {
+            Invoke-RestMethod @splatRequest
+        } catch {
+            throw (Get-HttpErrorText -ErrorRecord $PSItem)
+        }
+    }
+}
+
+function Invoke-ArmWeb {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [string]$Method = "Get",
+        $Body,
+        [Parameter(Mandatory)]
+        [string]$Operation
+    )
+
+    $uri = $Path
+    if ($uri -notmatch "^https://") {
+        $uri = "https://management.azure.com$Path"
+    }
+    $splatRequest = @{
+        Method     = $Method
+        Uri        = $uri
+        Headers    = @{ Authorization = "Bearer $(Get-ArmToken)" }
+        TimeoutSec = 120
+    }
+    if ($null -ne $Body) {
+        $splatRequest["Body"] = ($Body | ConvertTo-Json -Depth 10)
+        $splatRequest["ContentType"] = "application/json"
+    }
+    Invoke-WithRetry -Operation $Operation -Action {
+        try {
+            Invoke-WebRequest @splatRequest -UseBasicParsing
+        } catch {
+            throw (Get-HttpErrorText -ErrorRecord $PSItem)
+        }
+    }
+}
+
+function Invoke-ArmJson {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [string]$Method = "Get",
+        $Body,
+        [Parameter(Mandatory)]
+        [string]$Operation
+    )
+
+    $splatArm = @{
+        Path      = $Path
+        Method    = $Method
+        Body      = $Body
+        Operation = $Operation
+    }
+    $response = Invoke-ArmWeb @splatArm
+    if (-not $response.Content) {
+        return $null
+    }
+    $response.Content | ConvertFrom-Json -Depth 20
+}
+
+function Get-ResponseHeader {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Response,
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    $value = $Response.Headers[$Name]
+    if (-not $value) {
+        return $null
+    }
+    # PowerShell 7 gives every response header as a collection, even single-valued ones.
+    @($value)[0]
+}
+
+function Wait-ArmOperation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Response,
+        [Parameter(Mandatory)]
+        [string]$Operation,
+        [int]$TimeoutMinutes = 20
+    )
+
+    if ([int]$Response.StatusCode -ne 202) {
+        if ($Response.Content) {
+            return ($Response.Content | ConvertFrom-Json -Depth 20)
+        }
+        return $null
+    }
+
+    $asyncUri = Get-ResponseHeader -Response $Response -Name "Azure-AsyncOperation"
+    $locationUri = Get-ResponseHeader -Response $Response -Name "Location"
+    $deadline = [DateTimeOffset]::UtcNow.AddMinutes($TimeoutMinutes)
+    $pollSeconds = 5
+    $retryAfter = Get-ResponseHeader -Response $Response -Name "Retry-After"
+    if ($retryAfter -and [int]$retryAfter -gt 0) {
+        $pollSeconds = [int]$retryAfter
+    }
+
+    while ([DateTimeOffset]::UtcNow -lt $deadline) {
+        Start-Sleep -Seconds $pollSeconds
+        if ($asyncUri) {
+            $status = Invoke-ArmJson -Path $asyncUri -Operation "poll $Operation"
+            if ([string]$status.status -in @("Failed", "Canceled")) {
+                throw (New-TransientFleetException -Message "$Operation ended $($status.status). $($status.error.message)")
+            }
+            if ([string]$status.status -ne "Succeeded") {
+                continue
+            }
+            if (-not $locationUri) {
+                return $null
+            }
+            return (Invoke-ArmJson -Path $locationUri -Operation "read result of $Operation")
+        }
+        if (-not $locationUri) {
+            return $null
+        }
+        $poll = Invoke-ArmWeb -Path $locationUri -Operation "poll $Operation"
+        if ([int]$poll.StatusCode -eq 202) {
+            continue
+        }
+        if ($poll.Content) {
+            return ($poll.Content | ConvertFrom-Json -Depth 20)
+        }
+        return $null
+    }
+    throw (New-TransientFleetException -Message "$Operation did not finish within $TimeoutMinutes minutes")
+}
+
+function Invoke-ArmOperation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$Method,
+        $Body,
+        [Parameter(Mandatory)]
+        [string]$Operation,
+        [int]$TimeoutMinutes = 20
+    )
+
+    $splatArm = @{
+        Path      = $Path
+        Method    = $Method
+        Body      = $Body
+        Operation = $Operation
+    }
+    $response = Invoke-ArmWeb @splatArm
+    $splatWait = @{
+        Response       = $response
+        Operation      = $Operation
+        TimeoutMinutes = $TimeoutMinutes
+    }
+    Wait-ArmOperation @splatWait
+}
+
+function Get-RunnerPool {
+    param($Runner)
+    if (-not $Runner) {
+        return $null
+    }
+    $label = @($Runner.labels.name | Where-Object { $PSItem -like "$($script:Fleet.PoolLabelPrefix)*" } | Select-Object -First 1)
+    if (-not $label) {
+        return $null
+    }
+    $label[0].Substring($script:Fleet.PoolLabelPrefix.Length)
+}
+
+function Get-VmPool {
+    param($Vm)
+    if ($Vm.tags -and $Vm.tags.runnerPool) {
+        return [string]$Vm.tags.runnerPool
+    }
+    return $null
+}
+
+function Get-VmAgeMinutes {
+    param($Vm)
+    if (-not $Vm.created) {
+        return 0
+    }
+    [int](([DateTimeOffset]::UtcNow - [DateTimeOffset]::Parse($Vm.created)).TotalMinutes)
+}
+
+function Get-FleetState {
+    $splatRunners = @{
+        Path      = "repos/$($script:Fleet.Repo)/actions/runners?per_page=100"
+        Operation = "list GitHub runners"
+    }
+    $runnerResponse = Invoke-GhJson @splatRunners
+    $runners = @($runnerResponse.runners | Where-Object { $PSItem.labels.name -contains $script:Fleet.RunnerLabel })
+    # One list call, not the CLI's --show-details fan-out: the projection below is
+    # everything the fleet logic reads, and powerState was only ever projected, never
+    # used. Skipping the per-VM instanceView removes N round trips from every pass.
+    $splatVms = @{
+        Path      = "/subscriptions/$($script:Fleet.SubscriptionId)/resourceGroups/$($script:Fleet.ResourceGroup)/providers/Microsoft.Compute/virtualMachines?api-version=2024-07-01"
+        Operation = "list Azure runner VMs"
+    }
+    $vmResponse = Invoke-ArmJson @splatVms
+    $vms = @(
+        $vmResponse.value |
+            Where-Object { [string]$PSItem.name -like "$($script:Fleet.Vmss)_*" } |
+            ForEach-Object {
+                [pscustomobject]@{
+                    name         = [string]$PSItem.name
+                    id           = [string]$PSItem.id
+                    created      = [string]$PSItem.properties.timeCreated
+                    provisioning = [string]$PSItem.properties.provisioningState
+                    tags         = $PSItem.tags
+                }
+            }
+    )
+    [pscustomobject]@{ Runners = $runners; Vms = $vms }
+}
+
+function Get-RunnerForVm {
+    param($State, [string]$VmName)
+    @($State.Runners | Where-Object name -EQ $VmName | Select-Object -First 1)[0]
+}
+
+function Set-VmTag {
+    param([string]$VmId, [string]$VmName, [hashtable]$Tags, [string]$Operation)
+    # Use the dedicated tag API. `az vm update --set tags.*` can invoke Azure's
+    # unrelated zone-movement validation and reject otherwise valid VM tag changes.
+    $body = @{
+        operation  = "Merge"
+        properties = @{ tags = $Tags }
+    }
+    $splatTag = @{
+        Path      = "$VmId/providers/Microsoft.Resources/tags/default?api-version=2024-03-01"
+        Method    = "Patch"
+        Body      = $body
+        Operation = $Operation
+    }
+    $null = Invoke-ArmJson @splatTag
+}
+
+function Set-VmPool {
+    param($Vm, [string]$Pool)
+    if (Test-FleetDryRun -Decision "tag vm=$($Vm.name) pool=$Pool") {
+        return
+    }
+    $splatPoolTag = @{
+        VmId      = $Vm.id
+        VmName    = $Vm.name
+        Tags      = @{ runnerPool = $Pool }
+        Operation = "tag $($Vm.name) for pool $Pool"
+    }
+    Set-VmTag @splatPoolTag
+    Write-Host "assigned $($Vm.name) to pool $Pool"
+}
+
+function Set-VmTimestampTag {
+    param(
+        $Vm,
+        [string]$TagName
+    )
+    $stamp = [DateTimeOffset]::UtcNow.ToString("o")
+    if (Test-FleetDryRun -Decision "stamp vm=$($Vm.name) tag=$TagName") {
+        return
+    }
+    $splatStampTag = @{
+        VmId      = $Vm.id
+        VmName    = $Vm.name
+        Tags      = @{ $TagName = $stamp }
+        Operation = "stamp $($Vm.name) $TagName"
+    }
+    Set-VmTag @splatStampTag
+}
+
+function Set-VmRegisteredAt {
+    param($Vm)
+    # Records when bootstrap finished registering the runner. Paired with the VM's
+    # creation time in Remove-FleetVm, this separates boot overhead from hot-idle
+    # time -- the two are indistinguishable in Azure cost data alone.
+    Set-VmTimestampTag -Vm $Vm -TagName "registeredAt"
+}
+
+function Set-VmOnlineObservedAt {
+    param($State, $Vms)
+    # Records when the controller first observes a runner online. This is an upper bound
+    # on listener startup, not its exact timestamp: observation is delayed by up to the
+    # gap between passes. It still separates startup from longer hot-idle waiting
+    # without granting the runner an Azure identity.
+    #
+    # The controller does this rather than the VM because runner VMs hold no Azure
+    # identity and must not gain one. Resolution is therefore the reconcile interval.
+    foreach ($vm in $Vms) {
+        if (-not $vm.tags -or -not $vm.tags.registeredAt -or $vm.tags.onlineObservedAt) {
+            continue
+        }
+        $runner = Get-RunnerForVm -State $State -VmName $vm.name
+        if (-not $runner -or $runner.status -ne "online") {
+            continue
+        }
+        Set-VmTimestampTag -Vm $vm -TagName "onlineObservedAt"
+    }
+}
+
+function Remove-FleetVm {
+    param($State, $Vm, [string]$Reason)
+    if (-not $script:Fleet.DeletedVms.Add($Vm.name)) {
+        return
+    }
+    $runner = Get-RunnerForVm -State $State -VmName $Vm.name
+    if ($runner -and $runner.busy) {
+        $null = $script:Fleet.DeletedVms.Remove($Vm.name)
+        Write-Host "preserving busy $($Vm.name) despite: $Reason"
+        return
+    }
+    Write-Host "deleting $($Vm.name) -- $Reason"
+    if (-not $script:Fleet.DryRun) {
+        if ($runner) {
+            try {
+                $splatRunnerDelete = @{
+                    Path      = "repos/$($script:Fleet.Repo)/actions/runners/$($runner.id)"
+                    Method    = "Delete"
+                    Operation = "remove runner record $($runner.name)"
+                }
+                $null = Invoke-GhJson @splatRunnerDelete
+            } catch [TransientFleetException] {
+                if ($PSItem.Exception.Message -notmatch "currently running a job") {
+                    throw
+                }
+                $null = $script:Fleet.DeletedVms.Remove($Vm.name)
+                Write-Host "preserving $($Vm.name); it accepted a job during the deletion check"
+                return
+            }
+        }
+        # The CLI waited for the delete; so does this, because FLEETSTAT is emitted
+        # after it and the pass re-reads inventory expecting the VM to be gone.
+        $splatVmDelete = @{
+            Path      = "$($Vm.id)?api-version=2024-07-01"
+            Method    = "Delete"
+            Operation = "delete VM $($Vm.name)"
+        }
+        $null = Invoke-ArmOperation @splatVmDelete
+    } else {
+        Write-Host "DECISION delete vm=$($Vm.name) reason=$Reason"
+    }
+    # bootMin is creation to runner registration. onlineObservedMin is registration to
+    # the controller's first online observation, so it is a reconcile-resolution upper
+    # bound on listener startup rather than an exact reboot duration.
+    $bootMin = "unknown"
+    $onlineObservedMin = "unknown"
+    if ($Vm.tags -and $Vm.tags.registeredAt) {
+        $registered = [DateTimeOffset]::Parse([string]$Vm.tags.registeredAt)
+        $created = [DateTimeOffset]::Parse([string]$Vm.created)
+        $bootMin = [int]($registered - $created).TotalMinutes
+        if ($Vm.tags.onlineObservedAt) {
+            $onlineObserved = [DateTimeOffset]::Parse([string]$Vm.tags.onlineObservedAt)
+            $onlineObservedMin = [int]($onlineObserved - $registered).TotalMinutes
+        }
+    }
+    $servedJob = ($null -ne $Vm.tags) -and ($null -ne $Vm.tags.registeredAt) -and (-not $runner)
+    Write-Host "FLEETSTAT vm=$($Vm.name) pool=$(Get-VmPool -Vm $Vm) createdAt=$($Vm.created) ageMin=$(Get-VmAgeMinutes -Vm $Vm) bootMin=$bootMin onlineObservedMin=$onlineObservedMin servedJob=$servedJob reason=$Reason"
+}
+
+function Get-OrphanedNetworking {
+    # Unattached NICs and instance public IPs matching the CI naming convention. The
+    # filters mirror the janitor's own patterns (janitor-runbook.ps1:255, :265) so both
+    # sweepers agree on what counts as garbage.
+    $splatNics = @{
+        Path      = "/subscriptions/$($script:Fleet.SubscriptionId)/resourceGroups/$($script:Fleet.ResourceGroup)/providers/Microsoft.Network/networkInterfaces?api-version=2024-05-01"
+        Operation = "list orphaned NICs"
+    }
+    $nicResponse = Invoke-ArmJson @splatNics
+    $nics = @(
+        $nicResponse.value |
+            Where-Object { -not $PSItem.properties.virtualMachine -and [string]$PSItem.name -like "*Nic-*" } |
+            ForEach-Object { [string]$PSItem.name }
+    )
+    $splatPips = @{
+        Path      = "/subscriptions/$($script:Fleet.SubscriptionId)/resourceGroups/$($script:Fleet.ResourceGroup)/providers/Microsoft.Network/publicIPAddresses?api-version=2024-05-01"
+        Operation = "list orphaned public IPs"
+    }
+    $pipResponse = Invoke-ArmJson @splatPips
+    $pips = @(
+        $pipResponse.value |
+            Where-Object { -not $PSItem.properties.ipConfiguration -and [string]$PSItem.name -like "instancepublicip-*" } |
+            ForEach-Object { [string]$PSItem.name }
+    )
+    [pscustomobject]@{
+        Nics = $nics
+        Pips = $pips
+    }
+}
+
+function Remove-OrphanedNetworking {
+    param($Snapshot)
+    # The VM delete leaves its NIC and instance public IP behind; the 6-hourly janitor
+    # was the only thing reaping them, and they bill the whole time. July: 1661 IP-hours
+    # against 949 VM-hours.
+    #
+    # Only resources orphaned BOTH at the start of this run and now are deleted. A NIC
+    # created by this run's vmss scale reads virtualMachine==null for a moment before
+    # its VM attaches, and deleting it would break that VM's creation.
+    $current = Get-OrphanedNetworking
+    $staleNics = @($current.Nics | Where-Object { $PSItem -in $Snapshot.Nics })
+    $stalePips = @($current.Pips | Where-Object { $PSItem -in $Snapshot.Pips })
+    $resourceBase = "/subscriptions/$($script:Fleet.SubscriptionId)/resourceGroups/$($script:Fleet.ResourceGroup)/providers/Microsoft.Network"
+    foreach ($nicName in $staleNics) {
+        if (Test-FleetDryRun -Decision "reap nic=$nicName") {
+            continue
+        }
+        $splatDeleteNic = @{
+            Path      = "$resourceBase/networkInterfaces/$nicName`?api-version=2024-05-01"
+            Method    = "Delete"
+            Operation = "delete orphaned NIC $nicName"
+        }
+        $null = Invoke-ArmOperation @splatDeleteNic
+    }
+    # NICs first: a public IP still bound to a NIC cannot be deleted.
+    foreach ($pipName in $stalePips) {
+        if (Test-FleetDryRun -Decision "reap pip=$pipName") {
+            continue
+        }
+        $splatDeletePip = @{
+            Path      = "$resourceBase/publicIPAddresses/$pipName`?api-version=2024-05-01"
+            Method    = "Delete"
+            Operation = "delete orphaned public IP $pipName"
+        }
+        $null = Invoke-ArmOperation @splatDeletePip
+    }
+    Write-Host "reaped orphans: nics=$($staleNics.Count) pips=$($stalePips.Count)"
+}
+
+function Get-PoolJobDemand {
+    param([object[]]$WorkflowRuns)
+    # I/O only -- eligibility, matrix-state detection and the demand transform live in
+    # runner-policy.ps1, where they are unit tested. Rejected runs are filtered before
+    # I/O so an unmarked push cannot spend an API call or inflate an already-hot lane.
+    $eligibleLiveRuns = @($WorkflowRuns | Where-Object {
+            $splatEligibility = @{
+                Run            = $PSItem
+                OptInPushUsers = $script:Fleet.OptInPushUsers
+                Marker         = $script:Fleet.CiMarker
+            }
+            [string]$PSItem.status -ne "completed" -and (Test-CiRunEligible @splatEligibility)
+        })
+    $jobsByRun = @{ }
+    foreach ($run in $eligibleLiveRuns) {
+        $splatJobs = @{
+            Path      = "repos/$($script:Fleet.Repo)/actions/runs/$($run.id)/jobs?per_page=100"
+            Operation = "read jobs for run $($run.id)"
+        }
+        $jobResponse = Invoke-GhJson @splatJobs
+        $jobsByRun[[string]$run.id] = @($jobResponse.jobs)
+    }
+
+    $splatDemand = @{
+        WorkflowRuns    = $eligibleLiveRuns
+        JobsByRun       = $jobsByRun
+        Maintainers     = $script:Fleet.Maintainers
+        OptInPushUsers  = $script:Fleet.OptInPushUsers
+        Marker          = $script:Fleet.CiMarker
+        MaintainerCount = $script:Fleet.MaintainerCount
+        CommunityCount  = $script:Fleet.CommunityCount
+    }
+    Get-PoolJobDemandFromRuns @splatDemand
+}
+
+function Get-RunnerDemand {
+    param(
+        [AllowEmptyString()]
+        [string]$DirectTriggerActor = "",
+        [AllowEmptyString()]
+        [string]$DirectTriggerMessage = "",
+        [AllowEmptyString()]
+        [string]$DirectTriggerSha = "",
+        [AllowEmptyString()]
+        [string]$DirectTriggerRef = ""
+    )
+
+    $splatEvents = @{
+        Path      = "repos/$($script:Fleet.Repo)/events?per_page=100"
+        Operation = "read repository activity"
+    }
+    $events = @(Invoke-GhJson @splatEvents)
+    $splatRuns = @{
+        Path      = "repos/$($script:Fleet.Repo)/actions/workflows/$($script:Fleet.CiWorkflow)/runs?per_page=100"
+        Operation = "read CI build queue"
+    }
+    $runResponse = Invoke-GhJson @splatRuns
+    $workflowRuns = @($runResponse.workflow_runs)
+    $now = [DateTimeOffset]::UtcNow
+    $poolJobDemand = Get-PoolJobDemand -WorkflowRuns $workflowRuns
+    Write-Host "pending jobs: $(($poolJobDemand.GetEnumerator() | ForEach-Object { "$($PSItem.Key)=$($PSItem.Value)" }) -join ", ")"
+    $splatPolicy = @{
+        Events                  = $events
+        WorkflowRuns            = $workflowRuns
+        Maintainers             = $script:Fleet.Maintainers
+        OptInPushUsers          = $script:Fleet.OptInPushUsers
+        MaintainerCount         = $script:Fleet.MaintainerCount
+        MaintainerWindowMinutes = $script:Fleet.MaintainerWindowMinutes
+        CommunityCount          = $script:Fleet.CommunityCount
+        CommunityGraceMinutes   = $script:Fleet.CommunityGraceMinutes
+        MaxRunners              = $script:Fleet.MaxRunners
+        Marker                  = $script:Fleet.CiMarker
+        Now                     = $now
+        DirectTriggerActor      = $DirectTriggerActor
+        DirectTriggerMessage    = $DirectTriggerMessage
+        PoolJobDemand           = $poolJobDemand
+        WarmFloor               = $script:Fleet.WarmFloor
+    }
+    $desired = Get-DesiredRunnerPools @splatPolicy
+
+    $total = ($desired.Values | Measure-Object -Sum).Sum
+    Write-Host "desired pools: $(($desired.GetEnumerator() | ForEach-Object { "$($PSItem.Key)=$($PSItem.Value)" }) -join ', ') total=$total"
+    $splatDispatch = @{
+        Events               = $events
+        WorkflowRuns         = $workflowRuns
+        OptInPushUsers       = $script:Fleet.OptInPushUsers
+        Marker               = $script:Fleet.CiMarker
+        Cutoff               = $now.AddMinutes(-$script:Fleet.MaintainerWindowMinutes)
+        DirectTriggerActor   = $DirectTriggerActor
+        DirectTriggerMessage = $DirectTriggerMessage
+        DirectTriggerSha     = $DirectTriggerSha
+        DirectTriggerRef     = $DirectTriggerRef
+    }
+    [pscustomobject]@{
+        Desired  = $desired
+        Dispatch = Get-MarkedPushDispatch @splatDispatch
+    }
+}
+
+function Invoke-MarkedCiDispatch {
+    param(
+        [Parameter(Mandatory)]
+        $Request
+    )
+
+    if (Test-FleetDryRun -Decision "dispatch ci ref=$($Request.Ref) sha=$($Request.Sha) actor=$($Request.Actor)") {
+        return
+    }
+    $body = @{
+        ref    = $Request.Ref
+        inputs = @{ message = $Request.Message; pool_user = $Request.Actor }
+    }
+    $splatDispatch = @{
+        Path      = "repos/$($script:Fleet.Repo)/actions/workflows/$($script:Fleet.CiWorkflow)/dispatches"
+        Method    = "Post"
+        Body      = $body
+        Operation = "dispatch marked CI for $($Request.Sha)"
+    }
+    $null = Invoke-GhJson @splatDispatch
+    Write-Host "dispatched marked CI ref=$($Request.Ref) sha=$($Request.Sha)"
+}
+
+function Set-UnallocatedVmPool {
+    param($State, $Desired)
+    $available = New-Object -TypeName "System.Collections.Generic.Queue[object]"
+    foreach ($vm in $State.Vms | Sort-Object created) {
+        $runner = Get-RunnerForVm -State $State -VmName $vm.name
+        if (-not (Get-VmPool -Vm $vm) -and -not $runner) {
+            $available.Enqueue($vm)
+        }
+    }
+
+    foreach ($pool in $Desired.Keys) {
+        $current = @($State.Vms | Where-Object { (Get-VmPool -Vm $PSItem) -eq $pool }).Count
+        $deficit = $Desired[$pool] - $current
+        while ($deficit -gt 0 -and $available.Count -gt 0) {
+            $vm = $available.Dequeue()
+            Set-VmPool -Vm $vm -Pool $pool
+            $deficit--
+        }
+    }
+}
+
+function Invoke-VmRunCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ArmToken,
+        [Parameter(Mandatory)]
+        [string]$VmResourceId,
+        [Parameter(Mandatory)]
+        [string[]]$ScriptLines,
+        [Parameter(Mandatory)]
+        [object[]]$Parameters,
+        [int]$TimeoutMinutes = 20
+    )
+
+    # Deliberately self-contained -- no module state, no helper calls. Register-PoolVms
+    # injects this whole function into ForEach-Object -Parallel runspaces, which cannot
+    # see anything from the module scope.
+    $headers = @{ Authorization = "Bearer $ArmToken" }
+    $body = @{
+        commandId  = "RunPowerShellScript"
+        script     = $ScriptLines
+        parameters = $Parameters
+    } | ConvertTo-Json -Depth 6
+    $splatInvoke = @{
+        Method      = "Post"
+        Uri         = "https://management.azure.com$VmResourceId/runCommand?api-version=2024-07-01"
+        Headers     = $headers
+        Body        = $body
+        ContentType = "application/json"
+        TimeoutSec  = 120
+    }
+    $response = Invoke-WebRequest @splatInvoke -UseBasicParsing
+
+    $result = $null
+    if ([int]$response.StatusCode -ne 202) {
+        if ($response.Content) {
+            $result = $response.Content | ConvertFrom-Json -Depth 20
+        }
+    } else {
+        $asyncUri = @($response.Headers["Azure-AsyncOperation"])[0]
+        $locationUri = @($response.Headers["Location"])[0]
+        $deadline = [DateTimeOffset]::UtcNow.AddMinutes($TimeoutMinutes)
+        while ([DateTimeOffset]::UtcNow -lt $deadline) {
+            Start-Sleep -Seconds 5
+            if ($asyncUri) {
+                $splatStatus = @{
+                    Uri        = $asyncUri
+                    Headers    = $headers
+                    TimeoutSec = 60
+                }
+                $status = Invoke-RestMethod @splatStatus
+                if ([string]$status.status -in @("Failed", "Canceled")) {
+                    throw "run-command ended $($status.status). $($status.error.message)"
+                }
+                if ([string]$status.status -ne "Succeeded") {
+                    continue
+                }
+            }
+            if (-not $locationUri) {
+                break
+            }
+            $splatPoll = @{
+                Method     = "Get"
+                Uri        = $locationUri
+                Headers    = $headers
+                TimeoutSec = 60
+            }
+            $poll = Invoke-WebRequest @splatPoll -UseBasicParsing
+            if ([int]$poll.StatusCode -eq 202) {
+                continue
+            }
+            if ($poll.Content) {
+                $result = $poll.Content | ConvertFrom-Json -Depth 20
+            }
+            break
+        }
+        if (-not $result -and [DateTimeOffset]::UtcNow -ge $deadline) {
+            throw "run-command did not finish within $TimeoutMinutes minutes"
+        }
+    }
+    [string]@($result.value)[0].message
+}
+
+function Register-PoolVms {
+    param($State, $Desired)
+    $tasks = @()
+    foreach ($vm in $State.Vms) {
+        $pool = Get-VmPool -Vm $vm
+        $runner = Get-RunnerForVm -State $State -VmName $vm.name
+        if (-not $pool -or $Desired[$pool] -le 0 -or ($runner -and $runner.status -ne "offline")) {
+            continue
+        }
+        $labels = "$($script:Fleet.RunnerLabel),$($script:Fleet.PoolLabelPrefix)$pool"
+        if (Test-FleetDryRun -Decision "register vm=$($vm.name) labels=$labels") {
+            continue
+        }
+        # Probe offline ephemeral runners too. The bootstrap distinguishes a VM that
+        # is still starting from one whose runner already served its single job.
+        $splatToken = @{
+            Path      = "repos/$($script:Fleet.Repo)/actions/runners/registration-token"
+            Method    = "Post"
+            Operation = "mint registration token for $($vm.name)"
+        }
+        $tokenResponse = Invoke-GhJson @splatToken
+        $tasks += [pscustomobject]@{
+            Vm     = $vm
+            VmName = $vm.name
+            Token  = $tokenResponse.token
+            Labels = $labels
+        }
+    }
+    if (-not $tasks) {
+        return
+    }
+
+    Write-Host "registering $($tasks.Count) pool runner(s)"
+    $armToken = Get-ArmToken
+    $bootstrapLines = @(Get-Content -Path $script:Fleet.BootstrapPath)
+    $runCommandDefinition = ${function:Invoke-VmRunCommand}.ToString()
+    $results = $tasks | ForEach-Object -Parallel {
+        ${function:Invoke-VmRunCommand} = $using:runCommandDefinition
+        $parameters = @(
+            @{ name = "Token"; value = $PSItem.Token },
+            @{ name = "RunnerName"; value = $PSItem.VmName },
+            @{ name = "Labels"; value = $PSItem.Labels }
+        )
+        $splatRunCommand = @{
+            ArmToken     = $using:armToken
+            VmResourceId = $PSItem.Vm.id
+            ScriptLines  = $using:bootstrapLines
+            Parameters   = $parameters
+        }
+        $result = $null
+        foreach ($attempt in 1..3) {
+            try {
+                $outputText = Invoke-VmRunCommand @splatRunCommand
+                $result = [pscustomobject]@{ VmName = $PSItem.VmName; Vm = $PSItem.Vm; Succeeded = $true; Output = $outputText }
+                break
+            } catch {
+                $outputText = $PSItem.Exception.Message
+                # A bootstrap that reports SPENT-VM has done its job even if the
+                # transport around it stumbled; the caller still needs to see it.
+                if ($outputText -match "SPENT-VM") {
+                    $result = [pscustomobject]@{ VmName = $PSItem.VmName; Vm = $PSItem.Vm; Succeeded = $true; Output = $outputText }
+                    break
+                }
+                if ($attempt -lt 3) {
+                    Start-Sleep -Seconds (3 * $attempt)
+                } else {
+                    $result = [pscustomobject]@{ VmName = $PSItem.VmName; Vm = $PSItem.Vm; Succeeded = $false; Output = $outputText }
+                }
+            }
+        }
+        $result
+    } -ThrottleLimit 25
+
+    foreach ($result in $results) {
+        if (-not $result.Succeeded) {
+            Write-Warning "Registration for $($result.VmName) exhausted retries; leaving it for the next reconcile. $($result.Output)"
+            continue
+        }
+        Write-Host (($result.Output -split "`r?`n" | Select-Object -Last 3) -join [Environment]::NewLine)
+        # Only the first successful registration is stamped. Register-PoolVms re-probes
+        # any VM whose runner is still offline (:462), and bootstrap short-circuits with
+        # "runner already configured" (:33-36) -- which is also exit 0. Re-stamping there
+        # would overwrite the real registration time for exactly the VMs still inside the
+        # boot window, i.e. the whole population bootMin is meant to measure.
+        if ($result.Output -notmatch "already configured" -and $result.Output -notmatch "SPENT-VM") {
+            Set-VmRegisteredAt -Vm $result.Vm
+        }
+        if ($result.Output -match "SPENT-VM") {
+            $vm = @($State.Vms | Where-Object name -EQ $result.VmName | Select-Object -First 1)[0]
+            Remove-FleetVm -State $State -Vm $vm -Reason "ephemeral runner already served a job"
+        }
+    }
+}
+
+function Set-FleetHeartbeat {
+    [CmdletBinding()]
+    param()
+
+    # The janitor reads this tag to decide whether the controller is alive. Stamped as
+    # the last act of a live pass so a half-finished pass never looks healthy.
+    $stamp = [DateTimeOffset]::UtcNow.ToString("o")
+    if (Test-FleetDryRun -Decision "heartbeat vmss=$($script:Fleet.Vmss) at=$stamp") {
+        return
+    }
+    $vmssId = "/subscriptions/$($script:Fleet.SubscriptionId)/resourceGroups/$($script:Fleet.ResourceGroup)/providers/Microsoft.Compute/virtualMachineScaleSets/$($script:Fleet.Vmss)"
+    $splatHeartbeat = @{
+        VmId      = $vmssId
+        VmName    = $script:Fleet.Vmss
+        Tags      = @{ fleetHeartbeat = $stamp }
+        Operation = "stamp fleet heartbeat"
+    }
+    Set-VmTag @splatHeartbeat
+    Write-Host "heartbeat=$stamp"
+}
+
+function Invoke-FleetReconcile {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()]
+        [string]$DirectTriggerActor = "",
+        [AllowEmptyString()]
+        [string]$DirectTriggerMessage = "",
+        [AllowEmptyString()]
+        [string]$DirectTriggerSha = "",
+        [AllowEmptyString()]
+        [string]$DirectTriggerRef = ""
+    )
+
+    $null = Initialize-FleetContext
+    if ($script:Fleet.DryRun) {
+        Write-Host "DRY_RUN is on: decisions are logged, nothing is mutated"
+    }
+
+    try {
+        $splatDemand = @{
+            DirectTriggerActor   = $DirectTriggerActor
+            DirectTriggerMessage = $DirectTriggerMessage
+            DirectTriggerSha     = $DirectTriggerSha
+            DirectTriggerRef     = $DirectTriggerRef
+        }
+        $demand = Get-RunnerDemand @splatDemand
+        $orphanSnapshot = Get-OrphanedNetworking
+        if ($demand.Dispatch) {
+            Invoke-MarkedCiDispatch -Request $demand.Dispatch
+        }
+        $desired = $demand.Desired
+        $desiredTotal = ($desired.Values | Measure-Object -Sum).Sum
+        $state = Get-FleetState
+
+        # Migrate or remove generic pre-pool runners without interrupting active jobs.
+        foreach ($vm in $state.Vms) {
+            $runner = Get-RunnerForVm -State $state -VmName $vm.name
+            $vmPool = Get-VmPool -Vm $vm
+            $runnerPool = Get-RunnerPool -Runner $runner
+            if (-not $vmPool -and $runnerPool) {
+                Set-VmPool -Vm $vm -Pool $runnerPool
+            } elseif ($runner -and -not $runnerPool -and -not $runner.busy) {
+                Remove-FleetVm -State $state -Vm $vm -Reason "legacy runner lacks a pool label"
+            }
+        }
+
+        $state = Get-FleetState
+        Set-UnallocatedVmPool -State $state -Desired $desired
+        $state = Get-FleetState
+        Register-PoolVms -State $state -Desired $desired
+        $state = Get-FleetState
+        Set-VmOnlineObservedAt -State $state -Vms $state.Vms
+
+        # Remove dead runners and trim pools whose hot window has ended.
+        foreach ($vm in $state.Vms) {
+            $pool = Get-VmPool -Vm $vm
+            $runner = Get-RunnerForVm -State $state -VmName $vm.name
+            $ageMinutes = Get-VmAgeMinutes -Vm $vm
+            if (-not $pool -and -not $runner) {
+                Remove-FleetVm -State $state -Vm $vm -Reason "unallocated capacity exceeds all active pool targets"
+            } elseif ($runner -and $runner.status -eq "offline" -and $ageMinutes -gt 15) {
+                Remove-FleetVm -State $state -Vm $vm -Reason "runner offline after bootstrap grace period"
+            } elseif (-not $runner -and $pool -and $ageMinutes -gt 45) {
+                Remove-FleetVm -State $state -Vm $vm -Reason "never registered after 45 minutes"
+            }
+        }
+
+        $state = Get-FleetState
+        foreach ($pool in $desired.Keys) {
+            $poolVms = @($state.Vms | Where-Object { (Get-VmPool -Vm $PSItem) -eq $pool } | Sort-Object created)
+            $excess = $poolVms.Count - $desired[$pool]
+            foreach ($vm in $poolVms) {
+                if ($excess -le 0) {
+                    break
+                }
+                $runner = Get-RunnerForVm -State $state -VmName $vm.name
+                if ($runner -and $runner.busy) {
+                    continue
+                }
+                Remove-FleetVm -State $state -Vm $vm -Reason "pool $pool is $excess above desired capacity"
+                $excess--
+            }
+        }
+
+        $state = Get-FleetState
+        $transitionBusy = @($state.Vms | Where-Object {
+                $runner = Get-RunnerForVm -State $state -VmName $PSItem.name
+                $pool = Get-VmPool -Vm $PSItem
+                $outsideDesiredPool = -not $pool -or -not $desired.Contains($pool) -or $desired[$pool] -eq 0
+                $outsideDesiredPool -and $runner -and $runner.busy
+            }).Count
+        $target = [math]::Min($script:Fleet.MaxRunners, $desiredTotal + $transitionBusy)
+        $vmssPath = "/subscriptions/$($script:Fleet.SubscriptionId)/resourceGroups/$($script:Fleet.ResourceGroup)/providers/Microsoft.Compute/virtualMachineScaleSets/$($script:Fleet.Vmss)"
+        $splatCapacity = @{
+            Path      = "$vmssPath`?api-version=2024-07-01"
+            Operation = "read VMSS capacity"
+        }
+        $capacityResponse = Invoke-ArmJson @splatCapacity
+        $capacity = [int]$capacityResponse.sku.capacity
+        Write-Host "capacity=$capacity target=$target transition_busy=$transitionBusy"
+        if ($capacity -lt $target) {
+            if (Test-FleetDryRun -Decision "scale vmss=$($script:Fleet.Vmss) from=$capacity to=$target") {
+                # Nothing was scaled, so the provisioning wait below has nothing to
+                # wait for. Skipping it keeps a shadow pass to seconds, not minutes.
+            } else {
+                # Fire and forget, matching the CLI's --no-wait: the loop below is the
+                # real readiness check.
+                $splatScale = @{
+                    Path      = "$vmssPath`?api-version=2024-07-01"
+                    Method    = "Patch"
+                    Body      = @{ sku = @{ capacity = $target } }
+                    Operation = "scale VMSS to $target"
+                }
+                $null = Invoke-ArmWeb @splatScale
+                foreach ($attempt in 1..15) {
+                    Start-Sleep -Seconds 20
+                    $state = Get-FleetState
+                    $notReady = @($state.Vms | Where-Object provisioning -NE "Succeeded").Count
+                    if ($state.Vms.Count -ge $target -and $notReady -eq 0) {
+                        break
+                    }
+                    Write-Host "provisioning check $attempt of 15: vms=$($state.Vms.Count)/$target not_ready=$notReady"
+                }
+            }
+        }
+
+        $state = Get-FleetState
+        Set-UnallocatedVmPool -State $state -Desired $desired
+        $state = Get-FleetState
+        Register-PoolVms -State $state -Desired $desired
+        $state = Get-FleetState
+        Set-VmOnlineObservedAt -State $state -Vms $state.Vms
+        foreach ($pool in $desired.Keys) {
+            $poolVms = @($state.Vms | Where-Object { (Get-VmPool -Vm $PSItem) -eq $pool })
+            $poolRunners = @($state.Runners | Where-Object { (Get-RunnerPool -Runner $PSItem) -eq $pool })
+            $online = @($poolRunners | Where-Object status -EQ "online").Count
+            $busy = @($poolRunners | Where-Object busy).Count
+            Write-Host "pool=$pool desired=$($desired[$pool]) vms=$($poolVms.Count) online=$online busy=$busy"
+        }
+
+        Remove-OrphanedNetworking -Snapshot $orphanSnapshot
+        Set-FleetHeartbeat
+    } catch [TransientFleetException] {
+        Write-Warning "$($PSItem.Exception.Message) No further fleet changes will be attempted; a job-completion nudge or scheduled reconcile will retry."
+    }
+}
+
+function Invoke-FleetSpendReport {
+    [CmdletBinding()]
+    param()
+
+    $null = Initialize-FleetContext
+    $from = [DateTime]::UtcNow.ToString("yyyy-MM-01")
+    $to = [DateTime]::UtcNow.ToString("yyyy-MM-dd")
+    $cost = "unavailable"
+    try {
+        $body = @{
+            type       = "ActualCost"
+            timeframe  = "Custom"
+            timePeriod = @{ from = $from; to = $to }
+            dataset    = @{
+                granularity = "None"
+                aggregation = @{ totalCost = @{ name = "Cost"; function = "Sum" } }
+            }
+        }
+        $splatCost = @{
+            Path      = "/subscriptions/$($script:Fleet.SubscriptionId)/resourceGroups/$($script:Fleet.ResourceGroup)/providers/Microsoft.CostManagement/query?api-version=2023-11-01"
+            Method    = "Post"
+            Body      = $body
+            Operation = "query month-to-date spend"
+        }
+        $costResponse = Invoke-ArmJson @splatCost
+        $amount = @($costResponse.properties.rows)[0][0]
+        $cost = "{0:N2}" -f [double]$amount
+    } catch {
+        Write-Warning "Cost Management query failed; reporting unavailable. $($PSItem.Exception.Message)"
+    }
+
+    $titleFilter = "`"CI cost tracker`""
+    $issueQuery = [uri]::EscapeDataString("repo:$($script:Fleet.Repo) is:issue is:open in:title $titleFilter")
+    $splatIssues = @{
+        Path      = "search/issues?q=$issueQuery"
+        Operation = "find the CI cost tracker issue"
+    }
+    $search = Invoke-GhJson @splatIssues
+    $issueNumber = @($search.items | Select-Object -First 1).number
+    if (-not $issueNumber) {
+        $splatCreate = @{
+            Path      = "repos/$($script:Fleet.Repo)/issues"
+            Method    = "Post"
+            Body      = @{
+                title = "CI cost tracker"
+                body  = "Automated month-to-date Azure spend for the self-hosted runner fleet."
+            }
+            Operation = "open the CI cost tracker issue"
+        }
+        $issueNumber = (Invoke-GhJson @splatCreate).number
+    }
+    $comment = "Month-to-date spend for ``$($script:Fleet.ResourceGroup)`` as of $($to): **`$$cost**"
+    if (Test-FleetDryRun -Decision "comment issue=$issueNumber body=$comment") {
+        return
+    }
+    $splatComment = @{
+        Path      = "repos/$($script:Fleet.Repo)/issues/$issueNumber/comments"
+        Method    = "Post"
+        Body      = @{ body = $comment }
+        Operation = "comment month-to-date spend"
+    }
+    $null = Invoke-GhJson @splatComment
+    Write-Host "posted month-to-date spend $cost to issue $issueNumber"
+}
+
+function Get-FleetNudge {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$EventName,
+        [Parameter(Mandatory)]
+        $Payload,
+        [Parameter(Mandatory)]
+        [string[]]$BoostUsers,
+        [Parameter(Mandatory)]
+        [string]$RunnerLabel,
+        [Parameter(Mandatory)]
+        [string]$CiWorkflow
+    )
+
+    # Webhook bodies are hints, never decision inputs. All this decides is whether a
+    # pass is worth waking; the pass itself re-reads the whole GitHub queue and the
+    # whole Azure inventory, so a forged nudge buys an attacker one read-and-converge.
+    switch ($EventName) {
+        "workflow_job" {
+            if ([string]$Payload.action -notin @("queued", "completed")) {
+                return $null
+            }
+            # ci-azure's authorize job runs on ubuntu-latest and emits these events
+            # too. Only fleet-labelled jobs mean anything to the controller.
+            if (@($Payload.workflow_job.labels) -notcontains $RunnerLabel) {
+                return $null
+            }
+            return @{
+                reason = "workflow_job.$([string]$Payload.action)"
+            }
+        }
+        "workflow_run" {
+            if ([string]$Payload.action -notin @("requested", "completed")) {
+                return $null
+            }
+            $workflowPath = [string]$Payload.workflow_run.path
+            if ($workflowPath -and -not $workflowPath.EndsWith($CiWorkflow)) {
+                return $null
+            }
+            return @{
+                reason = "workflow_run.$([string]$Payload.action)"
+            }
+        }
+        "push" {
+            $actor = [string]$Payload.sender.login
+            if ($actor -notin $BoostUsers) {
+                return $null
+            }
+            # The [do ci] gate for opt-in users lives in the policy, not here: it also
+            # has to hold for pushes that arrive as repository events rather than as a
+            # webhook, and one implementation cannot drift from itself.
+            return @{
+                reason  = "push"
+                actor   = $actor
+                message = [string]$Payload.head_commit.message
+                sha     = [string]$Payload.after
+                ref     = [string]$Payload.ref
+            }
+        }
+    }
+    return $null
+}
+
+$splatExport = @{
+    Function = @(
+        "Invoke-FleetReconcile",
+        "Invoke-FleetSpendReport",
+        "Get-FleetNudge",
+        "Initialize-FleetContext",
+        "Get-FleetConfig",
+        "Get-FleetSetting",
+        "Invoke-VmRunCommand"
+    )
+}
+Export-ModuleMember @splatExport

--- a/.github/runners/controller/Modules/FleetCore/FleetCore.psm1
+++ b/.github/runners/controller/Modules/FleetCore/FleetCore.psm1
@@ -821,6 +821,14 @@ function Confirm-DirectTrigger {
     # GitHub for the ref's head settles that: a replay names a SHA that is no longer
     # the head and gets dropped, and the sha and message handed downstream come from
     # the API response rather than from the request body.
+    # Branches only. A push webhook fires for tags too, and both the commits endpoint below
+    # and workflow dispatch accept a tag ref, so without this a maintainer cutting a release
+    # tag would heat a lane and dispatch CI at the tag. Stripping the prefix without first
+    # requiring it also let refs/tags/x through as the "branch" refs/tags/x.
+    if ($Ref -notlike "refs/heads/*") {
+        Write-Warning "Trigger ref $Ref is not a branch; converging from repository activity instead"
+        return $empty
+    }
     $branch = $Ref -replace "^refs/heads/", ""
     # Conservative because this value reaches a REST path. Real branch names here are
     # well inside it, and anything stranger is dropped rather than escaped. The explicit

--- a/.github/runners/controller/Modules/FleetCore/FleetCore.psm1
+++ b/.github/runners/controller/Modules/FleetCore/FleetCore.psm1
@@ -1001,6 +1001,12 @@ function Invoke-VmRunCommand {
         [Parameter(Mandatory)]
         [string]$VmResourceId,
         [Parameter(Mandatory)]
+        # Mandatory on a [string[]] rejects the whole array when any element is an empty
+        # string, and this one is a PowerShell file read line by line -- bootstrap-runner.ps1
+        # has 16 blank lines. Every registration failed with "because it is an empty string"
+        # until this attribute went on. An empty array and a null still fail, which is what
+        # a missing or truncated bootstrap should do.
+        [AllowEmptyString()]
         [string[]]$ScriptLines,
         [Parameter(Mandatory)]
         [object[]]$Parameters,

--- a/.github/runners/controller/Modules/GitHubAppAuth/GitHubAppAuth.psm1
+++ b/.github/runners/controller/Modules/GitHubAppAuth/GitHubAppAuth.psm1
@@ -1,0 +1,181 @@
+<#
+.SYNOPSIS
+    Authenticates the fleet controller to GitHub as the dbatools-fleet-controller App.
+
+.DESCRIPTION
+    Two steps, both plain REST so nothing has to be installed in the Function sandbox:
+    an RS256 JWT signed with the App's private key proves we are the App, and that JWT
+    buys a one-hour installation token scoped to dataplat/dbatools.
+
+    The installation token is cached in module scope until five minutes before it
+    expires. A reconcile pass makes a few dozen calls and a webhook burst can wake
+    several passes; minting per call would spend the 5000/hour budget on nothing.
+
+.NOTES
+    Author: the dbatools team + Claude
+#>
+
+$script:InstallationToken = $null
+$script:InstallationTokenExpiry = [DateTimeOffset]::MinValue
+
+function ConvertTo-Base64Url {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [byte[]]$Bytes
+    )
+
+    ([Convert]::ToBase64String($Bytes)).TrimEnd("=").Replace("+", "-").Replace("/", "_")
+}
+
+function ConvertTo-RsaKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$PrivateKeyPem
+    )
+
+    # A PEM that travelled through an app setting sometimes arrives with its newlines
+    # escaped rather than real. ImportFromPem rejects that with an opaque ASN.1 error,
+    # so normalize before handing it over.
+    $pem = $PrivateKeyPem.Replace("\r\n", "`n").Replace("\n", "`n").Trim()
+    $rsa = [System.Security.Cryptography.RSA]::Create()
+    $rsa.ImportFromPem($pem)
+    $rsa
+}
+
+function New-GitHubAppJwt {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$AppId,
+        [Parameter(Mandatory)]
+        [string]$PrivateKeyPem
+    )
+
+    # iat is backdated a minute because GitHub rejects a JWT issued in its future, and
+    # a Function host clock can sit a few seconds ahead. exp is nine minutes out; ten
+    # is the documented maximum.
+    $issuedAt = [DateTimeOffset]::UtcNow.AddSeconds(-60).ToUnixTimeSeconds()
+    $expiresAt = [DateTimeOffset]::UtcNow.AddSeconds(540).ToUnixTimeSeconds()
+    $header = @{
+        alg = "RS256"
+        typ = "JWT"
+    }
+    $claims = @{
+        iat = $issuedAt
+        exp = $expiresAt
+        iss = $AppId
+    }
+    $encodedHeader = ConvertTo-Base64Url -Bytes ([System.Text.Encoding]::UTF8.GetBytes(($header | ConvertTo-Json -Compress)))
+    $encodedClaims = ConvertTo-Base64Url -Bytes ([System.Text.Encoding]::UTF8.GetBytes(($claims | ConvertTo-Json -Compress)))
+    $payload = "$encodedHeader.$encodedClaims"
+
+    $rsa = ConvertTo-RsaKey -PrivateKeyPem $PrivateKeyPem
+    try {
+        $splatSignature = @{
+            Data          = [System.Text.Encoding]::UTF8.GetBytes($payload)
+            HashAlgorithm = [System.Security.Cryptography.HashAlgorithmName]::SHA256
+            Padding       = [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+        }
+        $signature = $rsa.SignData($splatSignature.Data, $splatSignature.HashAlgorithm, $splatSignature.Padding)
+    } finally {
+        $rsa.Dispose()
+    }
+    "$payload.$(ConvertTo-Base64Url -Bytes $signature)"
+}
+
+function Get-GitHubInstallationToken {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$AppId,
+        [Parameter(Mandatory)]
+        [string]$InstallationId,
+        [Parameter(Mandatory)]
+        [string]$PrivateKeyPem,
+        [switch]$Force
+    )
+
+    if (-not $Force -and $script:InstallationToken -and [DateTimeOffset]::UtcNow -lt $script:InstallationTokenExpiry) {
+        return $script:InstallationToken
+    }
+
+    $jwt = New-GitHubAppJwt -AppId $AppId -PrivateKeyPem $PrivateKeyPem
+    $splatToken = @{
+        Method     = "Post"
+        Uri        = "https://api.github.com/app/installations/$InstallationId/access_tokens"
+        Headers    = @{
+            Accept                 = "application/vnd.github+json"
+            Authorization          = "Bearer $jwt"
+            "X-GitHub-Api-Version" = "2022-11-28"
+            "User-Agent"           = "dbatools-fleet-controller"
+        }
+        TimeoutSec = 30
+    }
+    $response = Invoke-RestMethod @splatToken
+
+    $script:InstallationToken = $response.token
+    $expiry = [DateTimeOffset]::UtcNow.AddMinutes(50)
+    if ($response.expires_at) {
+        $expiry = ([DateTimeOffset]::Parse([string]$response.expires_at)).AddMinutes(-5)
+    }
+    $script:InstallationTokenExpiry = $expiry
+    $script:InstallationToken
+}
+
+function Clear-GitHubInstallationToken {
+    [CmdletBinding()]
+    param()
+
+    $script:InstallationToken = $null
+    $script:InstallationTokenExpiry = [DateTimeOffset]::MinValue
+}
+
+function Test-GitHubWebhookSignature {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Body,
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Signature,
+        [Parameter(Mandatory)]
+        [string]$Secret
+    )
+
+    if (-not $Signature -or -not $Signature.StartsWith("sha256=")) {
+        return $false
+    }
+    $hmac = New-Object -TypeName System.Security.Cryptography.HMACSHA256
+    try {
+        $hmac.Key = [System.Text.Encoding]::UTF8.GetBytes($Secret)
+        $computed = "sha256=" + (($hmac.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Body)) | ForEach-Object { $PSItem.ToString("x2") }) -join "")
+    } finally {
+        $hmac.Dispose()
+    }
+    # Fixed-time comparison: a length-or-first-difference check leaks how much of a
+    # guessed signature was right, which is enough to forge one byte at a time.
+    $expected = [System.Text.Encoding]::UTF8.GetBytes($computed)
+    $actual = [System.Text.Encoding]::UTF8.GetBytes($Signature)
+    if ($expected.Length -ne $actual.Length) {
+        return $false
+    }
+    $difference = 0
+    for ($index = 0; $index -lt $expected.Length; $index++) {
+        $difference = $difference -bor ($expected[$index] -bxor $actual[$index])
+    }
+    $difference -eq 0
+}
+
+$splatExport = @{
+    Function = @(
+        "New-GitHubAppJwt",
+        "Get-GitHubInstallationToken",
+        "Clear-GitHubInstallationToken",
+        "Test-GitHubWebhookSignature",
+        "ConvertTo-Base64Url"
+    )
+}
+Export-ModuleMember @splatExport

--- a/.github/runners/controller/ReconcileQueue/function.json
+++ b/.github/runners/controller/ReconcileQueue/function.json
@@ -1,0 +1,11 @@
+{
+  "bindings": [
+    {
+      "name": "QueueItem",
+      "type": "queueTrigger",
+      "direction": "in",
+      "queueName": "%FLEET_QUEUE%",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}

--- a/.github/runners/controller/ReconcileQueue/run.ps1
+++ b/.github/runners/controller/ReconcileQueue/run.ps1
@@ -1,0 +1,25 @@
+# The only thing that reconciles. Serialization comes from three settings that have to
+# stay together: maximumInstanceCount 1 on the app, and batchSize 1 with
+# newBatchThreshold 0 in host.json. That triple is what the runner-fleet concurrency
+# group used to do in GitHub Actions.
+#
+# The queue message is a hint about why we woke up. Invoke-FleetReconcile re-reads the
+# whole GitHub queue and the whole Azure inventory regardless, so a wrong or forged hint
+# costs one converge pass and changes no decision.
+
+param($QueueItem, $TriggerMetadata)
+
+$nudge = $QueueItem
+if ($nudge -is [string]) {
+    $nudge = $nudge | ConvertFrom-Json -Depth 6
+}
+$reason = [string]$nudge.reason
+Write-Host "reconcile reason=$reason delivery=$($nudge.delivery) attempt=$($TriggerMetadata.DequeueCount)"
+
+$splatReconcile = @{
+    DirectTriggerActor   = [string]$nudge.actor
+    DirectTriggerMessage = [string]$nudge.message
+    DirectTriggerSha     = [string]$nudge.sha
+    DirectTriggerRef     = [string]$nudge.ref
+}
+Invoke-FleetReconcile @splatReconcile

--- a/.github/runners/controller/ReconcileQueue/run.ps1
+++ b/.github/runners/controller/ReconcileQueue/run.ps1
@@ -4,8 +4,9 @@
 # group used to do in GitHub Actions.
 #
 # The queue message is a hint about why we woke up. Invoke-FleetReconcile re-reads the
-# whole GitHub queue and the whole Azure inventory regardless, so a wrong or forged hint
-# costs one converge pass and changes no decision.
+# whole GitHub queue and the whole Azure inventory regardless, and corroborates the
+# actor/sha/ref against GitHub before any of it reaches a decision, so a wrong, stale or
+# replayed hint costs one converge pass and changes nothing.
 
 param($QueueItem, $TriggerMetadata)
 

--- a/.github/runners/controller/SafetyTick/function.json
+++ b/.github/runners/controller/SafetyTick/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "name": "Timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 */5 * * * *"
+    },
+    {
+      "type": "queue",
+      "direction": "out",
+      "name": "Nudge",
+      "queueName": "%FLEET_QUEUE%",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}

--- a/.github/runners/controller/SafetyTick/run.ps1
+++ b/.github/runners/controller/SafetyTick/run.ps1
@@ -1,0 +1,14 @@
+# The missed-webhook net, on the same five-minute cadence the cron reconcile used.
+# GitHub does not redeliver a webhook that failed, so without this a single dropped
+# delivery could leave a lane cold until the next unrelated event.
+#
+# It enqueues rather than reconciling inline: everything that reconciles has to go
+# through the one queue, or a tick and a nudge could run at the same time inside the
+# single instance.
+
+param($Timer)
+
+if ($Timer.IsPastDue) {
+    Write-Warning "Safety tick is running late; the host was likely idle or restarting."
+}
+Push-OutputBinding -Name Nudge -Value (@{ reason = "safety-tick" } | ConvertTo-Json -Compress)

--- a/.github/runners/controller/SpendReport/function.json
+++ b/.github/runners/controller/SpendReport/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "Timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 0 7 * * 1"
+    }
+  ]
+}

--- a/.github/runners/controller/SpendReport/run.ps1
+++ b/.github/runners/controller/SpendReport/run.ps1
@@ -1,0 +1,5 @@
+# Monday 07:00 UTC, the schedule the spend-report job ran on in runner-reconcile.yml.
+
+param($Timer)
+
+Invoke-FleetSpendReport

--- a/.github/runners/controller/fleet-config.psd1
+++ b/.github/runners/controller/fleet-config.psd1
@@ -1,0 +1,35 @@
+# Fleet policy constants. This file is the single source of truth for the numbers that
+# used to live in runner-reconcile.yml's env: block, and tests/runner-policy.Tests.ps1
+# asserts the janitor stays aligned with it.
+#
+# Every key can be overridden by an app setting of the same name on the Function App,
+# which is the emergency lever: change one number in the portal, no redeploy. The
+# committed values here are what the fleet runs on normally.
+@{
+    # Hard VMSS ceiling. Get-DesiredRunnerPools throws rather than exceed it.
+    MAX_RUNNERS             = 35
+
+    # Shared lane for everyone who is not a maintainer.
+    COMMUNITY_COUNT         = 5
+    COMMUNITY_GRACE_MINUTES = 20
+
+    # Each maintainer gets an independent lane.
+    BOOST_USERS             = "potatoqualitee andreasjordan niphlod"
+    BOOST_COUNT             = 10
+    BOOST_HOURS             = 1
+
+    # Held by a lane that is hot but has nothing pending. Mirrored by $warmFloor in
+    # janitor-runbook.ps1.
+    WARM_FLOOR              = 3
+
+    # Users whose pushes do NOT heat a lane unless the head commit carries CI_MARKER.
+    OPT_IN_PUSH_USERS       = "potatoqualitee"
+    CI_MARKER               = "[do ci]"
+
+    # Base runner label. Pool labels are dbatools-pool-<lane> on top of it.
+    RUNNER_LABEL            = "dbatools-modern"
+    POOL_LABEL_PREFIX       = "dbatools-pool-"
+
+    # Workflow the controller reads demand from and dispatches marked pushes to.
+    CI_WORKFLOW             = "ci-azure.yml"
+}

--- a/.github/runners/controller/host.json
+++ b/.github/runners/controller/host.json
@@ -1,0 +1,34 @@
+{
+  "version": "2.0",
+  "functionTimeout": "00:30:00",
+  "managedDependency": {
+    "enabled": false
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "queues": {
+      "batchSize": 1,
+      "newBatchThreshold": 0,
+      "maxDequeueCount": 5,
+      "visibilityTimeout": "00:01:00",
+      "maxPollingInterval": "00:00:02"
+    }
+  },
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": false
+      }
+    },
+    "logLevel": {
+      "default": "Information",
+      "Azure.Core": "Warning",
+      "Azure.Storage.Blobs": "Warning",
+      "Azure.Storage.Queues": "Warning",
+      "Host.Storage": "Warning"
+    }
+  }
+}

--- a/.github/runners/controller/profile.ps1
+++ b/.github/runners/controller/profile.ps1
@@ -1,0 +1,10 @@
+# Runs once per PowerShell worker. Flex Consumption gives app init 30 seconds, so this
+# stays to two local module imports -- no Az, no managed dependencies, no network.
+#
+# No Connect-AzAccount: every Azure call in FleetCore is raw REST against a token from
+# the managed identity endpoint, which needs nothing imported.
+
+$ErrorActionPreference = "Stop"
+
+Import-Module -Name "$PSScriptRoot/Modules/GitHubAppAuth/GitHubAppAuth.psm1" -Force
+Import-Module -Name "$PSScriptRoot/Modules/FleetCore/FleetCore.psm1" -Force

--- a/.github/runners/deploy-controller.ps1
+++ b/.github/runners/deploy-controller.ps1
@@ -17,6 +17,10 @@
     Sets the DRY_RUN app setting as part of the deployment. Left alone when not passed,
     so a routine redeploy cannot silently arm a shadowing controller.
 
+.PARAMETER ShowWebhookUrl
+    Prints the webhook URL, function key and all, for pasting into the GitHub App. The key
+    is a credential, so a routine deploy does not print it.
+
 .EXAMPLE
     PS C:\> ./deploy-controller.ps1
 
@@ -27,6 +31,11 @@
 
     Deploys and takes the controller live.
 
+.EXAMPLE
+    PS C:\> ./deploy-controller.ps1 -ShowWebhookUrl
+
+    Deploys and prints the URL the GitHub App should post to.
+
 .NOTES
     Author: the dbatools team + Claude
 #>
@@ -36,7 +45,8 @@ param(
     [string]$ResourceGroup = "dbatools-ci",
     [string]$FunctionAppName = "dbatools-fleet-controller",
     [ValidateSet("true", "false")]
-    [string]$DryRun
+    [string]$DryRun,
+    [switch]$ShowWebhookUrl
 )
 
 $ErrorActionPreference = "Stop"
@@ -47,96 +57,106 @@ if (-not (Test-Path -Path $controllerRoot)) {
     throw "No controller directory beside this script at $controllerRoot"
 }
 
-$staging = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "dbatools-fleet-controller-package"
-if (Test-Path -Path $staging) {
-    Remove-Item -Path $staging -Recurse -Force
-}
+# Unique per run rather than a fixed name in the shared temp directory. A predictable path
+# that this script then deletes -Recurse -Force is one a concurrent deploy clobbers halfway
+# through, and one anyone on the box can pre-create as a link pointing somewhere else.
+$runId = [System.Guid]::NewGuid().ToString("N")
+$staging = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "dbatools-fleet-controller-$runId"
+$zipPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "dbatools-fleet-controller-$runId.zip"
 $null = New-Item -Path $staging -ItemType Directory
 
-$splatCopy = @{
-    Path        = (Join-Path -Path $controllerRoot -ChildPath "*")
-    Destination = $staging
-    Recurse     = $true
-    Force       = $true
-}
-Copy-Item @splatCopy
-
-$fleetCoreDir = Join-Path -Path $staging -ChildPath "Modules/FleetCore"
-$bundled = @(
-    "runner-policy.ps1",
-    "bootstrap-runner.ps1"
-)
-foreach ($fileName in $bundled) {
-    $source = Join-Path -Path $runnerRoot -ChildPath $fileName
-    if (-not (Test-Path -Path $source)) {
-        throw "Cannot bundle $fileName; expected it at $source"
+try {
+    $splatCopy = @{
+        Path        = (Join-Path -Path $controllerRoot -ChildPath "*")
+        Destination = $staging
+        Recurse     = $true
+        Force       = $true
     }
-    Copy-Item -Path $source -Destination $fleetCoreDir -Force
-}
-Move-Item -Path (Join-Path -Path $staging -ChildPath "fleet-config.psd1") -Destination $fleetCoreDir -Force
+    Copy-Item @splatCopy
 
-$expected = @(
-    "host.json",
-    "profile.ps1",
-    "GithubWebhook/function.json",
-    "GithubWebhook/run.ps1",
-    "ReconcileQueue/function.json",
-    "ReconcileQueue/run.ps1",
-    "SafetyTick/function.json",
-    "SafetyTick/run.ps1",
-    "SpendReport/function.json",
-    "SpendReport/run.ps1",
-    "Modules/GitHubAppAuth/GitHubAppAuth.psm1",
-    "Modules/FleetCore/FleetCore.psm1",
-    "Modules/FleetCore/fleet-config.psd1",
-    "Modules/FleetCore/runner-policy.ps1",
-    "Modules/FleetCore/bootstrap-runner.ps1"
-)
-$missing = @($expected | Where-Object { -not (Test-Path -Path (Join-Path -Path $staging -ChildPath $PSItem)) })
-if ($missing) {
-    throw "Package is incomplete: $($missing -join ", ")"
-}
+    $fleetCoreDir = Join-Path -Path $staging -ChildPath "Modules/FleetCore"
+    $bundled = @(
+        "runner-policy.ps1",
+        "bootstrap-runner.ps1"
+    )
+    foreach ($fileName in $bundled) {
+        $source = Join-Path -Path $runnerRoot -ChildPath $fileName
+        if (-not (Test-Path -Path $source)) {
+            throw "Cannot bundle $fileName; expected it at $source"
+        }
+        Copy-Item -Path $source -Destination $fleetCoreDir -Force
+    }
+    Move-Item -Path (Join-Path -Path $staging -ChildPath "fleet-config.psd1") -Destination $fleetCoreDir -Force
 
-$zipPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "dbatools-fleet-controller.zip"
-if (Test-Path -Path $zipPath) {
-    Remove-Item -Path $zipPath -Force
-}
-# Not Compress-Archive: it has written Windows path separators into entry names, and a
-# Linux Functions host then unpacks the whole tree as flat files with backslashes in
-# their names. ZipFile always writes forward slashes.
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-[System.IO.Compression.ZipFile]::CreateFromDirectory($staging, $zipPath)
-Write-Host "packaged $([math]::Round((Get-Item -Path $zipPath).Length / 1KB)) KB from $staging"
+    $expected = @(
+        "host.json",
+        "profile.ps1",
+        "GithubWebhook/function.json",
+        "GithubWebhook/run.ps1",
+        "ReconcileQueue/function.json",
+        "ReconcileQueue/run.ps1",
+        "SafetyTick/function.json",
+        "SafetyTick/run.ps1",
+        "SpendReport/function.json",
+        "SpendReport/run.ps1",
+        "Modules/GitHubAppAuth/GitHubAppAuth.psm1",
+        "Modules/FleetCore/FleetCore.psm1",
+        "Modules/FleetCore/fleet-config.psd1",
+        "Modules/FleetCore/runner-policy.ps1",
+        "Modules/FleetCore/bootstrap-runner.ps1"
+    )
+    $missing = @($expected | Where-Object { -not (Test-Path -Path (Join-Path -Path $staging -ChildPath $PSItem)) })
+    if ($missing) {
+        throw "Package is incomplete: $($missing -join ", ")"
+    }
 
-if ($PSBoundParameters.ContainsKey("DryRun")) {
-    $splatDryRun = @(
-        "functionapp", "config", "appsettings", "set",
+    # Not Compress-Archive: it has written Windows path separators into entry names, and a
+    # Linux Functions host then unpacks the whole tree as flat files with backslashes in
+    # their names. ZipFile always writes forward slashes.
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($staging, $zipPath)
+    Write-Host "packaged $([math]::Round((Get-Item -Path $zipPath).Length / 1KB)) KB from $staging"
+
+    if ($PSBoundParameters.ContainsKey("DryRun")) {
+        $splatDryRun = @(
+            "functionapp", "config", "appsettings", "set",
+            "--subscription", $SubscriptionId,
+            "--resource-group", $ResourceGroup,
+            "--name", $FunctionAppName,
+            "--settings", "DRY_RUN=$DryRun",
+            "--only-show-errors", "--output", "none"
+        )
+        az @splatDryRun
+        if ($LASTEXITCODE -ne 0) {
+            throw "failed to set DRY_RUN=$DryRun"
+        }
+        Write-Host "DRY_RUN=$DryRun"
+    }
+
+    $splatDeploy = @(
+        "functionapp", "deployment", "source", "config-zip",
         "--subscription", $SubscriptionId,
         "--resource-group", $ResourceGroup,
         "--name", $FunctionAppName,
-        "--settings", "DRY_RUN=$DryRun",
+        "--src", $zipPath,
         "--only-show-errors", "--output", "none"
     )
-    az @splatDryRun
+    az @splatDeploy
     if ($LASTEXITCODE -ne 0) {
-        throw "failed to set DRY_RUN=$DryRun"
+        throw "one deploy failed for $FunctionAppName"
     }
-    Write-Host "DRY_RUN=$DryRun"
+    Write-Host "deployed $FunctionAppName"
+} finally {
+    Remove-Item -Path $staging -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $zipPath -Force -ErrorAction SilentlyContinue
 }
 
-$splatDeploy = @(
-    "functionapp", "deployment", "source", "config-zip",
-    "--subscription", $SubscriptionId,
-    "--resource-group", $ResourceGroup,
-    "--name", $FunctionAppName,
-    "--src", $zipPath,
-    "--only-show-errors", "--output", "none"
-)
-az @splatDeploy
-if ($LASTEXITCODE -ne 0) {
-    throw "one deploy failed for $FunctionAppName"
+# The function key is a credential: anyone holding it can post to the webhook. Printed only
+# when asked for, so it does not land in the scrollback of every routine redeploy.
+if (-not $ShowWebhookUrl) {
+    Write-Host "Webhook URL not printed. Rerun with -ShowWebhookUrl when you need it."
+    return
 }
-Write-Host "deployed $FunctionAppName"
 
 $splatHostName = @(
     "functionapp", "show",

--- a/.github/runners/deploy-controller.ps1
+++ b/.github/runners/deploy-controller.ps1
@@ -1,0 +1,177 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Packages and deploys the fleet controller Function App.
+
+.DESCRIPTION
+    Stages controller/ into a ready-to-run .zip and pushes it with one deploy, which is
+    the only deployment technology a Flex Consumption plan supports.
+
+    Staging is not a straight copy. runner-policy.ps1, bootstrap-runner.ps1 and
+    fleet-config.psd1 live at .github/runners/ in the repo, where the mirror tests and
+    runner-scale-up.yml expect them, but FleetCore resolves all three from its own
+    $PSScriptRoot. They are copied into Modules/FleetCore/ here so the module stays
+    self-contained at runtime and the repo keeps one copy of each file.
+
+.PARAMETER DryRun
+    Sets the DRY_RUN app setting as part of the deployment. Left alone when not passed,
+    so a routine redeploy cannot silently arm a shadowing controller.
+
+.EXAMPLE
+    PS C:\> ./deploy-controller.ps1
+
+    Packages and deploys, leaving DRY_RUN as it is.
+
+.EXAMPLE
+    PS C:\> ./deploy-controller.ps1 -DryRun false
+
+    Deploys and takes the controller live.
+
+.NOTES
+    Author: the dbatools team + Claude
+#>
+[CmdletBinding()]
+param(
+    [string]$SubscriptionId = "fda988ac-f308-440e-ad06-ad1c3f026218",
+    [string]$ResourceGroup = "dbatools-ci",
+    [string]$FunctionAppName = "dbatools-fleet-controller",
+    [ValidateSet("true", "false")]
+    [string]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+$runnerRoot = $PSScriptRoot
+$controllerRoot = Join-Path -Path $runnerRoot -ChildPath "controller"
+if (-not (Test-Path -Path $controllerRoot)) {
+    throw "No controller directory beside this script at $controllerRoot"
+}
+
+$staging = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "dbatools-fleet-controller-package"
+if (Test-Path -Path $staging) {
+    Remove-Item -Path $staging -Recurse -Force
+}
+$null = New-Item -Path $staging -ItemType Directory
+
+$splatCopy = @{
+    Path        = (Join-Path -Path $controllerRoot -ChildPath "*")
+    Destination = $staging
+    Recurse     = $true
+    Force       = $true
+}
+Copy-Item @splatCopy
+
+$fleetCoreDir = Join-Path -Path $staging -ChildPath "Modules/FleetCore"
+$bundled = @(
+    "runner-policy.ps1",
+    "bootstrap-runner.ps1"
+)
+foreach ($fileName in $bundled) {
+    $source = Join-Path -Path $runnerRoot -ChildPath $fileName
+    if (-not (Test-Path -Path $source)) {
+        throw "Cannot bundle $fileName; expected it at $source"
+    }
+    Copy-Item -Path $source -Destination $fleetCoreDir -Force
+}
+Move-Item -Path (Join-Path -Path $staging -ChildPath "fleet-config.psd1") -Destination $fleetCoreDir -Force
+
+$expected = @(
+    "host.json",
+    "profile.ps1",
+    "GithubWebhook/function.json",
+    "GithubWebhook/run.ps1",
+    "ReconcileQueue/function.json",
+    "ReconcileQueue/run.ps1",
+    "SafetyTick/function.json",
+    "SafetyTick/run.ps1",
+    "SpendReport/function.json",
+    "SpendReport/run.ps1",
+    "Modules/GitHubAppAuth/GitHubAppAuth.psm1",
+    "Modules/FleetCore/FleetCore.psm1",
+    "Modules/FleetCore/fleet-config.psd1",
+    "Modules/FleetCore/runner-policy.ps1",
+    "Modules/FleetCore/bootstrap-runner.ps1"
+)
+$missing = @($expected | Where-Object { -not (Test-Path -Path (Join-Path -Path $staging -ChildPath $PSItem)) })
+if ($missing) {
+    throw "Package is incomplete: $($missing -join ", ")"
+}
+
+$zipPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "dbatools-fleet-controller.zip"
+if (Test-Path -Path $zipPath) {
+    Remove-Item -Path $zipPath -Force
+}
+# Not Compress-Archive: it has written Windows path separators into entry names, and a
+# Linux Functions host then unpacks the whole tree as flat files with backslashes in
+# their names. ZipFile always writes forward slashes.
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+[System.IO.Compression.ZipFile]::CreateFromDirectory($staging, $zipPath)
+Write-Host "packaged $([math]::Round((Get-Item -Path $zipPath).Length / 1KB)) KB from $staging"
+
+if ($PSBoundParameters.ContainsKey("DryRun")) {
+    $splatDryRun = @(
+        "functionapp", "config", "appsettings", "set",
+        "--subscription", $SubscriptionId,
+        "--resource-group", $ResourceGroup,
+        "--name", $FunctionAppName,
+        "--settings", "DRY_RUN=$DryRun",
+        "--only-show-errors", "--output", "none"
+    )
+    az @splatDryRun
+    if ($LASTEXITCODE -ne 0) {
+        throw "failed to set DRY_RUN=$DryRun"
+    }
+    Write-Host "DRY_RUN=$DryRun"
+}
+
+$splatDeploy = @(
+    "functionapp", "deployment", "source", "config-zip",
+    "--subscription", $SubscriptionId,
+    "--resource-group", $ResourceGroup,
+    "--name", $FunctionAppName,
+    "--src", $zipPath,
+    "--only-show-errors", "--output", "none"
+)
+az @splatDeploy
+if ($LASTEXITCODE -ne 0) {
+    throw "one deploy failed for $FunctionAppName"
+}
+Write-Host "deployed $FunctionAppName"
+
+$splatHostName = @(
+    "functionapp", "show",
+    "--subscription", $SubscriptionId,
+    "--resource-group", $ResourceGroup,
+    "--name", $FunctionAppName,
+    "--query", "properties.defaultHostName || defaultHostName",
+    "--output", "tsv", "--only-show-errors"
+)
+$hostName = az @splatHostName
+
+# Trigger sync is asynchronous, so the webhook function may not be listed for a few
+# seconds after the deploy returns.
+$webhookKey = $null
+foreach ($attempt in 1..6) {
+    $splatKey = @(
+        "functionapp", "function", "keys", "list",
+        "--subscription", $SubscriptionId,
+        "--resource-group", $ResourceGroup,
+        "--name", $FunctionAppName,
+        "--function-name", "GithubWebhook",
+        "--query", "default",
+        "--output", "tsv", "--only-show-errors"
+    )
+    $webhookKey = az @splatKey 2>$null
+    if ($LASTEXITCODE -eq 0 -and $webhookKey) {
+        break
+    }
+    Start-Sleep -Seconds 10
+}
+
+if ($webhookKey) {
+    Write-Host ""
+    Write-Host "Webhook URL for the GitHub App:"
+    Write-Host "  https://$hostName/api/github-webhook?code=$webhookKey"
+} else {
+    Write-Warning "The GithubWebhook function is not listed yet. Once it is, read its URL with: az functionapp function keys list --subscription $SubscriptionId --resource-group $ResourceGroup --name $FunctionAppName --function-name GithubWebhook --query default --output tsv"
+}

--- a/.github/runners/tests/fleet-controller.Tests.ps1
+++ b/.github/runners/tests/fleet-controller.Tests.ps1
@@ -313,6 +313,78 @@ Describe "trigger corroboration" {
             Should -Invoke Invoke-GhJson -Times 0
         }
     }
+
+    It "attributes the trigger to the pusher, not to whoever wrote the commit" {
+        # The maintainer and opt-in lists are about who pushed. Reading the lane from
+        # head.author.login would hand a maintainer lane to anyone who pushes a commit a
+        # maintainer wrote, and deny one to a maintainer pushing a contributor's work.
+        InModuleScope FleetCore {
+            Mock Invoke-GhJson {
+                [pscustomobject]@{
+                    sha    = "5555555555555555555555555555555555555555"
+                    commit = [pscustomobject]@{ message = "Contributed work [do ci]" }
+                    author = [pscustomobject]@{ login = "potatoqualitee" }
+                }
+            }
+            $splatMismatch = @{
+                Actor = "some-drive-by"
+                Sha   = "5555555555555555555555555555555555555555"
+                Ref   = "refs/heads/development"
+            }
+            $trigger = Confirm-DirectTrigger @splatMismatch
+            $trigger.Actor | Should -Be "some-drive-by"
+        }
+    }
+}
+
+Describe "fail-closed settings" {
+    BeforeAll {
+        # Everything Initialize-FleetContext demands before it looks at DRY_RUN, so the
+        # required-settings check is not what fires
+        $script:RequiredForInit = @{
+            REPO                   = "dataplat/dbatools"
+            RG                     = "dbatools-ci"
+            VMSS                   = "dbatools-runners"
+            SUBSCRIPTION_ID        = "00000000-0000-0000-0000-000000000000"
+            GITHUB_APP_ID          = "1234567"
+            GITHUB_INSTALLATION_ID = "7654321"
+            GITHUB_APP_PRIVATE_KEY = "not-a-real-key"
+        }
+        $script:SavedForInit = @{ }
+        foreach ($settingName in $script:RequiredForInit.Keys) {
+            $script:SavedForInit[$settingName] = [Environment]::GetEnvironmentVariable($settingName)
+            [Environment]::SetEnvironmentVariable($settingName, $script:RequiredForInit[$settingName])
+        }
+        $script:SavedDryRun = $env:DRY_RUN
+    }
+
+    AfterAll {
+        foreach ($settingName in $script:SavedForInit.Keys) {
+            [Environment]::SetEnvironmentVariable($settingName, $script:SavedForInit[$settingName])
+        }
+        $env:DRY_RUN = $script:SavedDryRun
+    }
+
+    It "refuses to start unless DRY_RUN says exactly true or false" {
+        # A DRY_RUN that does not parse used to read as "not dry", which arms a controller
+        # that was only meant to be shadowing. The setting is one typo away from that.
+        foreach ($badValue in @($null, "", "yes", "0", "TRUE ")) {
+            $env:DRY_RUN = $badValue
+            $splatRefused = @{
+                ExpectedMessage = "*DRY_RUN*"
+                Because         = "`"$badValue`" is not a value the controller may guess at"
+            }
+            { InModuleScope FleetCore { Initialize-FleetContext } } | Should -Throw @splatRefused
+        }
+    }
+
+    It "accepts the two words it does understand" {
+        foreach ($goodValue in @("true", "false", "TRUE")) {
+            $env:DRY_RUN = $goodValue
+            $context = InModuleScope FleetCore { Initialize-FleetContext }
+            $context.DryRun | Should -Be ($goodValue -eq "true" -or $goodValue -eq "TRUE")
+        }
+    }
 }
 
 Describe "Azure inventory paging" {
@@ -332,6 +404,18 @@ Describe "Azure inventory paging" {
             $found = @(Invoke-ArmList -Path "/subscriptions/x/vms" -Operation "test paging")
             $found.Count | Should -Be 2
             $found.name | Should -Contain "page-two"
+        }
+    }
+
+    It "pages every ARM list, so orphaned NICs and IPs past a page boundary still get reaped" {
+        # az followed nextLink for us and raw REST does not, so a list call that skipped the
+        # helper would leave the tail of the inventory both uncounted and unreaped
+        $source = Get-Content -Path "$script:ControllerRoot/Modules/FleetCore/FleetCore.psm1" -Raw
+        $listPaths = [regex]::Matches($source, "(?m)^\s*Path\s*=\s*`"[^`"]*providers/Microsoft\.(Compute|Network)/[a-zA-Z]+\?api-version[^`"]*`"")
+        $listPaths.Count | Should -BeGreaterThan 0
+        foreach ($listPath in $listPaths) {
+            $tail = $source.Substring($listPath.Index, [math]::Min(400, $source.Length - $listPath.Index))
+            $tail | Should -Match "Invoke-ArmList" -Because "the list at $($listPath.Value.Trim()) has to paginate"
         }
     }
 }

--- a/.github/runners/tests/fleet-controller.Tests.ps1
+++ b/.github/runners/tests/fleet-controller.Tests.ps1
@@ -1,0 +1,254 @@
+BeforeAll {
+    $script:ControllerRoot = (Resolve-Path "$PSScriptRoot/../controller").Path
+    Import-Module "$script:ControllerRoot/Modules/GitHubAppAuth/GitHubAppAuth.psm1" -Force
+    Import-Module "$script:ControllerRoot/Modules/FleetCore/FleetCore.psm1" -Force
+
+    function ConvertFrom-Base64Url {
+        param([string]$Text)
+        $padded = $Text.Replace("-", "+").Replace("_", "/")
+        switch ($padded.Length % 4) {
+            2 { $padded = "$padded==" }
+            3 { $padded = "$padded=" }
+        }
+        [Convert]::FromBase64String($padded)
+    }
+
+    function Get-TestSignature {
+        param([string]$Body, [string]$Secret)
+        $hmac = New-Object -TypeName System.Security.Cryptography.HMACSHA256
+        try {
+            $hmac.Key = [System.Text.Encoding]::UTF8.GetBytes($Secret)
+            $hash = $hmac.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Body))
+        } finally {
+            $hmac.Dispose()
+        }
+        "sha256=" + (($hash | ForEach-Object { $PSItem.ToString("x2") }) -join "")
+    }
+}
+
+AfterAll {
+    Remove-Module -Name FleetCore, GitHubAppAuth -Force -ErrorAction SilentlyContinue
+}
+
+Describe "fleet configuration" {
+    It "reads the committed policy constants" {
+        $config = Get-FleetConfig
+        $config["MAX_RUNNERS"] | Should -Be 35
+        $config["WARM_FLOOR"] | Should -Be 3
+        $config["RUNNER_LABEL"] | Should -Be "dbatools-modern"
+        $config["CI_MARKER"] | Should -Be "[do ci]"
+    }
+
+    It "lets an app setting override a committed constant" {
+        $env:WARM_FLOOR = "7"
+        try {
+            (Get-FleetConfig)["WARM_FLOOR"] | Should -Be "7"
+        } finally {
+            Remove-Item -Path env:WARM_FLOOR
+        }
+    }
+}
+
+Describe "GitHub App authentication" {
+    BeforeAll {
+        $script:Rsa = [System.Security.Cryptography.RSA]::Create(2048)
+        $script:Pem = $script:Rsa.ExportRSAPrivateKeyPem()
+    }
+
+    AfterAll {
+        $script:Rsa.Dispose()
+    }
+
+    It "signs a JWT GitHub will accept" {
+        $jwt = New-GitHubAppJwt -AppId "1234567" -PrivateKeyPem $script:Pem
+        $parts = $jwt -split "\."
+        $parts.Count | Should -Be 3
+
+        $header = [System.Text.Encoding]::UTF8.GetString((ConvertFrom-Base64Url -Text $parts[0])) | ConvertFrom-Json
+        $header.alg | Should -Be "RS256"
+        $header.typ | Should -Be "JWT"
+
+        $claims = [System.Text.Encoding]::UTF8.GetString((ConvertFrom-Base64Url -Text $parts[1])) | ConvertFrom-Json
+        $claims.iss | Should -Be "1234567"
+        # Backdated one minute, ten-minute ceiling: GitHub rejects anything outside that.
+        ($claims.exp - $claims.iat) | Should -Be 600
+        $claims.iat | Should -BeLessThan ([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())
+
+        $splatVerify = @{
+            Data          = [System.Text.Encoding]::UTF8.GetBytes("$($parts[0]).$($parts[1])")
+            Signature     = (ConvertFrom-Base64Url -Text $parts[2])
+            HashAlgorithm = [System.Security.Cryptography.HashAlgorithmName]::SHA256
+            Padding       = [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+        }
+        $verified = $script:Rsa.VerifyData($splatVerify.Data, $splatVerify.Signature, $splatVerify.HashAlgorithm, $splatVerify.Padding)
+        $verified | Should -BeTrue
+    }
+
+    It "accepts a PEM whose newlines arrived escaped from an app setting" {
+        $escaped = $script:Pem.Replace("`n", "\n")
+        { New-GitHubAppJwt -AppId "1234567" -PrivateKeyPem $escaped } | Should -Not -Throw
+    }
+}
+
+Describe "webhook signature validation" {
+    BeforeAll {
+        $script:Body = "{`"action`":`"queued`",`"number`":7}"
+        $script:Secret = "not-the-real-webhook-secret"
+        $script:Good = Get-TestSignature -Body $script:Body -Secret $script:Secret
+    }
+
+    It "accepts a delivery signed with the shared secret" {
+        $splatValid = @{
+            Body      = $script:Body
+            Signature = $script:Good
+            Secret    = $script:Secret
+        }
+        Test-GitHubWebhookSignature @splatValid | Should -BeTrue
+    }
+
+    It "rejects a body that changed after signing" {
+        $splatTampered = @{
+            Body      = $script:Body.Replace("7", "8")
+            Signature = $script:Good
+            Secret    = $script:Secret
+        }
+        Test-GitHubWebhookSignature @splatTampered | Should -BeFalse
+    }
+
+    It "rejects a signature made with a different secret" {
+        $splatWrongSecret = @{
+            Body      = $script:Body
+            Signature = (Get-TestSignature -Body $script:Body -Secret "some-other-secret")
+            Secret    = $script:Secret
+        }
+        Test-GitHubWebhookSignature @splatWrongSecret | Should -BeFalse
+    }
+
+    It "rejects a delivery with no signature at all" {
+        $splatMissing = @{
+            Body      = $script:Body
+            Signature = ""
+            Secret    = $script:Secret
+        }
+        Test-GitHubWebhookSignature @splatMissing | Should -BeFalse
+    }
+
+    It "rejects the retired sha1 signature header format" {
+        $splatSha1 = @{
+            Body      = $script:Body
+            Signature = "sha1=0123456789abcdef0123456789abcdef01234567"
+            Secret    = $script:Secret
+        }
+        Test-GitHubWebhookSignature @splatSha1 | Should -BeFalse
+    }
+}
+
+Describe "webhook event filtering" {
+    BeforeAll {
+        $script:BoostUsers = @("potatoqualitee", "andreasjordan", "niphlod")
+    }
+
+    BeforeEach {
+        $script:SplatNudge = @{
+            BoostUsers  = $script:BoostUsers
+            RunnerLabel = "dbatools-modern"
+            CiWorkflow  = "ci-azure.yml"
+        }
+    }
+
+    It "wakes a pass when a fleet job is queued" {
+        $splatJob = $script:SplatNudge + @{
+            EventName = "workflow_job"
+            Payload   = [pscustomobject]@{
+                action       = "queued"
+                workflow_job = [pscustomobject]@{
+                    labels = @("self-hosted", "dbatools-modern", "dbatools-pool-niphlod")
+                }
+            }
+        }
+        (Get-FleetNudge @splatJob).reason | Should -Be "workflow_job.queued"
+    }
+
+    It "ignores the ubuntu-latest authorize job in ci-azure" {
+        $splatAuthorize = $script:SplatNudge + @{
+            EventName = "workflow_job"
+            Payload   = [pscustomobject]@{
+                action       = "queued"
+                workflow_job = [pscustomobject]@{ labels = @("ubuntu-latest") }
+            }
+        }
+        Get-FleetNudge @splatAuthorize | Should -BeNullOrEmpty
+    }
+
+    It "ignores a job that merely started running" {
+        $splatInProgress = $script:SplatNudge + @{
+            EventName = "workflow_job"
+            Payload   = [pscustomobject]@{
+                action       = "in_progress"
+                workflow_job = [pscustomobject]@{ labels = @("dbatools-modern") }
+            }
+        }
+        Get-FleetNudge @splatInProgress | Should -BeNullOrEmpty
+    }
+
+    It "ignores a workflow_run for a workflow the fleet does not serve" {
+        $splatOtherWorkflow = $script:SplatNudge + @{
+            EventName = "workflow_run"
+            Payload   = [pscustomobject]@{
+                action       = "requested"
+                workflow_run = [pscustomobject]@{ path = ".github/workflows/gallery.yml" }
+            }
+        }
+        Get-FleetNudge @splatOtherWorkflow | Should -BeNullOrEmpty
+    }
+
+    It "wakes a pass when a CI run is requested" {
+        $splatCiRun = $script:SplatNudge + @{
+            EventName = "workflow_run"
+            Payload   = [pscustomobject]@{
+                action       = "requested"
+                workflow_run = [pscustomobject]@{ path = ".github/workflows/ci-azure.yml" }
+            }
+        }
+        (Get-FleetNudge @splatCiRun).reason | Should -Be "workflow_run.requested"
+    }
+
+    It "carries the head commit through on a maintainer push" {
+        $splatPush = $script:SplatNudge + @{
+            EventName = "push"
+            Payload   = [pscustomobject]@{
+                sender      = [pscustomobject]@{ login = "niphlod" }
+                after       = "abc1234"
+                ref         = "refs/heads/development"
+                head_commit = [pscustomobject]@{ message = "Fix a thing [do ci]" }
+            }
+        }
+        $nudge = Get-FleetNudge @splatPush
+        $nudge.reason | Should -Be "push"
+        $nudge.actor | Should -Be "niphlod"
+        $nudge.sha | Should -Be "abc1234"
+        $nudge.ref | Should -Be "refs/heads/development"
+        $nudge.message | Should -Be "Fix a thing [do ci]"
+    }
+
+    It "ignores a push from someone with no lane" {
+        $splatStrangerPush = $script:SplatNudge + @{
+            EventName = "push"
+            Payload   = [pscustomobject]@{
+                sender      = [pscustomobject]@{ login = "a-first-time-contributor" }
+                after       = "def5678"
+                ref         = "refs/heads/development"
+                head_commit = [pscustomobject]@{ message = "Fix a thing [do ci]" }
+            }
+        }
+        Get-FleetNudge @splatStrangerPush | Should -BeNullOrEmpty
+    }
+
+    It "ignores event types the controller has no use for" {
+        $splatIssue = $script:SplatNudge + @{
+            EventName = "issues"
+            Payload   = [pscustomobject]@{ action = "opened" }
+        }
+        Get-FleetNudge @splatIssue | Should -BeNullOrEmpty
+    }
+}

--- a/.github/runners/tests/fleet-controller.Tests.ps1
+++ b/.github/runners/tests/fleet-controller.Tests.ps1
@@ -569,4 +569,30 @@ Describe "parallel registration" {
         $parallelBlock | Should -Match "\`$task = \`$PSItem"
         $parallelBlock | Should -Not -Match "VmName = \`$PSItem\.VmName"
     }
+
+    It "hands the real bootstrap script, blank lines and all, to the run-command binder" {
+        # Mandatory on a [string[]] rejects the whole array when any element is an empty
+        # string, and bootstrap-runner.ps1 is read line by line. Every live registration
+        # failed at the binder with "because it is an empty string", and nothing caught it
+        # because Test-FleetDryRun returns before this call in every non-live pass.
+        $bootstrapLines = @(Get-Content -Path "$PSScriptRoot/../bootstrap-runner.ps1")
+        $blankLines = @($bootstrapLines | Where-Object { $PSItem -eq "" }).Count
+        $blankLines | Should -BeGreaterThan 0 -Because "this only discriminates while the bootstrap still has a blank line"
+        InModuleScope FleetCore -Parameters @{ BootstrapLines = $bootstrapLines } {
+            param($BootstrapLines)
+            Mock Invoke-WebRequest {
+                [pscustomobject]@{
+                    StatusCode = 200
+                    Content    = "{`"value`":[{`"message`":`"runner registered`"}]}"
+                }
+            }
+            $splatRunCommand = @{
+                ArmToken     = "arm-token"
+                VmResourceId = "/subscriptions/s/resourceGroups/dbatools-ci/providers/Microsoft.Compute/virtualMachines/dbatools-runners_abc"
+                ScriptLines  = $BootstrapLines
+                Parameters   = @(@{ name = "Token"; value = "registration-token" })
+            }
+            Invoke-VmRunCommand @splatRunCommand | Should -Be "runner registered"
+        }
+    }
 }

--- a/.github/runners/tests/fleet-controller.Tests.ps1
+++ b/.github/runners/tests/fleet-controller.Tests.ps1
@@ -314,6 +314,24 @@ Describe "trigger corroboration" {
         }
     }
 
+    It "ignores a tag push, because a release tag is not a lane" {
+        # The push webhook fires for tags as well as branches, and refs/tags/v2.1.0 survives
+        # the branch-name check, resolves at the commits endpoint and dispatches. So without
+        # a branch test, cutting a release heated a pool and ran CI at the tag.
+        InModuleScope FleetCore {
+            Mock Invoke-GhJson { throw "GitHub should not have been called" }
+            $splatTag = @{
+                Actor = "potatoqualitee"
+                Sha   = "6666666666666666666666666666666666666666"
+                Ref   = "refs/tags/v2.1.0"
+            }
+            $tagTrigger = Confirm-DirectTrigger @splatTag
+            $tagTrigger.Sha | Should -BeNullOrEmpty
+            $tagTrigger.Actor | Should -BeNullOrEmpty
+            Should -Invoke Invoke-GhJson -Times 0
+        }
+    }
+
     It "attributes the trigger to the pusher, not to whoever wrote the commit" {
         # The maintainer and opt-in lists are about who pushed. Reading the lane from
         # head.author.login would hand a maintainer lane to anyone who pushes a commit a
@@ -416,6 +434,127 @@ Describe "Azure inventory paging" {
         foreach ($listPath in $listPaths) {
             $tail = $source.Substring($listPath.Index, [math]::Min(400, $source.Length - $listPath.Index))
             $tail | Should -Match "Invoke-ArmList" -Because "the list at $($listPath.Value.Trim()) has to paginate"
+        }
+    }
+}
+
+Describe "controller-infra rerun safety" {
+    BeforeAll {
+        # The decision is executed rather than described: the region is lifted verbatim out of
+        # the shipped script and dot-sourced against a stubbed az, so the test breaks if the
+        # script changes. It is anchored on the last committed app setting and on the tick
+        # itself, both of which are load-bearing lines nobody edits by accident.
+        $infraSource = Get-Content -Path "$PSScriptRoot/../controller-infra.ps1" -Raw
+        $splatRegion = @{
+            Input   = $infraSource
+            Pattern = "(?s)PSWorkerInProcConcurrencyUpperBound=10`"\r?\n\)\r?\n(.*?SafetyTick\.Disabled=0`"\r?\n\})"
+        }
+        $regionMatch = [regex]::Match($splatRegion.Input, $splatRegion.Pattern)
+        $regionMatch.Success | Should -BeTrue -Because "the tick decision has to be findable in controller-infra.ps1"
+        $script:TickDecision = [scriptblock]::Create($regionMatch.Groups[1].Value)
+    }
+
+    It "leaves a wired tick running when rerun without the ID parameters" {
+        # Rerunning controller-infra.ps1 is the documented way to finish the wiring, and it
+        # used to recompute the blockers from this invocation's parameters alone. A rerun that
+        # only meant to refresh a Key Vault reference therefore switched off a working tick.
+        function az {
+            if ($args[0] -eq "functionapp") {
+                return "[{`"name`":`"GITHUB_APP_ID`",`"value`":`"1234567`"},{`"name`":`"GITHUB_INSTALLATION_ID`",`"value`":`"7654321`"}]"
+            }
+            "https://dbatools-fleet-kv.vault.azure.net/secrets/a-secret/0123456789abcdef"
+        }
+        $FunctionAppName = "dbatools-fleet-controller"
+        $ResourceGroup = "dbatools-ci"
+        $SubscriptionId = "00000000-0000-0000-0000-000000000000"
+        $KeyVaultName = "dbatools-fleet-kv"
+        $GitHubAppId = ""
+        $GitHubInstallationId = ""
+        $settings = @()
+
+        . $script:TickDecision
+
+        $settings | Should -Contain "AzureWebJobs.SafetyTick.Disabled=0"
+    }
+
+    It "keeps the tick off when the app carries nothing to run on" {
+        function az {
+            if ($args[0] -eq "functionapp") {
+                return "[]"
+            }
+            ""
+        }
+        $FunctionAppName = "dbatools-fleet-controller"
+        $ResourceGroup = "dbatools-ci"
+        $SubscriptionId = "00000000-0000-0000-0000-000000000000"
+        $KeyVaultName = "dbatools-fleet-kv"
+        $GitHubAppId = ""
+        $GitHubInstallationId = ""
+        $settings = @()
+
+        . $script:TickDecision
+
+        $settings | Should -Contain "AzureWebJobs.SafetyTick.Disabled=1"
+    }
+
+    It "keeps the tick off while the private key is still outside Key Vault" {
+        # An App ID with no key fails initialization exactly as a missing App ID does, so the
+        # secrets count as blockers too
+        function az {
+            if ($args[0] -eq "functionapp") {
+                return "[{`"name`":`"GITHUB_APP_ID`",`"value`":`"1234567`"},{`"name`":`"GITHUB_INSTALLATION_ID`",`"value`":`"7654321`"}]"
+            }
+            ""
+        }
+        $FunctionAppName = "dbatools-fleet-controller"
+        $ResourceGroup = "dbatools-ci"
+        $SubscriptionId = "00000000-0000-0000-0000-000000000000"
+        $KeyVaultName = "dbatools-fleet-kv"
+        $GitHubAppId = ""
+        $GitHubInstallationId = ""
+        $settings = @()
+
+        . $script:TickDecision
+
+        $settings | Should -Contain "AzureWebJobs.SafetyTick.Disabled=1"
+    }
+}
+
+Describe "ARM token caching" {
+    BeforeAll {
+        $script:SavedIdentityEndpoint = $env:IDENTITY_ENDPOINT
+        $script:SavedIdentityHeader = $env:IDENTITY_HEADER
+        $env:IDENTITY_ENDPOINT = "http://127.0.0.1:0/msi/token"
+        $env:IDENTITY_HEADER = "not-a-real-identity-header"
+    }
+
+    AfterAll {
+        $env:IDENTITY_ENDPOINT = $script:SavedIdentityEndpoint
+        $env:IDENTITY_HEADER = $script:SavedIdentityHeader
+    }
+
+    It "caches a token whose expiry sits past the Int32 second boundary" {
+        # expires_on arrives as seconds since the epoch, and past 2038-01-19 that number no
+        # longer fits in an Int32. A token that cannot parse its own expiry is one the
+        # controller re-acquires on every ARM call it makes.
+        InModuleScope FleetCore {
+            $script:Fleet = [pscustomobject]@{
+                ArmToken       = $null
+                ArmTokenExpiry = [DateTimeOffset]::MinValue
+            }
+            $script:TokenCalls = 0
+            Mock Invoke-RestMethod {
+                $script:TokenCalls++
+                [pscustomobject]@{
+                    access_token = "arm-token-$script:TokenCalls"
+                    expires_on   = "2200000000"
+                }
+            }
+
+            Get-ArmToken | Should -Be "arm-token-1"
+            $script:Fleet.ArmTokenExpiry | Should -Be ([DateTimeOffset]::FromUnixTimeSeconds(2200000000).AddMinutes(-5))
+            Get-ArmToken | Should -Be "arm-token-1"
+            $script:TokenCalls | Should -Be 1
         }
     }
 }

--- a/.github/runners/tests/fleet-controller.Tests.ps1
+++ b/.github/runners/tests/fleet-controller.Tests.ps1
@@ -252,3 +252,98 @@ Describe "webhook event filtering" {
         Get-FleetNudge @splatIssue | Should -BeNullOrEmpty
     }
 }
+
+Describe "trigger corroboration" {
+    BeforeAll {
+        InModuleScope FleetCore {
+            $script:Fleet = [pscustomobject]@{ Repo = "dataplat/dbatools" }
+        }
+    }
+
+    It "drops a hint whose sha is no longer the head of the ref" {
+        InModuleScope FleetCore {
+            Mock Invoke-GhJson {
+                [pscustomobject]@{
+                    sha    = "1111111111111111111111111111111111111111"
+                    commit = [pscustomobject]@{ message = "Newer work [do ci]" }
+                    author = [pscustomobject]@{ login = "potatoqualitee" }
+                }
+            }
+            $splatStale = @{
+                Actor = "potatoqualitee"
+                Sha   = "2222222222222222222222222222222222222222"
+                Ref   = "refs/heads/development"
+            }
+            $trigger = Confirm-DirectTrigger @splatStale
+            $trigger.Sha | Should -BeNullOrEmpty
+            $trigger.Actor | Should -BeNullOrEmpty
+        }
+    }
+
+    It "takes the marker message from GitHub rather than from the caller" {
+        InModuleScope FleetCore {
+            Mock Invoke-GhJson {
+                [pscustomobject]@{
+                    sha    = "3333333333333333333333333333333333333333"
+                    commit = [pscustomobject]@{ message = "Real message, no marker" }
+                    author = [pscustomobject]@{ login = "potatoqualitee" }
+                }
+            }
+            $splatCurrent = @{
+                Actor = "potatoqualitee"
+                Sha   = "3333333333333333333333333333333333333333"
+                Ref   = "refs/heads/development"
+            }
+            $trigger = Confirm-DirectTrigger @splatCurrent
+            $trigger.Sha | Should -Be "3333333333333333333333333333333333333333"
+            $trigger.Message | Should -Be "Real message, no marker"
+        }
+    }
+
+    It "never calls GitHub for an empty or non-branch hint" {
+        InModuleScope FleetCore {
+            Mock Invoke-GhJson { throw "GitHub should not have been called" }
+            (Confirm-DirectTrigger -Actor "" -Sha "" -Ref "").Sha | Should -BeNullOrEmpty
+            $splatOdd = @{
+                Actor = "potatoqualitee"
+                Sha   = "4444444444444444444444444444444444444444"
+                Ref   = "refs/heads/../../etc"
+            }
+            (Confirm-DirectTrigger @splatOdd).Sha | Should -BeNullOrEmpty
+            Should -Invoke Invoke-GhJson -Times 0
+        }
+    }
+}
+
+Describe "Azure inventory paging" {
+    It "follows nextLink so no fleet VM is invisible" {
+        InModuleScope FleetCore {
+            $script:PagingCalls = 0
+            Mock Invoke-ArmJson {
+                $script:PagingCalls++
+                if ($script:PagingCalls -eq 1) {
+                    return [pscustomobject]@{
+                        value    = @([pscustomobject]@{ name = "page-one" })
+                        nextLink = "https://management.azure.com/next"
+                    }
+                }
+                [pscustomobject]@{ value = @([pscustomobject]@{ name = "page-two" }) }
+            }
+            $found = @(Invoke-ArmList -Path "/subscriptions/x/vms" -Operation "test paging")
+            $found.Count | Should -Be 2
+            $found.name | Should -Contain "page-two"
+        }
+    }
+}
+
+Describe "parallel registration" {
+    It "keeps the VM identity on the failure path" {
+        # $PSItem is the ErrorRecord inside catch, so a result built there from $PSItem
+        # would carry a null VM and silently skip the SPENT-VM delete.
+        $source = Get-Content -Path "$script:ControllerRoot/Modules/FleetCore/FleetCore.psm1" -Raw
+        $parallelBlock = [regex]::Match($source, "(?s)\`$results = \`$tasks \| ForEach-Object -Parallel \{.*?\} -ThrottleLimit").Value
+        $parallelBlock | Should -Not -BeNullOrEmpty
+        $parallelBlock | Should -Match "\`$task = \`$PSItem"
+        $parallelBlock | Should -Not -Match "VmName = \`$PSItem\.VmName"
+    }
+}

--- a/.github/workflows/ci-azure.yml
+++ b/.github/workflows/ci-azure.yml
@@ -241,30 +241,7 @@ jobs:
             }
           }
 
-      # AppVeyor replenishes a worker slot as soon as one matrix job ends. Nudging
-      # per job avoids waiting for the longest matrix row before replacing every VM.
-      - name: Nudge replacement for this worker
-        if: always()
-        shell: powershell
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          $splatNudge = @{
-              Method      = "Post"
-              Uri         = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/actions/workflows/runner-reconcile.yml/dispatches"
-              Headers     = @{ Authorization = "Bearer $env:GH_TOKEN"; Accept = "application/vnd.github+json" }
-              Body        = (ConvertTo-Json -InputObject @{ ref = "development" })
-              TimeoutSec  = 30
-          }
-          foreach ($attempt in 1..3) {
-              try {
-                  $null = Invoke-RestMethod @splatNudge
-                  return
-              } catch {
-                  Write-Warning "Reconcile nudge attempt $attempt of 3 failed. $($PSItem.Exception.Message)"
-                  if ($attempt -lt 3) {
-                      Start-Sleep -Seconds (3 * $attempt)
-                  }
-              }
-          }
-          Write-Warning "Reconcile nudge skipped after bounded retries; the next job completion or scheduled reconcile will recover it."
+      # The replacement nudge that used to live here is gone. Its job was to tell
+      # runner-reconcile.yml a worker slot had freed up, the way AppVeyor replenishes
+      # one as soon as a matrix job ends. The controller learns the same thing from the
+      # workflow_job.completed webhook, without a step in the critical path.


### PR DESCRIPTION
Moves the VMSS fleet controller off GitHub Actions and onto a PowerShell Azure Function, driven by GitHub App webhooks instead of a five-minute cron.

**This is already live.** The Function App has been running the fleet since 2026-08-02 20:08 UTC, and `runner-reconcile.yml` / `runner-boost.yml` are disabled on the repo. What is left in this PR is the source of truth catching up with what production is doing. `runner-scale-up.yml` is untouched and still active.

## What changed

- `.github/runners/controller/` — the Function App: a webhook receiver, a queue-triggered reconcile, a five-minute safety tick, and the weekly spend report. `FleetCore.psm1` is a port of `reconcile-runner-fleet.ps1`; `GitHubAppAuth.psm1` mints installation tokens from a Key Vault-backed private key.
- `.github/runners/controller/fleet-config.psd1` — the numbers that used to live in `runner-reconcile.yml`'s `env:` block, now in one file. Every key can be overridden by an app setting of the same name, which is the emergency lever: change a number in the portal, no redeploy.
- `.github/runners/controller-infra.ps1` / `deploy-controller.ps1` — provision and deploy. Both are rerunnable.
- `.github/runners/tests/fleet-controller.Tests.ps1` — 31 tests covering signature validation, event filtering, trigger corroboration, fail-closed settings, ARM paging and registration.
- `.github/workflows/ci-azure.yml` — drops the per-job reconcile nudge. The controller learns the same thing from `workflow_job.completed`.

## Security properties this preserves

1. Runner VMs still hold no Azure identity, no PAT, no secrets. Registration tokens are minted per VM and never stored.
2. Webhook bodies are hints, never decision inputs. Every pass re-reads the full GitHub queue and Azure inventory and converges from that, so a replayed or forged delivery cannot move the fleet anywhere the real state does not justify.
3. The janitor stays an independent control plane.
4. The controller's managed identity is scoped to resource group `dbatools-ci`.

## Verified live

A `[do ci]` push on this branch on 2026-08-02:

```
20:43:21  reconcile reason=push  actor=potatoqualitee ref=refs/heads/fleet-controller
20:43:24  desired pools: potatoqualitee=3
20:44:12  registering 3 pool runner(s)
20:53:30  SPENT-VM: dbatoolsJNAR0J already served a job
20:55:21  desired pools: potatoqualitee=0
```

`ci-azure [pool:potatoqualitee]` completed green in 11m41s on runners the controller provisioned, registered and then deleted. Seven `workflow_job.completed` reconciles landed during the run and the pool cooled to zero on its own.

## One defect worth calling out

`[Parameter(Mandatory)]` on a `[string[]]` rejects the whole array when any single element is an empty string. `Invoke-VmRunCommand` receives `bootstrap-runner.ps1` read line by line, and 16 of its 114 lines are blank, so every armed registration died at the binder before making a single HTTP call. Nothing caught it before cutover because `Test-FleetDryRun` returns ahead of that call and no other caller exists. Fixed in f82e486, with a test that binds the real bootstrap file and fails with the production message verbatim if the attribute is removed.

## Still to come, in a follow-up

- Delete `runner-reconcile.yml` and `runner-boost.yml` (disabled now, so the files are inert).
- Repoint `runner-scale-up.yml` at `actions/create-github-app-token`, and `runner-policy.Tests.ps1` at `fleet-config.psd1` instead of the reconcile workflow YAML.
- Rewrite `.github/runners/README.md` around the controller, including the GitHub App setup checklist `controller-infra.ps1` already points at.
- Janitor heartbeat consumption, and alerts on a zero-successful-reconcile window and poison-queue depth.
- `CI_RUNNER_PAT` and the stale repo variables come out after a week of stable Azure control, not with this PR.
- Follow the GitHub `Link` header on the runners, runs and jobs lists. Both implementations read only the first 100 results today, so neither is wrong relative to the other, but the ceiling is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
