### PR TITLE
Set-DbaLogin - Return the login as it is after unlocking it with a new password

### DIFF
--- a/public/Set-DbaLogin.ps1
+++ b/public/Set-DbaLogin.ps1
@@ -504,9 +504,10 @@ function Set-DbaLogin {
                         $l.ChangePassword($NewSecurePassword, $Unlock, $PasswordMustChange)
                         $passwordChanged = $true
 
-                        if (Test-Bound PasswordMustChange) {
-                            $l.Refresh()  # necessary so that the read only property PasswordMustChange is updated
-                        }
+                        # necessary so that the read only properties PasswordMustChange and IsLocked are
+                        # updated. Changing the password with unlock clears the lock on the instance, but
+                        # without this the login we return still reports itself as locked.
+                        $l.Refresh()
                     } catch {
                         $notes += "Couldn't change password"
                         $passwordChanged = $false

--- a/tests/Set-DbaLogin.Tests.ps1
+++ b/tests/Set-DbaLogin.Tests.ps1
@@ -38,21 +38,25 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
-    # TODO: Fix later
-    Context -Skip "???" {
-        BeforeAll {
+    Context "Parameter validation" {
+        BeforeDiscovery {
+            # -TestCases is read while Pester discovers the tests. Built in the BeforeAll below, as it
+            # was before, this list was still empty at discovery, so neither of the role tests existed
+            # at all - and with Pester 6 the empty list fails the whole file during discovery.
             $systemRoles = @(
-                @{role = 'bulkadmin' },
-                @{role = 'dbcreator' },
-                @{role = 'diskadmin' },
-                @{role = 'processadmin' },
-                @{role = 'public' },
-                @{role = 'securityadmin' },
-                @{role = 'serveradmin' },
-                @{role = 'setupadmin' },
-                @{role = 'sysadmin' }
+                @{role = "bulkadmin" },
+                @{role = "dbcreator" },
+                @{role = "diskadmin" },
+                @{role = "processadmin" },
+                @{role = "public" },
+                @{role = "securityadmin" },
+                @{role = "serveradmin" },
+                @{role = "setupadmin" },
+                @{role = "sysadmin" }
             )
+        }
 
+        BeforeAll {
             $command = Get-Command $CommandName
         }
 
@@ -252,8 +256,9 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
             $result.PasswordPolicyEnforced | Should -Be $false
         }
 
-        # TODO: The 'locked' test makes assumptions the password policy configuration is enabled for the Windows OS.
-        It -Skip "Unlock" {
+        # A login can only be locked out when the host running the instance has an account lockout
+        # threshold, so this test needs one that is not higher than the number of failed logons below.
+        It "unlocks a login that was locked out" {
             $results = Set-DbaLogin -SqlInstance $TestConfig.InstanceSingle -Login "testlogin1_$random" -PasswordPolicyEnforced -EnableException
             $results.PasswordPolicyEnforced | Should -Be $true
 
@@ -264,10 +269,14 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
             # exceed the lockout count
             for (($i = 0); $i -le 4; $i++) {
                 try {
-                    Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -SqlCredential $invalidSqlCredential
+                    # NonPooledConnection, because after a failed logon SqlClient blocks the pool for a
+                    # growing number of seconds and answers the following attempts itself. Those never
+                    # reach the instance, so the bad password count stops climbing before it reaches the
+                    # lockout threshold and the login is never locked.
+                    $null = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -SqlCredential $invalidSqlCredential -NonPooledConnection
                 } catch {
-                    Write-Message -Level Warning -Message "invalid login credentials used on purpose to lock out account"
-                    Start-Sleep -s 5
+                    # Verbose, not a warning: the failed logon is on purpose and a test run must not print warnings.
+                    Write-Verbose -Message "invalid login credentials used on purpose to lock out account"
                 }
             }
 
@@ -275,8 +284,9 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
             $results.IsLocked | Should -Be $true
 
             # this will generate a warning since neither the password or the -force param is specified
-            $results = Set-DbaLogin -SqlInstance $TestConfig.InstanceSingle -Login "testlogin1_$random" -Unlock
+            $results = Set-DbaLogin -SqlInstance $TestConfig.InstanceSingle -Login "testlogin1_$random" -Unlock -WarningAction SilentlyContinue
             $results | Should -BeNullOrEmpty
+            ($WarnVar -join " ") | Should -Match "Force"
 
             # this will use the workaround solution to turn off/on the check_policy
             $results = Set-DbaLogin -SqlInstance $TestConfig.InstanceSingle -Login "testlogin1_$random" -Unlock -Force
@@ -285,10 +295,14 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
             # exceed the lockout count again
             for (($i = 0); $i -le 4; $i++) {
                 try {
-                    Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -SqlCredential $invalidSqlCredential
+                    # NonPooledConnection, because after a failed logon SqlClient blocks the pool for a
+                    # growing number of seconds and answers the following attempts itself. Those never
+                    # reach the instance, so the bad password count stops climbing before it reaches the
+                    # lockout threshold and the login is never locked.
+                    $null = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -SqlCredential $invalidSqlCredential -NonPooledConnection
                 } catch {
-                    Write-Message -Level Warning -Message "invalid login credentials used on purpose to lock out account"
-                    Start-Sleep -s 5
+                    # Verbose, not a warning: the failed logon is on purpose and a test run must not print warnings.
+                    Write-Verbose -Message "invalid login credentials used on purpose to lock out account"
                 }
             }
 


### PR DESCRIPTION
> [!NOTE]
> **This is a draft on purpose.** It restores #10530, which was squash merged by mistake and then reverted
> in fc094677c. It is kept as a draft so it cannot land again before it has been reviewed. Mark it ready
> when you want it.

> [!IMPORTANT]
> **One test in this PR fails on CI until the fleet controller is redeployed.** The runners need an account
> lockout threshold for `unlocks a login that was locked out` to pass. #10718 added `net accounts /lockoutthreshold:5`
> to `bootstrap-runner.ps1` and is merged, but the controller bundles its own copy of that script when
> `deploy-controller.ps1` packages it, so new runners keep the old bootstrap until the controller is deployed again
> (see the comment on this PR for the evidence). Skipping the test instead would hide the very regression this PR fixes,
> so it is left enabled and red until then. Everything else in the file passes.

The change is the original commit of #10530, cherry-picked onto `development` and unmodified. The branch has since
taken current `development` (v2.9.0) by merge.

## The bug

Unlocking a login by setting a new password calls `Login.ChangePassword($NewSecurePassword, $Unlock, $PasswordMustChange)`, which really does clear the lock on the instance. But the login object was only refreshed when `-PasswordMustChange` was bound, so in every other case the object returned still reported `IsLocked` as `$true`:

```
locked before unlock (server): 1
returned object IsLocked : True
server says IsLocked     : 0
```

Anyone checking the result had to conclude the unlock had failed while the instance said it had worked. The object is refreshed in both cases now.

## Why nobody noticed

The test file was invisible. Its integration `Context` was skipped with a name of `"???"` and a `# TODO: Fix later`, and its `-TestCases` were built in a `BeforeAll`, which runs *after* discovery, so the cases were empty. Pester 5 silently produced no tests from an empty case list; Pester 6 fails the file during discovery instead, which is how this surfaced.

With the cases built in `BeforeDiscovery` and the `Context` named and enabled, the file runs **45 tests instead of 1**.

## The lockout tests needed a second fix

Two tests lock a login out by failing five logons. After a failed logon SqlClient blocks the connection pool for a growing number of seconds and answers the following attempts itself, so most of those logons never reached the instance. `BadPasswordCount` plateaued at 3 no matter how many attempts were made, even with the `Start-Sleep -s 5` the test already had, so the login was never locked.

They use `-NonPooledConnection` now. The bad password count then climbs one per attempt and the login locks exactly at the threshold, which also makes the sleeps unnecessary and the file faster.

## Testing

Re-verified on 2026-09-19 against current `development` (after the merge), on a lab whose hosts have an account lockout threshold of 5: **45 passed, 0 failed, 0 skipped** in Windows PowerShell 5.1 and in pwsh 7.

The precondition is only the threshold. SQL Server reads it from the local policy of the host running the instance, not from the domain policy - verified in a lab where the domain has no threshold and the local one has five, and the lockout follows the local value.

On a **domain member**, `net accounts /lockoutthreshold:5` does not survive: the Default Domain Policy re-applies its own account policy to the local account database at boot and every 16 hours, so the value silently goes back to `Never`. That is how the lab hosts lost it after a reboot, and there it had to move into a GPO linked to the OU the machines live in. The CI runners are **not** domain joined, so none of that applies to them - the bootstrap value is enough.

## After the controller redeploy

Once the runners have the threshold, this test passes on CI unchanged. No follow-up change to this file is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
