### PR TITLE
Test-DbaPath - Silence the expected warnings of the mocked failure tests

### DIFF
--- a/tests/Test-DbaPath.Tests.ps1
+++ b/tests/Test-DbaPath.Tests.ps1
@@ -49,13 +49,16 @@ Describe $CommandName -Tag UnitTests {
             }
 
             It "Returns false for a single path by default" {
-                $result = Test-DbaPath -SqlInstance "sql1" -Path "C:\temp\file1.bak"
+                # The mocked server throws on purpose, so the command warns. That warning is the
+                # subject of its own test below and is silenced here, because a test run must not
+                # print warnings - an unexpected one is the only sign that something went wrong.
+                $result = Test-DbaPath -SqlInstance "sql1" -Path "C:\temp\file1.bak" -WarningAction SilentlyContinue
 
                 $result | Should -Be $false
             }
 
             It "Returns false objects for array input by default" {
-                $results = Test-DbaPath -SqlInstance "sql1" -Path @("C:\temp\file1.bak", "C:\temp\file2.bak")
+                $results = Test-DbaPath -SqlInstance "sql1" -Path @("C:\temp\file1.bak", "C:\temp\file2.bak") -WarningAction SilentlyContinue
 
                 ($results | Measure-Object).Count | Should -Be 2
                 ($results | Where-Object FilePath -eq "C:\temp\file1.bak").FileExists | Should -Be $false


### PR DESCRIPTION
The `xp_fileexist execution failures` context mocks a server whose `ExecuteWithResults` throws on purpose, so `Test-DbaPath` warns that existence could not be determined. Two of the tests in that context let the warning reach the warning stream:

```
WARNING  [Test-DbaPath] xp_fileexist execution failed for path(s) on sql1, so existence could not be
determined and the path(s) are reported as not found. ...
```

Those warnings say nothing about a problem - they are the mocked failure doing its job. The test that is actually about the warning already captures it with a redirect and asserts on it, and is unchanged.

They are silenced with `-WarningAction SilentlyContinue` now. A test file runs without `EnableException`, so a problem inside a command surfaces only as a warning and Pester ignores warnings completely. That makes an unexpected warning the one signal that something went wrong, and it is worth nothing while expected warnings are printing next to it.

## Testing

`Test-DbaPath.Tests.ps1` passes 11/11 against a live lab with no warnings.

Found by running the full suite locally; this file only surfaced in the second half of the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)