### PR TITLE
Enable-DbaFilestream - Report what the WMI provider actually returned

### DIFF
--- a/private/functions/Get-FilestreamReturnValue.ps1
+++ b/private/functions/Get-FilestreamReturnValue.ps1
@@ -1,0 +1,88 @@
+function Get-FilestreamReturnValue {
+    <#
+        .SYNOPSIS
+            Translates the return value of the SQL WMI EnableFilestream method into a result object.
+
+        .DESCRIPTION
+            The FilestreamSettings WMI class reports the outcome of EnableFilestream through a
+            numeric return value. This maps that number onto the documented meaning and says which
+            of three categories it falls into, so a caller can tell a refusal from a success
+            instead of having to match on message text.
+
+            Codes that are in neither list are reported as Unknown together with the raw value.
+            Guessing in either direction is what made the original version of this misleading: a
+            caller that assumes success ignores a refusal, and one that assumes failure invents an
+            error the provider never reported.
+
+        .PARAMETER Value
+            The ReturnValue the EnableFilestream method produced.
+
+        .NOTES
+            Author: the dbatools team + Claude
+    #>
+    [CmdletBinding()]
+    param (
+        [object]$Value
+    )
+
+    if ($null -eq $Value) {
+        return [PSCustomObject]@{
+            ReturnValue = $null
+            Category    = "Unknown"
+            Message     = "The EnableFilestream method returned no value"
+        }
+    }
+
+    # The provider signals success with 0 or one of these two codes. Everything named in the
+    # switch below is a documented refusal.
+    $successCodes = 2147021885, 2147945411, 0
+
+    # An assignment inside a switch clause produces no output, so $message collects only the
+    # strings while the category rides along as a side effect. The default is Failure because
+    # every literal clause below is a documented failure.
+    $category = "Failure"
+
+    $message = switch ($Value) {
+        2147217396 {
+            "Filestream not supported on instance"
+        }
+        2147217386 {
+            "Filestream cannot change share"
+        }
+        2147024713 {
+            "Duplicate sharename"
+        }
+        2147024891 {
+            "Access denied"
+        }
+        2147023681 {
+            "Invalid sharename"
+        }
+        2147024690 {
+            "Sharename too long"
+        }
+        2147019889 {
+            "Primary node not enabled "
+        }
+        2147019848 {
+            "Sharename node mismatch"
+        }
+        214721740 {
+            "General error"
+        }
+        { $PSItem -in $successCodes } {
+            $category = "Success"
+            "The requested operation is successful. Changes will not be effective until the service is restarted."
+        }
+        default {
+            $category = "Unknown"
+            "The EnableFilestream method returned an unrecognized value: $Value"
+        }
+    }
+
+    [PSCustomObject]@{
+        ReturnValue = $Value
+        Category    = $category
+        Message     = $message
+    }
+}

--- a/private/functions/Set-FileSystemSetting.ps1
+++ b/private/functions/Set-FileSystemSetting.ps1
@@ -8,50 +8,6 @@ function Set-FileSystemSetting {
         [int]$FilestreamLevel,
         [switch]$EnableException
     )
