### PR TITLE
Install-DbaParquet - Keep the assemblies of the two PowerShell editions apart

### DIFF
--- a/private/functions/Get-DbaParquetEditionFolder.ps1
+++ b/private/functions/Get-DbaParquetEditionFolder.ps1
@@ -1,0 +1,33 @@
+function Get-DbaParquetEditionFolder {
+    <#
+    .SYNOPSIS
+        Gets the name of the Parquet.NET installation subfolder for the running PowerShell edition.
+
+    .DESCRIPTION
+        Install-DbaParquet picks the Parquet.NET assemblies that match the runtime it is running on:
+        .NET Framework targets on Windows PowerShell and net<major> targets on PowerShell 7. Both
+        editions share one dbatools data directory, so the assemblies have to live in a folder per
+        edition. Without that, whichever edition installs last leaves assemblies the other one cannot
+        load, and every import fails there with a type load error that looks like a broken install.
+
+    .NOTES
+        Tags: Parquet, Import
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2026 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .OUTPUTS
+        System.String. The subfolder name, either "core" or "desktop".
+    #>
+    [CmdletBinding()]
+    param ()
+
+    # PSEdition does not exist on PowerShell 3 and 4, and those are always Desktop.
+    if ($PSVersionTable.PSEdition -eq "Core") {
+        return "core"
+    }
+
+    return "desktop"
+}

