### PR TITLE
Import-DbaParquet - Report why the Parquet assemblies could not be loaded

### DIFF
--- a/public/Import-DbaParquet.ps1
+++ b/public/Import-DbaParquet.ps1
@@ -292,7 +292,21 @@ function Import-DbaParquet {
             try {
                 Add-Type -Path $parquetDllPath -ErrorAction Stop
             } catch {
-                Stop-Function -Message "Could not load Parquet.NET from $parquetDllPath. Run Install-DbaParquet to install the required assemblies." -ErrorRecord $_ -EnableException $EnableException
+                # A type load failure only says "Unable to find type" or "Unable to load one or more of
+                # the requested types" and keeps the reason in LoaderExceptions. Without those the
+                # message sends people to Install-DbaParquet even when the assemblies are installed and
+                # the real problem is a dependency that something else already loaded in another version.
+                $loadException = $_.Exception
+                while ($loadException -and -not $loadException.LoaderExceptions) {
+                    $loadException = $loadException.InnerException
+                }
+                $loaderDetail = ($loadException.LoaderExceptions | ForEach-Object { $PSItem.Message } | Sort-Object -Unique) -join " | "
+
+                if ($loaderDetail) {
+                    Stop-Function -Message "Could not load Parquet.NET from $parquetDllPath. The assemblies are present but could not be loaded: $loaderDetail" -ErrorRecord $_ -EnableException $EnableException
+                } else {
+                    Stop-Function -Message "Could not load Parquet.NET from $parquetDllPath. Run Install-DbaParquet to install the required assemblies." -ErrorRecord $_ -EnableException $EnableException
+                }
                 return
             }
         }


### PR DESCRIPTION
The `catch` around `Add-Type` dropped the `LoaderExceptions` of a type load failure, so the warning always advised running `Install-DbaParquet`. That is misleading when the assemblies are installed and the real problem is a dependency that something else already loaded in another version.

That is not hypothetical: in a full local test run every test of this command failed with `Unable to load one or more of the requested types`, and the advice sent me looking for a missing install. The assemblies were present the whole time, and the same test file passes 17/17 on its own in a fresh session.

The inner exceptions are now unwrapped and reported, and the advice to install is only given when there is nothing more specific to say.

## Testing

`Import-DbaParquet.Tests.ps1` passes 17/17 against a local lab instance. The test file is unchanged, because this only changes what the command reports on a failure path that the tests do not reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)