### PR TITLE
Tests - Replace the $env:APPVEYOR skips with real preconditions

### DIFF
--- a/tests/Add-DbaComputerCertificate.Tests.ps1
+++ b/tests/Add-DbaComputerCertificate.Tests.ps1
@@ -119,7 +119,10 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 
-    Context "PFX certificate with chain is imported properly" -Skip:($env:APPVEYOR) {
+    # The skip on this context recorded no reason at all. Unskipped on 2026-08-06 to find out
+    # whether one still applies: AppVeyor is gone, but tests\gha.shim.ps1 still sets
+    # $env:APPVEYOR, so the gate kept it skipped on the Azure fleet.
+    Context "PFX certificate with chain is imported properly" {
         BeforeAll {
             # Generate unique temp path for this test run
             $script:tempPath = "$($TestConfig.Temp)\$CommandName-$(Get-Random)"

--- a/tests/Enable-DbaFilestream.Tests.ps1
+++ b/tests/Enable-DbaFilestream.Tests.ps1
@@ -25,40 +25,6 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
-    BeforeDiscovery {
-        # Level 1 is T-SQL access and needs nothing from Windows. Level 2 adds Win32 file I/O
-        # streaming, which SQL Server exposes through a Windows file share - so level 2 depends on
-        # the host being able to serve a share at all, which is the Server service (LanmanServer).
-        # That is an OS prerequisite, not a SQL Server one: FILESTREAM is a configuration setting,
-        # not an installable feature, so nothing about how the instance was installed decides this.
-        #
-        # This is the split seen on ci-azure on 2026-08-06, where level 1 passed and level 2 failed
-        # on all three attempts. Probe that prerequisite rather than the CI provider: the old
-        # -Skip:$env:APPVEYOR stopped describing anything once AppVeyor went away, because
-        # tests\gha.shim.ps1 still sets the variable, so it skipped on every runner unconditionally.
-        #
-        # If the probe cannot answer, run the test. A skip has to be earned, and a probe that fails
-        # for its own reasons must not hide a regression in the command.
-        $filestreamHost = "$($TestConfig.InstanceRestart)".Split("\")[0].Split(",")[0]
-        if ($filestreamHost -in ".", "localhost", "(local)", "") {
-            $filestreamHost = $env:COMPUTERNAME
-        }
-
-        try {
-            $splatServerService = @{
-                ClassName   = "Win32_Service"
-                ErrorAction = "Stop"
-            }
-            if ($filestreamHost -ne $env:COMPUTERNAME) {
-                $splatServerService["ComputerName"] = $filestreamHost
-            }
-            $serverService = Get-CimInstance @splatServerService | Where-Object Name -eq "LanmanServer"
-            $canServeFileShare = $serverService.State -eq "Running"
-        } catch {
-            $canServeFileShare = $true
-        }
-    }
-
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
@@ -76,7 +42,24 @@ Describe $CommandName -Tag IntegrationTests {
             $results.ServiceAccessLevel | Should -Be 1
         }
 
-        It "Should change the FileStream Level to 2" -Skip:(-not $canServeFileShare) {
+        # Parked on issue #10524, not on any property of the environment.
+        #
+        # On ci-azure this leaves the instance at level 1 on every attempt while level 1 itself
+        # passes in the same run. The diagnostic below showed why that is as far as anyone can get
+        # today: the instance came back reporting ServiceShareName "SQL2019", the instance-name
+        # fallback that Set-FileSystemSetting uses when no share name is given - the value the
+        # level 1 test above leaves behind. So the level 2 call did not stall halfway, it changed
+        # nothing at all, and the WMI return code that would say why is swallowed by #10524:
+        # Get-FilestreamReturnValue reports every code as success, and Enable-DbaFilestream only
+        # surfaces it when -Force is absent, which is not the path used here.
+        #
+        # Two environmental explanations were tried and both are refuted, so do not re-guess:
+        # the RsFx filter driver is running even with FILESTREAM fully disabled, and the Server
+        # service is running on the ci-azure runners where this still fails.
+        #
+        # Once #10524 is fixed the return code becomes visible and this can be unskipped to read
+        # it. The assertions keep their diagnostics for exactly that.
+        It "Should change the FileStream Level to 2" -Skip:$true {
             $results = Enable-DbaFilestream -SqlInstance $TestConfig.InstanceRestart -FileStreamLevel 2 -ShareName TestShare -Force
 
             # A bare "Expected 2, but got 1" says nothing about which of the two levels stalled or

--- a/tests/Enable-DbaFilestream.Tests.ps1
+++ b/tests/Enable-DbaFilestream.Tests.ps1
@@ -42,8 +42,11 @@ Describe $CommandName -Tag IntegrationTests {
             $results.ServiceAccessLevel | Should -Be 1
         }
 
-        It "Should change the FileStream Level to 2" -Skip:$env:APPVEYOR {
-            # Skip this test on AppVeyor because the instance does not support FileStream Level 2.
+        It "Should change the FileStream Level to 2" {
+            # Was skipped on AppVeyor because that instance did not support FileStream Level 2.
+            # Unskipped on 2026-08-06: AppVeyor is gone, but tests\gha.shim.ps1 still sets
+            # $env:APPVEYOR, so the gate kept this skipped on the Azure fleet without anyone
+            # having checked whether those instances support level 2.
             $results = Enable-DbaFilestream -SqlInstance $TestConfig.InstanceRestart -FileStreamLevel 2 -ShareName TestShare -Force
 
             $results.InstanceAccessLevel | Should -Be 2

--- a/tests/Enable-DbaFilestream.Tests.ps1
+++ b/tests/Enable-DbaFilestream.Tests.ps1
@@ -25,6 +25,40 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
+    BeforeDiscovery {
+        # Level 1 is T-SQL access and needs nothing from Windows. Level 2 adds Win32 file I/O
+        # streaming, which SQL Server exposes through a Windows file share - so level 2 depends on
+        # the host being able to serve a share at all, which is the Server service (LanmanServer).
+        # That is an OS prerequisite, not a SQL Server one: FILESTREAM is a configuration setting,
+        # not an installable feature, so nothing about how the instance was installed decides this.
+        #
+        # This is the split seen on ci-azure on 2026-08-06, where level 1 passed and level 2 failed
+        # on all three attempts. Probe that prerequisite rather than the CI provider: the old
+        # -Skip:$env:APPVEYOR stopped describing anything once AppVeyor went away, because
+        # tests\gha.shim.ps1 still sets the variable, so it skipped on every runner unconditionally.
+        #
+        # If the probe cannot answer, run the test. A skip has to be earned, and a probe that fails
+        # for its own reasons must not hide a regression in the command.
+        $filestreamHost = "$($TestConfig.InstanceRestart)".Split("\")[0].Split(",")[0]
+        if ($filestreamHost -in ".", "localhost", "(local)", "") {
+            $filestreamHost = $env:COMPUTERNAME
+        }
+
+        try {
+            $splatServerService = @{
+                ClassName   = "Win32_Service"
+                ErrorAction = "Stop"
+            }
+            if ($filestreamHost -ne $env:COMPUTERNAME) {
+                $splatServerService["ComputerName"] = $filestreamHost
+            }
+            $serverService = Get-CimInstance @splatServerService | Where-Object Name -eq "LanmanServer"
+            $canServeFileShare = $serverService.State -eq "Running"
+        } catch {
+            $canServeFileShare = $true
+        }
+    }
+
     AfterAll {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
@@ -42,16 +76,17 @@ Describe $CommandName -Tag IntegrationTests {
             $results.ServiceAccessLevel | Should -Be 1
         }
 
-        It "Should change the FileStream Level to 2" {
-            # Was skipped on AppVeyor because that instance did not support FileStream Level 2.
-            # Unskipped on 2026-08-06: AppVeyor is gone, but tests\gha.shim.ps1 still sets
-            # $env:APPVEYOR, so the gate kept this skipped on the Azure fleet without anyone
-            # having checked whether those instances support level 2.
+        It "Should change the FileStream Level to 2" -Skip:(-not $canServeFileShare) {
             $results = Enable-DbaFilestream -SqlInstance $TestConfig.InstanceRestart -FileStreamLevel 2 -ShareName TestShare -Force
 
-            $results.InstanceAccessLevel | Should -Be 2
-            $results.ServiceAccessLevel | Should -Be 2
-            $results.ServiceShareName | Should -Be TestShare
+            # A bare "Expected 2, but got 1" says nothing about which of the two levels stalled or
+            # what the instance ended up with, which cost a full CI round trip on 2026-08-06.
+            # Report the state the instance actually reached so the next failure explains itself.
+            $reportedState = (Get-DbaFilestream -SqlInstance $TestConfig.InstanceRestart | Out-String).Trim()
+
+            $results.InstanceAccessLevel | Should -Be 2 -Because "the instance reported $reportedState"
+            $results.ServiceAccessLevel | Should -Be 2 -Because "the instance reported $reportedState"
+            $results.ServiceShareName | Should -Be TestShare -Because "the instance reported $reportedState"
         }
 
         It "Should warn if using ShareName with FileStreamLevel 1" {

--- a/tests/Get-DbaWindowsLog.Tests.ps1
+++ b/tests/Get-DbaWindowsLog.Tests.ps1
@@ -24,12 +24,17 @@ Describe $CommandName -Tag UnitTests {
     }
 }
 
-Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:APPVEYOR) {
+Describe $CommandName -Tag IntegrationTests {
     # These were skipped as "very unstable and should be reviewed". Reviewed on 2026-08-01: five
     # consecutive runs against the lab were all green, so they run again. If the instability comes
     # back, skip them once more but record what actually failed, not only that it is unstable.
     # AppVeyor is where they still fail: the command finds the error log through a SQL Server
     # startup event in the Windows Application log, and the CI runners have nothing to parse.
+    #
+    # Unskipped on 2026-08-06 to check that reason against the current fleet. AppVeyor is gone;
+    # the $env:APPVEYOR gate was still true because tests\gha.shim.ps1 sets it, so this kept
+    # skipping on runners it was never assessed against. Those VMs boot from a sysprepped image
+    # and start the instance on first boot, which should write the startup event this parses.
 
     Context "Command returns proper info" {
         It "returns results" {

--- a/tests/Get-DbaWindowsLog.Tests.ps1
+++ b/tests/Get-DbaWindowsLog.Tests.ps1
@@ -30,13 +30,55 @@ Describe $CommandName -Tag IntegrationTests {
     # back, skip them once more but record what actually failed, not only that it is unstable.
     # AppVeyor is where they still fail: the command finds the error log through a SQL Server
     # startup event in the Windows Application log, and the CI runners have nothing to parse.
-    #
-    # Unskipped on 2026-08-06 to check that reason against the current fleet. AppVeyor is gone;
-    # the $env:APPVEYOR gate was still true because tests\gha.shim.ps1 sets it, so this kept
-    # skipping on runners it was never assessed against. Those VMs boot from a sysprepped image
-    # and start the instance on first boot, which should write the startup event this parses.
 
-    Context "Command returns proper info" {
+    BeforeDiscovery {
+        # What actually failed, as that older note asked for: the command locates the error log by
+        # reading event 17111 - the SQL Server startup event - from the Windows Application log,
+        # and returns nothing at all when it is absent, because public\Get-DbaWindowsLog.ps1
+        # returns early rather than warning. On the ephemeral ci-azure VMs that event is not
+        # reliably there. It passed on one runner on 2026-08-06 and failed all three attempts on
+        # another on 2026-08-07, returning empty in under a second each time.
+        #
+        # So the skip is back, but on the missing event rather than on $env:APPVEYOR. That old
+        # condition described nothing after the move off AppVeyor: tests\gha.shim.ps1 still sets
+        # the variable, so it skipped on every runner unconditionally.
+        #
+        # Reading the log here is not circular - it is the same precondition the command needs,
+        # observed without going through the command. Where the event exists, the test runs.
+        # Get-WinEvent throws when nothing matches, and the test session reads the log as the same
+        # identity the command will, so a probe that cannot find the event means the command will
+        # not find it either.
+        $windowsLogComputer = "$($TestConfig.InstanceSingle)".Split("\")[0].Split(",")[0]
+        $windowsLogInstance = "$($TestConfig.InstanceSingle)".Split("\")[1]
+        if ($windowsLogComputer -in ".", "localhost", "(local)", "") {
+            $windowsLogComputer = $env:COMPUTERNAME
+        }
+        if (-not $windowsLogInstance -or $windowsLogInstance -match "^DEFAULT$|^MSSQLSERVER$") {
+            $windowsLogEventSource = "MSSQLSERVER"
+        } else {
+            $windowsLogEventSource = "MSSQL`$$windowsLogInstance"
+        }
+
+        try {
+            $splatStartupEvent = @{
+                FilterHashtable = @{
+                    LogName      = "Application"
+                    ID           = 17111
+                    ProviderName = $windowsLogEventSource
+                }
+                MaxEvents       = 1
+                ErrorAction     = "Stop"
+            }
+            if ($windowsLogComputer -ne $env:COMPUTERNAME) {
+                $splatStartupEvent["ComputerName"] = $windowsLogComputer
+            }
+            $hasSqlStartupEvent = [bool](Get-WinEvent @splatStartupEvent)
+        } catch {
+            $hasSqlStartupEvent = $false
+        }
+    }
+
+    Context "Command returns proper info" -Skip:(-not $hasSqlStartupEvent) {
         It "returns results" {
             $results = Get-DbaWindowsLog -SqlInstance $TestConfig.InstanceSingle
             $results | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
Follow-up to #10521.

AppVeyor the service is gone, but `tests/gha.shim.ps1` sets `$env:APPVEYOR` so the ported `appveyor.*.ps1` harness keeps working. A side effect: three skip conditions written for the old AppVeyor image were permanently true on the Azure fleet, silently skipping ever since the move, on runners the reasons were never assessed against.

Two CI runs on this branch settled what each one was really waiting for. **No skip in this file is gated on the CI provider any more** — each states the thing that is actually missing.

## Outcome

| Test | Lane | Outcome |
|---|---|---|
| `Add-DbaComputerCertificate.Tests.ps1` ("PFX certificate with chain") | default | Passed both runs — **skip removed** |
| `Get-DbaWindowsLog.Tests.ps1` | SINGLE | Intermittent — skip retained, on the missing startup event |
| `Enable-DbaFilestream.Tests.ps1` ("FileStream Level to 2") | RESTART | Fails consistently — parked on #10524 |

## Get-DbaWindowsLog

Not obsolete after all. It passed on one runner and then failed all three attempts on another, returning empty in under a second each time. A single green run was not evidence, and the older in-file note calling these "very unstable" was right.

That note asked for whoever revisited it to record *what* failed rather than only that it was unstable, so: the command locates the error log through event 17111, the SQL Server startup event in the Windows Application log, and `public/Get-DbaWindowsLog.ps1` returns early with nothing when that event is absent. On ephemeral CI VMs it is not reliably present.

The skip now tests for that event, read straight from the log rather than through the command — the same precondition, observed independently, so it is not circular. Verified on a live lab: the event is there, the test is **not** skipped, and it passes.

## Enable-DbaFilestream

Parked on #10524 rather than on any property of the environment, because the environment is no longer the open question.

The diagnostic added mid-PR paid for itself. The instance came back reporting:

```
InstanceAccess   : T-SQL access enabled
ServiceAccess    : FileStream enabled for T-Sql access
ServiceShareName : SQL2019
```

`SQL2019` is the instance-name fallback `Set-FileSystemSetting` uses when given no share name — the value the level 1 test leaves behind. The level 2 call passed `-ShareName TestShare` and the instance never saw it, so the call **changed nothing at all** rather than stalling halfway. The WMI return code that would say why is swallowed by #10524: `Get-FilestreamReturnValue` reports every code as success, and `Enable-DbaFilestream` only surfaces it when `-Force` is absent, which is not the path anything uses.

Two environmental explanations were tried and both are refuted. The comments record them so the work is not repeated:

- the RsFx filter driver is running even with FILESTREAM **fully disabled**, so its state says nothing about whether level 2 is reachable
- the Server service is running on the runners where this still fails

Guessing a third time without the return code is not worth a CI round trip. Once #10524 is fixed, unskipping this reads the real code straight away — the assertions keep their diagnostics for that.

## Note on policy

`tests/CLAUDE.md` prefers failing over skipping when a dependency is unprovisioned. Two skips survive here. Both name a specific, checkable condition and the filestream one names the issue that will remove it, which is the closest this can get until #10524 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)