### PR TITLE
New-DbaFirewallRule - Stop blaming a disabled DAC for a cycled ERRORLOG

### DIFF
--- a/public/New-DbaFirewallRule.ps1
+++ b/public/New-DbaFirewallRule.ps1
@@ -428,7 +428,10 @@ function New-DbaFirewallRule {
                 }
 
                 if (-not $dacMessage) {
-                    Write-Message -Level Warning -Message "No information about the dedicated admin connection (DAC) found in ERRORLOG, cannot create firewall rule for DAC. Use 'Set-DbaSpConfigure -SqlInstance '$instance' -Name RemoteDacConnectionsEnabled -Value 1' to enable remote DAC and try again."
+                    # SQL Server writes this message when the instance starts, and we only read the
+                    # current ERRORLOG. A log that was cycled since the last start therefore looks
+                    # exactly like a disabled DAC, so we must not claim the DAC is disabled here.
+                    Write-Message -Level Warning -Message "No information about the dedicated admin connection (DAC) found in the current ERRORLOG, cannot create firewall rule for DAC. That message is only written when the instance starts, so it is missing if the ERRORLOG was cycled since then. If remote DAC is disabled on $instance, enable it with Set-DbaSpConfigure -Name RemoteDacConnectionsEnabled -Value 1 and restart the instance."
                 } elseif ($dacMessage -match 'locally') {
                     Write-Message -Level Verbose -Message "Dedicated admin connection is only listening locally, so no firewall rule is needed."
                 } else {

--- a/tests/New-DbaFirewallRule.Tests.ps1
+++ b/tests/New-DbaFirewallRule.Tests.ps1
@@ -151,7 +151,11 @@ Describe $CommandName -Tag IntegrationTests {
             $null = Remove-DbaFirewallRule -SqlInstance $TestConfig.InstanceSingle
 
             # Create firewall rules with default RuleType (Program)
-            $resultsNew = New-DbaFirewallRule -SqlInstance $TestConfig.InstanceSingle
+            # The rule for the DAC can only be created when the instance wrote the DAC port to the
+            # current ERRORLOG, which it only does when it starts. On an instance whose ERRORLOG was
+            # cycled since then the command warns instead, so the warning is silenced here. It says
+            # nothing about the command and a test run must not print warnings.
+            $resultsNew = New-DbaFirewallRule -SqlInstance $TestConfig.InstanceSingle -WarningAction SilentlyContinue
             $resultsGet = Get-DbaFirewallRule -SqlInstance $TestConfig.InstanceSingle
             $resultsRemoveBrowser = $resultsGet | Where-Object Type -eq "Browser" | Remove-DbaFirewallRule
             $resultsRemove = Remove-DbaFirewallRule -SqlInstance $TestConfig.InstanceSingle -Type AllInstance
@@ -228,7 +232,8 @@ Describe $CommandName -Tag IntegrationTests {
             $null = Remove-DbaFirewallRule -SqlInstance $TestConfig.InstanceSingle
 
             # Create firewall rules with RuleType Port
-            $resultsNewPort = New-DbaFirewallRule -SqlInstance $TestConfig.InstanceSingle -RuleType Port
+            # Same as above: without the DAC port in the current ERRORLOG the command warns.
+            $resultsNewPort = New-DbaFirewallRule -SqlInstance $TestConfig.InstanceSingle -RuleType Port -WarningAction SilentlyContinue
             $resultsGetPort = Get-DbaFirewallRule -SqlInstance $TestConfig.InstanceSingle
             $resultsRemovePort = Remove-DbaFirewallRule -SqlInstance $TestConfig.InstanceSingle -Type AllInstance
 


### PR DESCRIPTION
SQL Server writes the port of the dedicated admin connection to the ERRORLOG when the instance starts, and the command reads only the current ERRORLOG. On an instance whose log has been cycled since the last start that entry is gone, which looks exactly like a disabled DAC. The warning then said:

```
No information about the dedicated admin connection (DAC) found in ERRORLOG, cannot create
firewall rule for DAC. Use 'Set-DbaSpConfigure -SqlInstance 'SQL03\SQL2019' -Name
RemoteDacConnectionsEnabled -Value 1' to enable remote DAC and try again.
```

On the instance that produced it, `RemoteDacConnectionsEnabled` was already `1` for both the configured and the running value, so the advice was wrong and sent me to check a setting that was fine.

The warning now says what is actually missing, that the message is only written at startup, and names enabling remote DAC as one possible cause rather than the cause. Detection is unchanged.

## Tests

The integration setup creates rules for the whole instance, so it hits this warning on any instance whose ERRORLOG has been cycled. It is silenced there with `-WarningAction SilentlyContinue` and a comment, because it says nothing about the command under test, and a test run should not print warnings.

`New-DbaFirewallRule.Tests.ps1` passes 15/15 with 6 skipped and no warnings. The 6 skipped are the existing port-based context, which the file already skips when the instance uses dynamic ports.

Reading older ERRORLOG files would make the DAC rule work in this situation instead of only reporting it accurately. That is a behaviour change and is deliberately not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)