### PR TITLE
Invoke-DbaDbIndexRebuild - Add index and heap maintenance command

### DIFF
--- a/.github/scripts/gh-actions.ps1
+++ b/.github/scripts/gh-actions.ps1
@@ -214,6 +214,35 @@ exec sp_addrolemember 'userrole','bob';
         Get-DbaPermission -Database tempdb | Should -Not -Be $null
     }
 
+    It "rebuilds a fragmented index" {
+        $indexDbName = "dbatoolsci_idxrebuild_$(Get-Random)"
+        try {
+            $null = New-DbaDatabase -Name $indexDbName
+            $indexDb = Get-DbaDatabase -Database $indexDbName
+            # Inserted row by row on purpose: the GUID keys then arrive out of order and the clustered index really fragments.
+            $indexFixture = @"
+CREATE TABLE dbo.frag1 (
+    id uniqueidentifier NOT NULL CONSTRAINT PK_frag1 PRIMARY KEY CLUSTERED,
+    filler char(2000) NOT NULL
+);
+SET NOCOUNT ON;
+DECLARE @i int = 0;
+WHILE @i < 2000 BEGIN
+    INSERT dbo.frag1 (id, filler) VALUES (NEWID(), 'x');
+    SET @i += 1;
+END
+"@
+            $indexDb.Query($indexFixture)
+
+            $indexResults = Invoke-DbaDbIndexRebuild -Database $indexDbName -Mode Rebuild
+            $indexResults.Operation | Should -Be "Rebuild"
+            $indexResults.Success | Should -Be $true
+            $indexResults.FragmentationAfter | Should -BeLessThan $indexResults.FragmentationBefore
+        } finally {
+            $null = Remove-DbaDatabase -Database $indexDbName -ErrorAction SilentlyContinue
+        }
+    }
+
     # Takes two minutes in GH, very boring
     It -Skip "returns the master key" {
         (Get-DbaDbMasterKey).Database | Should -Be "master"

--- a/.github/scripts/gh-actions.ps1
+++ b/.github/scripts/gh-actions.ps1
@@ -214,7 +214,8 @@ exec sp_addrolemember 'userrole','bob';
         Get-DbaPermission -Database tempdb | Should -Not -Be $null
     }
 
