### PR TITLE
New-DbaDacPackage - Report the real reason model validation failed

### DIFF
--- a/public/New-DbaDacPackage.ps1
+++ b/public/New-DbaDacPackage.ps1
@@ -345,7 +345,20 @@ function New-DbaDacPackage {
                 }
             }
         } catch {
-            $errorMessage = "Model validation failed: $($_.Exception.Message)"
+            # Validate() throws an AggregateException, whose own message is only "One or more errors
+            # occurred." - the reason is in its inner exceptions. Calling it from PowerShell wraps
+            # that in a MethodInvocationException as well, so we unwrap both to report the real cause.
+            $validationException = $_.Exception
+            if ($validationException -is [System.Management.Automation.MethodInvocationException] -and $validationException.InnerException) {
+                $validationException = $validationException.InnerException
+            }
+            if ($validationException -is [System.AggregateException]) {
+                $validationDetail = ($validationException.Flatten().InnerExceptions | ForEach-Object { $PSItem.Message }) -join " | "
+            } else {
+                $validationDetail = $validationException.Message
+            }
+
+            $errorMessage = "Model validation failed: $validationDetail"
             $null = $buildErrors.Add($errorMessage)
             Write-Message -Level Warning -Message $errorMessage
         }


### PR DESCRIPTION
`TSqlModel.Validate()` throws an `AggregateException`, whose own message is only `One or more errors occurred.`, and calling it from PowerShell wraps that in a `MethodInvocationException`. Reporting `$_.Exception.Message` therefore threw away every detail of why the model was rejected.

The warning read:

```
Model validation failed: Exception calling "Validate" with "0" argument(s): "One or more errors occurred."
```

Both wrappers are unwrapped now, so the inner messages reach the warning and say which object or reference the model rejected.

## Testing

`New-DbaDacPackage.Tests.ps1` passes 9/9. The test file is unchanged, because this only changes what the command reports on a failure path the tests do not reach.

The unwrapping itself was verified separately against a real `MethodInvocationException` wrapping an `AggregateException`: the raw message collapses to `One or more errors occurred.` while the unwrapped form carries the inner exception message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)