--- a/private/functions/Get-DbaParquetPath.ps1
+++ b/private/functions/Get-DbaParquetPath.ps1
@@ -37,9 +37,15 @@ function Get-DbaParquetPath {
 
     $searchPaths = @()
 
+    # The assemblies differ per PowerShell edition, so the folder of the running edition comes first
+    # and the flat folder is only the fallback for installations made before that split existed.
+    $editionFolder = Get-DbaParquetEditionFolder
+
     $configuredPath = Get-DbatoolsConfigValue -FullName "Path.DbatoolsParquet"
     if ($configuredPath) {
         $configuredPath = $configuredPath.TrimEnd("/", "\")
+        $searchPaths += Join-Path -Path $configuredPath -ChildPath $editionFolder | Join-Path -ChildPath "Parquet.dll"
+        $searchPaths += Join-Path -Path $configuredPath -ChildPath $editionFolder | Join-Path -ChildPath "Parquet.Net.dll"
         $searchPaths += Join-Path -Path $configuredPath -ChildPath "Parquet.dll"
         $searchPaths += Join-Path -Path $configuredPath -ChildPath "Parquet.Net.dll"
     }
@@ -47,6 +53,8 @@ function Get-DbaParquetPath {
     $dbatoolsData = Get-DbatoolsConfigValue -FullName "Path.DbatoolsData"
     if ($dbatoolsData) {
         $dbatoolsData = $dbatoolsData.TrimEnd("/", "\")
+        $searchPaths += Join-Path -Path $dbatoolsData -ChildPath "parquet" | Join-Path -ChildPath $editionFolder | Join-Path -ChildPath "Parquet.dll"
+        $searchPaths += Join-Path -Path $dbatoolsData -ChildPath "parquet" | Join-Path -ChildPath $editionFolder | Join-Path -ChildPath "Parquet.Net.dll"
         $searchPaths += Join-Path -Path $dbatoolsData -ChildPath "parquet" | Join-Path -ChildPath "Parquet.dll"
         $searchPaths += Join-Path -Path $dbatoolsData -ChildPath "parquet" | Join-Path -ChildPath "Parquet.Net.dll"
     }

--- a/public/Import-DbaParquet.ps1
+++ b/public/Import-DbaParquet.ps1
@@ -303,7 +303,13 @@ function Import-DbaParquet {
                 $loaderDetail = ($loadException.LoaderExceptions | ForEach-Object { $PSItem.Message } | Sort-Object -Unique) -join " | "
 
                 if ($loaderDetail) {
-                    Stop-Function -Message "Could not load Parquet.NET from $parquetDllPath. The assemblies are present but could not be loaded: $loaderDetail" -ErrorRecord $_ -EnableException $EnableException
+                    # Assemblies that are present but unloadable are almost always the ones the other
+                    # PowerShell edition installed, back when both editions shared one folder.
+                    $currentEdition = $PSVersionTable.PSEdition
+                    if (-not $currentEdition) {
+                        $currentEdition = "Desktop"
+                    }
+                    Stop-Function -Message "Could not load Parquet.NET from $parquetDllPath. The assemblies are present but could not be loaded: $loaderDetail. If they were installed from another PowerShell edition, run Install-DbaParquet again on this one ($currentEdition) to get the matching assemblies." -ErrorRecord $_ -EnableException $EnableException
                 } else {
                     Stop-Function -Message "Could not load Parquet.NET from $parquetDllPath. Run Install-DbaParquet to install the required assemblies." -ErrorRecord $_ -EnableException $EnableException
                 }

--- a/public/Install-DbaParquet.ps1
+++ b/public/Install-DbaParquet.ps1
@@ -4,19 +4,22 @@ function Install-DbaParquet {
         Installs Parquet.NET assemblies required by Import-DbaParquet.
 
     .DESCRIPTION
-        Downloads Parquet.NET from NuGet and installs the netstandard2.0 assemblies into the dbatools data directory.
-        The installer also downloads and extracts the managed dependency closure declared by the NuGet packages.
+        Downloads Parquet.NET from NuGet and installs it into the dbatools data directory, together with the managed
+        dependency closure declared by the NuGet packages.
 
-        Parquet.NET is a managed .NET library, so the installed assemblies work across Windows, Linux, and macOS as long
-        as the host PowerShell/.NET runtime can load netstandard2.0 assemblies.
+        The assemblies are picked for the runtime this is running on: .NET Framework targets on Windows PowerShell and
+        net<major> targets on PowerShell 7. Because both editions share the dbatools data directory, each one installs
+        into its own folder below the configured path ("desktop" or "core"). Run this once per edition if you use both.
 
         By default, assemblies are installed to the dbatools data directory for the current user. Use -Path for a custom
         portable location, or -LocalFile to install from an already downloaded nupkg, zip, or folder that contains
         Parquet.dll or Parquet.Net.dll and its dependencies.
 
     .PARAMETER Path
-        Specifies the directory where Parquet.NET assemblies will be installed.
-        If not specified, defaults to the Path.DbatoolsParquet configuration value.
+        Specifies the directory where Parquet.NET assemblies will be installed. Used exactly as given, so an installation
+        for another PowerShell edition in the same directory is overwritten.
+        If not specified, defaults to a subfolder of the Path.DbatoolsParquet configuration value named for the running
+        PowerShell edition, so the editions do not overwrite each other.
 
     .PARAMETER Version
         Specifies the Parquet.Net NuGet package version to install. Defaults to 5.4.0, the version used by Import-DbaParquet.
@@ -419,8 +422,33 @@ function Install-DbaParquet {
 
         Write-Progress -Activity "Installing Parquet.NET" -Status "Checking for existing installation..." -PercentComplete 0
 
-        $installedPath = Get-DbaParquetPath -Silent
-        if ($installedPath -and -not $Force) {
+        if (-not $Path) {
+            # Path.DbatoolsParquet ships with a default, so this is the normal case and not a fallback.
+            $basePath = Get-DbatoolsConfigValue -FullName "Path.DbatoolsParquet"
+            if (-not $basePath) {
+                $dbatoolsData = Get-DbatoolsConfigValue -FullName "Path.DbatoolsData"
+                $basePath = Join-Path -Path $dbatoolsData.TrimEnd("/", "\") -ChildPath "parquet"
+            }
+
+            # The assemblies are picked for the runtime this is running on, but both editions share
+            # the dbatools data directory, so each one installs into its own folder below the base
+            # path. Installing from PowerShell 7 used to leave net<major> assemblies that Windows
+            # PowerShell cannot load at all, and the failure looked like a missing installation.
+            $Path = Join-Path -Path $basePath.TrimEnd("/", "\") -ChildPath (Get-DbaParquetEditionFolder)
+        } else {
+            Set-DbatoolsConfig -FullName "Path.DbatoolsParquet" -Value $Path
+        }
+
+        # Only an installation in the folder this would write to counts as already installed. Asking
+        # Get-DbaParquetPath instead would report the assemblies of the *other* PowerShell edition as
+        # installed and then refuse to install the ones this edition can actually load, which left no
+        # way out of the failure except deleting the folder by hand.
+        $installedPath = Join-Path -Path $Path -ChildPath "Parquet.dll"
+        if (-not (Test-Path -Path $installedPath)) {
+            $installedPath = Join-Path -Path $Path -ChildPath "Parquet.Net.dll"
+        }
+
+        if ((Test-Path -Path $installedPath) -and -not $Force) {
             Write-Progress -Activity "Installing Parquet.NET" -Completed
             $notes = "Parquet.NET already exists at $installedPath. Skipped installation. Use -Force to overwrite."
             Write-Message -Level Verbose -Message $notes
@@ -432,17 +460,6 @@ function Install-DbaParquet {
                 Notes     = $notes
             }
             return
-        }
-
-        if (-not $Path) {
-            $Path = Get-DbatoolsConfigValue -FullName "Path.DbatoolsParquet"
-            if (-not $Path) {
-                $dbatoolsData = Get-DbatoolsConfigValue -FullName "Path.DbatoolsData"
-                $dbatoolsData = $dbatoolsData.TrimEnd("/", "\")
-                $Path = Join-Path -Path $dbatoolsData -ChildPath "parquet"
-            }
-        } else {
-            Set-DbatoolsConfig -FullName "Path.DbatoolsParquet" -Value $Path
         }
 
         $tempRoot = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "dbatools-parquet-$([System.Guid]::NewGuid().ToString())"

--- a/tests/Install-DbaParquet.Tests.ps1
+++ b/tests/Install-DbaParquet.Tests.ps1
@@ -46,5 +46,24 @@ Describe $CommandName -Tag IntegrationTests {
                 Test-Path -Path (Join-Path $installPath $assemblyName) | Should -BeTrue
             }
         }
+
+        It "keeps the editions apart by installing below the configured path" {
+            # The assemblies are picked for the runtime, so an installation made by the other edition
+            # cannot be loaded here. Both editions share the data directory, so they only stay usable
+            # side by side while each one installs into its own folder.
+            $basePath = Join-Path $TestDrive "editionbase"
+            Set-DbatoolsConfig -FullName "Path.DbatoolsParquet" -Value $basePath
+
+            $result = Install-DbaParquet -Force -EnableException
+
+            if ($PSVersionTable.PSEdition -eq "Core") {
+                $expectedFolder = "core"
+            } else {
+                $expectedFolder = "desktop"
+            }
+
+            $result.Installed | Should -BeTrue
+            Split-Path -Path $result.Path -Parent | Should -Be (Join-Path $basePath $expectedFolder)
+        }
     }
 }


### PR DESCRIPTION
`Import-DbaParquet` failed **every** import on Windows PowerShell in the lab - 2 of 17 tests passing - while
the same file passed 17/17 on PowerShell 7. The warning said the assemblies could not be loaded:

```
Could not load file or assembly 'System.Collections, Version=10.0.0.0' ... |
Could not load file or assembly 'System.Runtime, Version=10.0.0.0' ...
```

## The cause

`Install-DbaParquet` picks the assemblies that match the runtime it is running on: .NET Framework targets on
Windows PowerShell, `net<major>` targets on PowerShell 7. That part works. But it installed all of them into
**one folder that both editions share**, `Path.DbatoolsParquet`, default `<AppData>\PowerShell\dbatools\parquet`.

So whichever edition installs last decides what the other one finds. This installation had been made from
PowerShell 7, which left `Parquet.dll` and six of its dependencies as the `net10.0` builds. Those reference
`System.Runtime` and `System.Collections` 10.0.0.0, which .NET Framework cannot bind, so Windows PowerShell
could not load them at all.

Nothing was wrong with the package versions, and `Parquet.dll` was exactly the pinned 5.4.0 - which is why
this reads like a broken or missing installation rather than a layout problem.

## The fix

Each edition installs into its own folder below the configured path, `desktop` or `core`, chosen by the new
private function `Get-DbaParquetEditionFolder`. `Get-DbaParquetPath` looks in the folder of the running
edition first and falls back to the flat folder, so installations made before this change keep working.

Reporting an installation as already present now looks at the folder that **would be written to** rather than
at any folder `Get-DbaParquetPath` knows about. Without that, the other edition's assemblies counted as
installed and `Install-DbaParquet` skipped the install - so the command told you to run `Install-DbaParquet`,
and `Install-DbaParquet` then said it was already installed, with no way out except deleting the folder by
hand.

`Import-DbaParquet` also names the likely cause now when the assemblies are present but cannot be loaded, and
the help of `Install-DbaParquet` says which assemblies it installs and that both editions need their own run.

An explicit `-Path` is still used exactly as given.

## Testing

In a lab with SQL Server 2019/2022/2025:

| | before | after |
| --- | --- | --- |
| `Import-DbaParquet.Tests.ps1` on Windows PowerShell 5.1 | 2 passed / 15 failed | **17 passed / 0 failed** |
| `Import-DbaParquet.Tests.ps1` on PowerShell 7.4 | 17 passed | **17 passed** (through the fallback) |
| `Install-DbaParquet.Tests.ps1` | 2 passed | **3 passed** |

The PowerShell 7 run deliberately used the pre-existing flat installation to confirm the fallback keeps old
installations working.

`Install-DbaParquet.Tests.ps1` gains a test that installing without `-Path` lands in a subfolder named for the
running edition.

> [!NOTE]
> Unrelated to this PR, but found next to it: `Import-DbaParquet` followed by `New-DbaDacPackage` in one
> Windows PowerShell process crashes the process with an access violation. That survives this fix and is
> tracked in #10536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
