### PR TITLE
Tests - Run without warnings and fix test cases that never ran

### DIFF
--- a/tests/Get-DbaDbFile.Tests.ps1
+++ b/tests/Get-DbaDbFile.Tests.ps1
@@ -246,7 +246,9 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Warns and returns nothing when FileGroup is used on a database that cannot be opened" {
-            $filteredResults = Get-DbaDbFile -SqlInstance $TestConfig.InstanceSingle -Database $restoringDbName -FileGroup PRIMARY -WarningVariable fileGroupWarning
+            # The warning is what this test is about, so it is silenced on the stream and asserted on
+            # its own warning variable instead. A test run must not print warnings.
+            $filteredResults = Get-DbaDbFile -SqlInstance $TestConfig.InstanceSingle -Database $restoringDbName -FileGroup PRIMARY -WarningVariable fileGroupWarning -WarningAction SilentlyContinue
             $filteredResults | Should -BeNullOrEmpty
             $fileGroupWarning | Should -Match "FileGroup cannot be honored"
         }

--- a/tests/Get-DbaDbFileGroup.Tests.ps1
+++ b/tests/Get-DbaDbFileGroup.Tests.ps1
@@ -73,7 +73,10 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "Returns values for Instance" {
         BeforeAll {
-            $results = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle
+            # The BeforeAll of this file keeps an offline database around, so every scan over the whole
+            # instance warns about it. That warning is expected and is asserted in the context below,
+            # so it is silenced here to keep the test run free of warnings.
+            $results = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle -WarningAction SilentlyContinue
         }
 
         It "Results are not empty" {
@@ -117,23 +120,25 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "Databases that cannot be opened" {
         It "Warns rather than returning nothing when the database is named" {
-            $offlineResults = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            # The warning is what these tests are about, so it is silenced on the stream and asserted
+            # on $WarnVar instead. A test run must not print warnings.
+            $offlineResults = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -WarningAction SilentlyContinue
             $offlineResults | Should -BeNullOrEmpty
             ($WarnVar -join " ") | Should -Match ([regex]::Escape($offlineDb))
         }
 
         It "Says the database was skipped because it is not accessible" {
-            $null = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            $null = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -WarningAction SilentlyContinue
             ($WarnVar -join " ") | Should -Match "not accessible"
         }
 
         It "Names the instance in the warning" {
-            $null = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            $null = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -WarningAction SilentlyContinue
             ($WarnVar -join " ") | Should -Match ([regex]::Escape($TestConfig.InstanceSingle))
         }
 
         It "Still returns the accessible databases in a whole instance scan" {
-            $scanResults = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle
+            $scanResults = Get-DbaDbFileGroup -SqlInstance $TestConfig.InstanceSingle -WarningAction SilentlyContinue
             $scanResults.Parent.Name | Should -Contain $multifgdb
             $scanResults.Parent.Name | Should -Not -Contain $offlineDb
         }

--- a/tests/Get-DbaDbLogSpace.Tests.ps1
+++ b/tests/Get-DbaDbLogSpace.Tests.ps1
@@ -97,7 +97,10 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "System databases exclusions work" {
         BeforeAll {
-            $results = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -ExcludeSystemDatabase
+            # The BeforeAll of this file keeps an offline database around, so every scan over the whole
+            # instance warns about it. That warning is expected here, so it is silenced and left to the
+            # context below to assert on $WarnVar.
+            $results = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -ExcludeSystemDatabase -WarningAction SilentlyContinue
         }
 
         It "Should exclude system databases" {
@@ -111,7 +114,7 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "User databases exclusions work" {
         BeforeAll {
-            $results = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -ExcludeDatabase $db1
+            $results = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -ExcludeDatabase $db1 -WarningAction SilentlyContinue
         }
 
         It "Should include system databases" {
@@ -125,25 +128,27 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "Piping servers works" {
         It "Should have database name of $db1" {
-            $results = $TestConfig.InstanceSingle | Get-DbaDbLogSpace
+            $results = $TestConfig.InstanceSingle | Get-DbaDbLogSpace -WarningAction SilentlyContinue
             $results.Database | Should -Contain $db1
         }
     }
 
     Context "Databases that cannot be opened" {
         It "Warns rather than returning nothing when the database is named" {
-            $offlineResults = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            # The warning is what these tests are about, so it is silenced on the stream and asserted
+            # on $WarnVar instead. A test run must not print warnings.
+            $offlineResults = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -WarningAction SilentlyContinue
             $offlineResults | Should -BeNullOrEmpty
             ($WarnVar -join " ") | Should -Match ([regex]::Escape($offlineDb))
         }
 
         It "Says the database was skipped because it is not accessible" {
-            $null = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            $null = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -WarningAction SilentlyContinue
             ($WarnVar -join " ") | Should -Match "not accessible"
         }
 
         It "Names the instance in the warning" {
-            $null = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            $null = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -WarningAction SilentlyContinue
             ($WarnVar -join " ") | Should -Match ([regex]::Escape($TestConfig.InstanceSingle))
         }
 
@@ -156,7 +161,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Still returns the accessible databases in a whole instance scan" {
-            $scanResults = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle
+            $scanResults = Get-DbaDbLogSpace -SqlInstance $TestConfig.InstanceSingle -WarningAction SilentlyContinue
             $scanResults.Database | Should -Contain $db1
             $scanResults.Database | Should -Not -Contain $offlineDb
         }

--- a/tests/Get-DbaDbSpace.Tests.ps1
+++ b/tests/Get-DbaDbSpace.Tests.ps1
@@ -86,7 +86,10 @@ Describe $CommandName -Tag IntegrationTests {
     #Skipping these tests as internals of Get-DbaDbSpace seems to be unreliable in CI
     Context "Gets DbSpace" {
         BeforeAll {
-            $allResults = @(Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle | Where-Object Database -eq $dbName)
+            # The BeforeAll of this file keeps an offline database around, so every scan over the whole
+            # instance warns about it. That warning is expected and is asserted in the context below,
+            # so it is silenced here to keep the test run free of warnings.
+            $allResults = @(Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -WarningAction SilentlyContinue | Where-Object Database -eq $dbName)
         }
 
         It "Gets results" {
@@ -125,7 +128,7 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "Gets no DbSpace for specific database when using -ExcludeDatabase" {
         It "Gets no results for excluded database" {
-            $excludeResults = @(Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -ExcludeDatabase $dbName)
+            $excludeResults = @(Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -ExcludeDatabase $dbName -WarningAction SilentlyContinue)
             $excludeResults.Database | Should -Not -Contain $dbName
         }
     }
@@ -143,25 +146,27 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Includes the standby database in a whole instance scan" {
-            $scanResults = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle
+            $scanResults = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -WarningAction SilentlyContinue
             $scanResults.Database | Should -Contain $standbyDb
         }
     }
 
     Context "Databases that cannot be opened" {
         It "Warns rather than returning nothing when the database is named" {
-            $offlineResults = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            # The warning is what these tests are about, so it is silenced on the stream and asserted
+            # on $WarnVar instead. A test run must not print warnings.
+            $offlineResults = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -WarningAction SilentlyContinue
             $offlineResults | Should -BeNullOrEmpty
             ($WarnVar -join " ") | Should -Match ([regex]::Escape($offlineDb))
         }
 
         It "Says the database was skipped because it is not accessible" {
-            $null = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            $null = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -WarningAction SilentlyContinue
             ($WarnVar -join " ") | Should -Match "not accessible"
         }
 
         It "Still returns the accessible databases in a whole instance scan" {
-            $scanResults = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle
+            $scanResults = Get-DbaDbSpace -SqlInstance $TestConfig.InstanceSingle -WarningAction SilentlyContinue
             $scanResults.Database | Should -Contain $dbName
             $scanResults.Database | Should -Not -Contain $offlineDb
         }

--- a/tests/Get-DbaDbVirtualLogFile.Tests.ps1
+++ b/tests/Get-DbaDbVirtualLogFile.Tests.ps1
@@ -95,13 +95,15 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "Databases that cannot be opened" {
         It "Warns rather than returning nothing when the database is named" {
-            $offlineResults = Get-DbaDbVirtualLogFile -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            # The warning is what these tests are about, so it is silenced on the stream and asserted
+            # on $WarnVar instead. A test run must not print warnings.
+            $offlineResults = Get-DbaDbVirtualLogFile -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -WarningAction SilentlyContinue
             $offlineResults | Should -BeNullOrEmpty
             ($WarnVar -join " ") | Should -Match ([regex]::Escape($offlineDb))
         }
 
         It "Says the database was skipped because it is not accessible" {
-            $null = Get-DbaDbVirtualLogFile -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb
+            $null = Get-DbaDbVirtualLogFile -SqlInstance $TestConfig.InstanceSingle -Database $offlineDb -WarningAction SilentlyContinue
             ($WarnVar -join " ") | Should -Match "not accessible"
         }
 
@@ -114,7 +116,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Still returns the accessible databases in a whole instance scan" {
-            $scanResults = Get-DbaDbVirtualLogFile -SqlInstance $TestConfig.InstanceSingle
+            $scanResults = Get-DbaDbVirtualLogFile -SqlInstance $TestConfig.InstanceSingle -WarningAction SilentlyContinue
             $scanResults.Database | Should -Contain $testDbName
             $scanResults.Database | Should -Not -Contain $offlineDb
         }

--- a/tests/Get-DbaUnusedLogin.Tests.ps1
+++ b/tests/Get-DbaUnusedLogin.Tests.ps1
@@ -158,7 +158,9 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "Warns about a database that does not exist, because a typo searches nothing and calls every login unused" {
             $typoDbName = "dbatoolsci_nosuchdb_$random"
-            $null = Get-DbaUnusedLogin -SqlInstance $TestConfig.InstanceSingle -Database $typoDbName -WarningVariable typoWarning
+            # The warning is what this test is about, so it is silenced on the stream and asserted on
+            # its own warning variable instead. A test run must not print warnings.
+            $null = Get-DbaUnusedLogin -SqlInstance $TestConfig.InstanceSingle -Database $typoDbName -WarningVariable typoWarning -WarningAction SilentlyContinue
             $typoWarning | Should -Match $typoDbName
         }
     }
@@ -169,7 +171,9 @@ Describe $CommandName -Tag IntegrationTests {
             $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName -Offline -Force
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
 
-            $offlineResults = @(Get-DbaUnusedLogin -SqlInstance $TestConfig.InstanceSingle -Login $unusedLoginName -WarningVariable offlineWarning)
+            # The warning is what this context is about, so it is silenced on the stream and asserted
+            # on its own warning variable instead. A test run must not print warnings.
+            $offlineResults = @(Get-DbaUnusedLogin -SqlInstance $TestConfig.InstanceSingle -Login $unusedLoginName -WarningVariable offlineWarning -WarningAction SilentlyContinue)
         }
 
         AfterAll {

--- a/tests/Invoke-DbaDbDataGenerator.Tests.ps1
+++ b/tests/Invoke-DbaDbDataGenerator.Tests.ps1
@@ -147,19 +147,19 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Warns about the masking type and names the column" {
-            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $junkTypeConfigPath
+            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $junkTypeConfigPath -WarningAction SilentlyContinue
             ($WarnVar -join " ") | Should -BeLike "*Unsupported masking type*Locale*for column City*"
         }
 
         It "Warns about the masking sub type and names the column" {
-            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $junkSubTypeConfigPath
+            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $junkSubTypeConfigPath -WarningAction SilentlyContinue
             ($WarnVar -join " ") | Should -BeLike "*Unsupported masking sub type*ContainsKey*for column City*"
         }
 
         It "Skips the table instead of running an insert it cannot fill" {
             # The insert statement names every column of the table, so skipping a single column further down
             # left it with fewer values than columns and SQL Server answered with a syntax error.
-            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $junkTypeConfigPath
+            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $junkTypeConfigPath -WarningAction SilentlyContinue
             ($WarnVar -join " ") | Should -BeLike "*Skipping table dbo.people*"
             ($WarnVar -join " ") | Should -Not -BeLike "*Incorrect syntax*"
         }
@@ -293,7 +293,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Names the parameter the configuration cannot supply" {
-            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $needsFormatConfigPath
+            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $needsFormatConfigPath -WarningAction SilentlyContinue
             ($WarnVar -join " ") | Should -BeLike "*needs a Format*for column City*"
             ($WarnVar -join " ") | Should -BeLike "*Skipping table dbo.people*"
         }
@@ -347,7 +347,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Rejects the column before generating unique values for it" {
-            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $uniqueConfigPath
+            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $uniqueConfigPath -WarningAction SilentlyContinue
             ($WarnVar -join " ") | Should -BeLike "*Unsupported masking type*Locale*for column City*"
             ($WarnVar -join " ") | Should -BeLike "*Skipping table dbo.uniquepeople*"
         }

--- a/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
+++ b/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
@@ -62,11 +62,17 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     Context "verifying output when running queries" {
-        BeforeAll {
-            $columnnames = 'Item', 'RowError', 'RowState', 'Table', 'ItemArray', 'HasErrors'
+        BeforeDiscovery {
+            # -TestCases is read while Pester discovers the tests. Built in the BeforeAll below, as
+            # it was before, this list was still empty at discovery, so the column test did not exist
+            # at all - and with Pester 6 the empty list fails the whole file during discovery.
+            $columnnames = "Item", "RowError", "RowState", "Table", "ItemArray", "HasErrors"
             $TestCases = @()
             $columnnames.ForEach{ $TestCases += @{ columnname = $PSItem } }
-            $results = Invoke-DbaDiagnosticQuery -SqlInstance $TestConfig.InstanceSingle -QueryName 'Memory Clerk Usage'
+        }
+
+        BeforeAll {
+            $results = Invoke-DbaDiagnosticQuery -SqlInstance $TestConfig.InstanceSingle -QueryName "Memory Clerk Usage"
         }
 
         It "runs a specific query" {

--- a/tests/Remove-DbaClientAlias.Tests.ps1
+++ b/tests/Remove-DbaClientAlias.Tests.ps1
@@ -52,11 +52,17 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         Context "removes an array of aliases" {
-            BeforeAll {
+            BeforeDiscovery {
+                # -TestCases is read while Pester discovers the tests. Built in the BeforeAll below,
+                # as it was before, this list was still empty at discovery, so the alias test did not
+                # exist at all - and with Pester 6 the empty list fails the whole file during discovery.
                 $testCases = @(
                     @{"Alias" = "dbatoolscialias2" },
                     @{"Alias" = "dbatoolscialias3" }
                 )
+            }
+
+            BeforeAll {
                 $aliases = Get-DbaClientAlias
             }
 

--- a/tests/Remove-DbaDbCertificate.Tests.ps1
+++ b/tests/Remove-DbaDbCertificate.Tests.ps1
@@ -24,12 +24,49 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        # Set variables. They are available in all the It blocks.
+        # The name has to be unique: New-DbaDbCertificate defaults the name to the database name, so
+        # the certificate used to be called "master". A leftover from an earlier run then only made
+        # the command warn and return nothing, and the test failed on the empty result instead.
+        $certificateName = "dbatoolsci_cert_$(Get-Random)"
+
+        # Create the objects.
+        $null = New-DbaDbCertificate -SqlInstance $TestConfig.InstanceSingle -Database master -Name $certificateName
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        # Cleanup all created objects. The test removes the certificate itself, so this only cleans up
+        # after a test that failed before it got that far.
+        $splatLeftover = @{
+            SqlInstance = $TestConfig.InstanceSingle
+            Database    = "master"
+            Certificate = $certificateName
+            ErrorAction = "SilentlyContinue"
+        }
+        $null = Get-DbaDbCertificate @splatLeftover | Remove-DbaDbCertificate -ErrorAction SilentlyContinue
+
+        # $PSDefaultParameterValues is the same object in every test file, because they all get it from
+        # $TestConfig.Defaults. Leaving EnableException in it makes every later test file in the same
+        # process run with EnableException, which turns warnings into terminating errors there.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
     Context "Can remove a database certificate" {
         It "Successfully removes database certificate in master" {
-            # Create and then remove a database certificate for testing
-            $results = New-DbaDbCertificate -SqlInstance $TestConfig.InstanceSingle | Remove-DbaDbCertificate
+            $results = Get-DbaDbCertificate -SqlInstance $TestConfig.InstanceSingle -Database master -Certificate $certificateName | Remove-DbaDbCertificate
 
-            "$($results.Status)" -match "Success" | Should -Be $true
+            $results.Status | Should -Be "Success"
+            $WarnVar | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Set-DbaNetworkCertificate.Tests.ps1
+++ b/tests/Set-DbaNetworkCertificate.Tests.ps1
@@ -77,12 +77,17 @@ Describe $CommandName -Tag IntegrationTests {
         $suitability = Test-DbaNetworkCertificate -SqlInstance $TestConfig.InstanceRestart -Thumbprint $unsuitableCertificate.Thumbprint -EnableException
         $suitability.EnhancedKeyUsageValid | Should -BeFalse
 
+        # Forcing an unsuitable certificate warns about the failed checks, and not restarting the
+        # service warns that the certificate is not in effect yet. Both are expected, so they are
+        # silenced here because a test run must not print warnings. They are not asserted on $WarnVar:
+        # this call runs with EnableException, and then the warnings do not reach the warning variable.
         $splatSetUnsuitableCertificate = @{
             SqlInstance     = $TestConfig.InstanceRestart
             Thumbprint      = $unsuitableCertificate.Thumbprint
             Force           = $true
             Confirm         = $false
             EnableException = $true
+            WarningAction   = "SilentlyContinue"
         }
         $result = Set-DbaNetworkCertificate @splatSetUnsuitableCertificate
         $configuredCertificate = Test-DbaNetworkCertificate -SqlInstance $TestConfig.InstanceRestart -EnableException

--- a/tests/Start-DbaAzMigration.Tests.ps1
+++ b/tests/Start-DbaAzMigration.Tests.ps1
@@ -164,11 +164,14 @@ Describe $CommandName -Tag UnitTests {
             $filePath = Join-Path $TestDrive "not-a-directory.txt"
             Set-Content -LiteralPath $filePath -Value "not a directory"
             $warnings = @()
+            # The warning is what this test is about, so it is silenced on the stream and asserted on
+            # its own warning variable instead. A test run must not print warnings.
             $splatInvalidPath = @{
                 Source          = "not-used"
                 Destination     = "not-used"
                 Path            = $filePath
                 WarningVariable = "warnings"
+                WarningAction   = "SilentlyContinue"
             }
 
             $result = Start-DbaAzMigration @splatInvalidPath


### PR DESCRIPTION
Found while running the full suite against a live lab. Three separate problems, all of which made tests quieter than they should have been.

## Test cases that were never built

Two files built their `-TestCases` inside a `BeforeAll`. That runs *after* discovery, so the variable was still empty when Pester expanded the cases and the tests did not exist:

| File | Tests before | after |
| --- | --- | --- |
| `Invoke-DbaDiagnosticQuery.Tests.ps1` | 7 | 19 |
| `Remove-DbaClientAlias.Tests.ps1` | 4 | 10 |

Pester 5 silently produced no tests from an empty case list. Pester 6 fails the file during discovery instead (`Value can not be null or empty array ... Parameter name: ForEach`), which is how these surfaced - as files that reported `Failed` with a `FailedCount` of `0`.

The cases are built in `BeforeDiscovery` now, as `tests/CLAUDE.md` already requires. An AST scan over every test file in the tree found only one other file with the same mistake, `Set-DbaLogin.Tests.ps1`, which is in #10530 because fixing it also needed a change to the command.

## A test that depended on a leftover

`Remove-DbaDbCertificate.Tests.ps1` created its certificate inside the `It` and without a name, so `New-DbaDbCertificate` defaulted the name to the database name and created a certificate called `master`. A leftover from an earlier run then made the command warn, return nothing, and the test failed on the empty result rather than on anything about the command.

It now uses a unique name, sets up in `BeforeAll` and cleans up in `AfterAll`.

That `AfterAll` also removes `EnableException` from `$PSDefaultParameterValues` again, which matters beyond this one file: **every test file gets the same dictionary object from `$TestConfig.Defaults`**, so a file that leaves `EnableException` behind makes every later file in the same process turn its warnings into terminating errors. I introduced exactly that bug while writing this fix and watched it break the next file alphabetically, so it is worth knowing about.

## Warnings that reached the stream

The remaining files expected warnings but let them print. A test runs without `EnableException`, so a problem inside a command surfaces only as a warning - and Pester ignores warnings completely. That makes an unexpected warning the only signal that something went wrong, and it is worthless while expected warnings are printing too.

Expected warnings are now silenced with `-WarningAction SilentlyContinue` and asserted on `$WarnVar` (or the test's own warning variable) instead. Where a test asserts that a command must *not* warn, the call is deliberately left unsilenced.

## Testing

All twelve files pass against a live lab with **zero warnings**:

`Get-DbaDbFile` 21, `Get-DbaDbFileGroup` 12, `Get-DbaDbLogSpace` 14 (+1 pre-existing skip), `Get-DbaDbSpace` 14, `Get-DbaDbVirtualLogFile` 7, `Get-DbaUnusedLogin` 19, `Invoke-DbaDbDataGenerator` 14, `Invoke-DbaDiagnosticQuery` 19, `Remove-DbaClientAlias` 10, `Remove-DbaDbCertificate` 2, `Set-DbaNetworkCertificate` 8, `Start-DbaAzMigration` 20.

No command is changed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)