-    It "rebuilds a fragmented index" {
+    # The gallery job imports the released dbatools, which does not have this command until it ships.
+    It -Skip:([bool]$env:DBATOOLS_GALLERY_TEST) "rebuilds a fragmented index" {
         $indexDbName = "dbatoolsci_idxrebuild_$(Get-Random)"
         try {
             $null = New-DbaDatabase -Name $indexDbName

--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -460,7 +460,7 @@
         'Invoke-DbaDbDbccCleanTable',
         'Invoke-DbaDbDbccUpdateUsage',
         'Invoke-DbaDbDecryptObject',
-        'Invoke-DbaDbIndexRebuild',
+        "Invoke-DbaDbIndexRebuild",
         'Invoke-DbaDbLogShipping',
         'Invoke-DbaDbLogShipRecovery',
         'Invoke-DbaDbMirrorFailover',

--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -460,6 +460,7 @@
         'Invoke-DbaDbDbccCleanTable',
         'Invoke-DbaDbDbccUpdateUsage',
         'Invoke-DbaDbDecryptObject',
+        'Invoke-DbaDbIndexRebuild',
         'Invoke-DbaDbLogShipping',
         'Invoke-DbaDbLogShipRecovery',
         'Invoke-DbaDbMirrorFailover',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -545,7 +545,7 @@ $script:xplat = @(
         'Read-DbaTransactionLog',
         'Get-DbaDbTable',
         'Remove-DbaDbTable',
-        'Invoke-DbaDbIndexRebuild',
+        "Invoke-DbaDbIndexRebuild",
         'Invoke-DbaDbShrink',
         'Get-DbaEstimatedCompletionTime',
         'Get-DbaLinkedServer',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -545,6 +545,7 @@ $script:xplat = @(
         'Read-DbaTransactionLog',
         'Get-DbaDbTable',
         'Remove-DbaDbTable',
+        'Invoke-DbaDbIndexRebuild',
         'Invoke-DbaDbShrink',
         'Get-DbaEstimatedCompletionTime',
         'Get-DbaLinkedServer',

--- a/public/Invoke-DbaDbIndexRebuild.ps1
+++ b/public/Invoke-DbaDbIndexRebuild.ps1
@@ -50,7 +50,9 @@ function Invoke-DbaDbIndexRebuild {
 
     .PARAMETER Mode
         Controls which operation is performed. Rebuild issues ALTER INDEX ... REBUILD, Reorganize issues ALTER INDEX ... REORGANIZE, and Auto decides per index from measured fragmentation. Defaults to Rebuild.
+        Reorganize is skipped with a warning for heaps, disabled indexes, and indexes with ALLOW_PAGE_LOCKS = OFF, none of which SQL Server will reorganize.
         Auto is the Ola Hallengren approach: below ReorganizeThreshold the index is left alone, between the two thresholds it is reorganized, and at or above RebuildThreshold it is rebuilt.
+        Reorganize takes none of the rebuild options, so under Reorganize they are listed in a warning and skipped rather than refused. Auto still refuses an invalid rebuild combination, because Auto can decide to rebuild.
 
     .PARAMETER ReorganizeThreshold
         Sets the fragmentation percentage at which Auto mode starts reorganizing an index. Defaults to 5.
@@ -70,7 +72,7 @@ function Invoke-DbaDbIndexRebuild {
 
     .PARAMETER Online
         Performs the rebuild online so the table stays available to other sessions for the duration.
-        Requires Enterprise or Developer edition. Indexes that cannot be rebuilt online are skipped with a warning rather than being rebuilt offline behind your back, columnstore included: only a clustered columnstore index on SQL Server 2019 or later can rebuild online.
+        Requires Enterprise or Developer edition. Indexes that cannot be rebuilt online are skipped with a warning rather than being rebuilt offline behind your back. Columnstore is the exception: which columnstore indexes rebuild online depends on the version and index type in ways SMO does not report, so the request goes to the engine and a rejection comes back as a failed row.
 
     .PARAMETER MaxDop
         Limits the number of processors used for the operation by adding MAXDOP, from 0 to 64.
@@ -90,10 +92,10 @@ function Invoke-DbaDbIndexRebuild {
 
     .PARAMETER Resumable
         Makes the rebuild resumable so it can be paused and continued rather than rolled back.
-        Requires SQL Server 2017 or later, or Azure SQL Database, and must be combined with Online. Does not apply to heaps, columnstore indexes or disabled indexes, which are rebuilt without it.
+        Requires SQL Server 2017 or later, or Azure SQL Database, and must be combined with Online. It is dropped, and the reason recorded in Notes, for everything SQL Server documents as unsupported: heaps, columnstore indexes, disabled indexes, filtered indexes, a computed or rowversion key column, and a computed or LOB included column. Those objects are rebuilt without it rather than being skipped.
 
     .PARAMETER ResumableMaxDuration
-        Sets how many minutes a resumable rebuild runs before it pauses on its own, from 1 to 71582.
+        Sets how many minutes a resumable rebuild runs before it pauses on its own, from 1 to 10080 (7 days).
         Use this to fit index maintenance into a fixed maintenance window without leaving a long rollback behind.
 
     .PARAMETER WaitAtLowPriority
@@ -106,14 +108,14 @@ function Invoke-DbaDbIndexRebuild {
 
     .PARAMETER AbortAfterWait
         Specifies what happens when the low priority wait expires. None lets the operation keep waiting normally, Self aborts the rebuild, and Blockers kills the sessions holding the blocking locks. Defaults to None.
-        Only applies when WaitAtLowPriority is specified. Anything other than None needs MaxDurationMinutes set, because there is otherwise no wait to abort after.
+        Anything other than None needs both WaitAtLowPriority and MaxDurationMinutes, because there is otherwise no wait to abort after.
 
     .PARAMETER IncludeHeap
         Includes heaps, meaning tables with no clustered index, rebuilt with ALTER TABLE ... REBUILD.
-        Heaps fragment through forwarded records and deleted rows but are ignored by most maintenance solutions, so they are opt-in here rather than silently rebuilt. A heap rebuild also rebuilds the table's nonclustered indexes, so those are skipped for the rest of that table.
+        Heaps fragment through forwarded records and deleted rows but are ignored by most maintenance solutions, so they are opt-in here rather than silently rebuilt. A heap rebuild also rebuilds the table's nonclustered indexes, so the rest of that table is skipped for the run: their measured fragmentation is stale from that point on.
 
     .PARAMETER StatementTimeout
-        Sets the command timeout in minutes for each operation. Defaults to 0 (infinite timeout).
+        Sets the command timeout in minutes for each operation, from 0 to 35791394. Defaults to 0 (infinite timeout).
         Large rebuilds can run for hours, so the default lets them finish rather than failing partway through.
 
     .PARAMETER InputObject
@@ -243,8 +245,9 @@ function Invoke-DbaDbIndexRebuild {
         [switch]$PadIndex,
         [switch]$SortInTempdb,
         [switch]$Resumable,
-        # 71582 minutes is the documented ceiling for both MAX_DURATION clauses.
-        [ValidateRange(1, 71582)]
+        # The two MAX_DURATION clauses have different ceilings: 10080 minutes (7 days) for RESUMABLE,
+        # 71582 for WAIT_AT_LOW_PRIORITY. Both were confirmed against SQL Server 2022.
+        [ValidateRange(1, 10080)]
         [int]$ResumableMaxDuration,
         [switch]$WaitAtLowPriority,
         [ValidateRange(0, 71582)]
@@ -252,7 +255,8 @@ function Invoke-DbaDbIndexRebuild {
         [ValidateSet("None", "Self", "Blockers")]
         [string]$AbortAfterWait = "None",
         [switch]$IncludeHeap,
-        [ValidateRange(0, 2147483647)]
+        # The ceiling is int.MaxValue seconds expressed in minutes, because SMO's StatementTimeout is signed 32 bit seconds.
+        [ValidateRange(0, 35791394)]
         [int]$StatementTimeout = 0,
         [Parameter(ValueFromPipeline)]
         [object[]]$InputObject,
@@ -260,26 +264,6 @@ function Invoke-DbaDbIndexRebuild {
     )
 
     begin {
-        if ($Resumable -and -not $Online) {
-            Stop-Function -Message "A resumable index operation requires ONLINE = ON. Add -Online, or drop -Resumable."
-            return
-        }
-
-        if ($WaitAtLowPriority -and -not $Online) {
-            Stop-Function -Message "WAIT_AT_LOW_PRIORITY only applies to online index operations. Add -Online, or drop -WaitAtLowPriority."
-            return
-        }
-
-        if ($Resumable -and $SortInTempdb) {
-            Stop-Function -Message "SORT_IN_TEMPDB = ON cannot be combined with RESUMABLE = ON. Drop -SortInTempdb, or drop -Resumable."
-            return
-        }
-
-        if ($AbortAfterWait -ne "None" -and $MaxDurationMinutes -lt 1) {
-            Stop-Function -Message "AbortAfterWait $AbortAfterWait needs something to wait for. Set -MaxDurationMinutes to at least 1."
-            return
-        }
-
         if ($ReorganizeThreshold -gt $RebuildThreshold) {
             Stop-Function -Message "ReorganizeThreshold ($ReorganizeThreshold) cannot be greater than RebuildThreshold ($RebuildThreshold)."
             return
@@ -288,13 +272,41 @@ function Invoke-DbaDbIndexRebuild {
         if ($Mode -eq "Reorganize") {
             $ignoredByReorganize = @()
             # REORGANIZE is always an online operation, so -Online is not in this list: it is redundant, not ignored.
-            foreach ($optionName in "FillFactor", "PadIndex", "SortInTempdb", "MaxDop", "Resumable", "WaitAtLowPriority") {
+            foreach ($optionName in "FillFactor", "PadIndex", "SortInTempdb", "MaxDop", "Resumable", "ResumableMaxDuration", "WaitAtLowPriority", "MaxDurationMinutes", "AbortAfterWait") {
                 if (Test-Bound -ParameterName $optionName) {
                     $ignoredByReorganize += $optionName
                 }
             }
             if ($ignoredByReorganize) {
                 Write-Message -Level Warning -Message "REORGANIZE ignores these options and they will not be applied: $($ignoredByReorganize -join ", ")"
+            }
+        } else {
+            # Every option below belongs to REBUILD, so these combinations are only wrong when a rebuild can
+            # actually happen. Under -Mode Reorganize the options are already reported as ignored above, and
+            # refusing to run there would be a hard stop over something the caller was told does not apply.
+            if ($Resumable -and -not $Online) {
+                Stop-Function -Message "A resumable index operation requires ONLINE = ON. Add -Online, or drop -Resumable."
+                return
+            }
+
+            if ($WaitAtLowPriority -and -not $Online) {
+                Stop-Function -Message "WAIT_AT_LOW_PRIORITY only applies to online index operations. Add -Online, or drop -WaitAtLowPriority."
+                return
+            }
+
+            if ($Resumable -and $SortInTempdb) {
+                Stop-Function -Message "SORT_IN_TEMPDB = ON cannot be combined with RESUMABLE = ON. Drop -SortInTempdb, or drop -Resumable."
+                return
+            }
+
+            if ($AbortAfterWait -ne "None" -and -not $WaitAtLowPriority) {
+                Stop-Function -Message "AbortAfterWait only has meaning inside a low priority wait. Add -WaitAtLowPriority, or drop -AbortAfterWait."
+                return
+            }
+
+            if ($AbortAfterWait -ne "None" -and $MaxDurationMinutes -lt 1) {
+                Stop-Function -Message "AbortAfterWait $AbortAfterWait needs something to wait for. Set -MaxDurationMinutes to at least 1."
+                return
             }
         }
 
@@ -344,7 +356,12 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
                 }
                 $inputObjectByDatabase[$dbKey].Objects += $object
             } else {
-                Stop-Function -Message "InputObject of type $objectType is not supported. Pipe in databases from Get-DbaDatabase, tables from Get-DbaDbTable or views from Get-DbaDbView." -Target $object -Continue
+                $splatBadInput = @{
+                    Message  = "InputObject of type $objectType is not supported. Pipe in databases from Get-DbaDatabase, tables from Get-DbaDbTable or views from Get-DbaDbView."
+                    Target   = $object
+                    Continue = $true
+                }
+                Stop-Function @splatBadInput
             }
         }
 
@@ -360,9 +377,21 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $splatConnection = @{
+                    SqlInstance    = $instance
+                    SqlCredential  = $SqlCredential
+                    MinimumVersion = 9
+                }
+                $server = Connect-DbaInstance @splatConnection
             } catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $PSItem -Target $instance -Continue
+                $splatConnectionFailure = @{
+                    Message     = "Failure"
+                    Category    = "ConnectionError"
+                    ErrorRecord = $PSItem
+                    Target      = $instance
+                    Continue    = $true
+                }
+                Stop-Function @splatConnectionFailure
             }
 
             $dbs = $server.Databases | Where-Object { $PSItem.IsAccessible }
@@ -425,17 +454,33 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
 
             # Azure SQL Database reports version 12 but supports both clauses, so the version floors only apply to the box product.
             if ($Resumable -and $server.VersionMajor -lt 14 -and -not $server.IsAzure) {
-                Stop-Function -Message "Resumable index operations require SQL Server 2017 (version 14) or later. $server is running version $($server.VersionMajor)." -Target $server -Continue
+                $splatOldResumable = @{
+                    Message  = "Resumable index operations require SQL Server 2017 (version 14) or later. $server is running version $($server.VersionMajor)."
+                    Target   = $server
+                    Continue = $true
+                }
+                Stop-Function @splatOldResumable
             }
 
             if ($WaitAtLowPriority -and $server.VersionMajor -lt 12 -and -not $server.IsAzure) {
-                Stop-Function -Message "WAIT_AT_LOW_PRIORITY requires SQL Server 2014 (version 12) or later. $server is running version $($server.VersionMajor)." -Target $server -Continue
+                $splatOldWait = @{
+                    Message  = "WAIT_AT_LOW_PRIORITY requires SQL Server 2014 (version 12) or later. $server is running version $($server.VersionMajor)."
+                    Target   = $server
+                    Continue = $true
+                }
+                Stop-Function @splatOldWait
             }
 
             try {
                 $fragmentationRows = $db.Query($fragmentationSql)
             } catch {
-                Stop-Function -Message "Failed to read index fragmentation for $db on $server" -ErrorRecord $PSItem -Target $db -Continue
+                $splatScanFailure = @{
+                    Message     = "Failed to read index fragmentation for $db on $server"
+                    ErrorRecord = $PSItem
+                    Target      = $db
+                    Continue    = $true
+                }
+                Stop-Function @splatScanFailure
             }
 
             $fragmentation = New-Object -TypeName System.Collections.Hashtable
@@ -462,7 +507,10 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
             }
 
             foreach ($obj in $objects) {
-                if ($obj.IsMemoryOptimized) {
+                # Table.IsMemoryOptimized arrived with SQL Server 2014, and SMO throws rather than returning
+                # false when the property does not exist on the server it is talking to. Nothing before 2014
+                # has memory optimized tables anyway, so the question does not arise there.
+                if ($server.VersionMajor -ge 12 -and $obj.IsMemoryOptimized) {
                     Write-Message -Level Verbose -Message "Skipping memory optimized object $($obj.Schema).$($obj.Name) in $db, ALTER INDEX REBUILD does not apply to it."
                     continue
                 }
@@ -501,6 +549,14 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
                 foreach ($target in $targets) {
                     $objectLabel = "$($db.Name).$($obj.Schema).$($obj.Name).$($target.IndexName)"
                     $isColumnstore = $target.IndexType -match "Columnstore"
+
+                    # ALTER TABLE ... REBUILD on a heap moves every row, so SQL Server rebuilds the table's
+                    # nonclustered indexes as part of it. Their measured fragmentation is stale from here on,
+                    # which rules out an Auto decision as much as it rules out a second rebuild.
+                    if ($heapWasRebuilt) {
+                        Write-Message -Level Verbose -Message "Skipping $objectLabel, the heap rebuild on this table already rebuilt it."
+                        continue
+                    }
 
                     if ($isColumnstore) {
                         # sys.dm_db_index_physical_stats only sees a columnstore index's rowstore parts, so a
@@ -557,13 +613,6 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
                         $operation = $Mode
                     }
 
-                    # ALTER TABLE ... REBUILD on a heap moves every row, so SQL Server rebuilds the table's
-                    # nonclustered indexes as part of it. Rebuilding them again straight afterwards is pure waste.
-                    if ($heapWasRebuilt -and $operation -eq "Rebuild" -and -not $target.IsHeap) {
-                        Write-Message -Level Verbose -Message "Skipping $objectLabel, the heap rebuild on this table already rebuilt it."
-                        continue
-                    }
-
                     if ($operation -eq "Reorganize") {
                         if ($target.IsHeap) {
                             Write-Message -Level Warning -Message "Skipping heap $objectLabel, a heap cannot be reorganized. Use -Mode Rebuild to defragment it."
@@ -571,6 +620,12 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
                         }
                         if ($target.Index.IsDisabled) {
                             Write-Message -Level Warning -Message "Skipping disabled index $objectLabel, REORGANIZE cannot run against a disabled index. Use -Mode Rebuild to re-enable it."
+                            continue
+                        }
+                        # REORGANIZE compacts pages, so ALLOW_PAGE_LOCKS = OFF rules it out. The engine raises
+                        # error 2552 for it, and in Auto mode that would fail an index the caller never singled out.
+                        if (-not $isColumnstore -and $target.Index.DisallowPageLocks) {
+                            Write-Message -Level Warning -Message "Skipping $objectLabel, REORGANIZE needs page level locking and this index has ALLOW_PAGE_LOCKS = OFF. Use -Mode Rebuild to defragment it."
                             continue
                         }
                     }
@@ -581,15 +636,27 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
 
                     if ($operation -eq "Rebuild" -and $useOnline) {
                         # Never quietly downgrade to an offline rebuild: -Online is what stands between the caller
-                        # and a table lock, so an index that cannot honour it gets skipped and said out loud.
-                        # SMO reports IsOnlineRebuildSupported as false for every columnstore index even where the
-                        # engine supports it, so columnstore is decided from the version instead.
-                        if ($isColumnstore) {
-                            if ($target.IndexType -notmatch "^Clustered" -or ($server.VersionMajor -lt 15 -and -not $server.IsAzure)) {
-                                Write-Message -Level Warning -Message "Skipping $objectLabel, an online rebuild of this columnstore index is not supported on $server. Only a clustered columnstore index on SQL Server 2019 or later can rebuild online. Drop -Online to rebuild it offline."
+                        # and a table lock, so anything that cannot honour it is skipped or fails out loud.
+                        if ($target.IsHeap) {
+                            # There is no IsOnlineRebuildSupported for a heap, so ALTER TABLE ... REBUILD WITH (ONLINE = ON)
+                            # gets its own floor: SQL Server 2014, Enterprise or Developer.
+                            if ($server.VersionMajor -lt 12 -and -not $server.IsAzure) {
+                                Write-Message -Level Warning -Message "Skipping heap $objectLabel, an online heap rebuild requires SQL Server 2014 (version 12) or later. $server is running version $($server.VersionMajor). Drop -Online to rebuild it offline."
                                 continue
                             }
-                        } elseif (-not $target.IsHeap -and -not $target.Index.IsOnlineRebuildSupported -and -not $server.IsAzure) {
+                            # A whitelist, not a Standard check: Web, Express and Personal cannot do this either,
+                            # and SMO reports Developer as EnterpriseOrDeveloper.
+                            if ("$($server.EngineEdition)" -ne "EnterpriseOrDeveloper" -and -not $server.IsAzure) {
+                                Write-Message -Level Warning -Message "Skipping heap $objectLabel, an online heap rebuild requires Enterprise or Developer edition and $server is $($server.EngineEdition). Drop -Online to rebuild it offline."
+                                continue
+                            }
+                        } elseif ($isColumnstore) {
+                            # Which columnstore indexes rebuild online moves with the version, the index type and the
+                            # edition, and SMO reports IsOnlineRebuildSupported as false for all of them regardless.
+                            # Guessing here has already been wrong in both directions, so the engine decides: an
+                            # unsupported combination comes back as a failed row, never as a silent offline rebuild.
+                            Write-Message -Level Verbose -Message "Asking $server for an online rebuild of columnstore index $objectLabel. Support depends on the version and index type, so a rejection is reported as a failure."
+                        } elseif (-not $target.Index.IsOnlineRebuildSupported -and -not $server.IsAzure) {
                             Write-Message -Level Warning -Message "Skipping $objectLabel, this index does not support an online rebuild on $server. Drop -Online to rebuild it offline."
                             continue
                         }
@@ -605,6 +672,52 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
                         } elseif ($target.Index.IsDisabled) {
                             $useResumable = $false
                             $suppressed += "Resumable, which cannot re-enable a disabled index"
+                        } elseif ($target.Index.HasFilter) {
+                            $useResumable = $false
+                            $suppressed += "Resumable, which is not supported for a filtered index"
+                        } else {
+                            # The documented restrictions, which SQL Server does not always enforce by failing the
+                            # statement: a computed or rowversion key column, and a computed or LOB included column.
+                            # A nonclustered index silently carries the clustered key, so its restrictions apply here too.
+                            $keyColumnNames = @($target.Index.IndexedColumns | Where-Object { -not $PSItem.IsIncluded } | Select-Object -ExpandProperty Name)
+                            if ($target.IndexType -notmatch "^Clustered" -and $obj.HasClusteredIndex) {
+                                $clusteredIndex = $obj.Indexes | Where-Object { $PSItem.IndexType -match "^Clustered" -and $PSItem.IndexType -notmatch "Columnstore" }
+                                $keyColumnNames += @($clusteredIndex.IndexedColumns | Where-Object { -not $PSItem.IsIncluded } | Select-Object -ExpandProperty Name)
+                            }
+
+                            $blockingColumn = $null
+                            foreach ($keyColumnName in $keyColumnNames) {
+                                $keyColumn = $obj.Columns[$keyColumnName]
+                                if ($keyColumn.Computed) {
+                                    $blockingColumn = "key computed column $keyColumnName"
+                                    break
+                                }
+                                if ("$($keyColumn.DataType.SqlDataType)" -eq "Timestamp") {
+                                    $blockingColumn = "key rowversion column $keyColumnName"
+                                    break
+                                }
+                            }
+
+                            if (-not $blockingColumn) {
+                                $includedColumnNames = @($target.Index.IndexedColumns | Where-Object { $PSItem.IsIncluded } | Select-Object -ExpandProperty Name)
+                                foreach ($includedColumnName in $includedColumnNames) {
+                                    $includedColumn = $obj.Columns[$includedColumnName]
+                                    if ($includedColumn.Computed) {
+                                        $blockingColumn = "included computed column $includedColumnName"
+                                        break
+                                    }
+                                    # MaxLength is -1 for the max types, which is what makes a column LOB here.
+                                    if ("$($includedColumn.DataType.SqlDataType)" -in "NVarCharMax", "VarCharMax", "VarBinaryMax", "Text", "NText", "Image", "Xml" -or $includedColumn.DataType.MaximumLength -eq -1) {
+                                        $blockingColumn = "included LOB column $includedColumnName"
+                                        break
+                                    }
+                                }
+                            }
+
+                            if ($blockingColumn) {
+                                $useResumable = $false
+                                $suppressed += "Resumable, which a $blockingColumn rules out"
+                            }
                         }
                     }
 
@@ -641,6 +754,18 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
                     if ($suppressed) {
                         $notes = "Suppressed: $($suppressed -join "; ")"
                         Write-Message -Level Verbose -Message "$objectLabel - $notes"
+                    }
+
+                    # These are options for one operation rather than stored index settings, but SMO leaves them
+                    # set on the object afterwards. A caller who pipes the same SMO object in twice would
+                    # otherwise inherit the first run's MAXDOP or SORT_IN_TEMPDB. FillFactor and PadIndex are
+                    # deliberately not in this list: those are stored settings the caller asked to change.
+                    $transientOptions = "OnlineHeapOperation", "OnlineIndexOperation", "ResumableIndexOperation", "ResumableMaxDuration", "SortInTempdb", "MaximumDegreeOfParallelism", "LowPriorityMaxDuration", "LowPriorityAbortAfterWait"
+                    $previousOptions = New-Object -TypeName System.Collections.Hashtable
+                    foreach ($transientOption in $transientOptions) {
+                        if ($null -ne $smoTarget.PSObject.Properties[$transientOption]) {
+                            $previousOptions[$transientOption] = $smoTarget.$transientOption
+                        }
                     }
 
                     $previousStatementTimeout = $server.ConnectionContext.StatementTimeout
@@ -699,11 +824,24 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
                             Write-Message -Level Verbose -Message "Could not refresh $objectLabel after the failure."
                         }
                         if ($EnableException) {
-                            Stop-Function -Message $failureMessage -ErrorRecord $PSItem -Target $obj -EnableException $EnableException
+                            $splatOperationFailure = @{
+                                Message         = $failureMessage
+                                ErrorRecord     = $PSItem
+                                Target          = $obj
+                                EnableException = $EnableException
+                            }
+                            Stop-Function @splatOperationFailure
                         }
                         Write-Message -Level Warning -Message $failureMessage
                     } finally {
                         $server.ConnectionContext.StatementTimeout = $previousStatementTimeout
+                        foreach ($previousOption in $previousOptions.Keys) {
+                            try {
+                                $smoTarget.$previousOption = $previousOptions[$previousOption]
+                            } catch {
+                                Write-Message -Level Verbose -Message "Could not restore $previousOption on $objectLabel after the operation."
+                            }
+                        }
                     }
                     $end = Get-Date
 

--- a/public/Invoke-DbaDbIndexRebuild.ps1
+++ b/public/Invoke-DbaDbIndexRebuild.ps1
@@ -72,7 +72,7 @@ function Invoke-DbaDbIndexRebuild {
 
     .PARAMETER Online
         Performs the rebuild online so the table stays available to other sessions for the duration.
-        Requires Enterprise or Developer edition. Indexes that cannot be rebuilt online are skipped with a warning rather than being rebuilt offline behind your back. Columnstore is the exception: which columnstore indexes rebuild online depends on the version and index type in ways SMO does not report, so the request goes to the engine and a rejection comes back as a failed row.
+        Requires Enterprise or Developer edition, or Azure SQL Database. Anything that cannot be rebuilt online is skipped with a warning rather than being rebuilt offline behind your back: XML and spatial indexes, which SQL Server never rebuilds online on any version, edition or platform, columnstore indexes before SQL Server 2019, heaps before SQL Server 2014, and disabled clustered indexes and indexed views.
 
     .PARAMETER MaxDop
         Limits the number of processors used for the operation by adding MAXDOP, from 0 to 64.
@@ -452,8 +452,12 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
                 continue
             }
 
+            # REORGANIZE takes neither clause, and begin{} already warned that they will be ignored. Failing
+            # the database over a clause that is not going to be sent would contradict that warning.
+            $optionsReachTheEngine = $Mode -ne "Reorganize"
+
             # Azure SQL Database reports version 12 but supports both clauses, so the version floors only apply to the box product.
-            if ($Resumable -and $server.VersionMajor -lt 14 -and -not $server.IsAzure) {
+            if ($optionsReachTheEngine -and $Resumable -and $server.VersionMajor -lt 14 -and -not $server.IsAzure) {
                 $splatOldResumable = @{
                     Message  = "Resumable index operations require SQL Server 2017 (version 14) or later. $server is running version $($server.VersionMajor)."
                     Target   = $server
@@ -462,7 +466,7 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
                 Stop-Function @splatOldResumable
             }
 
-            if ($WaitAtLowPriority -and $server.VersionMajor -lt 12 -and -not $server.IsAzure) {
+            if ($optionsReachTheEngine -and $WaitAtLowPriority -and $server.VersionMajor -lt 12 -and -not $server.IsAzure) {
                 $splatOldWait = @{
                     Message  = "WAIT_AT_LOW_PRIORITY requires SQL Server 2014 (version 12) or later. $server is running version $($server.VersionMajor)."
                     Target   = $server
@@ -637,26 +641,46 @@ WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
                     if ($operation -eq "Rebuild" -and $useOnline) {
                         # Never quietly downgrade to an offline rebuild: -Online is what stands between the caller
                         # and a table lock, so anything that cannot honour it is skipped or fails out loud.
+
+                        # Online index operations are an Enterprise feature of the box product, and SQL Server 2016
+                        # SP1 did not move them to Standard. A whitelist rather than a Standard check: Web, Express
+                        # and Personal cannot do this either, and SMO reports Developer as EnterpriseOrDeveloper.
+                        # Azure SQL Database and Managed Instance always have them.
+                        if ("$($server.EngineEdition)" -ne "EnterpriseOrDeveloper" -and -not $server.IsAzure) {
+                            Write-Message -Level Warning -Message "Skipping $objectLabel, an online rebuild requires Enterprise or Developer edition and $server is $($server.EngineEdition). Drop -Online to rebuild it offline."
+                            continue
+                        }
+
                         if ($target.IsHeap) {
-                            # There is no IsOnlineRebuildSupported for a heap, so ALTER TABLE ... REBUILD WITH (ONLINE = ON)
-                            # gets its own floor: SQL Server 2014, Enterprise or Developer.
+                            # ALTER TABLE ... REBUILD WITH (ONLINE = ON) arrived with SQL Server 2014.
                             if ($server.VersionMajor -lt 12 -and -not $server.IsAzure) {
                                 Write-Message -Level Warning -Message "Skipping heap $objectLabel, an online heap rebuild requires SQL Server 2014 (version 12) or later. $server is running version $($server.VersionMajor). Drop -Online to rebuild it offline."
                                 continue
                             }
-                            # A whitelist, not a Standard check: Web, Express and Personal cannot do this either,
-                            # and SMO reports Developer as EnterpriseOrDeveloper.
-                            if ("$($server.EngineEdition)" -ne "EnterpriseOrDeveloper" -and -not $server.IsAzure) {
-                                Write-Message -Level Warning -Message "Skipping heap $objectLabel, an online heap rebuild requires Enterprise or Developer edition and $server is $($server.EngineEdition). Drop -Online to rebuild it offline."
+                        } elseif ($target.IndexType -match "Xml|Spatial") {
+                            # ALTER INDEX documents this with no version, edition or platform caveat: for an XML or
+                            # spatial index only ONLINE = OFF is supported, and ONLINE = ON raises an error. Azure
+                            # SQL Database is no exception, so this sits ahead of the Azure allowance below.
+                            Write-Message -Level Warning -Message "Skipping $objectLabel, SQL Server does not support an online rebuild of an XML or spatial index on any version, edition or platform. Drop -Online to rebuild it offline."
+                            continue
+                        } elseif ($isColumnstore) {
+                            # Online rebuild of a columnstore index arrived with SQL Server 2019, and Azure SQL
+                            # Database has it as well.
+                            if ($server.VersionMajor -lt 15 -and -not $server.IsAzure) {
+                                Write-Message -Level Warning -Message "Skipping columnstore index $objectLabel, an online columnstore rebuild requires SQL Server 2019 (version 15) or later. $server is running version $($server.VersionMajor). Drop -Online to rebuild it offline."
                                 continue
                             }
-                        } elseif ($isColumnstore) {
-                            # Which columnstore indexes rebuild online moves with the version, the index type and the
-                            # edition, and SMO reports IsOnlineRebuildSupported as false for all of them regardless.
-                            # Guessing here has already been wrong in both directions, so the engine decides: an
-                            # unsupported combination comes back as a failed row, never as a silent offline rebuild.
-                            Write-Message -Level Verbose -Message "Asking $server for an online rebuild of columnstore index $objectLabel. Support depends on the version and index type, so a rejection is reported as a failure."
-                        } elseif (-not $target.Index.IsOnlineRebuildSupported -and -not $server.IsAzure) {
+                        } elseif ($target.Index.IsDisabled -and ($target.IndexType -match "^Clustered" -or $isView)) {
+                            # The last documented exclusion for ALTER INDEX REBUILD ONLINE: a disabled clustered
+                            # index or a disabled indexed view. A disabled nonclustered index rebuilds online fine.
+                            Write-Message -Level Warning -Message "Skipping $objectLabel, SQL Server does not rebuild a disabled clustered index or indexed view online. Drop -Online to rebuild it offline."
+                            continue
+                        } elseif ($server.VersionMajor -lt 11 -and -not $server.IsAzure -and -not $target.Index.IsOnlineRebuildSupported) {
+                            # SMO decides IsOnlineRebuildSupported from the SQL Server 2008 rules and never caught up:
+                            # it reports false for a nonclustered index with a LOB included column, which SQL Server
+                            # 2012 made legal and SQL Server 2022 rebuilds online happily, and false for every
+                            # columnstore index regardless of version. Below 2012 those rules are still the engine's,
+                            # so the property is worth asking there and nowhere else.
                             Write-Message -Level Warning -Message "Skipping $objectLabel, this index does not support an online rebuild on $server. Drop -Online to rebuild it offline."
                             continue
                         }

--- a/public/Invoke-DbaDbIndexRebuild.ps1
+++ b/public/Invoke-DbaDbIndexRebuild.ps1
@@ -1,0 +1,755 @@
+function Invoke-DbaDbIndexRebuild {
+    <#
+    .SYNOPSIS
+        Rebuilds or reorganizes indexes and heaps across one or more databases.
+
+    .DESCRIPTION
+        Performs index maintenance against a collection of databases, tables, indexed views and indexes, exposing the full ALTER INDEX option set through SMO. Runs in three modes: Rebuild, Reorganize, or Auto, where Auto picks the operation per index from measured fragmentation the way Ola Hallengren's IndexOptimize does.
+
+        Fragmentation is measured once per database with a LIMITED scan of sys.dm_db_index_physical_stats, averaged across partitions by page count and read from the IN_ROW_DATA allocation units only. That scan drives the Auto decision, the MinimumFragmentation and MinimumPageCount filters, and the reported before and after numbers.
+
+        Columnstore indexes are the exception: that DMV only sees their rowstore parts, so their fragmentation and page counts are reported as null and they are skipped in Auto mode or under either filter. Maintain them with an explicit Mode instead.
+
+        Heaps are included with IncludeHeap. Heaps cannot be reorganized, and the popular maintenance solutions leave them alone entirely, so this is the only way to defragment one without hand-writing ALTER TABLE ... REBUILD. Rebuilding a heap also rebuilds the table's nonclustered indexes, so those are not rebuilt a second time in the same run.
+
+        Objects that cannot be processed are skipped with a warning rather than failing the run, so a single unsupported index does not stop maintenance across the rest of the instance.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. Requires SQL Server 2005 or later, because ALTER INDEX and sys.dm_db_index_physical_stats do not exist on SQL Server 2000.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        Specifies which databases to maintain on the target instance. Accepts multiple database names.
+        Use this when you want index maintenance on a known set of databases rather than the whole instance.
+
+    .PARAMETER ExcludeDatabase
+        Excludes specific databases from index maintenance, including databases that arrived through the pipeline.
+        Useful when maintaining every user database but skipping ones that have their own maintenance window.
+
+    .PARAMETER AllDatabases
+        Targets every accessible database on the instance, including the system databases master, model and msdb.
+        Requiring this switch means an unqualified call never silently rebuilds every index on the instance.
+
+    .PARAMETER AllUserDatabases
+        Targets all user databases on the instance, excluding the system databases.
+        Use this for routine maintenance across an instance while leaving system databases alone.
+
+    .PARAMETER Table
+        Limits maintenance to specific tables. Accepts schema-qualified names such as dbo.Orders, and bracketed names for objects with special characters.
+        When omitted, every non-system table in the selected databases is processed along with any indexed views.
+
+    .PARAMETER Index
+        Limits maintenance to specific index names within the selected tables.
+        Use this to rebuild one known problem index rather than everything on the table. Heaps have no index name, so no heap is returned when this is specified.
+
+    .PARAMETER Mode
+        Controls which operation is performed. Rebuild issues ALTER INDEX ... REBUILD, Reorganize issues ALTER INDEX ... REORGANIZE, and Auto decides per index from measured fragmentation. Defaults to Rebuild.
+        Auto is the Ola Hallengren approach: below ReorganizeThreshold the index is left alone, between the two thresholds it is reorganized, and at or above RebuildThreshold it is rebuilt.
+
+    .PARAMETER ReorganizeThreshold
+        Sets the fragmentation percentage at which Auto mode starts reorganizing an index. Defaults to 5.
+        Indexes below this level are skipped entirely because the cost of maintenance outweighs the benefit.
+
+    .PARAMETER RebuildThreshold
+        Sets the fragmentation percentage at which Auto mode switches from reorganize to rebuild. Defaults to 30.
+        Only applies when Mode is Auto.
+
+    .PARAMETER MinimumFragmentation
+        Skips any index whose measured fragmentation is below this percentage, in every mode.
+        Use this to make an explicit Rebuild or Reorganize run skip indexes that are already healthy. Columnstore indexes cannot be measured this way and are skipped with a warning when this is specified.
+
+    .PARAMETER MinimumPageCount
+        Skips any index or heap smaller than this many pages. Defaults to 0, which processes everything.
+        A common cutoff is 1000 pages, below which fragmentation rarely costs enough to be worth acting on. Columnstore indexes cannot be measured this way and are skipped with a warning when this is above 0.
+
+    .PARAMETER Online
+        Performs the rebuild online so the table stays available to other sessions for the duration.
+        Requires Enterprise or Developer edition. Indexes that cannot be rebuilt online are skipped with a warning rather than being rebuilt offline behind your back, columnstore included: only a clustered columnstore index on SQL Server 2019 or later can rebuild online.
+
+    .PARAMETER MaxDop
+        Limits the number of processors used for the operation by adding MAXDOP, from 0 to 64.
+        Use this to stop a large rebuild from consuming every core on a busy instance.
+
+    .PARAMETER FillFactor
+        Sets the fill factor percentage applied during the rebuild, from 1 to 100.
+        Leaving free space on each page reduces page splits on indexes that see frequent inserts into the middle of the key range. Omit it to keep whatever fill factor the index already has.
+
+    .PARAMETER PadIndex
+        Applies the fill factor to the intermediate index pages as well as the leaf level.
+        Only meaningful alongside FillFactor, and ignored by REORGANIZE.
+
+    .PARAMETER SortInTempdb
+        Performs the intermediate sort for the rebuild in tempdb instead of the destination filegroup.
+        Speeds up rebuilds when tempdb is on separate storage, at the cost of extra tempdb space. Cannot be combined with Resumable.
+
+    .PARAMETER Resumable
+        Makes the rebuild resumable so it can be paused and continued rather than rolled back.
+        Requires SQL Server 2017 or later, or Azure SQL Database, and must be combined with Online. Does not apply to heaps, columnstore indexes or disabled indexes, which are rebuilt without it.
+
+    .PARAMETER ResumableMaxDuration
+        Sets how many minutes a resumable rebuild runs before it pauses on its own, from 1 to 71582.
+        Use this to fit index maintenance into a fixed maintenance window without leaving a long rollback behind.
+
+    .PARAMETER WaitAtLowPriority
+        Makes the online rebuild wait at low priority for the schema modification locks it needs, so it does not block short queries behind it.
+        Requires SQL Server 2014 or later, or Azure SQL Database, and must be combined with Online.
+
+    .PARAMETER MaxDurationMinutes
+        Sets how many minutes the low priority wait lasts before AbortAfterWait takes effect, from 0 to 71582.
+        Only applies when WaitAtLowPriority is specified, and must be at least 1 when AbortAfterWait is not None.
+
+    .PARAMETER AbortAfterWait
+        Specifies what happens when the low priority wait expires. None lets the operation keep waiting normally, Self aborts the rebuild, and Blockers kills the sessions holding the blocking locks. Defaults to None.
+        Only applies when WaitAtLowPriority is specified. Anything other than None needs MaxDurationMinutes set, because there is otherwise no wait to abort after.
+
+    .PARAMETER IncludeHeap
+        Includes heaps, meaning tables with no clustered index, rebuilt with ALTER TABLE ... REBUILD.
+        Heaps fragment through forwarded records and deleted rows but are ignored by most maintenance solutions, so they are opt-in here rather than silently rebuilt. A heap rebuild also rebuilds the table's nonclustered indexes, so those are skipped for the rest of that table.
+
+    .PARAMETER StatementTimeout
+        Sets the command timeout in minutes for each operation. Defaults to 0 (infinite timeout).
+        Large rebuilds can run for hours, so the default lets them finish rather than failing partway through.
+
+    .PARAMETER InputObject
+        Accepts SMO objects from the pipeline: databases from Get-DbaDatabase, tables from Get-DbaDbTable, or views from Get-DbaDbView.
+        Use this to filter the target objects with the full power of those commands before handing them over for maintenance.
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run.
+
+    .PARAMETER Confirm
+        Prompts for confirmation of every step. For example:
+
+        Are you sure you want to perform this action?
+        Performing the operation "Rebuild ClusteredIndex PK_Orders" on target "dbo.Orders in Northwind on SQL2016".
+        [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"):
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .OUTPUTS
+        PSCustomObject
+
+        Returns one object per index or heap that was actually processed. Objects filtered out by a threshold, or skipped because they are incompatible with the requested operation, produce verbose messages or warnings instead of output. Nothing is returned when WhatIf is used.
+
+        Default display properties (via Select-DefaultView):
+        - SqlInstance: The full SQL Server instance name (computer\instance)
+        - Database: Name of the database containing the object
+        - Schema: Schema of the table or view
+        - Table: Name of the table or view
+        - IndexName: Name of the index, or the table name when the object is a heap
+        - IndexType: The SMO index type such as ClusteredIndex or NonClusteredIndex, or "Heap" for a heap
+        - Operation: The operation performed, either Rebuild or Reorganize
+        - PageCount: Number of pages in the index or heap as measured before the operation (long); null for a columnstore index
+        - FragmentationBefore: Average fragmentation percentage before the operation (double, 0-100); null for a columnstore index
+        - FragmentationAfter: Average fragmentation percentage after the operation (double, 0-100); null when the operation failed or the object is a columnstore index
+        - Duration: Elapsed time of the operation as hours:minutes:seconds, where hours is a running total rather than a clock reading
+        - Success: Boolean indicating whether the operation completed without error
+
+        Additional properties available:
+        - ComputerName: The name of the computer hosting the SQL Server instance
+        - InstanceName: The SQL Server instance name
+        - Online: Boolean indicating whether the operation actually ran online; always true for a reorganize, which never takes the object offline
+        - Resumable: Boolean indicating whether the operation actually ran as resumable
+        - Start: DateTime when the operation began
+        - End: DateTime when the operation completed
+        - Notes: Error text when the operation failed, or an explanation of why requested options were suppressed; null otherwise
+
+    .NOTES
+        Tags: Index, Maintenance, Rebuild, Reorganize, Fragmentation
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Invoke-DbaDbIndexRebuild
+
+    .EXAMPLE
+        PS C:\> Invoke-DbaDbIndexRebuild -SqlInstance sql2017 -Database Northwind
+
+        Rebuilds every index on every table and indexed view in Northwind.
+
+    .EXAMPLE
+        PS C:\> Invoke-DbaDbIndexRebuild -SqlInstance sql2017 -AllUserDatabases -Mode Auto -MinimumPageCount 1000
+
+        Runs fragmentation driven maintenance across all user databases, leaving indexes under 1000 pages alone, reorganizing those between 5 and 30 percent fragmented and rebuilding anything worse.
+
+    .EXAMPLE
+        PS C:\> Invoke-DbaDbIndexRebuild -SqlInstance sql2019 -Database Sales -Table dbo.Orders -Index IX_Orders_CustomerID -Online -MaxDop 4
+
+        Rebuilds one named index online, limited to four processors.
+
+    .EXAMPLE
+        PS C:\> Invoke-DbaDbIndexRebuild -SqlInstance sql2019 -Database Sales -Online -Resumable -ResumableMaxDuration 60
+
+        Rebuilds the indexes in Sales as a resumable online operation that pauses itself after an hour, so maintenance fits inside a fixed window.
+
+    .EXAMPLE
+        PS C:\> Invoke-DbaDbIndexRebuild -SqlInstance sql2019 -Database Staging -IncludeHeap
+
+        Rebuilds the indexes in Staging and also rebuilds its heaps, which most maintenance solutions skip entirely.
+
+    .EXAMPLE
+        PS C:\> Get-DbaDbTable -SqlInstance sql2019 -Database Sales -Table dbo.Orders | Invoke-DbaDbIndexRebuild -Mode Reorganize
+
+        Reorganizes the indexes on a table piped in from Get-DbaDbTable.
+
+    .EXAMPLE
+        PS C:\> Get-DbaDatabase -SqlInstance sql2019 | Where-Object Name -match "^prod" | Invoke-DbaDbIndexRebuild -Mode Auto
+
+        Runs Auto mode against the databases whose names start with prod.
+
+    .EXAMPLE
+        PS C:\> Invoke-DbaDbIndexRebuild -SqlInstance sql2022 -Database Sales -Online -WaitAtLowPriority -MaxDurationMinutes 5 -AbortAfterWait Blockers
+
+        Rebuilds online, waiting at low priority for five minutes for the locks it needs, then killing the blocking sessions if they have not cleared.
+
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Database,
+        [string[]]$ExcludeDatabase,
+        [switch]$AllDatabases,
+        [switch]$AllUserDatabases,
+        [string[]]$Table,
+        [string[]]$Index,
+        [ValidateSet("Rebuild", "Reorganize", "Auto")]
+        [string]$Mode = "Rebuild",
+        [ValidateRange(0, 100)]
+        [double]$ReorganizeThreshold = 5,
+        [ValidateRange(0, 100)]
+        [double]$RebuildThreshold = 30,
+        [ValidateRange(0, 100)]
+        [double]$MinimumFragmentation,
+        [ValidateRange(0, 2147483647)]
+        [int]$MinimumPageCount = 0,
+        [switch]$Online,
+        [ValidateRange(0, 64)]
+        [int]$MaxDop,
+        [ValidateRange(1, 100)]
+        [int]$FillFactor,
+        [switch]$PadIndex,
+        [switch]$SortInTempdb,
+        [switch]$Resumable,
+        # 71582 minutes is the documented ceiling for both MAX_DURATION clauses.
+        [ValidateRange(1, 71582)]
+        [int]$ResumableMaxDuration,
+        [switch]$WaitAtLowPriority,
+        [ValidateRange(0, 71582)]
+        [int]$MaxDurationMinutes,
+        [ValidateSet("None", "Self", "Blockers")]
+        [string]$AbortAfterWait = "None",
+        [switch]$IncludeHeap,
+        [ValidateRange(0, 2147483647)]
+        [int]$StatementTimeout = 0,
+        [Parameter(ValueFromPipeline)]
+        [object[]]$InputObject,
+        [switch]$EnableException
+    )
+
+    begin {
+        if ($Resumable -and -not $Online) {
+            Stop-Function -Message "A resumable index operation requires ONLINE = ON. Add -Online, or drop -Resumable."
+            return
+        }
+
+        if ($WaitAtLowPriority -and -not $Online) {
+            Stop-Function -Message "WAIT_AT_LOW_PRIORITY only applies to online index operations. Add -Online, or drop -WaitAtLowPriority."
+            return
+        }
+
+        if ($Resumable -and $SortInTempdb) {
+            Stop-Function -Message "SORT_IN_TEMPDB = ON cannot be combined with RESUMABLE = ON. Drop -SortInTempdb, or drop -Resumable."
+            return
+        }
+
+        if ($AbortAfterWait -ne "None" -and $MaxDurationMinutes -lt 1) {
+            Stop-Function -Message "AbortAfterWait $AbortAfterWait needs something to wait for. Set -MaxDurationMinutes to at least 1."
+            return
+        }
+
+        if ($ReorganizeThreshold -gt $RebuildThreshold) {
+            Stop-Function -Message "ReorganizeThreshold ($ReorganizeThreshold) cannot be greater than RebuildThreshold ($RebuildThreshold)."
+            return
+        }
+
+        if ($Mode -eq "Reorganize") {
+            $ignoredByReorganize = @()
+            # REORGANIZE is always an online operation, so -Online is not in this list: it is redundant, not ignored.
+            foreach ($optionName in "FillFactor", "PadIndex", "SortInTempdb", "MaxDop", "Resumable", "WaitAtLowPriority") {
+                if (Test-Bound -ParameterName $optionName) {
+                    $ignoredByReorganize += $optionName
+                }
+            }
+            if ($ignoredByReorganize) {
+                Write-Message -Level Warning -Message "REORGANIZE ignores these options and they will not be applied: $($ignoredByReorganize -join ", ")"
+            }
+        }
+
+        $statementTimeoutSeconds = $StatementTimeout * 60
+        $fragmentationBound = Test-Bound -ParameterName MinimumFragmentation
+
+        # One LIMITED scan per database drives the Auto decision, both filters and the reported numbers.
+        # Only IN_ROW_DATA counts: LOB and row-overflow allocation units always report zero fragmentation and
+        # would drag the average down. The average is weighted by pages so an unevenly filled partitioned index
+        # is not decided by its smallest partition.
+        $fragmentationSql = @"
+SELECT s.object_id AS ObjectId, s.index_id AS IndexId, SUM(s.page_count) AS PageCount,
+       CASE WHEN SUM(s.page_count) = 0 THEN 0.0
+            ELSE SUM(s.avg_fragmentation_in_percent * s.page_count) / SUM(s.page_count) END AS AvgFragmentation
+FROM sys.dm_db_index_physical_stats(DB_ID(), NULL, NULL, NULL, 'LIMITED') AS s
+WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
+GROUP BY s.object_id, s.index_id
+"@
+
+        # Placeholders are filled with SMO object ids, which are integers, so this cannot carry injected text.
+        $singleFragmentationSql = @"
+SELECT CASE WHEN SUM(s.page_count) = 0 THEN 0.0
+            ELSE SUM(s.avg_fragmentation_in_percent * s.page_count) / SUM(s.page_count) END AS AvgFragmentation
+FROM sys.dm_db_index_physical_stats(DB_ID(), {0}, {1}, NULL, 'LIMITED') AS s
+WHERE s.alloc_unit_type_desc = 'IN_ROW_DATA'
+"@
+    }
+
+    process {
+        if (Test-FunctionInterrupt) { return }
+
+        $inputDatabase = @()
+        $inputObjectByDatabase = New-Object -TypeName System.Collections.Hashtable
+
+        foreach ($object in $InputObject) {
+            $objectType = $object.GetType().FullName
+            if ($objectType -eq "Microsoft.SqlServer.Management.Smo.Database") {
+                $inputDatabase += $object
+            } elseif ($objectType -in "Microsoft.SqlServer.Management.Smo.Table", "Microsoft.SqlServer.Management.Smo.View") {
+                $parentDb = $object.Parent
+                $dbKey = "$($parentDb.Parent.Name)|$($parentDb.Name)"
+                if (-not $inputObjectByDatabase.ContainsKey($dbKey)) {
+                    $inputObjectByDatabase[$dbKey] = [PSCustomObject]@{
+                        Database = $parentDb
+                        Objects  = @()
+                    }
+                }
+                $inputObjectByDatabase[$dbKey].Objects += $object
+            } else {
+                Stop-Function -Message "InputObject of type $objectType is not supported. Pipe in databases from Get-DbaDatabase, tables from Get-DbaDbTable or views from Get-DbaDbView." -Target $object -Continue
+            }
+        }
+
+        if (-not $Database -and -not $ExcludeDatabase -and -not $AllDatabases -and -not $AllUserDatabases -and -not $InputObject) {
+            Stop-Function -Message "You must specify databases to execute against using -Database, -ExcludeDatabase, -AllDatabases or -AllUserDatabases, or by piping them in"
+            return
+        }
+
+        if (-not $SqlInstance -and -not $InputObject) {
+            Stop-Function -Message "You must specify -SqlInstance, or pipe in databases from Get-DbaDatabase, tables from Get-DbaDbTable or views from Get-DbaDbView"
+            return
+        }
+
+        foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $PSItem -Target $instance -Continue
+            }
+
+            $dbs = $server.Databases | Where-Object { $PSItem.IsAccessible }
+
+            if ($AllUserDatabases -and -not $AllDatabases) {
+                $dbs = $dbs | Where-Object { $PSItem.IsSystemObject -eq $false }
+            }
+
+            if ($Database) {
+                $dbs = $dbs | Where-Object Name -In $Database
+            }
+
+            if ($ExcludeDatabase) {
+                $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
+            }
+
+            foreach ($db in $dbs) {
+                $inputDatabase += $db
+            }
+        }
+
+        # A piped table brings its own database along, so those databases carry a restricted object list.
+        $workItems = @()
+        foreach ($db in $inputDatabase) {
+            $workItems += [PSCustomObject]@{
+                Database = $db
+                Objects  = $null
+            }
+        }
+        foreach ($entry in $inputObjectByDatabase.Values) {
+            $workItems += $entry
+        }
+
+        # ExcludeDatabase has to reach piped databases and piped tables too, not only the ones -SqlInstance found.
+        if ($ExcludeDatabase) {
+            $workItems = $workItems | Where-Object { $PSItem.Database.Name -notin $ExcludeDatabase }
+        }
+
+        foreach ($workItem in $workItems) {
+            $db = $workItem.Database
+            $server = $db.Parent
+
+            Write-Message -Level Verbose -Message "Processing $db on $server"
+
+            if ($db.IsDatabaseSnapshot) {
+                Write-Message -Level Warning -Message "Database $db on $server is a snapshot and is read only. Skipping."
+                continue
+            }
+
+            if ($db.Status -ne "Normal") {
+                Write-Message -Level Warning -Message "Database $db on $server has status $($db.Status) and will be skipped."
+                continue
+            }
+
+            # A read-only database is online and accessible, so Status is Normal. Without this it would fail once per index.
+            if (-not $db.IsUpdateable) {
+                Write-Message -Level Warning -Message "Database $db on $server is read only and will be skipped."
+                continue
+            }
+
+            # Azure SQL Database reports version 12 but supports both clauses, so the version floors only apply to the box product.
+            if ($Resumable -and $server.VersionMajor -lt 14 -and -not $server.IsAzure) {
+                Stop-Function -Message "Resumable index operations require SQL Server 2017 (version 14) or later. $server is running version $($server.VersionMajor)." -Target $server -Continue
+            }
+
+            if ($WaitAtLowPriority -and $server.VersionMajor -lt 12 -and -not $server.IsAzure) {
+                Stop-Function -Message "WAIT_AT_LOW_PRIORITY requires SQL Server 2014 (version 12) or later. $server is running version $($server.VersionMajor)." -Target $server -Continue
+            }
+
+            try {
+                $fragmentationRows = $db.Query($fragmentationSql)
+            } catch {
+                Stop-Function -Message "Failed to read index fragmentation for $db on $server" -ErrorRecord $PSItem -Target $db -Continue
+            }
+
+            $fragmentation = New-Object -TypeName System.Collections.Hashtable
+            foreach ($row in $fragmentationRows) {
+                $fragmentation["$($row.ObjectId)|$($row.IndexId)"] = $row
+            }
+
+            if ($workItem.Objects) {
+                $objects = $workItem.Objects
+            } elseif ($Table) {
+                $tableParts = $Table | ForEach-Object { Get-ObjectNameParts -ObjectName $PSItem }
+                $objects = foreach ($tablePart in $tableParts) {
+                    $db.Tables | Where-Object {
+                        $PSItem.IsSystemObject -eq $false -and
+                        $PSItem.Name -eq $tablePart.Name -and
+                        $tablePart.Schema -in ($PSItem.Schema, $null) -and
+                        $tablePart.Database -in ($db.Name, $null)
+                    }
+                }
+            } else {
+                $objects = @($db.Tables | Where-Object { $PSItem.IsSystemObject -eq $false })
+                # Indexed views are only worth walking when the caller did not name specific tables.
+                $objects += @($db.Views | Where-Object { $PSItem.IsSystemObject -eq $false -and $PSItem.Indexes.Count -gt 0 })
+            }
+
+            foreach ($obj in $objects) {
+                if ($obj.IsMemoryOptimized) {
+                    Write-Message -Level Verbose -Message "Skipping memory optimized object $($obj.Schema).$($obj.Name) in $db, ALTER INDEX REBUILD does not apply to it."
+                    continue
+                }
+
+                $isView = $obj.GetType().FullName -eq "Microsoft.SqlServer.Management.Smo.View"
+
+                $targets = @()
+
+                # A heap is index_id 0 on the table itself rather than a member of the Indexes collection, and -Index cannot name it.
+                # It goes first because rebuilding a heap moves every row, which rebuilds the table's nonclustered indexes too.
+                if ($IncludeHeap -and -not $isView -and -not $obj.HasClusteredIndex -and -not $Index) {
+                    $targets += [PSCustomObject]@{
+                        Index     = $null
+                        IndexId   = 0
+                        IndexName = $obj.Name
+                        IndexType = "Heap"
+                        IsHeap    = $true
+                    }
+                }
+
+                foreach ($smoIndex in $obj.Indexes) {
+                    if ($Index -and $smoIndex.Name -notin $Index) {
+                        continue
+                    }
+                    $targets += [PSCustomObject]@{
+                        Index     = $smoIndex
+                        IndexId   = $smoIndex.ID
+                        IndexName = $smoIndex.Name
+                        IndexType = "$($smoIndex.IndexType)"
+                        IsHeap    = $false
+                    }
+                }
+
+                $heapWasRebuilt = $false
+
+                foreach ($target in $targets) {
+                    $objectLabel = "$($db.Name).$($obj.Schema).$($obj.Name).$($target.IndexName)"
+                    $isColumnstore = $target.IndexType -match "Columnstore"
+
+                    if ($isColumnstore) {
+                        # sys.dm_db_index_physical_stats only sees a columnstore index's rowstore parts, so a
+                        # clustered columnstore over millions of rows reports a handful of pages and a fragmentation
+                        # figure that means nothing. Reporting nothing beats reporting that.
+                        $pageCount = $null
+                        $fragmentationBefore = $null
+                        $hasStats = $false
+                    } else {
+                        $statsRow = $fragmentation["$($obj.ID)|$($target.IndexId)"]
+
+                        if ($statsRow) {
+                            $pageCount = [long]$statsRow.PageCount
+                            $fragmentationBefore = [math]::Round([double]$statsRow.AvgFragmentation, 2)
+                            $hasStats = $true
+                        } else {
+                            # An index with no allocated pages has no row in the DMV at all.
+                            $pageCount = [long]0
+                            $fragmentationBefore = [double]0
+                            $hasStats = $false
+                        }
+
+                        if ($pageCount -lt $MinimumPageCount) {
+                            Write-Message -Level Verbose -Message "Skipping $objectLabel, $pageCount pages is below MinimumPageCount $MinimumPageCount."
+                            continue
+                        }
+
+                        if ($fragmentationBound -and $fragmentationBefore -lt $MinimumFragmentation) {
+                            Write-Message -Level Verbose -Message "Skipping $objectLabel, $fragmentationBefore percent fragmentation is below MinimumFragmentation $MinimumFragmentation."
+                            continue
+                        }
+                    }
+
+                    if ($isColumnstore -and ($Mode -eq "Auto" -or $fragmentationBound -or $MinimumPageCount -gt 0)) {
+                        Write-Message -Level Warning -Message "Skipping columnstore index $objectLabel, its fragmentation cannot be measured with sys.dm_db_index_physical_stats. Run it with an explicit -Mode Rebuild or -Mode Reorganize and no fragmentation or page filters."
+                        continue
+                    }
+
+                    if ($Mode -eq "Auto") {
+                        if (-not $hasStats) {
+                            Write-Message -Level Verbose -Message "Skipping $objectLabel in Auto mode, it has no allocated pages to measure."
+                            continue
+                        }
+                        if ($fragmentationBefore -lt $ReorganizeThreshold) {
+                            Write-Message -Level Verbose -Message "Skipping $objectLabel, $fragmentationBefore percent fragmentation is below ReorganizeThreshold $ReorganizeThreshold."
+                            continue
+                        }
+                        if ($fragmentationBefore -ge $RebuildThreshold) {
+                            $operation = "Rebuild"
+                        } else {
+                            $operation = "Reorganize"
+                        }
+                    } else {
+                        $operation = $Mode
+                    }
+
+                    # ALTER TABLE ... REBUILD on a heap moves every row, so SQL Server rebuilds the table's
+                    # nonclustered indexes as part of it. Rebuilding them again straight afterwards is pure waste.
+                    if ($heapWasRebuilt -and $operation -eq "Rebuild" -and -not $target.IsHeap) {
+                        Write-Message -Level Verbose -Message "Skipping $objectLabel, the heap rebuild on this table already rebuilt it."
+                        continue
+                    }
+
+                    if ($operation -eq "Reorganize") {
+                        if ($target.IsHeap) {
+                            Write-Message -Level Warning -Message "Skipping heap $objectLabel, a heap cannot be reorganized. Use -Mode Rebuild to defragment it."
+                            continue
+                        }
+                        if ($target.Index.IsDisabled) {
+                            Write-Message -Level Warning -Message "Skipping disabled index $objectLabel, REORGANIZE cannot run against a disabled index. Use -Mode Rebuild to re-enable it."
+                            continue
+                        }
+                    }
+
+                    $suppressed = @()
+                    $useOnline = [bool]$Online
+                    $useResumable = [bool]$Resumable
+
+                    if ($operation -eq "Rebuild" -and $useOnline) {
+                        # Never quietly downgrade to an offline rebuild: -Online is what stands between the caller
+                        # and a table lock, so an index that cannot honour it gets skipped and said out loud.
+                        # SMO reports IsOnlineRebuildSupported as false for every columnstore index even where the
+                        # engine supports it, so columnstore is decided from the version instead.
+                        if ($isColumnstore) {
+                            if ($target.IndexType -notmatch "^Clustered" -or ($server.VersionMajor -lt 15 -and -not $server.IsAzure)) {
+                                Write-Message -Level Warning -Message "Skipping $objectLabel, an online rebuild of this columnstore index is not supported on $server. Only a clustered columnstore index on SQL Server 2019 or later can rebuild online. Drop -Online to rebuild it offline."
+                                continue
+                            }
+                        } elseif (-not $target.IsHeap -and -not $target.Index.IsOnlineRebuildSupported -and -not $server.IsAzure) {
+                            Write-Message -Level Warning -Message "Skipping $objectLabel, this index does not support an online rebuild on $server. Drop -Online to rebuild it offline."
+                            continue
+                        }
+                    }
+
+                    if ($useResumable) {
+                        if ($target.IsHeap) {
+                            $useResumable = $false
+                            $suppressed += "Resumable, which does not apply to heaps"
+                        } elseif ($isColumnstore) {
+                            $useResumable = $false
+                            $suppressed += "Resumable, which a columnstore index does not support"
+                        } elseif ($target.Index.IsDisabled) {
+                            $useResumable = $false
+                            $suppressed += "Resumable, which cannot re-enable a disabled index"
+                        }
+                    }
+
+                    if ($target.IsHeap -or $isColumnstore) {
+                        if ($target.IsHeap) {
+                            $unsupportedReason = "does not apply to heaps"
+                        } else {
+                            $unsupportedReason = "does not apply to columnstore indexes"
+                        }
+                        foreach ($unsupportedOption in "FillFactor", "PadIndex", "SortInTempdb") {
+                            if (Test-Bound -ParameterName $unsupportedOption) {
+                                $suppressed += "$unsupportedOption, which $unsupportedReason"
+                            }
+                        }
+                    }
+
+                    # REORGANIZE never takes the object offline, whatever -Online said.
+                    if ($operation -eq "Reorganize") {
+                        $useOnline = $true
+                        $useResumable = $false
+                    }
+
+                    if (-not $Pscmdlet.ShouldProcess("$($obj.Schema).$($obj.Name) in $($db.Name) on $server", "$operation $($target.IndexType) $($target.IndexName)")) {
+                        continue
+                    }
+
+                    if ($target.IsHeap) {
+                        $smoTarget = $obj
+                    } else {
+                        $smoTarget = $target.Index
+                    }
+
+                    $notes = $null
+                    if ($suppressed) {
+                        $notes = "Suppressed: $($suppressed -join "; ")"
+                        Write-Message -Level Verbose -Message "$objectLabel - $notes"
+                    }
+
+                    $previousStatementTimeout = $server.ConnectionContext.StatementTimeout
+                    $start = Get-Date
+                    try {
+                        $server.ConnectionContext.StatementTimeout = $statementTimeoutSeconds
+
+                        if ($operation -eq "Reorganize") {
+                            # -1 means every partition. SMO has no parameterless Reorganize overload.
+                            $smoTarget.Reorganize(-1)
+                        } else {
+                            if ($target.IsHeap) {
+                                $smoTarget.OnlineHeapOperation = $useOnline
+                            } else {
+                                $smoTarget.OnlineIndexOperation = $useOnline
+                                $smoTarget.ResumableIndexOperation = $useResumable
+                                if ($useResumable -and (Test-Bound -ParameterName ResumableMaxDuration)) {
+                                    $smoTarget.ResumableMaxDuration = $ResumableMaxDuration
+                                }
+                                if (-not $isColumnstore) {
+                                    if (Test-Bound -ParameterName FillFactor) {
+                                        $smoTarget.FillFactor = $FillFactor
+                                    }
+                                    if (Test-Bound -ParameterName PadIndex) {
+                                        $smoTarget.PadIndex = [bool]$PadIndex
+                                    }
+                                    if (Test-Bound -ParameterName SortInTempdb) {
+                                        $smoTarget.SortInTempdb = [bool]$SortInTempdb
+                                    }
+                                }
+                            }
+
+                            if (Test-Bound -ParameterName MaxDop) {
+                                $smoTarget.MaximumDegreeOfParallelism = $MaxDop
+                            }
+
+                            if ($WaitAtLowPriority -and $useOnline) {
+                                $smoTarget.LowPriorityMaxDuration = $MaxDurationMinutes
+                                $smoTarget.LowPriorityAbortAfterWait = [Microsoft.SqlServer.Management.Smo.AbortAfterWait]$AbortAfterWait
+                            }
+
+                            $smoTarget.Rebuild()
+                        }
+                        $success = $true
+                        if ($target.IsHeap) {
+                            $heapWasRebuilt = $true
+                        }
+                    } catch {
+                        $success = $false
+                        $failureMessage = "$operation failed for $objectLabel on $server. $($PSItem.Exception.GetBaseException().Message)"
+                        $notes = $failureMessage
+                        # A half-applied property set would otherwise leak into the next operation on this object.
+                        try {
+                            $smoTarget.Refresh()
+                        } catch {
+                            Write-Message -Level Verbose -Message "Could not refresh $objectLabel after the failure."
+                        }
+                        if ($EnableException) {
+                            Stop-Function -Message $failureMessage -ErrorRecord $PSItem -Target $obj -EnableException $EnableException
+                        }
+                        Write-Message -Level Warning -Message $failureMessage
+                    } finally {
+                        $server.ConnectionContext.StatementTimeout = $previousStatementTimeout
+                    }
+                    $end = Get-Date
+
+                    $fragmentationAfter = $null
+                    if ($success -and -not $isColumnstore) {
+                        try {
+                            # Formatted outside the call: a comma inside a method argument list splits it into two arguments.
+                            $afterScanSql = $singleFragmentationSql -f $obj.ID, $target.IndexId
+                            $afterRow = $db.Query($afterScanSql)
+                            if ($afterRow.AvgFragmentation -isnot [DBNull] -and $null -ne $afterRow.AvgFragmentation) {
+                                $fragmentationAfter = [math]::Round([double]$afterRow.AvgFragmentation, 2)
+                            }
+                        } catch {
+                            Write-Message -Level Verbose -Message "Could not re-measure fragmentation for $objectLabel. $($PSItem.Exception.Message)"
+                        }
+                    }
+
+                    # Built from the total, not from a DateTime: a rebuild that runs past midnight would otherwise wrap to zero.
+                    $span = New-TimeSpan -Start $start -End $end
+                    $elapsed = "{0:00}:{1:00}:{2:00}" -f [math]::Floor($span.TotalHours), $span.Minutes, $span.Seconds
+
+                    $output = [PSCustomObject]@{
+                        ComputerName        = $server.ComputerName
+                        InstanceName        = $server.ServiceName
+                        SqlInstance         = $server.DomainInstanceName
+                        Database            = $db.Name
+                        Schema              = $obj.Schema
+                        Table               = $obj.Name
+                        IndexName           = $target.IndexName
+                        IndexType           = $target.IndexType
+                        PageCount           = $pageCount
+                        FragmentationBefore = $fragmentationBefore
+                        FragmentationAfter  = $fragmentationAfter
+                        Operation           = $operation
+                        Online              = $useOnline
+                        Resumable           = $useResumable
+                        Start               = $start
+                        End                 = $end
+                        Duration            = $elapsed
+                        Success             = $success
+                        Notes               = $notes
+                    }
+
+                    Select-DefaultView -InputObject $output -Property SqlInstance, Database, Schema, Table, IndexName, IndexType, Operation, PageCount, FragmentationBefore, FragmentationAfter, Duration, Success
+                }
+            }
+        }
+    }
+}

--- a/tests/Invoke-DbaDbIndexRebuild.Tests.ps1
+++ b/tests/Invoke-DbaDbIndexRebuild.Tests.ps1
@@ -65,6 +65,16 @@ Describe $CommandName -Tag IntegrationTests {
         $testDb = Get-DbaDatabase -SqlInstance $server -Database $dbName
 
         $createFixtures = @"
+CREATE TABLE dbo.lobinc1 (
+    id int NOT NULL CONSTRAINT PK_lobinc1 PRIMARY KEY CLUSTERED,
+    val int NOT NULL,
+    note nvarchar(max) NULL
+);
+INSERT dbo.lobinc1 (id, val, note) SELECT TOP 200 ROW_NUMBER() OVER (ORDER BY name), 1, N'x' FROM sys.all_objects;
+CREATE NONCLUSTERED INDEX IX_lobinc1_val ON dbo.lobinc1 (val) INCLUDE (note);
+CREATE TABLE dbo.xml1 (id int NOT NULL CONSTRAINT PK_xml1 PRIMARY KEY CLUSTERED, doc xml NULL);
+INSERT dbo.xml1 (id, doc) SELECT TOP 200 ROW_NUMBER() OVER (ORDER BY name), '<a/>' FROM sys.all_objects;
+CREATE PRIMARY XML INDEX PXML_xml1_doc ON dbo.xml1 (doc);
 CREATE TABLE dbo.frag1 (
     id uniqueidentifier NOT NULL CONSTRAINT PK_frag1 PRIMARY KEY CLUSTERED,
     filler char(2000) NOT NULL,
@@ -617,6 +627,34 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
             $onlineResult.Success | Should -Be $true
         }
 
+        It "Skips an online rebuild of an XML index rather than letting the engine reject it" {
+            $splatOnlineXml = @{
+                SqlInstance     = $TestConfig.InstanceSingle
+                Database        = $dbName
+                Table           = "dbo.xml1"
+                Index           = "PXML_xml1_doc"
+                Online          = $true
+                WarningVariable = "xmlOnlineWarning"
+                WarningAction   = "SilentlyContinue"
+            }
+            $onlineXml = Invoke-DbaDbIndexRebuild @splatOnlineXml
+            $onlineXml | Should -BeNullOrEmpty
+            $xmlOnlineWarning | Should -Match "XML or spatial"
+        }
+
+        It "Rebuilds the same XML index offline" {
+            $splatOfflineXml = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Table       = "dbo.xml1"
+                Index       = "PXML_xml1_doc"
+            }
+            $offlineXml = Invoke-DbaDbIndexRebuild @splatOfflineXml
+            $offlineXml.IndexName | Should -Be "PXML_xml1_doc"
+            $offlineXml.Online | Should -Be $false
+            $offlineXml.Success | Should -Be $true
+        }
+
         It "Rebuilds as a resumable online operation" {
             if ($server.EngineEdition -ne "EnterpriseOrDeveloper") {
                 Set-ItResult -Skipped -Because "resumable index rebuilds require Enterprise or Developer edition"
@@ -685,6 +723,30 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
             $computedResumable = Invoke-DbaDbIndexRebuild @splatComputedResumable
             $computedResumable.Resumable | Should -Be $false
             $computedResumable.Success | Should -Be $true
+        }
+
+        It "Suppresses resumable on an index with a LOB included column" {
+            if ($server.EngineEdition -ne "EnterpriseOrDeveloper") {
+                Set-ItResult -Skipped -Because "resumable index rebuilds require Enterprise or Developer edition"
+                return
+            }
+            if ($server.VersionMajor -lt 14) {
+                Set-ItResult -Skipped -Because "resumable index rebuilds require SQL Server 2017 or later"
+                return
+            }
+            $splatLobIncludeResumable = @{
+                SqlInstance          = $TestConfig.InstanceSingle
+                Database             = $dbName
+                Table                = "dbo.lobinc1"
+                Index                = "IX_lobinc1_val"
+                Online               = $true
+                Resumable            = $true
+                ResumableMaxDuration = 5
+            }
+            $lobIncludeResumable = Invoke-DbaDbIndexRebuild @splatLobIncludeResumable
+            $lobIncludeResumable.Resumable | Should -Be $false
+            $lobIncludeResumable.Success | Should -Be $true
+            $lobIncludeResumable.Notes | Should -Match "included LOB column note"
         }
 
         It "Refuses a resumable duration above the seven day ceiling" {

--- a/tests/Invoke-DbaDbIndexRebuild.Tests.ps1
+++ b/tests/Invoke-DbaDbIndexRebuild.Tests.ps1
@@ -77,6 +77,19 @@ CREATE NONCLUSTERED INDEX IX_heap2_val ON dbo.heap2 (val);
 INSERT dbo.heap2 (val) SELECT TOP 500 1 FROM sys.all_objects;
 CREATE TABLE dbo.tiny1 (id int IDENTITY(1,1) NOT NULL CONSTRAINT PK_tiny1 PRIMARY KEY CLUSTERED, val int NOT NULL);
 INSERT dbo.tiny1 (val) SELECT TOP 10 1 FROM sys.all_objects;
+CREATE TABLE dbo.calc1 (
+    id int NOT NULL CONSTRAINT PK_calc1 PRIMARY KEY CLUSTERED,
+    num int NOT NULL,
+    doubled AS (num * 2) PERSISTED
+);
+CREATE NONCLUSTERED INDEX IX_calc1_doubled ON dbo.calc1 (doubled);
+INSERT dbo.calc1 (id, num) SELECT TOP 200 ROW_NUMBER() OVER (ORDER BY name), 1 FROM sys.all_objects;
+CREATE TABLE dbo.nopage1 (id int NOT NULL CONSTRAINT PK_nopage1 PRIMARY KEY CLUSTERED, val int NOT NULL);
+INSERT dbo.nopage1 (id, val) SELECT TOP 200 ROW_NUMBER() OVER (ORDER BY name), 1 FROM sys.all_objects;
+CREATE NONCLUSTERED INDEX IX_nopage1_val ON dbo.nopage1 (val) WITH (ALLOW_PAGE_LOCKS = OFF);
+CREATE TABLE dbo.filtered1 (id int NOT NULL CONSTRAINT PK_filtered1 PRIMARY KEY CLUSTERED, val int NOT NULL);
+INSERT dbo.filtered1 (id, val) SELECT TOP 200 ROW_NUMBER() OVER (ORDER BY name), 1 FROM sys.all_objects;
+CREATE NONCLUSTERED INDEX IX_filtered1_val ON dbo.filtered1 (val) WHERE val > 0;
 SET NOCOUNT ON;
 DECLARE @i int = 0;
 WHILE @i < 3000 BEGIN
@@ -149,7 +162,13 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
         } catch {
             Write-Warning "Could not drop dbo.$msdbTableName from msdb. $PSItem"
         }
-        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbName -Confirm:$false -ErrorAction SilentlyContinue
+        $splatCleanup = @{
+            SqlInstance = $TestConfig.InstanceSingle
+            Database    = $dbName
+            Confirm     = $false
+            ErrorAction = "SilentlyContinue"
+        }
+        $null = Remove-DbaDatabase @splatCleanup
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
@@ -203,6 +222,38 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
         It "Reports the reorganize as online, because REORGANIZE always is" {
             $reorganizeResult.Online | Should -Be $true
         }
+
+        It "Skips an index that has page level locking disabled" {
+            $splatNoPageLocks = @{
+                SqlInstance     = $TestConfig.InstanceSingle
+                Database        = $dbName
+                Table           = "dbo.nopage1"
+                Index           = "IX_nopage1_val"
+                Mode            = "Reorganize"
+                WarningVariable = "noPageLockWarning"
+                WarningAction   = "SilentlyContinue"
+            }
+            $noPageLocks = Invoke-DbaDbIndexRebuild @splatNoPageLocks
+            $noPageLocks | Should -BeNullOrEmpty
+            $noPageLockWarning | Should -Match "ALLOW_PAGE_LOCKS"
+        }
+
+        It "Warns about rebuild only options rather than refusing to reorganize" {
+            $splatIgnoredOptions = @{
+                SqlInstance     = $TestConfig.InstanceSingle
+                Database        = $dbName
+                Table           = "dbo.frag1"
+                Index           = "PK_frag1"
+                Mode            = "Reorganize"
+                Resumable       = $true
+                WarningVariable = "ignoredWarning"
+                WarningAction   = "SilentlyContinue"
+            }
+            $ignoredOptions = Invoke-DbaDbIndexRebuild @splatIgnoredOptions
+            $ignoredOptions.Operation | Should -Be "Reorganize"
+            $ignoredOptions.Success | Should -Be $true
+            $ignoredWarning | Should -Match "REORGANIZE ignores these options"
+        }
     }
 
     Context "Auto mode picks the operation from measured fragmentation" {
@@ -246,8 +297,10 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
                 Mode                = "Auto"
                 ReorganizeThreshold = 100
                 RebuildThreshold    = 100
+                WarningVariable     = "autoSkipWarning"
+                WarningAction       = "SilentlyContinue"
             }
-            $autoSkip = Invoke-DbaDbIndexRebuild @splatAutoSkip -WarningVariable autoSkipWarning -WarningAction SilentlyContinue
+            $autoSkip = Invoke-DbaDbIndexRebuild @splatAutoSkip
             $autoSkip | Should -BeNullOrEmpty
             $autoSkipWarning | Should -BeNullOrEmpty
         }
@@ -259,8 +312,10 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
                 Mode                = "Auto"
                 ReorganizeThreshold = 60
                 RebuildThreshold    = 30
+                WarningVariable     = "thresholdWarning"
+                WarningAction       = "SilentlyContinue"
             }
-            $badThresholds = Invoke-DbaDbIndexRebuild @splatBadThresholds -WarningVariable thresholdWarning -WarningAction SilentlyContinue
+            $badThresholds = Invoke-DbaDbIndexRebuild @splatBadThresholds
             $badThresholds | Should -BeNullOrEmpty
             $thresholdWarning | Should -Match "cannot be greater than RebuildThreshold"
         }
@@ -288,13 +343,15 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
 
         It "Warns rather than failing when asked to reorganize a heap" {
             $splatHeapReorganize = @{
-                SqlInstance = $TestConfig.InstanceSingle
-                Database    = $dbName
-                Table       = "dbo.heap1"
-                IncludeHeap = $true
-                Mode        = "Reorganize"
+                SqlInstance     = $TestConfig.InstanceSingle
+                Database        = $dbName
+                Table           = "dbo.heap1"
+                IncludeHeap     = $true
+                Mode            = "Reorganize"
+                WarningVariable = "heapWarning"
+                WarningAction   = "SilentlyContinue"
             }
-            $heapReorganize = Invoke-DbaDbIndexRebuild @splatHeapReorganize -WarningVariable heapWarning -WarningAction SilentlyContinue
+            $heapReorganize = Invoke-DbaDbIndexRebuild @splatHeapReorganize
             $heapReorganize | Should -BeNullOrEmpty
             $heapWarning | Should -Match "cannot be reorganized"
         }
@@ -309,6 +366,21 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
             $heapWithIndex = Invoke-DbaDbIndexRebuild @splatHeapWithIndex
             $heapWithIndex.IndexName | Should -Be "heap2"
             $heapWithIndex.IndexName | Should -Not -Contain "IX_heap2_val"
+        }
+
+        It "Does not decide Auto mode from fragmentation the heap rebuild already invalidated" {
+            $splatHeapAuto = @{
+                SqlInstance         = $TestConfig.InstanceSingle
+                Database            = $dbName
+                Table               = "dbo.heap2"
+                IncludeHeap         = $true
+                Mode                = "Auto"
+                ReorganizeThreshold = 0
+                RebuildThreshold    = 0
+            }
+            $heapAuto = Invoke-DbaDbIndexRebuild @splatHeapAuto
+            $heapAuto.IndexName | Should -Be "heap2"
+            $heapAuto.IndexName | Should -Not -Contain "IX_heap2_val"
         }
     }
 
@@ -328,12 +400,14 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
 
         It "Skips a columnstore index in Auto mode and says why" {
             $splatColumnstoreAuto = @{
-                SqlInstance = $TestConfig.InstanceSingle
-                Database    = $dbName
-                Table       = "dbo.cs1"
-                Mode        = "Auto"
+                SqlInstance     = $TestConfig.InstanceSingle
+                Database        = $dbName
+                Table           = "dbo.cs1"
+                Mode            = "Auto"
+                WarningVariable = "columnstoreWarning"
+                WarningAction   = "SilentlyContinue"
             }
-            $columnstoreAuto = Invoke-DbaDbIndexRebuild @splatColumnstoreAuto -WarningVariable columnstoreWarning -WarningAction SilentlyContinue
+            $columnstoreAuto = Invoke-DbaDbIndexRebuild @splatColumnstoreAuto
             $columnstoreAuto | Should -BeNullOrEmpty
             $columnstoreWarning | Should -Match "cannot be measured"
         }
@@ -341,35 +415,69 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
 
     Context "Filters" {
         It "Returns nothing when every index is below MinimumPageCount" {
-            $pageFiltered = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -Database $dbName -MinimumPageCount 100000
+            $splatPageFilter = @{
+                SqlInstance      = $TestConfig.InstanceSingle
+                Database         = $dbName
+                MinimumPageCount = 100000
+                WarningAction    = "SilentlyContinue"
+            }
+            $pageFiltered = Invoke-DbaDbIndexRebuild @splatPageFilter
             $pageFiltered | Should -BeNullOrEmpty
         }
 
         It "Returns nothing when every index is below MinimumFragmentation" {
-            $fragFiltered = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -Database $dbName -MinimumFragmentation 100
+            $splatFragFilter = @{
+                SqlInstance          = $TestConfig.InstanceSingle
+                Database             = $dbName
+                MinimumFragmentation = 100
+                WarningAction        = "SilentlyContinue"
+            }
+            $fragFiltered = Invoke-DbaDbIndexRebuild @splatFragFilter
             $fragFiltered | Should -BeNullOrEmpty
         }
     }
 
     Context "Database selection" {
         It "Warns when no database was specified" {
-            $noSelector = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -WarningVariable selectorWarning -WarningAction SilentlyContinue
+            $splatNoSelector = @{
+                SqlInstance     = $TestConfig.InstanceSingle
+                WarningVariable = "selectorWarning"
+                WarningAction   = "SilentlyContinue"
+            }
+            $noSelector = Invoke-DbaDbIndexRebuild @splatNoSelector
             $noSelector | Should -BeNullOrEmpty
             $selectorWarning | Should -Match "You must specify databases"
         }
 
         It "Reaches system databases with AllDatabases" {
-            $allDatabases = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -AllDatabases -Table "dbo.$msdbTableName"
+            $splatAllDatabases = @{
+                SqlInstance   = $TestConfig.InstanceSingle
+                AllDatabases  = $true
+                Table         = "dbo.$msdbTableName"
+                WarningAction = "SilentlyContinue"
+            }
+            $allDatabases = Invoke-DbaDbIndexRebuild @splatAllDatabases
             $allDatabases.Database | Should -Contain "msdb"
         }
 
         It "Leaves system databases alone with AllUserDatabases" {
-            $allUserDatabases = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -AllUserDatabases -Table "dbo.$msdbTableName"
+            $splatAllUserDatabases = @{
+                SqlInstance      = $TestConfig.InstanceSingle
+                AllUserDatabases = $true
+                Table            = "dbo.$msdbTableName"
+                WarningAction    = "SilentlyContinue"
+            }
+            $allUserDatabases = Invoke-DbaDbIndexRebuild @splatAllUserDatabases
             $allUserDatabases | Should -BeNullOrEmpty
         }
 
         It "Warns when there is neither an instance nor pipeline input" {
-            $noInstance = Invoke-DbaDbIndexRebuild -Database $dbName -WarningVariable instanceWarning -WarningAction SilentlyContinue
+            $splatNoInstance = @{
+                Database        = $dbName
+                WarningVariable = "instanceWarning"
+                WarningAction   = "SilentlyContinue"
+            }
+            $noInstance = Invoke-DbaDbIndexRebuild @splatNoInstance
             $noInstance | Should -BeNullOrEmpty
             $instanceWarning | Should -Match "You must specify -SqlInstance"
         }
@@ -387,19 +495,44 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
             $null = New-DbaDatabase -SqlInstance $server -Name $readOnlyDbName
             $readOnlyDb = Get-DbaDatabase -SqlInstance $server -Database $readOnlyDbName
             $readOnlyDb.Query("CREATE TABLE dbo.ro1 (id int NOT NULL CONSTRAINT PK_ro1 PRIMARY KEY CLUSTERED);")
-            $null = Set-DbaDbState -SqlInstance $server -Database $readOnlyDbName -ReadOnly -Force
+            $splatMakeReadOnly = @{
+                SqlInstance = $server
+                Database    = $readOnlyDbName
+                ReadOnly    = $true
+                Force       = $true
+            }
+            $null = Set-DbaDbState @splatMakeReadOnly
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-            $null = Set-DbaDbState -SqlInstance $server -Database $readOnlyDbName -ReadWrite -Force -ErrorAction SilentlyContinue
-            $null = Remove-DbaDatabase -SqlInstance $server -Database $readOnlyDbName -Confirm:$false -ErrorAction SilentlyContinue
+            $splatMakeWritable = @{
+                SqlInstance = $server
+                Database    = $readOnlyDbName
+                ReadWrite   = $true
+                Force       = $true
+                ErrorAction = "SilentlyContinue"
+            }
+            $null = Set-DbaDbState @splatMakeWritable
+            $splatReadOnlyCleanup = @{
+                SqlInstance = $server
+                Database    = $readOnlyDbName
+                Confirm     = $false
+                ErrorAction = "SilentlyContinue"
+            }
+            $null = Remove-DbaDatabase @splatReadOnlyCleanup
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Skips the database once rather than failing once per index" {
-            $readOnlyResult = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -Database $readOnlyDbName -WarningVariable readOnlyWarning -WarningAction SilentlyContinue
+            $splatReadOnly = @{
+                SqlInstance     = $TestConfig.InstanceSingle
+                Database        = $readOnlyDbName
+                WarningVariable = "readOnlyWarning"
+                WarningAction   = "SilentlyContinue"
+            }
+            $readOnlyResult = Invoke-DbaDbIndexRebuild @splatReadOnly
             $readOnlyResult | Should -BeNullOrEmpty
             $readOnlyWarning | Should -Match "is read only"
         }
@@ -409,7 +542,12 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
         BeforeAll {
             $testDb.Query($fragmentFrag1)
             $fragmentationBeforeWhatIf = ($testDb.Query($measureFrag1)).AvgFragmentation
-            $whatIfResult = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -Database $dbName -WhatIf
+            $splatWhatIf = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                WhatIf      = $true
+            }
+            $whatIfResult = Invoke-DbaDbIndexRebuild @splatWhatIf
             $fragmentationAfterWhatIf = ($testDb.Query($measureFrag1)).AvgFragmentation
         }
 
@@ -430,7 +568,12 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
         }
 
         It "Accepts tables from Get-DbaDbTable" {
-            $pipedTable = Get-DbaDbTable -SqlInstance $TestConfig.InstanceSingle -Database $dbName -Table "dbo.frag1" | Invoke-DbaDbIndexRebuild
+            $splatPipedTable = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Table       = "dbo.frag1"
+            }
+            $pipedTable = Get-DbaDbTable @splatPipedTable | Invoke-DbaDbIndexRebuild
             $pipedTable.Table | Should -Not -Contain "tiny1"
             ($pipedTable.IndexName | Sort-Object) | Should -Be @("IX_frag1_num", "PK_frag1")
         }
@@ -497,13 +640,73 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
             $resumableResult.Success | Should -Be $true
         }
 
+        It "Suppresses resumable on a filtered index" {
+            if ($server.EngineEdition -ne "EnterpriseOrDeveloper") {
+                Set-ItResult -Skipped -Because "resumable index rebuilds require Enterprise or Developer edition"
+                return
+            }
+            if ($server.VersionMajor -lt 14) {
+                Set-ItResult -Skipped -Because "resumable index rebuilds require SQL Server 2017 or later"
+                return
+            }
+            $splatFilteredResumable = @{
+                SqlInstance          = $TestConfig.InstanceSingle
+                Database             = $dbName
+                Table                = "dbo.filtered1"
+                Index                = "IX_filtered1_val"
+                Online               = $true
+                Resumable            = $true
+                ResumableMaxDuration = 5
+            }
+            $filteredResumable = Invoke-DbaDbIndexRebuild @splatFilteredResumable
+            $filteredResumable.Resumable | Should -Be $false
+            $filteredResumable.Success | Should -Be $true
+            $filteredResumable.Notes | Should -Match "filtered index"
+        }
+
+        It "Suppresses resumable on an index whose key column is computed" {
+            if ($server.EngineEdition -ne "EnterpriseOrDeveloper") {
+                Set-ItResult -Skipped -Because "resumable index rebuilds require Enterprise or Developer edition"
+                return
+            }
+            if ($server.VersionMajor -lt 14) {
+                Set-ItResult -Skipped -Because "resumable index rebuilds require SQL Server 2017 or later"
+                return
+            }
+            $splatComputedResumable = @{
+                SqlInstance          = $TestConfig.InstanceSingle
+                Database             = $dbName
+                Table                = "dbo.calc1"
+                Index                = "IX_calc1_doubled"
+                Online               = $true
+                Resumable            = $true
+                ResumableMaxDuration = 5
+            }
+            $computedResumable = Invoke-DbaDbIndexRebuild @splatComputedResumable
+            $computedResumable.Resumable | Should -Be $false
+            $computedResumable.Success | Should -Be $true
+        }
+
+        It "Refuses a resumable duration above the seven day ceiling" {
+            $splatOverCeiling = @{
+                SqlInstance          = $TestConfig.InstanceSingle
+                Database             = $dbName
+                Online               = $true
+                Resumable            = $true
+                ResumableMaxDuration = 10081
+            }
+            { Invoke-DbaDbIndexRebuild @splatOverCeiling } | Should -Throw
+        }
+
         It "Refuses a resumable rebuild that is not online" {
             $splatBadResumable = @{
-                SqlInstance = $TestConfig.InstanceSingle
-                Database    = $dbName
-                Resumable   = $true
+                SqlInstance     = $TestConfig.InstanceSingle
+                Database        = $dbName
+                Resumable       = $true
+                WarningVariable = "resumableWarning"
+                WarningAction   = "SilentlyContinue"
             }
-            $badResumable = Invoke-DbaDbIndexRebuild @splatBadResumable -WarningVariable resumableWarning -WarningAction SilentlyContinue
+            $badResumable = Invoke-DbaDbIndexRebuild @splatBadResumable
             $badResumable | Should -BeNullOrEmpty
             $resumableWarning | Should -Match "requires ONLINE"
         }
@@ -513,21 +716,25 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
                 SqlInstance       = $TestConfig.InstanceSingle
                 Database          = $dbName
                 WaitAtLowPriority = $true
+                WarningVariable   = "waitWarning"
+                WarningAction     = "SilentlyContinue"
             }
-            $badWait = Invoke-DbaDbIndexRebuild @splatBadWait -WarningVariable waitWarning -WarningAction SilentlyContinue
+            $badWait = Invoke-DbaDbIndexRebuild @splatBadWait
             $badWait | Should -BeNullOrEmpty
             $waitWarning | Should -Match "WAIT_AT_LOW_PRIORITY"
         }
 
         It "Refuses SortInTempdb combined with Resumable" {
             $splatBadSort = @{
-                SqlInstance  = $TestConfig.InstanceSingle
-                Database     = $dbName
-                Online       = $true
-                Resumable    = $true
-                SortInTempdb = $true
+                SqlInstance     = $TestConfig.InstanceSingle
+                Database        = $dbName
+                Online          = $true
+                Resumable       = $true
+                SortInTempdb    = $true
+                WarningVariable = "sortWarning"
+                WarningAction   = "SilentlyContinue"
             }
-            $badSort = Invoke-DbaDbIndexRebuild @splatBadSort -WarningVariable sortWarning -WarningAction SilentlyContinue
+            $badSort = Invoke-DbaDbIndexRebuild @splatBadSort
             $badSort | Should -BeNullOrEmpty
             $sortWarning | Should -Match "SORT_IN_TEMPDB"
         }
@@ -539,10 +746,25 @@ INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
                 Online            = $true
                 WaitAtLowPriority = $true
                 AbortAfterWait    = "Blockers"
+                WarningVariable   = "abortWarning"
+                WarningAction     = "SilentlyContinue"
             }
-            $badAbort = Invoke-DbaDbIndexRebuild @splatBadAbort -WarningVariable abortWarning -WarningAction SilentlyContinue
+            $badAbort = Invoke-DbaDbIndexRebuild @splatBadAbort
             $badAbort | Should -BeNullOrEmpty
             $abortWarning | Should -Match "MaxDurationMinutes"
+        }
+
+        It "Refuses AbortAfterWait without WaitAtLowPriority" {
+            $splatLonelyAbort = @{
+                SqlInstance     = $TestConfig.InstanceSingle
+                Database        = $dbName
+                AbortAfterWait  = "Blockers"
+                WarningVariable = "lonelyAbortWarning"
+                WarningAction   = "SilentlyContinue"
+            }
+            $lonelyAbort = Invoke-DbaDbIndexRebuild @splatLonelyAbort
+            $lonelyAbort | Should -BeNullOrEmpty
+            $lonelyAbortWarning | Should -Match "WaitAtLowPriority"
         }
     }
 }

--- a/tests/Invoke-DbaDbIndexRebuild.Tests.ps1
+++ b/tests/Invoke-DbaDbIndexRebuild.Tests.ps1
@@ -1,0 +1,548 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Invoke-DbaDbIndexRebuild",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Database",
+                "ExcludeDatabase",
+                "AllDatabases",
+                "AllUserDatabases",
+                "Table",
+                "Index",
+                "Mode",
+                "ReorganizeThreshold",
+                "RebuildThreshold",
+                "MinimumFragmentation",
+                "MinimumPageCount",
+                "Online",
+                "MaxDop",
+                "FillFactor",
+                "PadIndex",
+                "SortInTempdb",
+                "Resumable",
+                "ResumableMaxDuration",
+                "WaitAtLowPriority",
+                "MaxDurationMinutes",
+                "AbortAfterWait",
+                "IncludeHeap",
+                "StatementTimeout",
+                "InputObject",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeDiscovery {
+        # -Skip: is read while Pester discovers the tests, long before BeforeAll runs, so the columnstore
+        # decision has to be made here instead.
+        $discoveryServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+        $columnstoreSupported = $discoveryServer.VersionMajor -ge 13
+    }
+
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $random = Get-Random
+        $dbName = "dbatoolsci_idxrebuild_$random"
+        $msdbTableName = "dbatoolsci_idxrebuild_msdb_$random"
+
+        $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+        $null = New-DbaDatabase -SqlInstance $server -Name $dbName
+        $testDb = Get-DbaDatabase -SqlInstance $server -Database $dbName
+
+        $createFixtures = @"
+CREATE TABLE dbo.frag1 (
+    id uniqueidentifier NOT NULL CONSTRAINT PK_frag1 PRIMARY KEY CLUSTERED,
+    filler char(2000) NOT NULL,
+    num int NOT NULL
+);
+CREATE NONCLUSTERED INDEX IX_frag1_num ON dbo.frag1 (num);
+CREATE TABLE dbo.heap1 (id int IDENTITY(1,1) NOT NULL, filler char(2000) NOT NULL);
+CREATE TABLE dbo.heap2 (id int IDENTITY(1,1) NOT NULL, val int NOT NULL);
+CREATE NONCLUSTERED INDEX IX_heap2_val ON dbo.heap2 (val);
+INSERT dbo.heap2 (val) SELECT TOP 500 1 FROM sys.all_objects;
+CREATE TABLE dbo.tiny1 (id int IDENTITY(1,1) NOT NULL CONSTRAINT PK_tiny1 PRIMARY KEY CLUSTERED, val int NOT NULL);
+INSERT dbo.tiny1 (val) SELECT TOP 10 1 FROM sys.all_objects;
+SET NOCOUNT ON;
+DECLARE @i int = 0;
+WHILE @i < 3000 BEGIN
+    INSERT dbo.heap1 (filler) VALUES ('x');
+    SET @i += 1;
+END
+DELETE FROM dbo.heap1 WHERE id % 3 = 0;
+"@
+
+        # Inserted row by row on purpose: the GUID keys then arrive out of order and the clustered index really fragments.
+        $fragmentFrag1 = @"
+TRUNCATE TABLE dbo.frag1;
+SET NOCOUNT ON;
+DECLARE @i int = 0;
+WHILE @i < 3000 BEGIN
+    INSERT dbo.frag1 (id, filler, num) VALUES (NEWID(), 'x', @i);
+    SET @i += 1;
+END
+"@
+
+        $measureFrag1 = @"
+SELECT AVG(s.avg_fragmentation_in_percent) AS AvgFragmentation
+FROM sys.dm_db_index_physical_stats(DB_ID(), OBJECT_ID('dbo.frag1'), 1, NULL, 'LIMITED') AS s
+"@
+
+        $measureFillFactor = @"
+SELECT fill_factor
+FROM sys.indexes
+WHERE object_id = OBJECT_ID('dbo.frag1') AND name = 'IX_frag1_num'
+"@
+
+        $testDb.Query($createFixtures)
+        $testDb.Query($fragmentFrag1)
+
+        # Columnstore is SQL Server 2016 and later on every edition. Older instances get no columnstore fixture
+        # and the columnstore context skips itself.
+        $supportsColumnstore = $server.VersionMajor -ge 13
+        if ($supportsColumnstore) {
+            $createColumnstore = @"
+CREATE TABLE dbo.cs1 (id int NOT NULL, val int NOT NULL);
+INSERT dbo.cs1 (id, val) SELECT TOP 500 1, 1 FROM sys.all_objects;
+CREATE CLUSTERED COLUMNSTORE INDEX CCI_cs1 ON dbo.cs1;
+"@
+            $testDb.Query($createColumnstore)
+        }
+
+        # A user table in msdb is the only way to tell -AllDatabases from -AllUserDatabases, because
+        # every table msdb ships with is a system object and is skipped.
+        $msdbDb = Get-DbaDatabase -SqlInstance $server -Database msdb
+        $createMsdbTable = @"
+CREATE TABLE dbo.$msdbTableName (
+    id int IDENTITY(1,1) NOT NULL CONSTRAINT PK_$msdbTableName PRIMARY KEY CLUSTERED,
+    val int NOT NULL
+);
+INSERT dbo.$msdbTableName (val) SELECT TOP 100 1 FROM sys.all_objects;
+"@
+        $msdbDb.Query($createMsdbTable)
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        # The msdb table has to be dropped whatever happened to it, or the database still goes even if it is already gone.
+        try {
+            $msdbDb.Query("DROP TABLE IF EXISTS dbo.$msdbTableName")
+        } catch {
+            Write-Warning "Could not drop dbo.$msdbTableName from msdb. $PSItem"
+        }
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbName -Confirm:$false -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "Rebuilding a named index" {
+        BeforeAll {
+            $testDb.Query($fragmentFrag1)
+            $splatRebuild = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Table       = "dbo.frag1"
+                Index       = "PK_frag1"
+            }
+            $rebuildResult = Invoke-DbaDbIndexRebuild @splatRebuild
+        }
+
+        It "Returns one row for the requested index" {
+            $rebuildResult.IndexName | Should -Be "PK_frag1"
+            $rebuildResult.IndexType | Should -Be "ClusteredIndex"
+        }
+
+        It "Reports the operation it performed" {
+            $rebuildResult.Operation | Should -Be "Rebuild"
+            $rebuildResult.Success | Should -Be $true
+        }
+
+        It "Leaves the index less fragmented than it found it" {
+            $rebuildResult.FragmentationBefore | Should -BeGreaterThan 30
+            $rebuildResult.FragmentationAfter | Should -BeLessThan $rebuildResult.FragmentationBefore
+        }
+    }
+
+    Context "Reorganizing" {
+        BeforeAll {
+            $testDb.Query($fragmentFrag1)
+            $splatReorganize = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Table       = "dbo.frag1"
+                Index       = "PK_frag1"
+                Mode        = "Reorganize"
+            }
+            $reorganizeResult = Invoke-DbaDbIndexRebuild @splatReorganize
+        }
+
+        It "Reports a reorganize rather than a rebuild" {
+            $reorganizeResult.Operation | Should -Be "Reorganize"
+            $reorganizeResult.Success | Should -Be $true
+        }
+
+        It "Reports the reorganize as online, because REORGANIZE always is" {
+            $reorganizeResult.Online | Should -Be $true
+        }
+    }
+
+    Context "Auto mode picks the operation from measured fragmentation" {
+        BeforeEach {
+            $testDb.Query($fragmentFrag1)
+        }
+
+        It "Rebuilds when fragmentation is at or above RebuildThreshold" {
+            $splatAutoRebuild = @{
+                SqlInstance      = $TestConfig.InstanceSingle
+                Database         = $dbName
+                Table            = "dbo.frag1"
+                Index            = "PK_frag1"
+                Mode             = "Auto"
+                RebuildThreshold = 30
+            }
+            $autoRebuild = Invoke-DbaDbIndexRebuild @splatAutoRebuild
+            $autoRebuild.Operation | Should -Be "Rebuild"
+        }
+
+        It "Reorganizes when fragmentation sits between the two thresholds" {
+            $splatAutoReorganize = @{
+                SqlInstance         = $TestConfig.InstanceSingle
+                Database            = $dbName
+                Table               = "dbo.frag1"
+                Index               = "PK_frag1"
+                Mode                = "Auto"
+                ReorganizeThreshold = 1
+                RebuildThreshold    = 100
+            }
+            $autoReorganize = Invoke-DbaDbIndexRebuild @splatAutoReorganize
+            $autoReorganize.Operation | Should -Be "Reorganize"
+        }
+
+        It "Skips anything below ReorganizeThreshold" {
+            $splatAutoSkip = @{
+                SqlInstance         = $TestConfig.InstanceSingle
+                Database            = $dbName
+                Table               = "dbo.frag1"
+                Index               = "PK_frag1"
+                Mode                = "Auto"
+                ReorganizeThreshold = 100
+                RebuildThreshold    = 100
+            }
+            $autoSkip = Invoke-DbaDbIndexRebuild @splatAutoSkip -WarningVariable autoSkipWarning -WarningAction SilentlyContinue
+            $autoSkip | Should -BeNullOrEmpty
+            $autoSkipWarning | Should -BeNullOrEmpty
+        }
+
+        It "Refuses thresholds that are the wrong way round" {
+            $splatBadThresholds = @{
+                SqlInstance         = $TestConfig.InstanceSingle
+                Database            = $dbName
+                Mode                = "Auto"
+                ReorganizeThreshold = 60
+                RebuildThreshold    = 30
+            }
+            $badThresholds = Invoke-DbaDbIndexRebuild @splatBadThresholds -WarningVariable thresholdWarning -WarningAction SilentlyContinue
+            $badThresholds | Should -BeNullOrEmpty
+            $thresholdWarning | Should -Match "cannot be greater than RebuildThreshold"
+        }
+    }
+
+    Context "Heaps" {
+        It "Rebuilds a heap when IncludeHeap is used" {
+            $splatHeap = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Table       = "dbo.heap1"
+                IncludeHeap = $true
+            }
+            $heapResult = Invoke-DbaDbIndexRebuild @splatHeap
+            $heapResult.IndexType | Should -Be "Heap"
+            $heapResult.IndexName | Should -Be "heap1"
+            $heapResult.Operation | Should -Be "Rebuild"
+            $heapResult.Success | Should -Be $true
+        }
+
+        It "Leaves heaps alone by default" {
+            $defaultResult = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -Database $dbName
+            $defaultResult.IndexType | Should -Not -Contain "Heap"
+        }
+
+        It "Warns rather than failing when asked to reorganize a heap" {
+            $splatHeapReorganize = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Table       = "dbo.heap1"
+                IncludeHeap = $true
+                Mode        = "Reorganize"
+            }
+            $heapReorganize = Invoke-DbaDbIndexRebuild @splatHeapReorganize -WarningVariable heapWarning -WarningAction SilentlyContinue
+            $heapReorganize | Should -BeNullOrEmpty
+            $heapWarning | Should -Match "cannot be reorganized"
+        }
+
+        It "Does not rebuild a nonclustered index the heap rebuild already covered" {
+            $splatHeapWithIndex = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Table       = "dbo.heap2"
+                IncludeHeap = $true
+            }
+            $heapWithIndex = Invoke-DbaDbIndexRebuild @splatHeapWithIndex
+            $heapWithIndex.IndexName | Should -Be "heap2"
+            $heapWithIndex.IndexName | Should -Not -Contain "IX_heap2_val"
+        }
+    }
+
+    Context "Columnstore" -Skip:(-not $columnstoreSupported) {
+        It "Rebuilds a columnstore index without pretending to measure it" {
+            $splatColumnstore = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Table       = "dbo.cs1"
+            }
+            $columnstoreResult = Invoke-DbaDbIndexRebuild @splatColumnstore
+            $columnstoreResult.IndexType | Should -Be "ClusteredColumnStoreIndex"
+            $columnstoreResult.Success | Should -Be $true
+            $columnstoreResult.PageCount | Should -BeNullOrEmpty
+            $columnstoreResult.FragmentationBefore | Should -BeNullOrEmpty
+        }
+
+        It "Skips a columnstore index in Auto mode and says why" {
+            $splatColumnstoreAuto = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Table       = "dbo.cs1"
+                Mode        = "Auto"
+            }
+            $columnstoreAuto = Invoke-DbaDbIndexRebuild @splatColumnstoreAuto -WarningVariable columnstoreWarning -WarningAction SilentlyContinue
+            $columnstoreAuto | Should -BeNullOrEmpty
+            $columnstoreWarning | Should -Match "cannot be measured"
+        }
+    }
+
+    Context "Filters" {
+        It "Returns nothing when every index is below MinimumPageCount" {
+            $pageFiltered = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -Database $dbName -MinimumPageCount 100000
+            $pageFiltered | Should -BeNullOrEmpty
+        }
+
+        It "Returns nothing when every index is below MinimumFragmentation" {
+            $fragFiltered = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -Database $dbName -MinimumFragmentation 100
+            $fragFiltered | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Database selection" {
+        It "Warns when no database was specified" {
+            $noSelector = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -WarningVariable selectorWarning -WarningAction SilentlyContinue
+            $noSelector | Should -BeNullOrEmpty
+            $selectorWarning | Should -Match "You must specify databases"
+        }
+
+        It "Reaches system databases with AllDatabases" {
+            $allDatabases = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -AllDatabases -Table "dbo.$msdbTableName"
+            $allDatabases.Database | Should -Contain "msdb"
+        }
+
+        It "Leaves system databases alone with AllUserDatabases" {
+            $allUserDatabases = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -AllUserDatabases -Table "dbo.$msdbTableName"
+            $allUserDatabases | Should -BeNullOrEmpty
+        }
+
+        It "Warns when there is neither an instance nor pipeline input" {
+            $noInstance = Invoke-DbaDbIndexRebuild -Database $dbName -WarningVariable instanceWarning -WarningAction SilentlyContinue
+            $noInstance | Should -BeNullOrEmpty
+            $instanceWarning | Should -Match "You must specify -SqlInstance"
+        }
+
+        It "Applies ExcludeDatabase to piped databases" {
+            $excludedPipe = Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbName | Invoke-DbaDbIndexRebuild -ExcludeDatabase $dbName
+            $excludedPipe | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Read only databases" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            $readOnlyDbName = "dbatoolsci_idxrebuild_ro_$random"
+            $null = New-DbaDatabase -SqlInstance $server -Name $readOnlyDbName
+            $readOnlyDb = Get-DbaDatabase -SqlInstance $server -Database $readOnlyDbName
+            $readOnlyDb.Query("CREATE TABLE dbo.ro1 (id int NOT NULL CONSTRAINT PK_ro1 PRIMARY KEY CLUSTERED);")
+            $null = Set-DbaDbState -SqlInstance $server -Database $readOnlyDbName -ReadOnly -Force
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            $null = Set-DbaDbState -SqlInstance $server -Database $readOnlyDbName -ReadWrite -Force -ErrorAction SilentlyContinue
+            $null = Remove-DbaDatabase -SqlInstance $server -Database $readOnlyDbName -Confirm:$false -ErrorAction SilentlyContinue
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Skips the database once rather than failing once per index" {
+            $readOnlyResult = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -Database $readOnlyDbName -WarningVariable readOnlyWarning -WarningAction SilentlyContinue
+            $readOnlyResult | Should -BeNullOrEmpty
+            $readOnlyWarning | Should -Match "is read only"
+        }
+    }
+
+    Context "WhatIf" {
+        BeforeAll {
+            $testDb.Query($fragmentFrag1)
+            $fragmentationBeforeWhatIf = ($testDb.Query($measureFrag1)).AvgFragmentation
+            $whatIfResult = Invoke-DbaDbIndexRebuild -SqlInstance $TestConfig.InstanceSingle -Database $dbName -WhatIf
+            $fragmentationAfterWhatIf = ($testDb.Query($measureFrag1)).AvgFragmentation
+        }
+
+        It "Returns nothing" {
+            $whatIfResult | Should -BeNullOrEmpty
+        }
+
+        It "Does not touch the index" {
+            $fragmentationAfterWhatIf | Should -Be $fragmentationBeforeWhatIf
+        }
+    }
+
+    Context "Pipeline input" {
+        It "Accepts databases from Get-DbaDatabase" {
+            $pipedDatabase = Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbName | Invoke-DbaDbIndexRebuild
+            $pipedDatabase.Database | Should -Contain $dbName
+            $pipedDatabase.Success | Should -Not -Contain $false
+        }
+
+        It "Accepts tables from Get-DbaDbTable" {
+            $pipedTable = Get-DbaDbTable -SqlInstance $TestConfig.InstanceSingle -Database $dbName -Table "dbo.frag1" | Invoke-DbaDbIndexRebuild
+            $pipedTable.Table | Should -Not -Contain "tiny1"
+            ($pipedTable.IndexName | Sort-Object) | Should -Be @("IX_frag1_num", "PK_frag1")
+        }
+
+        It "Warns about input it cannot use" {
+            $badInput = "not an smo object" | Invoke-DbaDbIndexRebuild -WarningVariable inputWarning -WarningAction SilentlyContinue
+            $badInput | Should -BeNullOrEmpty
+            $inputWarning | Should -Match "is not supported"
+        }
+    }
+
+    Context "Index options" {
+        It "Applies FillFactor to the rebuilt index" {
+            $splatFillFactor = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Table       = "dbo.frag1"
+                Index       = "IX_frag1_num"
+                FillFactor  = 70
+            }
+            $null = Invoke-DbaDbIndexRebuild @splatFillFactor
+            $fillFactorRow = $testDb.Query($measureFillFactor)
+            $fillFactorRow.fill_factor | Should -Be 70
+        }
+
+        It "Rebuilds online" {
+            # Set-ItResult marks the result but does not stop the block, so the rest has to be skipped explicitly.
+            if ($server.EngineEdition -ne "EnterpriseOrDeveloper") {
+                Set-ItResult -Skipped -Because "online index rebuilds require Enterprise or Developer edition"
+                return
+            }
+            $splatOnline = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Table       = "dbo.frag1"
+                Index       = "PK_frag1"
+                Online      = $true
+            }
+            $onlineResult = Invoke-DbaDbIndexRebuild @splatOnline
+            $onlineResult.Online | Should -Be $true
+            $onlineResult.Success | Should -Be $true
+        }
+
+        It "Rebuilds as a resumable online operation" {
+            if ($server.EngineEdition -ne "EnterpriseOrDeveloper") {
+                Set-ItResult -Skipped -Because "resumable index rebuilds require Enterprise or Developer edition"
+                return
+            }
+            if ($server.VersionMajor -lt 14) {
+                Set-ItResult -Skipped -Because "resumable index rebuilds require SQL Server 2017 or later"
+                return
+            }
+            $splatResumable = @{
+                SqlInstance          = $TestConfig.InstanceSingle
+                Database             = $dbName
+                Table                = "dbo.frag1"
+                Index                = "PK_frag1"
+                Online               = $true
+                Resumable            = $true
+                ResumableMaxDuration = 5
+            }
+            $resumableResult = Invoke-DbaDbIndexRebuild @splatResumable
+            $resumableResult.Resumable | Should -Be $true
+            $resumableResult.Success | Should -Be $true
+        }
+
+        It "Refuses a resumable rebuild that is not online" {
+            $splatBadResumable = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Resumable   = $true
+            }
+            $badResumable = Invoke-DbaDbIndexRebuild @splatBadResumable -WarningVariable resumableWarning -WarningAction SilentlyContinue
+            $badResumable | Should -BeNullOrEmpty
+            $resumableWarning | Should -Match "requires ONLINE"
+        }
+
+        It "Refuses WaitAtLowPriority that is not online" {
+            $splatBadWait = @{
+                SqlInstance       = $TestConfig.InstanceSingle
+                Database          = $dbName
+                WaitAtLowPriority = $true
+            }
+            $badWait = Invoke-DbaDbIndexRebuild @splatBadWait -WarningVariable waitWarning -WarningAction SilentlyContinue
+            $badWait | Should -BeNullOrEmpty
+            $waitWarning | Should -Match "WAIT_AT_LOW_PRIORITY"
+        }
+
+        It "Refuses SortInTempdb combined with Resumable" {
+            $splatBadSort = @{
+                SqlInstance  = $TestConfig.InstanceSingle
+                Database     = $dbName
+                Online       = $true
+                Resumable    = $true
+                SortInTempdb = $true
+            }
+            $badSort = Invoke-DbaDbIndexRebuild @splatBadSort -WarningVariable sortWarning -WarningAction SilentlyContinue
+            $badSort | Should -BeNullOrEmpty
+            $sortWarning | Should -Match "SORT_IN_TEMPDB"
+        }
+
+        It "Refuses AbortAfterWait without something to wait for" {
+            $splatBadAbort = @{
+                SqlInstance       = $TestConfig.InstanceSingle
+                Database          = $dbName
+                Online            = $true
+                WaitAtLowPriority = $true
+                AbortAfterWait    = "Blockers"
+            }
+            $badAbort = Invoke-DbaDbIndexRebuild @splatBadAbort -WarningVariable abortWarning -WarningAction SilentlyContinue
+            $badAbort | Should -BeNullOrEmpty
+            $abortWarning | Should -Match "MaxDurationMinutes"
+        }
+    }
+}


