### PR TITLE
Query Store - Silence the expected warnings of the system database tests

### DIFF
--- a/tests/Get-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Get-DbaDbQueryStoreOption.Tests.ps1
@@ -34,14 +34,16 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "When a system database is named explicitly" {
         It "Warns about master and tempdb instead of silently returning nothing" {
-            $resultsSystemDb = Get-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database master, tempdb -WarningVariable warnSystemDb
+            $resultsSystemDb = Get-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database master, tempdb -WarningVariable warnSystemDb -WarningAction SilentlyContinue
             $resultsSystemDb | Should -BeNullOrEmpty
             $warnSystemDb -join "`n" | Should -Match "Query Store cannot be enabled on system database master"
             $warnSystemDb -join "`n" | Should -Match "Query Store cannot be enabled on system database tempdb"
         }
 
         It "Reads model from SQL Server 2022 on and warns about it before that" {
-            $resultsModel = Get-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database model -WarningVariable warnModel
+            # Silenced because the pre-2022 branch below expects a warning. The warning is still
+            # captured in $warnModel, so an unexpected one on 2022 and later fails the assertion.
+            $resultsModel = Get-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database model -WarningVariable warnModel -WarningAction SilentlyContinue
 
             if ($serverSingle.VersionMajor -ge 16) {
                 $resultsModel.Database | Should -Be "model"

--- a/tests/Set-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Set-DbaDbQueryStoreOption.Tests.ps1
@@ -118,7 +118,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Warns about master and tempdb instead of doing nothing at all" {
-            $resultsSystemDb = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceMulti1 -Database master, tempdb -State ReadWrite -WarningVariable warnSystemDb
+            $resultsSystemDb = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceMulti1 -Database master, tempdb -State ReadWrite -WarningVariable warnSystemDb -WarningAction SilentlyContinue
             $resultsSystemDb | Should -BeNullOrEmpty
             $warnSystemDb -join "`n" | Should -Match "Query Store cannot be enabled on system database master"
             $warnSystemDb -join "`n" | Should -Match "Query Store cannot be enabled on system database tempdb"
@@ -138,7 +138,7 @@ Describe $CommandName -Tag IntegrationTests {
                     $null = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceMulti1 -Database model -StaleQueryThreshold $originalThreshold
                 }
             } else {
-                $resultsModel = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceMulti1 -Database model -StaleQueryThreshold 45 -WarningVariable warnModel
+                $resultsModel = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceMulti1 -Database model -StaleQueryThreshold 45 -WarningVariable warnModel -WarningAction SilentlyContinue
                 $resultsModel | Should -BeNullOrEmpty
                 $warnModel -join "`n" | Should -Match "Query Store cannot be read on model before SQL Server 2022"
             }


### PR DESCRIPTION
Follow-up to #10533, found by a full lab run of the merged branch.

The integration tests added by #10533 assert on their own `-WarningVariable` but never set
`-WarningAction`, so the warnings they expect still reach the warning stream. The run ended with
five warnings - three from `Get-DbaDbQueryStoreOption`, two from `Set-DbaDbQueryStoreOption` -
that all had to be traced back by hand before they could be dismissed as expected. That is the
noise the warning-free rule exists to prevent: the tests run without `EnableException`, so an
unexpected warning is the only signal that something went wrong inside a command, and that signal
is worth nothing while expected warnings print next to it.

Four calls now carry `-WarningAction SilentlyContinue`. The assertions are unchanged - the
warnings are still captured in the same `-WarningVariable` and still checked.

The two calls that are asserted *not* to warn deliberately stay unsilenced, so a regression still
shows up as an unexpected warning in the run.

Verified against SQL Server 2019 and 2025: `Get-DbaDbQueryStoreOption` 4/4 and
`Set-DbaDbQueryStoreOption` 8/8, with no warnings on the stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
