### PR TITLE
Invoke-ManualPester - Check the test file and the repository style gate

### DIFF
--- a/.github/CONTRIBUTING-TESTING.md
+++ b/.github/CONTRIBUTING-TESTING.md
@@ -329,14 +329,31 @@ Invoke-ManualPester -Path Get-DbaDatabase -TestIntegration -Coverage
 # Run with full coverage including dependencies
 Invoke-ManualPester -Path Get-DbaDatabase -TestIntegration -Coverage -DependencyCoverage
 
-# Run with script analyzer check
+# Run with script analyzer check on the test file and the command
 Invoke-ManualPester -Path Get-DbaDatabase -TestIntegration -ScriptAnalyzer
+
+# Run the repository wide style checks that CI enforces
+Invoke-ManualPester -Path Get-DbaDatabase -TestIntegration -Compliance
 
 # Run multiple tests matching a pattern
 Invoke-ManualPester -Path "*Backup*" -TestIntegration
 
 # Show less output
 Invoke-ManualPester -Path Get-DbaDatabase -TestIntegration -Show None
+```
+
+### Before opening a pull request
+
+`Invoke-ManualPester -Path <command>` runs only that command's test file. Two of the checks CI runs
+belong to no command's test file at all, so a green run of it says nothing about them:
+
+| Switch | What it adds |
+|---|---|
+| `-ScriptAnalyzer` | Checks the test file and the command under test against [tests/PSScriptAnalyzerRules.psd1](../tests/PSScriptAnalyzerRules.psd1), the repository style profile. |
+| `-Compliance` | Runs the `Compliance` tagged tests from [tests/dbatools.Tests.ps1](../tests/dbatools.Tests.ps1) over the whole repository: no UTF-8 BOM, no tabs, no trailing spaces, no ScriptAnalyzer errors. Takes about half a minute. |
+
+```powershell
+Invoke-ManualPester -Path Get-DbaDatabase -TestIntegration -ScriptAnalyzer -Compliance
 ```
 
 ### Method 2: Direct Pester Invocation
@@ -568,6 +585,7 @@ Invoke-ManualPester -Path "*Backup*" -TestIntegration
 | [tests/constants.local.ps1.example](../tests/constants.local.ps1.example) | Template for local config |
 | [private/testing/Get-TestConfig.ps1](../private/testing/Get-TestConfig.ps1) | Loads test configuration |
 | [private/testing/Invoke-ManualPester.ps1](../private/testing/Invoke-ManualPester.ps1) | Local test runner helper |
+| [private/testing/Get-TestInstanceUsage.ps1](../private/testing/Get-TestInstanceUsage.ps1) | Reports which `$TestConfig` instances a test file uses, and therefore which CI lane it runs in |
 | [tests/pester.groups.ps1](../tests/pester.groups.ps1) | Scenario definitions |
 | [tests/appveyor.common.ps1](../tests/appveyor.common.ps1) | CI test discovery logic |
 | [tests/CLAUDE.md](../tests/CLAUDE.md) | Ongoing test policy and Pester 6 standards |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
  - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
  - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
  - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
- - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
+ - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester -Path <command> -ScriptAnalyzer -Compliance`)
  - [ ] Adding code coverage to existing functionality
  - [ ] Pester test is included
  - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?

