### PR TITLE
Tests - Stop writing a file called null into the current directory

### DIFF
--- a/tests/Get-DbaExternalProcess.Tests.ps1
+++ b/tests/Get-DbaExternalProcess.Tests.ps1
@@ -47,7 +47,10 @@ Describe $CommandName -Tag IntegrationTests {
         Set-Content -Path $sqlFile -Value "xp_cmdshell 'powershell -command ""sleep 5""'"
 
         # Run sql file to start external process
-        Start-Process -FilePath sqlcmd -ArgumentList "-S $($TestConfig.InstanceRestart) -i $sqlFile" -NoNewWindow -RedirectStandardOutput null
+        # -RedirectStandardOutput takes a file name, so "null" wrote a file called null into whatever
+        # the current directory happened to be. The output goes next to the sql file instead.
+        $sqlcmdOutputFile = "$($TestConfig.Temp)\sleep.out"
+        Start-Process -FilePath sqlcmd -ArgumentList "-S $($TestConfig.InstanceRestart) -i $sqlFile" -NoNewWindow -RedirectStandardOutput $sqlcmdOutputFile
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
@@ -70,7 +73,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Restart the SQL Service to ensure we can remove the temporary file.
         $null = Restart-DbaService -ComputerName $TestConfig.InstanceRestart -Type Engine -Force
-        Remove-Item -Path $sqlFile
+        Remove-Item -Path $sqlFile, $sqlcmdOutputFile
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }

--- a/tests/Stop-DbaExternalProcess.Tests.ps1
+++ b/tests/Stop-DbaExternalProcess.Tests.ps1
@@ -48,7 +48,10 @@ Describe $CommandName -Tag IntegrationTests {
         Set-Content -Path $sqlFile -Value "xp_cmdshell 'powershell -command ""sleep 5""'"
 
         # Run sql file to start external process
-        Start-Process -FilePath sqlcmd -ArgumentList "-S $($TestConfig.InstanceRestart) -i $sqlFile" -NoNewWindow -RedirectStandardOutput null
+        # -RedirectStandardOutput takes a file name, so "null" wrote a file called null into whatever
+        # the current directory happened to be. The output goes next to the sql file instead.
+        $sqlcmdOutputFile = "$($TestConfig.Temp)\sleep.out"
+        Start-Process -FilePath sqlcmd -ArgumentList "-S $($TestConfig.InstanceRestart) -i $sqlFile" -NoNewWindow -RedirectStandardOutput $sqlcmdOutputFile
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
@@ -71,7 +74,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Restart the SQL Service to ensure we can remove the temporary file.
         $null = Restart-DbaService -ComputerName $TestConfig.InstanceRestart -Type Engine -Force
-        Remove-Item -Path $sqlFile
+        Remove-Item -Path $sqlFile, $sqlcmdOutputFile
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }


### PR DESCRIPTION
`Get-DbaExternalProcess.Tests.ps1` and `Stop-DbaExternalProcess.Tests.ps1` both start `sqlcmd` like this:

```powershell
Start-Process -FilePath sqlcmd -ArgumentList "-S $($TestConfig.InstanceRestart) -i $sqlFile" -NoNewWindow -RedirectStandardOutput null
```

`-RedirectStandardOutput` takes a **file name**, not a stream, so `null` does not discard anything. It writes the sqlcmd output to a file literally called `null` in whatever the current directory happens to be - the repository checkout on a CI runner, or the directory a local test run was started from.

Found after a full local run, which left this behind:

```
output
------------------------------------------------------------------------------
NULL

(1 row affected)
```

That is the `sqlcmd` output of the `xp_cmdshell 'powershell -command "sleep 5"'` the test runs, and its timestamp lines up with `Get-DbaExternalProcess` in the run.

The output now goes to a file next to the sql file the test already writes to `$TestConfig.Temp`, and the `AfterAll` of each file removes both. `NUL` would also work but only on Windows, and putting the file where the test already keeps its temporary file matches what the rest of the file does.

## Testing

Both files pass, 2 tests each, with no warnings. Verified that no `null` file appears in the working directory afterwards and that `$TestConfig.Temp` is left with neither `sleep.sql` nor `sleep.out`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)