### PR TITLE
ps3-smoke - retry teardown deletes and warn when resources leak

### DIFF
--- a/.github/workflows/ps3-smoke.yml
+++ b/.github/workflows/ps3-smoke.yml
@@ -45,11 +45,27 @@ jobs:
           # no tr|head pipeline here: with pipefail the SIGPIPE would kill the step
           PASS="Db$(openssl rand -hex 10)!5k"
 
+          # an NRP transient (NetworkingInternalOperationError) has leaked a VM before,
+          # and the || true made it invisible: retry each delete, then surface anything
+          # left behind as a warning annotation instead of failing the smoke verdict
+          retry() {
+            for attempt in 1 2 3; do
+              "$@" && return 0
+              echo "delete attempt $attempt failed, retrying in 30s: $*"
+              sleep 30
+            done
+            return 1
+          }
+
           cleanup() {
             echo "== cleanup"
-            az vm delete -g "$RG" -n "$VM" --yes || true
-            az network nic delete -g "$RG" -n "${VM}VMNic" || true
-            az network public-ip delete -g "$RG" -n "${VM}PublicIP" || true
+            retry az vm delete -g "$RG" -n "$VM" --yes || true
+            retry az network nic delete -g "$RG" -n "${VM}VMNic" || true
+            retry az network public-ip delete -g "$RG" -n "${VM}PublicIP" || true
+            leaked=$(az resource list -g "$RG" --query "[?contains(name, '$VM')].name" -o tsv 2>/dev/null | paste -sd, - || true)
+            if [ -n "$leaked" ]; then
+              echo "::warning::ps3-smoke cleanup leaked $leaked in $RG -- delete manually"
+            fi
           }
           trap cleanup EXIT
 


### PR DESCRIPTION
Run 30973874597 showed green while its teardown failed: an Azure NRP transient (`NetworkingInternalOperationError`) killed the `az vm delete`, the `|| true` swallowed it, and `ps3smoke-26` + NIC + public IP sat leaked in `dbatools-ci` — only visible as failed delete operations in the portal activity log.

This hardens the cleanup trap:

- each delete (VM, NIC, public IP) now retries up to 3 times with a 30s pause, which is enough for NRP transients to clear
- after the deletes, anything still matching the VM name in the resource group is surfaced as a `::warning::` annotation on the run page, so a leak can never be silent again
- the smoke verdict itself is unchanged — teardown trouble warns, it does not fail the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)