### PR TITLE
ci-azure - Skip the Windows SSPI test when the build exits early

### DIFF
--- a/.github/workflows/ci-azure.yml
+++ b/.github/workflows/ci-azure.yml
@@ -243,12 +243,19 @@ jobs:
       # The SSPI provider is .NET 8 only, so this test cannot run under the Windows
       # PowerShell 5.1 pipeline and needs a portable pwsh 7 alongside it. Gated on the
       # test file rather than a branch name so it keeps running after this branch is gone.
+      # When the scoped test selection leaves this partition empty, appveyor.prep exits
+      # early without installing the pinned dbatools.library, so the SSPI test would load
+      # whatever stale library the reused runner has - skip on the shim's early-exit flag.
       - name: Install PowerShell 7 for Windows SSPI integration test
         if: matrix.scenario == 'SINGLE' && matrix.part == '1/5'
         shell: powershell
         run: |
           if (-not (Test-Path C:\github\dbatools\tests\Connect-DbaInstance.WindowsSspi.Tests.ps1)) {
               Write-Host "Connect-DbaInstance.WindowsSspi.Tests.ps1 is not present, skipping."
+              exit 0
+          }
+          if (Test-Path C:\Temp\gha-exit-build.flag) {
+              Write-Host "CI pipeline exited early without provisioning, skipping."
               exit 0
           }
           $assetUrl = "https://github.com/PowerShell/PowerShell/releases/download/v7.4.18/PowerShell-7.4.18-win-x64.zip"
@@ -268,6 +275,10 @@ jobs:
         run: |
           if (-not (Test-Path C:\github\dbatools\tests\Connect-DbaInstance.WindowsSspi.Tests.ps1)) {
               Write-Host "Connect-DbaInstance.WindowsSspi.Tests.ps1 is not present, skipping."
+              exit 0
+          }
+          if (Test-Path C:\Temp\gha-exit-build.flag) {
+              Write-Host "CI pipeline exited early without provisioning, skipping."
               exit 0
           }
           $scriptPath = Join-Path $env:RUNNER_TEMP "Invoke-WindowsSspiTest.ps1"


### PR DESCRIPTION
## The intermittent SSPI failure ([example](https://github.com/dataplat/dbatools/actions/runs/30957616435/job/92154241891))

The `Run PowerShell 7 Windows SSPI integration test` step fails only sometimes, and the pattern finally fell out of the logs:

1. On PR events, `DBATOOLS_COMMIT_MESSAGE` falls back to the **PR title**. When a title carries a `(do ...)` marker (like #10514's did), the run is scoped.
2. If that scope leaves the **SINGLE 1/5** partition with zero tests, `appveyor.prep` exits early **without installing the pinned dbatools.library**: `appveyor.prep: exit early without provisioning (no tests to run)`.
3. The SSPI steps are gated only on `scenario == SINGLE && part == 1/5` plus test-file presence, so they still run. Under pwsh 7 the `dbatools.psd1` import fails (required module unresolvable), `Invoke-ManualPester` falls back to the psm1 import, and that loads **whatever stale dbatools.library the reused runner has lying around**. If that build predates `NetworkCredentialSspiContextProvider`, the test's type guard throws.

Green vs. red depends on which runner the job lands on and what a previous job left in `Program Files`, which is why it looked random. Full runs (development pushes, unscoped PRs) always install the pinned library first, so they always pass.

## Fix

Both SSPI steps now honor `C:\Temp\gha-exit-build.flag` — the exact flag `Exit-AppveyorBuild` drops for the later pipeline stages to skip on. The shim deletes it at the start of every job's pipeline step, so the flag state is always this job's own.

## Validation

This PR's title deliberately carries the same `(do ...)` scope as #10514 (normally PR titles shouldn't, but this PR changes no commands, so the title is the only way to reproduce the trigger). The workflow-only diff means changed-file detection narrows nothing, the title scope empties SINGLE 1/5, prep early-exits, and the SSPI step must log `CI pipeline exited early without provisioning, skipping.` and stay green — the exact A/B of the failing run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)