### PR DESCRIPTION
Closes #3862.

dbatools has no index maintenance command today, so this adds one that works across collections of databases, tables, indexed views and indexes, exposing the ALTER INDEX option set through SMO.

### What it does

- **Three modes.** `Rebuild`, `Reorganize`, and `Auto`, where Auto picks the operation per index from measured fragmentation the way Ola Hallengren's IndexOptimize does: below `-ReorganizeThreshold` (default 5) it is left alone, between the thresholds it is reorganized, at or above `-RebuildThreshold` (default 30) it is rebuilt.
- **Heaps.** `-IncludeHeap` rebuilds heaps with `ALTER TABLE ... REBUILD`. This is the follow-up ask on the issue: Ola's scripts leave heaps alone entirely, so today there is no way to defragment one without hand-writing the T-SQL. A heap rebuild also rebuilds the table's nonclustered indexes, so those are not rebuilt a second time in the same run.
- **Explicit "all databases".** Reaching every database takes `-AllDatabases` (includes system databases) or `-AllUserDatabases`. An unqualified call warns instead of rebuilding an entire instance.
- **The full option set.** `-Online`, `-MaxDop`, `-FillFactor`, `-PadIndex`, `-SortInTempdb`, `-Resumable` / `-ResumableMaxDuration`, `-WaitAtLowPriority` / `-MaxDurationMinutes` / `-AbortAfterWait`, plus `-StatementTimeout` so a long rebuild is not cut off.
- **Filters.** `-MinimumFragmentation` and `-MinimumPageCount` apply in every mode, so an explicit Rebuild run can still skip indexes that are already healthy.
- **Pipeline.** Accepts databases from `Get-DbaDatabase`, tables from `Get-DbaDbTable`, and views from `Get-DbaDbView`.