--- a/private/testing/Get-TestInstanceUsage.ps1
+++ b/private/testing/Get-TestInstanceUsage.ps1
@@ -1,0 +1,79 @@
+function Get-TestInstanceUsage {
+<#
+.SYNOPSIS
+    Reports which $TestConfig instances each test file uses.
+
+.DESCRIPTION
+    tests\pester.groups.ps1 assigns a test file to a CI scenario by autodetecting which
+    $TestConfig.Instance* variable the file references, so this is what decides which lane a test
+    runs in - and the lanes are not equally available. Only InstanceSingle, InstanceMulti1 and
+    InstanceMulti2 exist on GitHub Actions; a test written against InstanceCopy, InstanceHadr or
+    InstanceRestart runs on the Azure runners only.
+
+    Use it to see which lane a change lands in before writing the test, or to find every test that
+    a given instance would affect.
+
+    Commented out code is ignored, so a reference left behind in a comment does not move a file
+    into a scenario it does not belong to.
+
+.PARAMETER Path
+    The folder holding the test files. Defaults to the tests folder of this working copy.
+
+.PARAMETER Command
+    Only report the test files of these commands. Wildcards are supported. Defaults to all of them.
+
+.EXAMPLE
+    Get-TestInstanceUsage
+
+    Reports the instances used by every test file.
+
+.EXAMPLE
+    Get-TestInstanceUsage -Command Get-DbaDb*
+
+    Reports the instances used by the test files of every command starting with Get-DbaDb.
+
+.EXAMPLE
+    Get-TestInstanceUsage | Group-Object -Property InstanceList -NoElement | Sort-Object -Property Count -Descending
+
+    Shows how many test files use each combination of instances.
+
+.EXAMPLE
+    Get-TestInstanceUsage | Where-Object Instances -contains "Hadr"
+
+    Lists every test that needs the availability group instance, which only the Azure runners have.
+#>
+    [CmdletBinding()]
+    param (
+        [string]$Path = (Join-Path (Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent) "tests"),
+        [string[]]$Command = "*"
+    )
+
+    foreach ($commandName in $Command) {
+        $testFiles = Get-ChildItem -Path "$Path\$commandName.Tests.ps1" -ErrorAction SilentlyContinue | Sort-Object -Property Name
+        if (-not $testFiles) {
+            Write-Warning -Message "No test file found for [$commandName]"
+            continue
+        }
+
+        foreach ($testFile in $testFiles) {
+            $content = Get-Content -Path $testFile.FullName
+            # This matches the current names ($TestConfig.InstanceSingle, $TestConfig.InstanceMulti1
+            # and so on) as well as the legacy $TestConfig.instance1, because both spellings still
+            # appear in the autodetection in pester.groups.ps1.
+            $instanceNames = foreach ($line in $content) {
+                $code = $line -replace "#.*$", ""
+                [regex]::Matches($code, "\`$TestConfig\.Instance(\w+)", [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
+                    ForEach-Object { $PSItem.Groups[1].Value }
+            }
+            $instanceNames = @($instanceNames | Sort-Object -Unique)
+
+            [PSCustomObject]@{
+                Command      = $testFile.Name -replace "\.Tests\.ps1$", ""
+                TestFileName = $testFile.Name
+                Instances    = $instanceNames
+                # A single string as well, so that the result can be grouped on it directly
+                InstanceList = $instanceNames -join " "
+            }
+        }
+    }
+}

--- a/private/testing/Invoke-ManualPester.ps1
+++ b/private/testing/Invoke-ManualPester.ps1
@@ -1,50 +1,67 @@
 function Invoke-ManualPester {
 <#
 .SYNOPSIS
-    Runs dbatools tests with support for both Pester v4 and v5.
+    Runs dbatools tests locally the way the CI runs them.
 
 .DESCRIPTION
-    This is a helper function to automate running tests locally. It supports both Pester v4 and v5 tests,
-    automatically detecting which version to use based on the test file requirements. For Pester v5 tests,
-    it uses the new configuration system while maintaining backward compatibility with v4 tests.
+    This is a helper function to automate running tests locally. It imports the module from the
+    working copy, runs the given test files with Pester, and reports at the end which files failed
+    and why, so that a run over several files does not have to be read by scrolling back.
+
+    It also runs the style checks that CI enforces but that live outside the per-command test files
+    and are therefore easy to miss locally:
+
+    - ScriptAnalyzer checks the test file and the command under test, using the dbatools profile.
+    - Compliance runs the repository wide checks from tests\dbatools.Tests.ps1 (no UTF-8 BOM,
+      no tabs, no trailing spaces, no ScriptAnalyzer errors).
 
 .PARAMETER Path
     The Path to the test files to run. It accepts multiple test file paths passed in (e.g. .\Find-DbaOrphanedFile.Tests.ps1) as well
     as simple strings (e.g. "orphaned" will run all files matching .\*orphaned*.Tests.ps1)
 
 .PARAMETER Show
-    Gets passed down to Pester's -Show parameter (useful if you want to reduce verbosity)
+    Gets passed down to Pester's Output.Verbosity setting (useful if you want to reduce verbosity)
     Valid values are: None, Normal, Detailed, Diagnostic
 
 .PARAMETER PassThru
-    Gets passed down to Pester's -PassThru parameter (useful if you want to return an object to analyze)
+    Gets passed down to Pester's PassThru setting (useful if you want to return an object to analyze)
 
 .PARAMETER TestIntegration
     dbatools's suite has unittests and integrationtests. This switch enables IntegrationTests, which need live instances
     see Get-TestConfig for customizations
 
 .PARAMETER Coverage
-    Enables measuring code coverage on the tested function. For Pester v5 tests, this will generate coverage in JaCoCo format.
+    Enables measuring code coverage on the tested function, in JaCoCo format.
 
 .PARAMETER DependencyCoverage
     Enables measuring code coverage also of "lower level" (i.e. called) functions
 
 .PARAMETER ScriptAnalyzer
-    Enables checking the called function's code with Invoke-ScriptAnalyzer, with dbatools's profile
+    Enables checking the test file and the command under test with Invoke-ScriptAnalyzer, using
+    dbatools's profile in tests\PSScriptAnalyzerRules.psd1. Combined with DependencyCoverage the
+    called functions are checked as well.
+
+.PARAMETER Compliance
+    Runs the Compliance tagged tests from tests\dbatools.Tests.ps1 before the test files.
+
+    These are the repository wide checks that CI runs in its "default" lane: no UTF-8 BOM, no tabs,
+    no trailing spaces and no ScriptAnalyzer errors, across every PowerShell file in the repository.
+    They belong to no single command, so a green run of a command's own test file says nothing about
+    them and a pull request can still fail CI on style. They take about half a minute.
 
 .EXAMPLE
-    Invoke-ManualPester -Path Find-DbaOrphanedFile.Tests.ps1 -TestIntegration -Coverage -DependencyCoverage -ScriptAnalyzer
+    Invoke-ManualPester -Path Find-DbaOrphanedFile.Tests.ps1 -TestIntegration -Coverage -DependencyCoverage -ScriptAnalyzer -Compliance
 
     The most complete number of checks:
+    - Runs the repository wide compliance checks
     - Runs both unittests and integrationtests
     - Gathers and shows code coverage measurement for Find-DbaOrphanedFile and all its dependencies
-    - Checks Find-DbaOrphanedFile with Invoke-ScriptAnalyzer
-    - Automatically detects and uses the appropriate Pester version
+    - Checks the test file, Find-DbaOrphanedFile and its dependencies with Invoke-ScriptAnalyzer
 
 .EXAMPLE
     Invoke-ManualPester -Path Find-DbaOrphanedFile.Tests.ps1
 
-    Runs tests stored in Find-DbaOrphanedFile.Tests.ps1, automatically detecting whether to use Pester v4 or v5
+    Runs tests stored in Find-DbaOrphanedFile.Tests.ps1
 
 .EXAMPLE
     Invoke-ManualPester -Path Find-DbaOrphanedFile.Tests.ps1 -PassThru
@@ -67,55 +84,51 @@ function Invoke-ManualPester {
     Runs both unittests and integrationtests stored in Find-DbaOrphanedFile.Tests.ps1
 
 .EXAMPLE
-    Invoke-ManualPester -Path Find-DbaOrphanedFile.Tests.ps1 -TestIntegration -Coverage
+    Invoke-ManualPester -Path Find-DbaOrphanedFile.Tests.ps1 -ScriptAnalyzer -Compliance
 
-    Gathers and shows code coverage measurement for Find-DbaOrphanedFile.
-    For Pester v5 tests, this will generate coverage in JaCoCo format.
-
-.EXAMPLE
-    Invoke-ManualPester -Path Find-DbaOrphanedFile.Tests.ps1 -TestIntegration -Coverage -DependencyCoverage
-
-    Gathers and shows code coverage measurement for Find-DbaOrphanedFile and all its dependencies.
-    For Pester v5 tests, this will generate coverage in JaCoCo format.
+    Runs the tests and then the two style checks that CI enforces but that a per-command test run
+    does not cover. This is the combination to use before opening a pull request.
 
 .NOTES
-    For Pester v5 tests, include the following requirement in your test file:
-    #Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0.0" }
+    Every test file has to carry this requirement in its first line:
+    #Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 
-    Tests without this requirement will be run using Pester v4.4.2.
+    A file without it is reported and skipped rather than run, because dbatools no longer has
+    Pester 4 tests and a missing header is a mistake in the test file.
 #>
     [CmdletBinding()]
     param (
         [Parameter(Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
-        [Alias('FullName')]
+        [Alias("FullName")]
         [string[]]$Path,
-        [ValidateSet('None', 'Normal', 'Detailed', 'Diagnostic')]
+        [ValidateSet("None", "Normal", "Detailed", "Diagnostic")]
         [string]$Show = "Normal",
         [switch]$PassThru,
         [switch]$TestIntegration,
         [switch]$Coverage,
         [switch]$DependencyCoverage,
-        [switch]$ScriptAnalyzer
+        [switch]$ScriptAnalyzer,
+        [switch]$Compliance
     )
     begin {
         Remove-Module -Name Pester -ErrorAction SilentlyContinue
         $stopProcess = $false
         function Get-CoverageIndications($Path, $ModuleBase) {
             # takes a test file path and figures out what to analyze for coverage (i.e. dependencies)
-            $CBHRex = [regex]'(?smi)<#(.*)#>'
+            $CBHRex = [regex]"(?smi)<#(.*)#>"
             $everything = (Get-Module dbatools).ExportedCommands.Values
             $everyfunction = $everything.Name
             $funcs = @()
             $leaf = Split-Path $path -Leaf
             # assuming Get-DbaFoo.Tests.ps1 wants coverage for "Get-DbaFoo"
             # but allowing also Get-DbaFoo.one.Tests.ps1 and Get-DbaFoo.two.Tests.ps1
-            $func_name += ($leaf -replace '^([^.]+)(.+)?.Tests.ps1', '$1')
+            $func_name += ($leaf -replace "^([^.]+)(.+)?.Tests.ps1", "`$1")
             if ($func_name -in $everyfunction) {
                 $funcs += $func_name
                 $f = $everything | Where-Object Name -eq $func_name
                 $source = $f.Definition
                 $CBH = $CBHRex.match($source).Value
-                $cmdonly = $source.Replace($CBH, '')
+                $cmdonly = $source.Replace($CBH, "")
                 foreach ($e in $everyfunction) {
                     # hacky, I know, but every occurrence of any function plus a space kinda denotes usage !?
                     $searchme = "$e "
@@ -125,12 +138,12 @@ function Invoke-ManualPester {
                 }
             }
             $testpaths = @()
-            $allfiles = Get-ChildItem -File -Path "$ModuleBase\private\functions", "$ModuleBase\public" -Filter '*.ps1'
+            $allfiles = Get-ChildItem -File -Path "$ModuleBase\private\functions", "$ModuleBase\public" -Filter "*.ps1"
             foreach ($f in $funcs) {
                 # exclude always used functions ?!
-                if ($f -in ('Connect-DbaInstance', 'Select-DefaultView', 'Stop-Function', 'Write-Message')) { continue }
+                if ($f -in ("Connect-DbaInstance", "Select-DefaultView", "Stop-Function", "Write-Message")) { continue }
                 # can I find a correspondence to a physical file (again, on the convenience of having Get-DbaFoo.ps1 actually defining Get-DbaFoo)?
-                $res = $allfiles | Where-Object { $_.Name.Replace('.ps1', '') -eq $f }
+                $res = $allfiles | Where-Object { $PSItem.Name.Replace(".ps1", "") -eq $f }
                 if ($res.count -gt 0) {
                     $testpaths += $res.FullName
                 }
@@ -138,44 +151,64 @@ function Invoke-ManualPester {
             return @() + ($testpaths | Select-Object -Unique)
         }
 
-        function Get-PesterTestVersion($testFilePath) {
-            $testFileContent = Get-Content -Path $testFilePath -Raw
-            if ($testFileContent -match '#Requires\s+-Module\s+@\{\s+ModuleName="Pester";\s+ModuleVersion="5\.') {
-                return '5'
+        # The file that defines the command a test file belongs to, or nothing for the few test
+        # files that do not test a single command (dbatools.Tests.ps1, InModule.*, appveyor.*).
+        # Get-CoverageIndications cannot answer this: it returns the command and its dependencies
+        # in one list, and for a command it does not know - a private function, or one that is not
+        # exported yet - it returns nothing at all while its dependencies are still found. Taking
+        # the first entry of that list therefore silently analysed and measured a dependency
+        # instead of the command under test.
+        function Get-CommandFile($testFilePath, $ModuleBase) {
+            # Get-DbaFoo.Tests.ps1, and also Get-DbaFoo.one.Tests.ps1, belong to Get-DbaFoo
+            $commandName = (Split-Path $testFilePath -Leaf) -replace "^([^.]+)(.+)?.Tests.ps1", "`$1"
+            $splatCommandFile = @{
+                Path        = "$ModuleBase\public", "$ModuleBase\private"
+                Filter      = "$commandName.ps1"
+                File        = $true
+                Recurse     = $true
+                ErrorAction = "SilentlyContinue"
             }
-            return '4'
+            return (Get-ChildItem @splatCommandFile | Select-Object -First 1).FullName
+        }
+
+        # Every test file has to declare the Pester 5 requirement. dbatools has no Pester 4 tests
+        # left, so a file without the header is a mistake in the file and not a request for an
+        # older runtime - it is reported instead of being run with something else.
+        function Test-PesterTestHeader($testFilePath) {
+            $testFileContent = Get-Content -Path $testFilePath -Raw
+            return $testFileContent -match "#Requires\s+-Module\s+@\{\s+ModuleName=`"Pester`";\s+ModuleVersion=`"5\."
         }
 
         # Go up the folder structure until we find the root of the module, where dbatools.psd1 is located
         function Get-ModuleBase {
             $startOfSearch = $PSScriptRoot
             for ($i = 0; $i -lt 10; $i++) {
-                if (Test-Path (Join-Path $startOfSearch 'dbatools.psd1')) {
-                    $ModuleBase = $startOfSearch
-                    break
+                if (Test-Path (Join-Path $startOfSearch "dbatools.psd1")) {
+                    return $startOfSearch
                 }
                 $startOfSearch = Split-Path -Path $startOfSearch -Parent
             }
-            return $ModuleBase
         }
 
         function Write-DetailedMessage($message) {
-            if ($Show -in @('Normal', 'Detailed', 'Diagnostic')) {
+            if ($Show -in @("Normal", "Detailed", "Diagnostic")) {
                 Write-Host -Object $message
             }
         }
 
         $invokeFormatterVersion = (Get-Command Invoke-Formatter -ErrorAction SilentlyContinue).Version
         $HasScriptAnalyzer = $null -ne $invokeFormatterVersion
-        $MinimumPesterVersion = [Version] '4.0.0.0' # Because this is when -Show was introduced
-        $MaximumPesterVersion = [Version] '7.0.0.0' # Because we have either pester4 or pester5+ tests
+        # Pester 5 introduced the configuration object this function builds, and every test file in
+        # the repository requires it. The CI pins 6.0.0 in tests\appveyor.prep.ps1.
+        $MinimumPesterVersion = [Version] "5.0.0.0"
+        $MaximumPesterVersion = [Version] "7.0.0.0"
         $PesterVersion = (Get-Command Invoke-Pester -ErrorAction SilentlyContinue).Version
         $HasPester = $null -ne $PesterVersion
-        $ScriptAnalyzerCorrectVersion = '1.18.2'
+        $ScriptAnalyzerCorrectVersion = "1.18.2"
 
         if (!($HasScriptAnalyzer)) {
             Write-Warning "Please install PSScriptAnalyzer"
-            Write-Warning "     Install-Module -Name PSScriptAnalyzer -RequiredVersion '$ScriptAnalyzerCorrectVersion'"
+            Write-Warning "     Install-Module -Name PSScriptAnalyzer -RequiredVersion $ScriptAnalyzerCorrectVersion"
             Write-Warning "     or go to https://github.com/PowerShell/PSScriptAnalyzer"
         } else {
             if ($invokeFormatterVersion -ne $ScriptAnalyzerCorrectVersion) {
@@ -184,7 +217,7 @@ function Invoke-ManualPester {
                     Import-Module PSScriptAnalyzer -RequiredVersion $ScriptAnalyzerCorrectVersion -ErrorAction Stop
                 } catch {
                     Write-Warning "Please install PSScriptAnalyzer $ScriptAnalyzerCorrectVersion"
-                    Write-Warning "     Install-Module -Name PSScriptAnalyzer -RequiredVersion '$ScriptAnalyzerCorrectVersion'"
+                    Write-Warning "     Install-Module -Name PSScriptAnalyzer -RequiredVersion $ScriptAnalyzerCorrectVersion"
                 }
                 # Re-read the version after the corrective import so the gate below compares the
                 # module that is loaded now, not the stale value captured before Import-Module ran
@@ -199,21 +232,21 @@ function Invoke-ManualPester {
             Write-Warning "     or go to https://github.com/pester/Pester"
         }
         if ($PesterVersion -lt $MinimumPesterVersion) {
-            Write-Warning "Please update Pester to at least 3.4.5"
-            Write-Warning "     Install-Module -Name Pester  -MaximumVersion '4.10' -Force -SkipPublisherCheck"
+            Write-Warning "Please update Pester to at least $MinimumPesterVersion"
+            Write-Warning "     Install-Module -Name Pester -RequiredVersion 6.0.0 -Force -SkipPublisherCheck"
             Write-Warning "     or go to https://github.com/pester/Pester"
         }
-        if ($PesterVersion -gt $MaximumPesterVersion) {
-            Write-Warning "Please get Pester to the 6.0.0 release"
-            Write-Warning "     Install-Module -Name Pester -RequiredVersion '6.0.0' -Force -SkipPublisherCheck"
+        if ($PesterVersion -ge $MaximumPesterVersion) {
+            Write-Warning "Pester $PesterVersion is newer than this runner has been tested with"
+            Write-Warning "     Install-Module -Name Pester -RequiredVersion 6.0.0 -Force -SkipPublisherCheck"
             Write-Warning "     or go to https://github.com/pester/Pester"
         }
 
-        # PSScriptAnalyzer is only consumed by the -ScriptAnalyzer and -Coverage paths, so a
+        # PSScriptAnalyzer is only consumed by the -ScriptAnalyzer and -Compliance paths, so a
         # missing or wrong-version module must not block plain test runs (e.g. on PS 5.1 where
-        # another PSScriptAnalyzer version resolves first)
+        # another PSScriptAnalyzer version resolves first). Coverage does not use it at all.
         $ScriptAnalyzerGateOk = $true
-        if ($ScriptAnalyzer -or $Coverage) {
+        if ($ScriptAnalyzer -or $Compliance) {
             $ScriptAnalyzerGateOk = $HasScriptAnalyzer -and ($invokeFormatterVersion -eq $ScriptAnalyzerCorrectVersion)
         }
 
@@ -222,44 +255,95 @@ function Invoke-ManualPester {
             $stopProcess = $true
         }
 
+        if (-not $stopProcess) {
+            $ModuleBase = Get-ModuleBase
+            if (-not $ModuleBase) {
+                Write-Warning "Could not find dbatools.psd1 above $PSScriptRoot, exiting..."
+                $stopProcess = $true
+            }
+        }
 
+        if (-not $stopProcess) {
+            # dbatools.psm1 only dot sources the individual files - and thereby makes the private
+            # functions reachable from a test - when the module looks like a checkout. A working
+            # copy that has never been cloned (a download of the source zip) has no .git, so we
+            # create it. Anything without a tests folder is not a working copy at all and the test
+            # paths below would silently resolve to nothing, so we refuse that instead.
+            if (-not (Test-Path -Path "$ModuleBase\tests" -PathType Container)) {
+                Write-Warning "$ModuleBase does not contain a tests folder, so it is not a dbatools working copy. Exiting..."
+                $stopProcess = $true
+            } else {
+                $gitPath = Join-Path $ModuleBase ".git"
+                if (-not (Test-Path $gitPath -Type Container)) {
+                    $null = New-Item -Type Container -Path $gitPath -Force
+                }
+            }
+        }
 
+        if (-not $stopProcess) {
+            Import-Module Pester -MinimumVersion $MinimumPesterVersion -ErrorAction Stop
+
+            #removes previously imported dbatools, if any
+            # No need the force will do it
+            #Remove-Module dbatools -ErrorAction Ignore
+            #imports the module making sure DLL is loaded ok
+            Write-DetailedMessage "Importing dbatools psd1"
+            Import-Module "$ModuleBase\dbatools.psd1" -DisableNameChecking -Force -NoClobber
+            #imports the psm1 to be able to use internal functions in tests
+            Write-DetailedMessage "Importing dbatools psm1"
+            Import-Module "$ModuleBase\dbatools.psm1" -DisableNameChecking -Force -NoClobber
+
+            Write-DetailedMessage "Reading test configuration"
+            $TestConfig = Get-TestConfig
+
+            # The dbatools profile is the same set of rules the repository documents as its style.
+            # Before it was passed here, -ScriptAnalyzer ran the default rule set instead, so the
+            # documented behaviour and the actual behaviour were two different checks.
+            $ScriptAnalyzerSettings = "$ModuleBase\tests\PSScriptAnalyzerRules.psd1"
+
+            $testInt = [bool]$TestIntegration
+
+            # The summary at the end is the reason these are collected rather than only reported as
+            # they happen: a run over several files is unreadable if the only record of a failure is
+            # a Pester report that has already scrolled past.
+            $runSummary = @()
+            $startTime = Get-Date
+        }
+
+        # The compliance checks belong to no command, so they run once and first. Running them first
+        # also keeps the last Pester result on the pipeline the one of the last test file, which is
+        # what callers that pick a single result with Select-Object -Last 1 expect.
+        if (-not $stopProcess -and $Compliance) {
+            Write-DetailedMessage "Running the repository wide compliance checks"
+            $complianceConfig = New-PesterConfiguration
+            $complianceConfig.Run.Path = "$ModuleBase\tests\dbatools.Tests.ps1"
+            $complianceConfig.Run.PassThru = $true
+            $complianceConfig.Output.Verbosity = $Show
+            $complianceConfig.Filter.Tag = "Compliance"
+            $complianceResult = Invoke-Pester -Configuration $complianceConfig
+
+            $runSummary += [PSCustomObject]@{
+                TestFileName    = "dbatools.Tests.ps1 (Compliance)"
+                Result          = $complianceResult.Result
+                TotalCount      = $complianceResult.TotalCount
+                PassedCount     = $complianceResult.PassedCount
+                FailedCount     = $complianceResult.FailedCount
+                SkippedCount    = $complianceResult.SkippedCount
+                DurationSeconds = [int]$complianceResult.Duration.TotalSeconds
+                Failed          = $complianceResult.Failed
+            }
+
+            if ($PassThru) {
+                $complianceResult
+            }
+        }
     }
     process {
         if ($stopProcess) {
             return
         }
 
-
-        $ModuleBase = Get-ModuleBase
-
-        $gitPath = Join-Path $ModuleBase '.git'
-        if (-not(Test-Path $gitPath -Type Container)) {
-            $null = New-Item -Type Container -Path $gitPath -Force
-        }
-
-        #removes previously imported dbatools, if any
-        # No need the force will do it
-        #Remove-Module dbatools -ErrorAction Ignore
-        #imports the module making sure DLL is loaded ok
-        Write-DetailedMessage "Importing dbatools psd1"
-        Import-Module "$ModuleBase\dbatools.psd1" -DisableNameChecking -Force -NoClobber
-        #imports the psm1 to be able to use internal functions in tests
-        Write-DetailedMessage "Importing dbatools psm1"
-        Import-Module "$ModuleBase\dbatools.psm1" -DisableNameChecking -Force -NoClobber
-
-        Write-DetailedMessage "Reading test configuration"
-        $TestConfig = Get-TestConfig
-
-        $ScriptAnalyzerRulesExclude = @('PSUseOutputTypeCorrectly', 'PSAvoidUsingPlainTextForPassword', 'PSUseBOMForUnicodeEncodedFile')
-
-        $testInt = $false
-        if ($config_TestIntegration) {
-            $testInt = $true
-        }
-        if ($TestIntegration) {
-            $testInt = $true
-        }
+        $ScriptAnalyzerRulesExclude = @("PSUseOutputTypeCorrectly", "PSAvoidUsingPlainTextForPassword", "PSUseBOMForUnicodeEncodedFile")
 
         $files = @()
 
@@ -279,83 +363,115 @@ function Invoke-ManualPester {
 
         $AllTestsWithinScenario = $files
 
-
-
         foreach ($f in $AllTestsWithinScenario) {
-            $pesterVersionToUse = Get-PesterTestVersion -testFilePath $f.FullName
+            if (-not (Test-PesterTestHeader -testFilePath $f.FullName)) {
+                Write-Warning "$($f.Name) does not declare the mandatory Pester 5 header, skipping it. See tests\CLAUDE.md."
+                continue
+            }
 
-            #opt-in
-            $HeadFunctionPath = $f.FullName
+            # The test file is always analyzed. That is the part the old code missed: it looked at
+            # the command only, so a trailing space or a misaligned splat in the test file itself
+            # was never reported here and first showed up as a failing CI run.
+            $AnalyzePaths = @($f.FullName)
+            $CoverFiles = @()
+            $HeadFunctionPath = $null
 
             if ($Coverage -or $ScriptAnalyzer) {
-                Write-DetailedMessage "Getting coverage indications for $f"
-                $CoverFiles = Get-CoverageIndications -Path $f -ModuleBase $ModuleBase
-                $HeadFunctionPath = $CoverFiles | Select-Object -First 1
-
+                $HeadFunctionPath = Get-CommandFile -testFilePath $f.FullName -ModuleBase $ModuleBase
+                if (-not $HeadFunctionPath) {
+                    Write-DetailedMessage "No command file found for $($f.Name), only the test file itself is checked"
+                } else {
+                    $AnalyzePaths += $HeadFunctionPath
+                    $CoverFiles = @($HeadFunctionPath)
+                }
             }
+
+            if ($HeadFunctionPath -and $DependencyCoverage) {
+                Write-DetailedMessage "Getting coverage indications for $f"
+                $dependencyFiles = @(Get-CoverageIndications -Path $f -ModuleBase $ModuleBase) | Where-Object { $PSItem -ne $HeadFunctionPath }
+                $CoverFiles += $dependencyFiles
+                $AnalyzePaths += $dependencyFiles
+            }
+
+            Write-DetailedMessage "Running tests $($f.Name)"
+            $pester5Config = New-PesterConfiguration
+            $pester5Config.Run.Path = $f.FullName
+            $pester5Config.Run.PassThru = $true
+            $pester5Config.Output.Verbosity = $Show
             if ($Coverage) {
-                if ($DependencyCoverage) {
-                    $CoverFilesPester = $CoverFiles
+                if ($CoverFiles.Count -eq 0) {
+                    Write-Warning "Cannot measure coverage for $($f.Name), no command file found for it"
+                } else {
+                    $pester5Config.CodeCoverage.Enabled = $true
                     Write-DetailedMessage "We're going to target these files for coverage:"
                     foreach ($cf in $CoverFiles) {
                         Write-DetailedMessage "$cf"
                     }
-                } else {
-                    $CoverFilesPester = $HeadFunctionPath
+                    $pester5Config.CodeCoverage.Path = $CoverFiles
                 }
             }
+            if (!($testInt)) {
+                $pester5Config.Filter.ExcludeTag = "IntegrationTests"
+            }
+            $pester5Result = Invoke-Pester -Configuration $pester5Config
 
-            if ($pesterVersionToUse -eq '5') {
-                Write-DetailedMessage "Running Pester 5 tests $($f.Name)"
-                Remove-Module -Name Pester -ErrorAction SilentlyContinue
-                Import-Module Pester -RequiredVersion 6.0.0 -ErrorAction Stop
-                $pester5Config = New-PesterConfiguration
-                $pester5Config.Run.Path = $f.FullName
-                if ($PassThru) {
-                    $pester5config.Run.PassThru = $true
-                }
-                $pester5config.Output.Verbosity = $show
-                if ($Coverage) {
-                    $pester5Config.CodeCoverage.Enabled = $true
-                    $pester5Config.CodeCoverage.Path = $CoverFilesPester
-                }
-                if (!($testInt)) {
-                    $pester5Config.Filter.ExcludeTag = "IntegrationTests"
-                }
-                Invoke-Pester -Configuration $pester5config
-            } else {
-                Write-DetailedMessage "Running Pester 4 tests $($f.FullName)"
-                Remove-Module -Name Pester -ErrorAction SilentlyContinue
-                Import-Module Pester -MaximumVersion 4.99 -ErrorAction Stop
-                $pester4Show = 'Default'
-                switch ($Show) {
-                    'None' { $pester4Show = 'None' }
-                    'Normal' { $pester4Show = 'Default' }
-                    'Detailed' { $pester4Show = 'All' }
-                    'Diagnostic' { $pester4Show = 'All' }
-                }
-                $PesterSplat = @{
-                    'Script'   = $f.FullName
-                    'Show'     = $pester4Show
-                    'PassThru' = $passThru
-                }
-                if ($Coverage) {
-                    $PesterSplat['CodeCoverage'] = $CoverFilesPester
-                }
-                if (!($testInt)) {
-                    $PesterSplat['ExcludeTag'] = "IntegrationTests"
-                }
-                Invoke-Pester @PesterSplat
+            $runSummary += [PSCustomObject]@{
+                TestFileName    = $f.Name
+                Result          = $pester5Result.Result
+                TotalCount      = $pester5Result.TotalCount
+                PassedCount     = $pester5Result.PassedCount
+                FailedCount     = $pester5Result.FailedCount
+                SkippedCount    = $pester5Result.SkippedCount
+                DurationSeconds = [int]$pester5Result.Duration.TotalSeconds
+                Failed          = $pester5Result.Failed
             }
 
-
+            if ($PassThru) {
+                $pester5Result
+            }
 
             if ($ScriptAnalyzer) {
                 if ($Show -ne "None") {
-                    Write-Host -ForegroundColor green -Object "ScriptAnalyzer check for $HeadFunctionPath"
+                    Write-Host -ForegroundColor Green -Object "ScriptAnalyzer check for $($AnalyzePaths -join ", ")"
                 }
-                Invoke-ScriptAnalyzer -Path $HeadFunctionPath -ExcludeRule $ScriptAnalyzerRulesExclude
+                # -Path takes a single file, so the list is walked rather than passed as an array
+                foreach ($analyzePath in $AnalyzePaths) {
+                    $splatAnalyzer = @{
+                        Path        = $analyzePath
+                        Settings    = $ScriptAnalyzerSettings
+                        ExcludeRule = $ScriptAnalyzerRulesExclude
+                    }
+                    Invoke-ScriptAnalyzer @splatAnalyzer
+                }
             }
+        }
+    }
+    end {
+        if ($stopProcess -or $runSummary.Count -eq 0 -or $Show -eq "None") {
+            return
+        }
+
+        Write-Host "`n$("=" * 60)"
+        Write-Host "Ran $($runSummary.Count) test files in $([int]((Get-Date) - $startTime).TotalSeconds) seconds"
+        $runSummary | Format-Table -Property TestFileName, Result, TotalCount, PassedCount, FailedCount, SkippedCount, DurationSeconds -AutoSize | Out-Host
+
+        foreach ($summary in $runSummary | Where-Object FailedCount -gt 0) {
+            Write-Host "$($summary.TestFileName)" -ForegroundColor Yellow
+            foreach ($failedTest in $summary.Failed) {
+                Write-Host "  FAILED  $($failedTest.ExpandedPath)"
+                if ($failedTest.ErrorRecord.TargetObject.Line) {
+                    Write-Host "          line $($failedTest.ErrorRecord.TargetObject.Line): $($failedTest.ErrorRecord.TargetObject.LineText.Trim())"
+                }
+                $failedMessage = ($failedTest.ErrorRecord.Exception.Message -split "`n" | ForEach-Object { $PSItem.Trim() }) -join " "
+                Write-Host "          $failedMessage"
+            }
+        }
+
+        # The style gate that CI runs is not part of any command's test file, so a run without it
+        # can be green here and still fail the pipeline. Say so rather than let it be discovered
+        # in the pull request.
+        if (-not $Compliance) {
+            Write-Host "`nThe repository wide style checks did not run. Add -Compliance before opening a pull request." -ForegroundColor Cyan
         }
     }
 }

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -44,6 +44,13 @@ This allows you to manually test commands against actual SQL Server instances be
 | `InstanceHadr` | Availability groups, mirroring, log shipping. | HADR |
 | `InstanceRestart` | Anything that restarts the service or changes service-level configuration: network certificates, TCP ports, extended protection, filestream, service accounts. | RESTART |
 
+`Get-TestInstanceUsage` (private, available after importing the psm1) reports the same autodetection, so you can see which lane a test file lands in without reading `pester.groups.ps1`:
+
+```powershell
+Get-TestInstanceUsage -Command Get-DbaDb*
+Get-TestInstanceUsage | Group-Object -Property InstanceList -NoElement | Sort-Object -Property Count -Descending
+```
+
 Two consequences worth knowing before you write the test:
 
 - **Only `InstanceSingle`, `InstanceMulti1` and `InstanceMulti2` exist on GitHub Actions.** A test written against `InstanceCopy*`, `InstanceHadr` or `InstanceRestart` runs on AppVeyor only. For new or changed command behavior, the required real-boundary coverage must also run on GitHub Actions or an Azure test runner; provision the needed boundary instead of omitting the regression test.
@@ -86,7 +93,7 @@ param(
 )
 ```
 
-The suite runs on Pester 6.0.0. The `ModuleVersion="5.0"` declaration is intentionally retained as a minimum-version header because `Invoke-ManualPester` uses it to select the Pester 6 execution path. Converting the headers and runner together is separate behavior-changing work.
+The suite runs on Pester 6.0.0. The `ModuleVersion="5.0"` declaration is intentionally retained as a minimum-version header: `#Requires` reads it as "5.0 or newer", so it is satisfied by 6.0.0. `Invoke-ManualPester` refuses to run a test file that does not carry it, because dbatools has no Pester 4 tests left and a missing header is a mistake in the file.
 
 **Critical Requirements:**
 - Use a **static command name** as a string literal (e.g., "Get-DbaDatabase")

--- a/tests/Get-DbaUnusedLogin.Tests.ps1
+++ b/tests/Get-DbaUnusedLogin.Tests.ps1
@@ -73,6 +73,10 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $mappedDbName, $ownedDbName, $offlineDbName -ErrorAction SilentlyContinue
         # The pipeline test drops its own login, so this cleanup is deliberately best effort.
         $null = Remove-DbaLogin -SqlInstance $TestConfig.InstanceSingle -Login $unusedLoginName, $mappedLoginName, $roleLoginName, $ownerLoginName, $pipeLoginName -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+
+        # $PSDefaultParameterValues is the object from $TestConfig.Defaults, so leaving the setting
+        # on would carry EnableException into whatever runs next in the same session.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When looking for unused logins on an instance" {

--- a/tests/New-DbaConnectionStringBuilder.Tests.ps1
+++ b/tests/New-DbaConnectionStringBuilder.Tests.ps1
@@ -63,11 +63,13 @@ Describe $CommandName -Tag IntegrationTests {
     }
     Context "Build a ConnectionStringBuilder by parameters" {
         BeforeAll {
-            $results = New-DbaConnectionStringBuilder `
-                -DataSource "localhost,1433" `
-                -InitialCatalog "AlwaysEncryptedSample" `
-                -UserName "sa" `
-                -Password "alwaysB3Encrypt1ng"
+            $splatBuilder = @{
+                DataSource     = "localhost,1433"
+                InitialCatalog = "AlwaysEncryptedSample"
+                UserName       = "sa"
+                Password       = "alwaysB3Encrypt1ng"
+            }
+            $results = New-DbaConnectionStringBuilder @splatBuilder
         }
         It "Should be a connection string builder" {
             $results.GetType() | Should -Be Microsoft.Data.SqlClient.SqlConnectionStringBuilder

--- a/tests/PSScriptAnalyzerRules.psd1
+++ b/tests/PSScriptAnalyzerRules.psd1
@@ -8,6 +8,9 @@
         'PSReservedParams',
         'PSAvoidUsingWMICmdlet',
         'PSMisleadingBacktick',
+        # The style test in dbatools.Tests.ps1 fails the build on a trailing space, so the profile
+        # that is meant to be run before pushing has to report it too.
+        'PSAvoidTrailingWhitespace',
         'PSMissingModuleManifestField',
         'PSPossibleIncorrectComparisonWithNull',
         'PSUseApprovedVerbs',
@@ -54,7 +57,11 @@
         PSUseConsistentWhitespace  = @{
             Enable          = $true
             CheckInnerBrace = $true
-            CheckOpenBrace  = $true
+            # CheckOpenBrace reports "Use space before open brace" for every statement that starts
+            # with a script block, which is what { Get-DbaFoo } | Should -Throw looks like. Across
+            # the test tree it produced 180 findings, 178 of them that idiom, so the rule buried
+            # everything else it found. The remaining checks still cover real spacing mistakes.
+            CheckOpenBrace  = $false
             CheckOpenParen  = $true
             CheckOperator   = $false
             CheckPipe       = $true

--- a/tests/Test-DbaBackupEncrypted.Tests.ps1
+++ b/tests/Test-DbaBackupEncrypted.Tests.ps1
@@ -44,13 +44,13 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Command actually works" {
         It "should detect encryption" {
             $passwd = ConvertTo-SecureString "dbatools.IO" -AsPlainText -Force
-            $splat = @{
+            $splatEncryption = @{
                 MasterKeySecurePassword = $passwd
                 BackupSecurePassword    = $passwd
                 BackupPath              = $backupPath
                 EnableException         = $true
             }
-            $null = $alldbs | Start-DbaDbEncryption @splat
+            $null = $alldbs | Start-DbaDbEncryption @splatEncryption
             $backups = $alldbs | Select-Object -First 1 | Backup-DbaDatabase -Path $backupPath
             $results = $backups | Test-DbaBackupEncrypted -SqlInstance $TestConfig.InstanceSingle
             $results.Encrypted | Should -Be $true

--- a/tests/constants.local.ps1.example
+++ b/tests/constants.local.ps1.example
@@ -12,6 +12,12 @@ $config['InstanceCopy2'] = "localhost\SQLInstance2"
 $config['InstanceHadr'] = "localhost\SQLInstance1"
 $config['InstanceRestart'] = "localhost\SQLInstance1"
 
+# Where the tests write backups, scripts and other temporary files. It defaults to C:\Temp, which
+# has to exist - several tests fail with nothing pointing at the cause if it does not. When the
+# instance under test is remote, this has to be a share that both the instance and this machine can
+# write to, because the instance writes the backups itself.
+$config['Temp'] = "C:\Temp"
+
 # SQL Server credentials
 # Replace 'YourPassword' with your actual password and 'sa' with your username if different
 $securePassword = ConvertTo-SecureString "YourPassword" -AsPlainText -Force

--- a/tests/dbatools.Tests.ps1
+++ b/tests/dbatools.Tests.ps1
@@ -375,6 +375,388 @@ Describe "$ModuleName Function Name" -Tag Compliance {
     }
 }
 
+Describe "$ModuleName test file structure" -Tag Compliance {
+    <#
+    Static checks over tests\*.Tests.ps1, so that a test file that cannot do its job is caught here
+    rather than by someone eventually noticing.
+
+    Several of these are not style. A loop that emits It blocks, a -ForEach fed from a BeforeAll and
+    an assertion that is never piped to Should all produce a green test report while testing nothing
+    at all - Update-DbaInstance.Tests.ps1 carried 44 such tests for years.
+
+    The findings are collected per rule rather than asserted per file. The per-file form produces one
+    test result for every rule and every file, which is 14000 results and two and a half minutes; the
+    failure message still names every file it found.
+
+    The checks tagged Goal are the ones the tree does not meet yet, so they are skipped unless
+    $env:DbatoolsTestFileGoals is set. To work on that backlog:
+        $env:DbatoolsTestFileGoals = 1
+        Invoke-Pester -Path .\tests\dbatools.Tests.ps1 -TagFilter Compliance
+    #>
+    BeforeDiscovery {
+        # -Skip: is read while the tests are discovered, so the switch cannot come from a BeforeAll.
+        $includeGoals = [bool]$env:DbatoolsTestFileGoals
+    }
+
+    BeforeAll {
+        $ModulePath = Split-Path $PSScriptRoot -Parent
+
+        # The only files in tests\ that are not the test of a single command, so the only ones that
+        # cannot follow the layout. Everything else - including the tests of private functions like
+        # Stop-Function - can and does.
+        $notACommandTest = @(
+            "appveyor.common.Tests.ps1",
+            "appveyor.watchdog.Tests.ps1",
+            "dbatools.Tests.ps1",
+            "InModule.Commands.Tests.ps1",
+            "InModule.Help.Tests.ps1"
+        )
+
+        $parseErrorFiles = @()
+        $paramBlockFiles = @()
+        $topLevelFiles = @()
+        $noUnitTestFiles = @()
+        $loopBuiltTests = @()
+        $unbalancedEnableException = @()
+        $discardedComparisons = @()
+        $forEachNotFromDiscovery = @()
+        $stringSkips = @()
+        $quotedCommandNames = @()
+        $oldInstanceNames = @()
+        $backtickContinuations = @()
+        $plainSplats = @()
+        $missingEnableException = @()
+        $mocksWithoutModuleName = @()
+        $integrationWithoutCleanup = @()
+        $tempWithoutRandom = @()
+        $underscoreVariables = @()
+        $bareSkips = @()
+
+        $testFiles = Get-ChildItem -Path "$ModulePath\tests\*.Tests.ps1" | Sort-Object -Property Name
+
+        foreach ($testFile in $testFiles) {
+            $isCommandTest = $testFile.Name -notin $notACommandTest
+            # Get-DbaFoo.Tests.ps1 tests Get-DbaFoo, and so does the supplementary
+            # Get-DbaFoo.Something.Tests.ps1 - which is why the command name is the first segment.
+            $commandName = $testFile.Name -replace "^([^.]+)(.+)?\.Tests\.ps1$", "`$1"
+            $isSupplementary = $testFile.Name -notmatch "^[^.]+\.Tests\.ps1$"
+
+            $tokens = $null
+            $errors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($testFile.FullName, [ref]$tokens, [ref]$errors)
+            if ($errors) {
+                $parseErrorFiles += "$($testFile.Name): $($errors.Count) parse errors, first at line $($errors[0].Extent.StartLineNumber)"
+                continue
+            }
+
+            # One walk over the tree rather than one per rule. The walk is what this Describe spends
+            # its time on, so the nodes are collected once and then filtered in memory.
+            $allNodes = $ast.FindAll({
+                    $args[0] -is [System.Management.Automation.Language.CommandAst] -or
+                    $args[0] -is [System.Management.Automation.Language.LoopStatementAst]
+                }, $true)
+            $commandNodes = @($allNodes | Where-Object { $PSItem -is [System.Management.Automation.Language.CommandAst] })
+            $loopNodes = @($allNodes | Where-Object { $PSItem -is [System.Management.Automation.Language.LoopStatementAst] })
+
+            $describeNodes = @($commandNodes | Where-Object { $PSItem.CommandElements[0].Value -eq "Describe" })
+            $blockNodes = @($commandNodes | Where-Object { $PSItem.CommandElements[0].Value -in "Describe", "Context", "It" })
+            $itNodes = @($commandNodes | Where-Object { $PSItem.CommandElements[0].Value -eq "It" })
+            $mockNodes = @($commandNodes | Where-Object { $PSItem.CommandElements[0].Value -eq "Mock" })
+            $inModuleScopeNodes = @($commandNodes | Where-Object { $PSItem.CommandElements[0].Value -eq "InModuleScope" })
+            $beforeDiscoveryNodes = @($commandNodes | Where-Object { $PSItem.CommandElements[0].Value -eq "BeforeDiscovery" })
+
+            # Returns every tag of a block, handling -Tag and its alias -Tags, the -Tag:Value form,
+            # and both a single value and an array literal. Reading only "-Tag <bareword>" missed
+            # "-Tags IntegrationTests" and "-Tag UnitTests, 'Something'", and a block missed here
+            # silently skipped the checks below instead of running them.
+            $tagsOf = {
+                param($CommandAst)
+                $elements = $CommandAst.CommandElements
+                for ($i = 0; $i -lt $elements.Count; $i++) {
+                    if ($elements[$i] -isnot [System.Management.Automation.Language.CommandParameterAst]) { continue }
+                    if ($elements[$i].ParameterName -notin "Tag", "Tags") { continue }
+                    # -Tag:Value binds the value to the parameter itself, -Tag Value puts it next
+                    $value = $elements[$i].Argument
+                    if (-not $value -and $i -lt $elements.Count - 1) { $value = $elements[$i + 1] }
+                    if ($value -is [System.Management.Automation.Language.ArrayLiteralAst]) {
+                        return @($value.Elements.Value)
+                    }
+                    return @($value.Value)
+                }
+            }
+
+            $unitTestBlocks = @($describeNodes | Where-Object { "UnitTests" -in (& $tagsOf $PSItem) })
+            $integrationTestBlocks = @($describeNodes | Where-Object { "IntegrationTests" -in (& $tagsOf $PSItem) })
+
+            if ($isCommandTest) {
+                $paramBlockParameters = $ast.ParamBlock.Parameters
+                $paramNames = $paramBlockParameters.Name.VariablePath.UserPath
+                $declaredCommandName = ($paramBlockParameters | Where-Object { $PSItem.Name.VariablePath.UserPath -eq "CommandName" }).DefaultValue.Value
+                $declaredModuleName = ($paramBlockParameters | Where-Object { $PSItem.Name.VariablePath.UserPath -eq "ModuleName" }).DefaultValue.Value
+                $declaredDefaults = ($paramBlockParameters | Where-Object { $PSItem.Name.VariablePath.UserPath -eq "PSDefaultParameterValues" }).DefaultValue.Extent.Text
+                # A supplementary file may name either the command or its own basename, both of
+                # which are unambiguous - Connect-DbaInstance.WindowsSspi.Tests.ps1 tests
+                # Connect-DbaInstance, appveyor.watchdog.Tests.ps1 tests appveyor.watchdog.
+                $allowedCommandNames = @($commandName, ($testFile.Name -replace "\.Tests\.ps1$", ""))
+                if ($paramBlockParameters.Count -ne 3 -or
+                    "ModuleName" -notin $paramNames -or
+                    "CommandName" -notin $paramNames -or
+                    "PSDefaultParameterValues" -notin $paramNames -or
+                    $declaredModuleName -ne "dbatools" -or
+                    $declaredCommandName -notin $allowedCommandNames -or
+                    $declaredDefaults -ne "`$TestConfig.Defaults") {
+                    $paramBlockFiles += $testFile.Name
+                }
+
+                # No dot sourcing: a private function does not need it, because a checkout has no
+                # dbatools.dat and the psm1 then exports every function, private ones included.
+                $allowedTopLevel = @("Describe", "InModuleScope", "BeforeDiscovery")
+                $topLevelStatements = $ast.EndBlock.Statements
+                $notACommand = @($topLevelStatements | Where-Object { $PSItem.PipelineElements[0] -isnot [System.Management.Automation.Language.CommandAst] })
+                # Note the ForEach-Object: the CommandElements of all statements flatten into a
+                # single list, so indexing [0] into that returns the first element of the first
+                # command and nothing else, and a top level Write-Host passes.
+                $topLevelNames = $topLevelStatements.PipelineElements |
+                    Where-Object { $PSItem -is [System.Management.Automation.Language.CommandAst] } |
+                    ForEach-Object { $PSItem.CommandElements[0].Value }
+                $otherCommands = @($topLevelNames | Where-Object { $PSItem -notin $allowedTopLevel })
+                if ($notACommand -or $otherCommands) {
+                    $topLevelFiles += "$($testFile.Name): $(@($notACommand).Count) statements that are not commands, $(@($otherCommands | Sort-Object -Unique) -join ", ")"
+                }
+
+                # A supplementary file adds integration coverage to a command whose unit tests live
+                # in its own file, so it does not need a UnitTests Describe of its own.
+                if (-not $unitTestBlocks -and -not $isSupplementary) {
+                    $noUnitTestFiles += $testFile.Name
+                }
+            }
+
+            # A loop that builds test blocks runs while Pester discovers the tests, and its variables
+            # no longer exist when the bodies run. The generated tests are either missing entirely or
+            # assert nothing, and in both cases the test report looks healthy.
+            #
+            # InModule.Help.Tests.ps1 is the known exception, and a live one: it loops over
+            # $global:commandsWithHelp, which a BeforeAll fills long after discovery has read it, so
+            # the file produces zero tests in a fresh session - verified, Invoke-Pester reports
+            # TotalCount 0. Rewriting it onto -ForEach turns several thousand help assertions on at
+            # once and is its own piece of work, so it is named here rather than left to fail this
+            # check on every run.
+            $knownLoopExceptions = @("InModule.Help.Tests.ps1")
+            foreach ($loop in $loopNodes | Where-Object { $testFile.Name -notin $knownLoopExceptions }) {
+                $blocksInLoop = @($blockNodes | Where-Object {
+                        $PSItem.Extent.StartOffset -ge $loop.Extent.StartOffset -and
+                        $PSItem.Extent.EndOffset -le $loop.Extent.EndOffset
+                    })
+                if ($blocksInLoop) {
+                    $loopBuiltTests += "$($testFile.Name):$($loop.Extent.StartLineNumber)"
+                }
+            }
+
+            # A statement inside an It that computes a comparison and throws the result away. It
+            # reads like an assertion, it runs, and it can never fail. Only comparisons are flagged,
+            # a bare method call is usually a deliberate side effect.
+            foreach ($itNode in $itNodes) {
+                $body = $itNode.CommandElements | Where-Object { $PSItem -is [System.Management.Automation.Language.ScriptBlockExpressionAst] } | Select-Object -First 1
+                if (-not $body) { continue }
+                foreach ($statement in $body.ScriptBlock.EndBlock.Statements) {
+                    if ($statement -isnot [System.Management.Automation.Language.PipelineAst]) { continue }
+                    if ($statement.PipelineElements.Count -ne 1) { continue }
+                    $element = $statement.PipelineElements[0]
+                    if ($element -isnot [System.Management.Automation.Language.CommandExpressionAst]) { continue }
+                    if ($element.Expression -is [System.Management.Automation.Language.BinaryExpressionAst]) {
+                        $discardedComparisons += "$($testFile.Name):$($statement.Extent.StartLineNumber): $($statement.Extent.Text)"
+                    }
+                }
+            }
+
+            # -ForEach is read at discovery, so its cases have to be built in a BeforeDiscovery. Fed
+            # from a BeforeAll the variable is still empty at discovery and the block produces no
+            # tests at all - the same failure as a foreach loop around It, spelled differently.
+            $discoveryVariables = @()
+            foreach ($beforeDiscovery in $beforeDiscoveryNodes) {
+                $discoveryVariables += $beforeDiscovery.FindAll({ $args[0] -is [System.Management.Automation.Language.AssignmentStatementAst] }, $true) |
+                    ForEach-Object { $PSItem.Left.Extent.Text.TrimStart("`$") }
+            }
+            foreach ($block in $blockNodes) {
+                $elements = $block.CommandElements
+                for ($i = 0; $i -lt $elements.Count; $i++) {
+                    if ($elements[$i] -isnot [System.Management.Automation.Language.CommandParameterAst]) { continue }
+                    if ($elements[$i].ParameterName -ne "ForEach") { continue }
+                    $value = $elements[$i].Argument
+                    if (-not $value -and $i -lt $elements.Count - 1) { $value = $elements[$i + 1] }
+                    if ($value -is [System.Management.Automation.Language.VariableExpressionAst] -and $value.VariablePath.UserPath -notin $discoveryVariables) {
+                        $forEachNotFromDiscovery += "$($testFile.Name):$($block.Extent.StartLineNumber): $($block.CommandElements[0].Value) $($block.CommandElements[1].Extent.Text)"
+                    }
+                }
+            }
+
+            # Blocks switched off with a bare -Skip, so no condition can ever switch them back on.
+            # Not wrong in itself, but nothing makes it visible afterwards, and Update-DbaInstance
+            # hid 69 unit tests behind one for two years.
+            foreach ($block in $blockNodes) {
+                $bareSkip = $block.CommandElements | Where-Object {
+                    $PSItem -is [System.Management.Automation.Language.CommandParameterAst] -and
+                    $PSItem.ParameterName -eq "Skip" -and -not $PSItem.Argument
+                }
+                if ($bareSkip) {
+                    $bareSkips += "$($testFile.Name):$($block.Extent.StartLineNumber): $($block.CommandElements[0].Value) $($block.CommandElements[1].Extent.Text)"
+                }
+            }
+
+            # A Mock without -ModuleName does not apply to the code inside the module, so the command
+            # under test runs unmocked while the test looks like it is isolated. Only mocks inside an
+            # InModuleScope are already in the right scope.
+            foreach ($mockNode in $mockNodes) {
+                $hasModuleName = $mockNode.CommandElements | Where-Object {
+                    $PSItem -is [System.Management.Automation.Language.CommandParameterAst] -and $PSItem.ParameterName -eq "ModuleName"
+                }
+                if ($hasModuleName) { continue }
+                $insideInModuleScope = $inModuleScopeNodes | Where-Object {
+                    $mockNode.Extent.StartOffset -ge $PSItem.Extent.StartOffset -and
+                    $mockNode.Extent.EndOffset -le $PSItem.Extent.EndOffset
+                }
+                if (-not $insideInModuleScope) {
+                    $mocksWithoutModuleName += "$($testFile.Name):$($mockNode.Extent.StartLineNumber)"
+                }
+            }
+
+            # An integration Describe that creates objects on the instance but has no AfterAll
+            # anywhere. A heuristic - some of these clean up in a way this cannot see - so it is a
+            # Goal and only reports.
+            foreach ($describeNode in $integrationTestBlocks) {
+                if ($describeNode.Extent.Text -match "New-Dba|Backup-Dba|New-Item" -and $describeNode.Extent.Text -notmatch "AfterAll") {
+                    $integrationWithoutCleanup += "$($testFile.Name):$($describeNode.Extent.StartLineNumber)"
+                }
+            }
+
+            $content = Get-Content -Path $testFile.FullName
+
+            # The setup of the integration tests has to run with EnableException so that the test
+            # fails loudly if the setup fails, instead of testing against a broken state. Where the
+            # two statements are placed is deliberately not tested - both of these are in use:
+            #   BeforeAll { enable ... remove } and AfterAll { enable ... }
+            #   BeforeAll { enable ... }        and AfterAll { ... remove }
+            # What always has to hold is that every enable is matched by a remove, because
+            # $PSDefaultParameterValues is the object from $TestConfig.Defaults and an enable left
+            # behind carries into whatever runs next in the same session.
+            $enableCount = ($content -match [regex]::Escape("`$PSDefaultParameterValues[`"*-Dba*:EnableException`"] = `$true")).Count
+            $removeCount = ($content -match [regex]::Escape("`$PSDefaultParameterValues.Remove(`"*-Dba*:EnableException`")")).Count
+            if ($integrationTestBlocks) {
+                if ($enableCount -ne $removeCount) {
+                    $unbalancedEnableException += "$($testFile.Name): $enableCount enabled, $removeCount removed"
+                }
+                if ($enableCount -eq 0) {
+                    $missingEnableException += $testFile.Name
+                }
+            }
+
+            # Every one of these is wrapped in @() because -match against $null returns the boolean
+            # $false rather than an empty array, and $false is not empty - the check would then fail
+            # on every file instead of none.
+            if (@($content -match "-Skip:\s*`"(true|false)`"")) {
+                $stringSkips += $testFile.Name
+            }
+            # The dollar signs below are escaped twice on purpose: once for PowerShell, so that the
+            # string is not expanded, and once for the regex, where a bare $ is the end of line
+            # anchor and would make the pattern match nothing.
+            if (@($content -match "^\s*(Describe|Context)\s+`"\`$CommandName`"")) {
+                $quotedCommandNames += $testFile.Name
+            }
+            if (@($content -match "\`$TestConfig\.instance[123]\b")) {
+                $oldInstanceNames += $testFile.Name
+            }
+            if (@($content -match "``\s*`$")) {
+                $backtickContinuations += $testFile.Name
+            }
+            if (@($content -match "^\s*\`$splat\s*=")) {
+                $plainSplats += $testFile.Name
+            }
+            if (@($content -match "\`$_\.")) {
+                $underscoreVariables += $testFile.Name
+            }
+            if (@($content -match [regex]::Escape("`$TestConfig.Temp")) -and -not @($content -match "Get-Random")) {
+                $tempWithoutRandom += $testFile.Name
+            }
+        }
+    }
+
+    It "every test file can be parsed" {
+        $parseErrorFiles | Should -BeNullOrEmpty
+    }
+
+    It "every test file has the expected param block" {
+        $paramBlockFiles | Should -BeNullOrEmpty -Because "the header in tests\CLAUDE.md is mandatory"
+    }
+
+    It "every test file has only Describe, InModuleScope and BeforeDiscovery at the top level" {
+        $topLevelFiles | Should -BeNullOrEmpty
+    }
+
+    It "every test file has at least one Describe block for the unit tests" {
+        $noUnitTestFiles | Should -BeNullOrEmpty
+    }
+
+    It "no test file builds test blocks in a loop" {
+        $loopBuiltTests | Should -BeNullOrEmpty -Because "a loop around It runs at discovery and its variables are gone when the body runs - use -ForEach with cases from BeforeDiscovery"
+    }
+
+    It "no It block computes a comparison and throws it away" {
+        $discardedComparisons | Should -BeNullOrEmpty -Because "an assertion has to be piped to Should, otherwise it runs and can never fail"
+    }
+
+    It "every -ForEach case list is built in a BeforeDiscovery" {
+        $forEachNotFromDiscovery | Should -BeNullOrEmpty -Because "-ForEach is read at discovery, so a case list built in BeforeAll is still empty and the block produces no tests"
+    }
+
+    It "every EnableException that is set is removed again" {
+        $unbalancedEnableException | Should -BeNullOrEmpty -Because "an enable left behind carries into whatever runs next in the same session"
+    }
+
+    It "no test file uses a string for -Skip" {
+        $stringSkips | Should -BeNullOrEmpty -Because "a non-empty string is always true, so -Skip:`"false`" skips the test"
+    }
+
+    It "no test file quotes the command name" {
+        $quotedCommandNames | Should -BeNullOrEmpty -Because "Describe `$CommandName does not need quoting"
+    }
+
+    It "no test file uses the retired TestConfig instance names" {
+        $oldInstanceNames | Should -BeNullOrEmpty -Because "instance1, instance2 and instance3 no longer exist, see the instance table in tests\CLAUDE.md"
+    }
+
+    It "no test file uses backtick line continuation" {
+        $backtickContinuations | Should -BeNullOrEmpty -Because "backticks are banned, use splatting or a natural line break"
+    }
+
+    It "every splat is named after its purpose" {
+        $plainSplats | Should -BeNullOrEmpty -Because "a plain `$splat collides across scopes, the guide asks for `$splat<Purpose>"
+    }
+
+    It "every integration test enables EnableException for its setup" -Tag Goal -Skip:(-not $includeGoals) {
+        $missingEnableException | Should -BeNullOrEmpty
+    }
+
+    It "every Mock outside of InModuleScope uses ModuleName" -Tag Goal -Skip:(-not $includeGoals) {
+        $mocksWithoutModuleName | Should -BeNullOrEmpty -Because "a Mock without -ModuleName never applies to the code inside the module"
+    }
+
+    It "every integration test that creates objects cleans up after itself" -Tag Goal -Skip:(-not $includeGoals) {
+        $integrationWithoutCleanup | Should -BeNullOrEmpty -Because "a Describe that creates objects on the instance needs an AfterAll that removes them"
+    }
+
+    It "every temporary path is made unique with Get-Random" -Tag Goal -Skip:(-not $includeGoals) {
+        $tempWithoutRandom | Should -BeNullOrEmpty -Because "two test files sharing a temp path collide when they run in the same lab"
+    }
+
+    It "every test file uses PSItem rather than the underscore variable" -Tag Goal -Skip:(-not $includeGoals) {
+        $underscoreVariables | Should -BeNullOrEmpty -Because "the guide asks for `$PSItem except where compatibility needs `$_"
+    }
+
+    It "no block is switched off with a bare -Skip" -Tag Goal -Skip:(-not $includeGoals) {
+        $bareSkips | Should -BeNullOrEmpty -Because "a block skipped without a condition can never run again"
+    }
+}
+
 # test the module manifest - exports the right functions, processes the right formats, and is generally correct
 <#
 Describe "Manifest" {


### PR DESCRIPTION
Follow-up to the question in https://github.com/dataplat/dbatools/pull/10463#issuecomment-5153094978: `Invoke-ManualPester` was supposed to warn about the whitespace problems and did not.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [X] Documentation
 - [ ] Build system

### Purpose

A local run of `Invoke-ManualPester` could be green while CI failed on style, because neither of the two checks that catch it is part of a command's test file. PR #10463 is the worked example: nine trailing space lines, and nothing locally reported any of them.

I checked out that PR's head commit and ran ScriptAnalyzer exactly the way `-ScriptAnalyzer` called it. It reported two of the nine, both in `public\Install-DbaFirstResponderKit.ps1`. The other seven were in the test file, and `-ScriptAnalyzer` never looked at the test file: it set `$HeadFunctionPath` to the first *coverage* file, so the file you passed in was discarded. The check that actually failed the build is `Describe "$ModuleName style" -Tag Compliance` in `tests\dbatools.Tests.ps1`, and the runner had no way to run it.

### Approach

**`Invoke-ManualPester`**

- `-ScriptAnalyzer` now checks the test file as well as the command under test.
- `-ScriptAnalyzer` now passes `tests\PSScriptAnalyzerRules.psd1`, which the help already claimed it used. That profile had no consumer anywhere in the repository, and it did not include `PSAvoidTrailingWhitespace` - the rule the style test fails the build on - so that is added. `CheckOpenBrace` is turned off: across the test tree it produced 180 findings, 178 of them the `{ ... } | Should -Throw` idiom, which buried everything else the rule found.
- New `-Compliance` switch runs the `Compliance` tagged tests over the whole repository (about half a minute). A run without it now says so at the end.
- The command under test is resolved from its own file name. Taking the first entry of `Get-CoverageIndications` measured and analysed a *dependency* for a private function, and returned nothing at all for 19 test files - where `-ScriptAnalyzer` then failed on a null path and `-Coverage` silently measured nothing.
- The Pester 4 branch is removed. All 742 test files declare the Pester 5 header, so it was unreachable; a file without the header is now reported instead of being run with something else. The version warnings that contradicted their own constants are corrected, and the `$config_TestIntegration` variable that is set nowhere in the repository is gone.
- A run over several files ends with a summary of which files failed, with the failing line and message, instead of leaving the reports to be read by scrolling back.
- It refuses a module base without a `tests` folder rather than creating a `.git` directory in it, and says so when `dbatools.psd1` cannot be found instead of failing later on a confusing path.

**Test file structure checks**

`tests\dbatools.Tests.ps1` gains `Describe "$ModuleName test file structure" -Tag Compliance`, ported from the `testing-dbatools` repository. They are aggregated one test per rule rather than one per rule and file - the per-file form is 14023 results and two and a half minutes, this is 19 results in 24 seconds, and a failure still names every file it found.

Thirteen rules are enforced and the tree passes them. Six describe a backlog the tree does not meet yet and are skipped unless `$env:DbatoolsTestFileGoals` is set.

Several of these are not style. A loop that emits `It` blocks, a `-ForEach` fed from a `BeforeAll` and an assertion never piped to `Should` all produce a green report while testing nothing.

**One finding worth its own look, deliberately not fixed here**

`tests\InModule.Help.Tests.ps1` builds its `Describe` blocks in `foreach ($command in $global:commandsWithHelp)`, and a `BeforeAll` fills that variable - long after discovery has read the loop. Verified in a fresh session: `Invoke-Pester` on that file reports `TotalCount 0`. The whole help suite has never run an assertion.

Rewriting it onto `BeforeDiscovery` and `-ForEach` switches several thousand help assertions on at once and nobody knows yet how many fail, so it is named in `$knownLoopExceptions` with the reasoning rather than fixed in this PR.

**Smaller things**

- `Get-TestInstanceUsage` reports which `$TestConfig` instances a test file uses, and therefore which CI lane it runs in. 395 test files use `InstanceSingle`, 21 need `Hadr`, 220 need no instance at all.
- `tests\constants.local.ps1.example` gains the missing `$config['Temp']` placeholder - the other Learning from #10463, where the run failed because `C:\Temp` did not exist and nothing hinted that the key could be set.
- Three test files needed a fix to pass the new rules: `New-DbaConnectionStringBuilder` (backtick continuation), `Test-DbaBackupEncrypted` (plain `$splat`), `Get-DbaUnusedLogin` (an `EnableException` enabled in `AfterAll` and never removed, which carries into whatever runs next in the same session).

### Commands to test

`Invoke-ManualPester` itself, and the `Compliance` tagged tests:

```powershell
Invoke-ManualPester -Path Get-DbaDatabase -ScriptAnalyzer -Compliance

# the backlog the Goal rules describe
$env:DbatoolsTestFileGoals = 1
Invoke-Pester -Path .\tests\dbatools.Tests.ps1 -TagFilter Compliance
```

### Learning

The `{ Get-DbaFoo } | Should -Throw` idiom trips `PSUseConsistentWhitespace`'s `CheckOpenBrace`, because the statement starts with the brace. 178 of 180 findings across the test tree were that; the two that were not are a nested `FindAll({` and one genuine double space before a brace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)