### PR TITLE
Query Store - Warn instead of silently skipping named system databases

### DIFF
--- a/private/functions/Get-QueryStoreUnsupportedDatabase.ps1
+++ b/private/functions/Get-QueryStoreUnsupportedDatabase.ps1
@@ -1,0 +1,75 @@
+function Get-QueryStoreUnsupportedDatabase {
+    <#
+    .SYNOPSIS
+        Internal function. Returns the databases the Query Store commands have to skip on a given instance.
+
+    .DESCRIPTION
+        Query Store is never available on master or tempdb. SQL Server rejects the ALTER there with
+        "Cannot perform action because Query Store cannot be enabled on system database master." and
+        sys.database_query_store_options has no row for those databases on any version.
+
+        model depends on the version. Before SQL Server 2022 the ALTER is accepted but
+        sys.database_query_store_options stays empty and SMO reports nothing back, so there is no state to read
+        or verify. From SQL Server 2022 (v16) on, Query Store is enabled on model by default, which is how newly
+        created databases get it, and model reports its configuration like any other database.
+
+        Even where model works it stays out of the automatic sweep, because -AllDatabases means the user
+        databases and changing Query Store on model changes the default for every database created afterwards.
+        It is honoured only when the caller names it explicitly.
+
+        The Query Store commands used to append these names to -ExcludeDatabase unconditionally, and
+        Get-DbaDatabase lets -ExcludeDatabase win over -Database, so an explicit -Database master produced no
+        output, no warning and no error. Callers pass their -Database list in here so that a database the user
+        named on purpose is reported rather than silently dropped.
+
+    .PARAMETER SqlInstance
+        The connected server object, used to decide whether model is supported.
+
+    .PARAMETER Database
+        The database names the caller was asked to work on. Any name in this list that has to be skipped gets a
+        warning explaining why.
+
+    .PARAMETER FunctionName
+        The name of the calling command, so the warning is attributed to it instead of to this helper.
+
+    .EXAMPLE
+        PS C:\> Get-QueryStoreUnsupportedDatabase -SqlInstance $server -Database master, model
+
+        Returns the names to exclude and warns that master cannot have Query Store enabled.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object]$SqlInstance,
+        [object[]]$Database,
+        [string]$FunctionName = (Get-PSCallStack)[1].Command
+    )
+
+    $unsupportedDatabase = @("master", "tempdb")
+
+    if ($Database -notcontains "model" -or $SqlInstance.VersionMajor -lt 16) {
+        $unsupportedDatabase += "model"
+    }
+
+    foreach ($unsupportedName in $unsupportedDatabase) {
+        if ($Database -notcontains $unsupportedName) {
+            continue
+        }
+
+        if ($unsupportedName -eq "model") {
+            $warningMessage = "Query Store cannot be read on model before SQL Server 2022. Skipping model on $SqlInstance."
+        } else {
+            $warningMessage = "Query Store cannot be enabled on system database $unsupportedName. Skipping $unsupportedName on $SqlInstance."
+        }
+
+        $splatWarnUnsupported = @{
+            Level        = "Warning"
+            Message      = $warningMessage
+            FunctionName = $FunctionName
+            Target       = $SqlInstance
+        }
+        Write-Message @splatWarnUnsupported
+    }
+
+    $unsupportedDatabase
+}