-    begin {
-        function Get-FilestreamReturnValue {
-            [CmdletBinding()]
-            param (
-                [object]$Value
-            )
-            switch ($Value) {
-                2147217396 {
-                    "Filestream not supported on instance"
-                }
-                2147217386 {
-                    "Filestream cannot change share"
-                }
-                2147024713 {
-                    "Duplicate sharename"
-                }
-                2147024891 {
-                    "Access denied"
-                }
-                2147023681 {
-                    "Invalid sharename"
-                }
-                2147024690 {
-                    "Sharename too long"
-                }
-                2147019889 {
-                    "Primary node not enabled "
-                }
-                2147019848 {
-                    "Sharename node mismatch"
-                }
-                214721740 {
-                    "General error"
-                }
-                { 2147021885 -or 2147945411 -or 0 } {
-                    "The requested operation is successful. Changes will not be effective until the service is restarted."
-                }
-                default {
-                    $Value
-                }
-            }
-        }
-    }
-
     process {
         if ($Force -or $PSCmdlet.ShouldProcess($Instance, "Setting filestream")) {
             try {
@@ -72,8 +28,7 @@ function Set-FileSystemSetting {
                             ShareName   = $ShareName
                         }
                         $return = Invoke-CimMethod -InputObject $fileStreamCim -MethodName EnableFilestream -Arguments $arguments
-                        $returnvalue = Get-FilestreamReturnValue -Value $return.ReturnValue
-                        $returnvalue
+                        Get-FilestreamReturnValue -Value $return.ReturnValue
                     } else {
                         Stop-Function -Message "No cim object for class FilestreamSettings found"
                     }

--- a/public/Enable-DbaFilestream.ps1
+++ b/public/Enable-DbaFilestream.ps1
@@ -142,13 +142,32 @@ function Enable-DbaFilestream {
 
             if ($Force -or $PSCmdlet.ShouldProcess($instance, "Changing from '$($OutputLookup[$filestreamstate])' to '$($OutputLookup[$level])' at the instance level")) {
                 # Server level
+                $serviceLevelProblem = $null
                 if ($server.IsClustered) {
                     $nodes = Get-DbaWsfcNode -ComputerName $instance
                     foreach ($node in $nodes.Name) {
                         $result = Set-FileSystemSetting -Instance $node -Credential $Credential -ShareName $ShareName -FilestreamLevel $level
+                        if (-not $serviceLevelProblem -and $result.Category -ne "Success") {
+                            $serviceLevelProblem = $result
+                        }
                     }
                 } else {
                     $result = Set-FileSystemSetting -Instance $instance -Credential $Credential -ShareName $ShareName -FilestreamLevel $level
+                    if ($result.Category -ne "Success") {
+                        $serviceLevelProblem = $result
+                    }
+                }
+
+                # The WMI provider says through its return value why it refused, and that used to be
+                # thrown away: every code was translated to the success message, and even that was
+                # only shown when -Force was absent. A refusal at the service level means the
+                # sp_configure below cannot take effect, so report it instead of returning a state
+                # that was never reached. -Force means do not prompt, not do not report errors.
+                if ($serviceLevelProblem.Category -eq "Failure") {
+                    Stop-Function -Message "[$instance] Could not set filestream at the service level: $($serviceLevelProblem.Message)" -Target $instance -Continue
+                }
+                if ($serviceLevelProblem.Category -eq "Unknown") {
+                    Write-Message -Level Warning -Message "[$instance] $($serviceLevelProblem.Message)"
                 }
 
                 # Instance level
@@ -169,7 +188,9 @@ function Enable-DbaFilestream {
 
                 Get-DbaFilestream -SqlInstance $instance -SqlCredential $SqlCredential -Credential $Credential
                 if ($filestreamstate -ne $level -and -not $Force) {
-                    Write-Message -Level Warning -Message "[$instance] $result"
+                    # Without -Force nothing was restarted, so the change is staged rather than
+                    # live. The message carries that caveat.
+                    Write-Message -Level Warning -Message "[$instance] $($result.Message)"
                 }
             }
         }

--- a/tests/Enable-DbaFilestream.Tests.ps1
+++ b/tests/Enable-DbaFilestream.Tests.ps1
@@ -22,6 +22,57 @@ Describe $CommandName -Tag UnitTests {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
+
+    Context "Get-FilestreamReturnValue translates the WMI return value" {
+        # The clause for the success codes used to read { 2147021885 -or 2147945411 -or 0 }, a
+        # constant expression that is always true, so it matched every code. Since switch runs
+        # every matching clause, a documented refusal came back as its own message *and* the
+        # success message, and an unrecognized code never reached default and was reported as a
+        # plain success. Enable-DbaFilestream then discarded even that, so a refused call looked
+        # like a successful one that had simply not taken effect yet.
+
+        It "reports a documented refusal as a failure, with only its own message" {
+            InModuleScope dbatools {
+                $result = Get-FilestreamReturnValue -Value 2147024891
+
+                $result.Category | Should -Be "Failure"
+                $result.Message | Should -Be "Access denied"
+                @($result.Message).Count | Should -Be 1
+            }
+        }
+
+        It "reports the success codes as a success" {
+            InModuleScope dbatools {
+                (Get-FilestreamReturnValue -Value 0).Category | Should -Be "Success"
+                (Get-FilestreamReturnValue -Value 2147021885).Category | Should -Be "Success"
+                (Get-FilestreamReturnValue -Value 2147945411).Category | Should -Be "Success"
+            }
+        }
+
+        It "reports an unrecognized code as unknown and keeps the raw value" {
+            InModuleScope dbatools {
+                $result = Get-FilestreamReturnValue -Value 99999
+
+                $result.Category | Should -Be "Unknown"
+                $result.ReturnValue | Should -Be 99999
+                $result.Message | Should -BeLike "*99999*"
+            }
+        }
+
+        It "reports a missing return value as unknown rather than as a success" {
+            InModuleScope dbatools {
+                (Get-FilestreamReturnValue -Value $null).Category | Should -Be "Unknown"
+            }
+        }
+
+        It "matches the return value whatever numeric type the provider used" {
+            # Invoke-CimMethod hands back a UInt32, so a switch that only matched Int32 would send
+            # every real call down the unknown path.
+            InModuleScope dbatools {
+                (Get-FilestreamReturnValue -Value ([uint32]2147024891)).Category | Should -Be "Failure"
+            }
+        }
+    }
 }
 
 Describe $CommandName -Tag IntegrationTests {


### PR DESCRIPTION
Fixes #10524.

## The bug

`Get-FilestreamReturnValue` gated its success message on a constant expression:

```powershell
{ 2147021885 -or 2147945411 -or 0 } {
    "The requested operation is successful. ..."
}
```

`$Value` never appears in it. `2147021885 -or 2147945411 -or 0` is just `$true`, so the clause matched every code. And because `switch` runs *every* matching clause without a `break`, that produced three separate problems:

| Return code | Before | After |
|---|---|---|
| `2147024891` "Access denied" | `Access denied` **and** the success message | `Failure` / `Access denied` |
| any unlisted code | **only** the success message, raw value lost | `Unknown`, raw value kept |
| `0` / the two `21470…` codes | success | `Success` |

`default` was unreachable, so an unrecognized code could never fall through to report its own value.

`Enable-DbaFilestream` then discarded even that, surfacing the value only when `-Force` was absent — and `-Force` is the documented non-interactive path used by the examples and every test. A refused call produced no warning, no error, and an unchanged instance.

## How it showed up

On a ci-azure RESTART runner while working #10522, setting FILESTREAM level 2 left the instance at level 1 on every attempt with nothing reported. The instance came back with `ServiceShareName` still set to the instance-name fallback rather than the share name that was passed, so the call had changed nothing at all — and the return code that would have said why was gone.

## The change

`Get-FilestreamReturnValue` moves into its own file under `private/functions/` so it can be tested, and returns `ReturnValue`, `Category` and `Message`. `Category` is `Success`, `Failure` or `Unknown`.

Codes in neither list are reported as `Unknown` with the raw value rather than guessed at in either direction — assuming success hides a refusal, assuming failure invents an error the provider never reported. A null return value is `Unknown` for the same reason, since `switch` enters no clause at all for `$null`.

`Enable-DbaFilestream` now stops on a documented refusal and warns on an unrecognized code, **both regardless of `-Force`**. `-Force` should mean "do not prompt", not "do not report errors". The existing warning that changes need a service restart is unchanged.

## Testing

Five unit tests cover each category, plus two edge cases worth calling out:

- **a null return value** — `switch ($null)` enters no clause, so without an explicit guard this reported `Failure` for a call that never returned anything
- **numeric type** — `Invoke-CimMethod` hands back a `UInt32`, so a comparison that only matched `Int32` would push every real call down the unknown path

Against a live lab, all three filestream commands still pass: `Enable-DbaFilestream` 3 integration tests (levels 1 and 2 and the ShareName warning), `Disable-DbaFilestream` and `Get-DbaFilestream` unchanged. Repo compliance and structure gates: 0 failures.

## Note

This does not by itself fix the level 2 failure on ci-azure — it makes the provider's reason visible so that can finally be diagnosed. The level 2 test is skipped in #10522 with a pointer to #10524; once this merges it can be unskipped to read the real return code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)