### PR TITLE
Stop the potato CI marker from skipping every merge to development

### DIFF
--- a/.github/runners/tests/runner-policy.Tests.ps1
+++ b/.github/runners/tests/runner-policy.Tests.ps1
@@ -614,6 +614,17 @@ Describe "Runner workflow policy wiring" {
         $script:CiWorkflow | Should -Match "\[do ci\]"
     }
 
+    It "scopes that gate to controller dispatches so every merge to development runs" {
+        # push only fires on development here, so the earlier "not a pull_request" form
+        # skipped the entire suite on every merge -- authorize green, test skipped, run
+        # green in ten seconds. The marker is only meant to stop an ordinary feature-branch
+        # push, and those arrive as a controller dispatch carrying pool_user.
+        $script:CiWorkflow | Should -Match "\`$CI_EVENT`" = `"workflow_dispatch`""
+        $script:CiWorkflow | Should -Match "-n `"\`$CI_POOL_USER`""
+        $script:CiWorkflow | Should -Not -Match "\`$CI_EVENT`" != `"pull_request`""
+        $script:CiWorkflow | Should -Match "CI_POOL_USER: \S+\{\{ inputs\.pool_user \}\}"
+    }
+
     It "defines all four pool labels" {
         foreach ($pool in @("potatoqualitee", "andreasjordan", "niphlod", "community")) {
             $script:CiWorkflow | Should -Match ([regex]::Escape("'$pool'"))

--- a/.github/workflows/ci-azure.yml
+++ b/.github/workflows/ci-azure.yml
@@ -84,12 +84,22 @@ jobs:
         env:
           CI_ACTOR: ${{ inputs.pool_user || github.actor }}
           CI_EVENT: ${{ github.event_name }}
+          CI_POOL_USER: ${{ inputs.pool_user }}
           CI_MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title || inputs.message }}
         shell: bash
         run: |
           set -euo pipefail
           run_ci=true
-          if [ "$CI_ACTOR" = "potatoqualitee" ] && [ "$CI_EVENT" != "pull_request" ]; then
+          # The marker exists so a maintainer's ordinary feature-branch push does not
+          # acquire runners. Those pushes only ever reach this workflow as a controller
+          # dispatch, which sets pool_user -- so that is the only path still checked.
+          #
+          # The old condition was "not a pull_request", which also caught push. But push
+          # here only fires on development, so every merge to development was silently
+          # skipped: authorize green, test skipped, run green in ten seconds. Merges are
+          # the one thing that must always run the whole suite. A hand-started dispatch
+          # (no pool_user) is a deliberate act and runs too.
+          if [ "$CI_ACTOR" = "potatoqualitee" ] && [ "$CI_EVENT" = "workflow_dispatch" ] && [ -n "$CI_POOL_USER" ]; then
             message_lower=$(printf '%s' "$CI_MESSAGE" | tr '[:upper:]' '[:lower:]')
             if [[ "$message_lower" != *"[do ci]"* ]]; then
               run_ci=false


### PR DESCRIPTION
Both merges to `development` today finished green in ten seconds without testing anything:

| run | authorize | test |
| --- | --- | --- |
| `ci-azure` for #10506 | success | **skipped** |
| `ci-azure` for #10505 | success | **skipped** |

## Why

The `authorize` job required the `[do ci]` marker whenever the actor was `potatoqualitee` and the event was not a `pull_request`:

```bash
if [ "$CI_ACTOR" = "potatoqualitee" ] && [ "$CI_EVENT" != "pull_request" ]; then
```

The marker is meant to stop a maintainer's ordinary feature-branch push from acquiring Azure runners. But this workflow's `push:` trigger is scoped to `development`, so `push` here *is* a merge — the condition never guarded a feature branch, it only ever skipped merges. A squash commit message is the PR title plus `(#NNNNN)`, and PR titles deliberately do not carry `[do ci]`, so every merge was skipped.

Feature-branch pushes reach this workflow a different way: the fleet controller dispatches it with `pool_user` set, after applying the marker policy itself. So the check moves to that path and nowhere else.

## Verified

The policy block was lifted verbatim out of the shipped workflow and run against each case:

```
merge to development, no marker                      run-ci=true
merge to development, marker                         run-ci=true
controller dispatch, no marker                       run-ci=false
controller dispatch, marker                          run-ci=true
hand-started dispatch, no marker                     run-ci=true
pull request                                         run-ci=true
community push, no marker                            run-ci=true
```

The first row is the bug and the third is the guard that has to survive. A hand-started dispatch from the Actions UI now runs too, which it previously did not.

## Scope was never the problem

Worth stating since it is the other half of "every merge runs 100%": test selection is already correct on a merge. `appveyor.common.ps1` narrows by changed files only when `$IsInPullRequest`, and by `(do ...)` only when the commit message carries one. A squash commit carries neither, so `$AllTests` stays whole and the full matrix runs — SINGLE 1/5 through 5/5, MULTI, COPY, HADR, RESTART and default.

87 tests pass in `.github/runners/tests/`, including a new one that fails against the old condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