--- a/public/Get-DbaDbQueryStoreOption.ps1
+++ b/public/Get-DbaDbQueryStoreOption.ps1
@@ -51,8 +51,10 @@ function Get-DbaDbQueryStoreOption {
         Specifies which user databases to retrieve Query Store configuration from. Accepts database names, wildcards, or arrays for multiple databases.
         Use this when you need to audit Query Store settings for specific databases rather than scanning your entire instance.
 
+        master and tempdb are skipped with a warning, because SQL Server never reports Query Store settings for them. model is skipped with a warning before SQL Server 2022, where sys.database_query_store_options stays empty; from SQL Server 2022 on it reports its configuration like any other database.
+
     .PARAMETER ExcludeDatabase
-        Excludes specific databases from Query Store configuration retrieval. System databases (master, tempdb, model) are automatically excluded.
+        Excludes specific databases from Query Store configuration retrieval. master, tempdb and model are excluded on top of whatever you list here unless model is named explicitly in -Database on SQL Server 2022 or later.
         Useful for skipping databases that you know don't need Query Store monitoring or have restricted access permissions.
 
     .PARAMETER EnableException
@@ -97,10 +99,6 @@ function Get-DbaDbQueryStoreOption {
         [object[]]$ExcludeDatabase,
         [switch]$EnableException
     )
-    begin {
-        # We exclude model because SMO cannot tell if Query Store is enabled there
-        $ExcludeDatabase += 'master', 'tempdb', "model"
-    }
     process {
         foreach ($instance in $SqlInstance) {
             try {
@@ -109,8 +107,22 @@ function Get-DbaDbQueryStoreOption {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            # We have to exclude system databases since they cannot have the Query Store feature enabled
-            $dbs = Get-DbaDatabase -SqlInstance $server -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object IsAccessible
+            # We have to exclude the system databases that cannot have the Query Store feature enabled. Get-DbaDatabase
+            # lets -ExcludeDatabase win over -Database, so this is worked out per instance and warns about anything the
+            # caller named on purpose instead of dropping it silently.
+            $splatUnsupported = @{
+                SqlInstance  = $server
+                Database     = $Database
+                FunctionName = $PSCmdlet.MyInvocation.MyCommand.Name
+            }
+            $skipDatabase = @($ExcludeDatabase) + (Get-QueryStoreUnsupportedDatabase @splatUnsupported)
+
+            $splatGetDatabase = @{
+                SqlInstance     = $server
+                ExcludeDatabase = $skipDatabase
+                Database        = $Database
+            }
+            $dbs = Get-DbaDatabase @splatGetDatabase | Where-Object IsAccessible
 
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $($db.Name) on $instance"

--- a/public/Set-DbaDbQueryStoreOption.ps1
+++ b/public/Set-DbaDbQueryStoreOption.ps1
@@ -22,12 +22,14 @@ function Set-DbaDbQueryStoreOption {
         Specifies which databases to configure Query Store options for. Accepts database names, wildcards, or database objects from Get-DbaDatabase.
         Use this when you need to configure Query Store for specific databases instead of all user databases on the instance.
 
+        master and tempdb are skipped with a warning, because SQL Server does not allow Query Store there. model is skipped with a warning before SQL Server 2022, where the ALTER is accepted but nothing can be read back; from SQL Server 2022 on it is configured like any other database, which sets the Query Store defaults for every database created afterwards.
+
     .PARAMETER ExcludeDatabase
-        Excludes specific databases from Query Store configuration changes. System databases (master, tempdb, model) are automatically excluded.
+        Excludes specific databases from Query Store configuration changes. master, tempdb and model are excluded on top of whatever you list here unless model is named explicitly in -Database on SQL Server 2022 or later.
         Useful when you want to configure most databases but skip certain ones like staging or temporary databases.
 
     .PARAMETER AllDatabases
-        Configures Query Store options for all user databases on the instance. System databases are automatically excluded.
+        Configures Query Store options for all user databases on the instance. System databases are automatically excluded, model included, so a sweep never changes the defaults for databases created later.
         Use this switch when you want to apply consistent Query Store settings across all user databases without specifying individual database names.
 
     .PARAMETER State
@@ -188,10 +190,6 @@ function Set-DbaDbQueryStoreOption {
         [int64]$CustomCapturePolicyStaleThresholdHours,
         [switch]$EnableException
     )
-    begin {
-        $ExcludeDatabase += 'master', 'tempdb', "model"
-    }
-
     process {
         if (-not $Database -and -not $ExcludeDatabase -and -not $AllDatabases) {
             Stop-Function -Message "You must specify a database(s) to execute against using either -Database, -ExcludeDatabase or -AllDatabases"
@@ -218,8 +216,22 @@ function Set-DbaDbQueryStoreOption {
                 Write-Message -Level Warning -Message "Custom Capture Policies can only be set in SQL Server 2019 and above. These options will be skipped for $instance"
             }
 
-            # We have to exclude all the system databases since they cannot have the Query Store feature enabled
-            $dbs = Get-DbaDatabase -SqlInstance $server -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object { $_.IsAccessible -and !$_.IsDatabaseSnapshot }
+            # We have to exclude the system databases that cannot have the Query Store feature enabled. Get-DbaDatabase
+            # lets -ExcludeDatabase win over -Database, so this is worked out per instance and warns about anything the
+            # caller named on purpose instead of dropping it silently.
+            $splatUnsupported = @{
+                SqlInstance  = $server
+                Database     = $Database
+                FunctionName = $PSCmdlet.MyInvocation.MyCommand.Name
+            }
+            $skipDatabase = @($ExcludeDatabase) + (Get-QueryStoreUnsupportedDatabase @splatUnsupported)
+
+            $splatGetDatabase = @{
+                SqlInstance     = $server
+                ExcludeDatabase = $skipDatabase
+                Database        = $Database
+            }
+            $dbs = Get-DbaDatabase @splatGetDatabase | Where-Object { $_.IsAccessible -and !$_.IsDatabaseSnapshot }
 
             foreach ($db in $dbs) {
                 $dbName = $db.Name

--- a/public/Test-DbaDbQueryStore.ps1
+++ b/public/Test-DbaDbQueryStore.ps1
@@ -32,8 +32,10 @@ function Test-DbaDbQueryStore {
         Specifies which databases to test for Query Store best practices. Accepts wildcards for pattern matching.
         Use this when you need to evaluate Query Store settings for specific databases instead of all user databases on the instance.
 
+        master and tempdb are skipped with a warning, because SQL Server never reports Query Store settings for them. model is skipped with a warning before SQL Server 2022, where sys.database_query_store_options stays empty; from SQL Server 2022 on it is evaluated like any other database.
+
     .PARAMETER ExcludeDatabase
-        Excludes specific databases from Query Store evaluation. System databases (master, model, tempdb) are automatically excluded.
+        Excludes specific databases from Query Store evaluation. master, tempdb and model are excluded on top of whatever you list here unless model is named explicitly in -Database on SQL Server 2022 or later.
         Use this when you want to test most databases but skip certain ones like development or temporary databases.
 
     .PARAMETER InputObject
@@ -121,10 +123,6 @@ function Test-DbaDbQueryStore {
         [switch]$EnableException
     )
 
-    begin {
-        $ExcludeDatabase += "master", "model", "tempdb"
-    }
-
     process {
         if (Test-FunctionInterrupt) { return }
 
@@ -141,17 +139,17 @@ function Test-DbaDbQueryStore {
             $inputType = $input.GetType().FullName
 
             switch ($inputType) {
-                'Dataplat.Dbatools.Parameter.DbaInstanceParameter' {
+                "Dataplat.Dbatools.Parameter.DbaInstanceParameter" {
                     Write-Message -Level Verbose -Message "Processing DbaInstanceParameter through InputObject"
-                    $dbDatabases = Get-DbaDatabase -SqlInstance $input -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -OnlyAccessible
+                    $connectTarget = $input
                 }
-                'Microsoft.SqlServer.Management.Smo.Server' {
+                "Microsoft.SqlServer.Management.Smo.Server" {
                     Write-Message -Level Verbose -Message "Processing Server through InputObject"
-                    $dbDatabases = Get-DbaDatabase -SqlInstance $input -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -OnlyAccessible
+                    $connectTarget = $input
                 }
-                'Microsoft.SqlServer.Management.Smo.Database' {
+                "Microsoft.SqlServer.Management.Smo.Database" {
                     Write-Message -Level Verbose -Message "Processing Database through InputObject"
-                    $dbDatabases = $input | Where-Object { $_.Name -notin $ExcludeDatabase }
+                    $connectTarget = $input.Parent
                 }
                 default {
                     Stop-Function -Message "InputObject is not a server or database."
@@ -159,23 +157,50 @@ function Test-DbaDbQueryStore {
                 }
             }
 
+            # We connect before filtering, because which databases have to be skipped depends on the version and
+            # because filtering first left nothing to read the server off when every database was excluded.
             try {
-                $server = Connect-DbaInstance -SqlInstance $dbDatabases[0].Parent -SqlCredential $SqlCredential -MinimumVersion 13
+                $server = Connect-DbaInstance -SqlInstance $connectTarget -SqlCredential $SqlCredential -MinimumVersion 13
             } catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $connectTarget -Continue
             }
 
+            # Warn about anything the caller named on purpose that cannot be evaluated instead of dropping it silently.
+            # Piping a database object in is as explicit as naming it in -Database, so it counts as named on purpose.
+            if ($inputType -eq "Microsoft.SqlServer.Management.Smo.Database") {
+                $namedDatabase = @($Database) + $input.Name
+            } else {
+                $namedDatabase = $Database
+            }
+
+            $splatUnsupported = @{
+                SqlInstance  = $server
+                Database     = $namedDatabase
+                FunctionName = $PSCmdlet.MyInvocation.MyCommand.Name
+            }
+            $skipDatabase = @($ExcludeDatabase) + (Get-QueryStoreUnsupportedDatabase @splatUnsupported)
+
             if ($server.DatabaseEngineType -eq "SqlAzureDatabase") {
-                $ExcludeDatabase += "msdb"
+                $skipDatabase += "msdb"
+            }
+
+            if ($inputType -eq "Microsoft.SqlServer.Management.Smo.Database") {
+                $dbDatabases = $input
+            } else {
+                $splatGetDatabase = @{
+                    SqlInstance     = $server
+                    Database        = $Database
+                    ExcludeDatabase = $skipDatabase
+                    OnlyAccessible  = $true
+                }
+                $dbDatabases = Get-DbaDatabase @splatGetDatabase
             }
 
             if ($Database) {
                 $dbDatabases = $dbDatabases | Where-Object { $Database -contains $_.Name }
             }
 
-            if ($ExcludeDatabase) {
-                $dbDatabases = $dbDatabases | Where-Object Name -NotIn $ExcludeDatabase
-            }
+            $dbDatabases = $dbDatabases | Where-Object Name -NotIn $skipDatabase
 
             $desiredState = [PSCustomObject]@{
                 Property      = 'ActualState'
@@ -224,8 +249,15 @@ function Test-DbaDbQueryStore {
             }
 
             try {
-                Write-Message -Level Verbose -Message "Evaluating Query Store options"
-                $currentOptions = Get-DbaDbQueryStoreOption -SqlInstance $server -Database $dbDatabases.name
+                if ($dbDatabases) {
+                    Write-Message -Level Verbose -Message "Evaluating Query Store options"
+                    $currentOptions = Get-DbaDbQueryStoreOption -SqlInstance $server -Database $dbDatabases.name
+                } else {
+                    # An empty -Database means "every database" to Get-DbaDbQueryStoreOption, so once the filters have
+                    # left nothing the call has to be skipped rather than evaluating the whole instance.
+                    Write-Message -Level Verbose -Message "No databases left to evaluate on $server"
+                    $currentOptions = @()
+                }
 
                 foreach ($db in $currentOptions) {
                     $props = $db.GetPropertySet() | Where-Object Name -NotIn ('CurrentStorageSizeInMB', 'ReadOnlyReason', 'DesiredState')

--- a/tests/Get-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Get-DbaDbQueryStoreOption.Tests.ps1
@@ -21,8 +21,43 @@ Describe $CommandName -Tag UnitTests {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/dataplat/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $serverSingle = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "When a system database is named explicitly" {
+        It "Warns about master and tempdb instead of silently returning nothing" {
+            $resultsSystemDb = Get-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database master, tempdb -WarningVariable warnSystemDb
+            $resultsSystemDb | Should -BeNullOrEmpty
+            $warnSystemDb -join "`n" | Should -Match "Query Store cannot be enabled on system database master"
+            $warnSystemDb -join "`n" | Should -Match "Query Store cannot be enabled on system database tempdb"
+        }
+
+        It "Reads model from SQL Server 2022 on and warns about it before that" {
+            $resultsModel = Get-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database model -WarningVariable warnModel
+
+            if ($serverSingle.VersionMajor -ge 16) {
+                $resultsModel.Database | Should -Be "model"
+                $warnModel | Should -BeNullOrEmpty
+            } else {
+                $resultsModel | Should -BeNullOrEmpty
+                $warnModel -join "`n" | Should -Match "Query Store cannot be read on model before SQL Server 2022"
+            }
+        }
+    }
+
+    Context "When no database is named" {
+        It "Keeps model out of the sweep so instance defaults are never changed by accident" {
+            $resultsSweep = Get-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -WarningVariable warnSweep
+            $resultsSweep.Database | Should -Not -Contain "model"
+            $warnSweep | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Set-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Set-DbaDbQueryStoreOption.Tests.ps1
@@ -105,4 +105,43 @@ Describe $CommandName -Tag IntegrationTests {
             }
         }
     }
+
+    Context "When a system database is named explicitly" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $serverMulti1 = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Warns about master and tempdb instead of doing nothing at all" {
+            $resultsSystemDb = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceMulti1 -Database master, tempdb -State ReadWrite -WarningVariable warnSystemDb
+            $resultsSystemDb | Should -BeNullOrEmpty
+            $warnSystemDb -join "`n" | Should -Match "Query Store cannot be enabled on system database master"
+            $warnSystemDb -join "`n" | Should -Match "Query Store cannot be enabled on system database tempdb"
+        }
+
+        It "Configures model from SQL Server 2022 on and warns about it before that" {
+            if ($serverMulti1.VersionMajor -ge 16) {
+                # Query Store on model decides the defaults of every database created afterwards, so the original
+                # value is restored here rather than in an AfterAll that a failing assertion would reach too late.
+                $originalThreshold = (Get-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceMulti1 -Database model).StaleQueryThresholdInDays
+                try {
+                    $resultsModel = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceMulti1 -Database model -StaleQueryThreshold 45 -WarningVariable warnModel
+                    $resultsModel.Database | Should -Be "model"
+                    $resultsModel.StaleQueryThresholdInDays | Should -Be 45
+                    $warnModel | Should -BeNullOrEmpty
+                } finally {
+                    $null = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceMulti1 -Database model -StaleQueryThreshold $originalThreshold
+                }
+            } else {
+                $resultsModel = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceMulti1 -Database model -StaleQueryThreshold 45 -WarningVariable warnModel
+                $resultsModel | Should -BeNullOrEmpty
+                $warnModel -join "`n" | Should -Match "Query Store cannot be read on model before SQL Server 2022"
+            }
+        }
+    }
 }

--- a/tests/Test-DbaDbQueryStore.Tests.ps1
+++ b/tests/Test-DbaDbQueryStore.Tests.ps1
@@ -95,6 +95,19 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 
+    Context "When a system database is named explicitly" {
+        It "Warns about master instead of failing with a null array" {
+            $resultsSystemDb = Test-DbaDbQueryStore -SqlInstance $TestConfig.InstanceSingle -Database master -WarningVariable warnSystemDb
+            $warnSystemDb -join "`n" | Should -Match "Query Store cannot be enabled on system database master"
+            ($resultsSystemDb | Where-Object Database) | Should -BeNullOrEmpty
+        }
+
+        It "Does not fall back to evaluating every database once the filters leave nothing" {
+            $resultsSystemDb = Test-DbaDbQueryStore -SqlInstance $TestConfig.InstanceSingle -Database master
+            ($resultsSystemDb | Where-Object Database -eq $dbname) | Should -BeNullOrEmpty
+        }
+    }
+
     Context "Function works with piping smo server object" {
         BeforeAll {
             $svrPipe = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle


### PR DESCRIPTION
Fixes #10523.

## Problem

`Set-DbaDbQueryStoreOption -SqlInstance $x -Database master, tempdb, model` is a silent no-op: no output, no warning, no error. @ReeceGoding reported it and was right that it should do at least one of them.

## Mechanism

All three read commands appended the names to `-ExcludeDatabase` in `begin`:

```powershell
$ExcludeDatabase += 'master', 'tempdb', "model"
```

`Get-DbaDatabase` lets `-ExcludeDatabase` win over `-Database`, so a database named on purpose was dropped before anything could be emitted.

`Test-DbaDbQueryStore` failed differently and worse: it read the server off `$dbDatabases[0].Parent` *after* filtering, so `-Database master` died with `Cannot index into a null array.`

## What the lab says

Reproduced and verified against SQL Server 2019 (v15), 2022 (v16) and 2025 (v17):

| | 2019 and earlier | 2022 and later |
|---|---|---|
| master / tempdb | `ALTER` errors with *"Query Store cannot be enabled on system database master"* | same error |
| model | `ALTER` succeeds, but `sys.database_query_store_options` returns **zero rows** and SMO reads back nothing | Query Store **on by default** (`READ_WRITE`), reports like any other database |

So the `model` exclusion added in #6777 ("SMO cannot tell if Query Store is enabled there") was correct for 2019 and is now wrong: from SQL Server 2022 on, model is exactly how newly created databases get their Query Store defaults, and dbatools could neither read nor change it.

## What changed

A shared private helper `Get-QueryStoreUnsupportedDatabase` works the exclusion list out per instance and warns about anything the caller named explicitly:

```
WARNING: [Set-DbaDbQueryStoreOption] Query Store cannot be enabled on system database master. Skipping master on [SQL03\SQL2019].
WARNING: [Set-DbaDbQueryStoreOption] Query Store cannot be read on model before SQL Server 2022. Skipping model on [SQL03\SQL2019].
```

- `Get-DbaDbQueryStoreOption`, `Set-DbaDbQueryStoreOption`, `Test-DbaDbQueryStore` now warn instead of dropping silently.
- An explicit `-Database model` is honoured from SQL Server 2022 on; before that it warns. Piping a database object counts as naming it explicitly.
- `Test-DbaDbQueryStore` connects before filtering, which removes the null-array crash.

`Get-` had to change with `Set-`, not optionally: `Set-` returns its result by calling `Get-`, so fixing `Set-` alone would still emit nothing.

### Also fixed

`Test-DbaDbQueryStore` passed `$dbDatabases.name` to `Get-DbaDbQueryStoreOption`. An empty list makes that `-Database $null`, which means *every* database — so an over-filtered request quietly evaluated the whole instance instead of nothing. The crash had been hiding it.

## What deliberately did not change

- **model stays out of the automatic sweep**, even on SQL Server 2022+. `-AllDatabases` means the user databases, and changing Query Store on model changes the default for every database created afterwards. It is honoured only when named.
- **`Copy-DbaDbQueryStoreOption` is untouched.** Its destination uses `-ExcludeSystem` and it already reports `No matching databases found. Check the spelling and try again.`, so it is not silent. Its source-side flaw — a null `$SourceQSConfig` splatted into `Set-` — is a separate defect.

## Tests

New regression coverage in all three test files, version-branching so it asserts the real behaviour on whatever the runner provisions rather than skipping:

- master/tempdb warn and return nothing (`Get-`, `Set-`, `Test-`)
- model is read/configured on v16+ and warns below that (`Get-`, `Set-`); the `Set-` test restores model's original value in a `finally`
- model stays out of a sweep that does not name it (`Get-`)
- `Test-` no longer crashes on `-Database master`, and does not fall back to evaluating every database

All 29 tests across the four Query Store files pass against a live 2019/2022/2025 lab, with the lab left clean.