### Measurement

Fragmentation is read once per database with a `LIMITED` scan of `sys.dm_db_index_physical_stats`, averaged across partitions weighted by page count, and restricted to `IN_ROW_DATA` so the zero-fragmentation LOB and row-overflow rows do not drag the number down. That single scan drives the Auto decision, both filters, and the reported before/after values.

Columnstore indexes are the exception. That DMV only sees their rowstore parts, so a clustered columnstore over half a million rows reports a handful of pages and a fragmentation figure that means nothing. Their `PageCount` and fragmentation come back null, and they are skipped with a warning under `Auto` or either filter rather than being decided on a bad number.

### Safety

Anything that cannot honour the requested operation is skipped with a warning rather than quietly downgraded. `-Online` in particular is what stands between the caller and a table lock, so an index that cannot rebuild online is skipped and said out loud instead of rebuilt offline. Objects that cannot be processed at all — memory-optimized tables, read-only databases, snapshots, disabled indexes under Reorganize — are skipped without failing the run, so one unsupported index does not stop maintenance across the rest of the instance. `SupportsShouldProcess` is per operation.

Requires SQL Server 2005 or later; `ALTER INDEX` and the DMV do not exist on 2000, and `-Resumable` / `-WaitAtLowPriority` carry their own version floors that are waived on Azure SQL Database.

### Tests

`tests/Invoke-DbaDbIndexRebuild.Tests.ps1` — 36 tests, all against a real instance with no mocks: parameter validation, the three modes, the Auto threshold bands, heaps (including the double-rebuild case), columnstore, both filters, database selection including `-AllDatabases` vs `-AllUserDatabases`, read-only databases, `-WhatIf`, all three pipeline shapes, and the option guards. A rebuild case was also added to `.github/scripts/gh-actions.ps1`.

Out of scope: wiring this into `Invoke-DbaDbUpgrade`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
