### PR TITLE
Tests - Stop leaving backup files behind in the lab

### DIFF
--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -526,12 +526,17 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "clones when using Backup-DabInstace" {
             $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -Database tempdb
-            $results = Backup-DbaDatabase -SqlInstance $server -Database msdb
+            # The backups have to go to the shared temp folder. Without a path they land in the default
+            # backup folder of the instance, which is a path on the SQL Server, so the Remove-Item below
+            # runs against a path that does not exist on the machine running the tests and silently does
+            # nothing. The backup was then left behind on every remote instance, and because this file
+            # runs early in the suite, every later test file reported it as a leftover of its own.
+            $results = Backup-DbaDatabase -SqlInstance $server -Database msdb -Path $TestConfig.Temp
             if ($results.FullName) {
                 Remove-Item -Path $results.FullName -ErrorAction SilentlyContinue
             }
 
-            $results = Backup-DbaDatabase -SqlInstance $server -Database msdb -WarningVariable warn
+            $results = Backup-DbaDatabase -SqlInstance $server -Database msdb -Path $TestConfig.Temp -WarningVariable warn
             $warn | Should -BeNullOrEmpty
 
             if ($results.FullName) {

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -55,8 +55,9 @@ Describe $CommandName -Tag IntegrationTests {
 
         # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
         # Other files can be written there as well, maybe we change the name of that variable later. But for now we focus on backups.
-        $NetworkPath = $TestConfig.Temp
         $random = Get-Random
+        $NetworkPath = Join-Path -Path $TestConfig.Temp -ChildPath "dbatoolsci_copydatabase$random"
+        $null = New-Item -Path $NetworkPath -ItemType Directory -Force
         $backuprestoredb = "dbatoolsci_backuprestore$random"
         $backuprestoredb2 = "dbatoolsci_backuprestoreother$random"
         $detachattachdb = "dbatoolsci_detachattach$random"
@@ -105,6 +106,10 @@ Describe $CommandName -Tag IntegrationTests {
             Database    = $supportDbs
         }
         Remove-DbaDatabase @splatRemoveSupport -ErrorAction SilentlyContinue
+
+        # The backups taken during the tests stay behind otherwise, and every test file that runs
+        # afterwards then reports them as leftovers of its own.
+        Remove-Item -Path $NetworkPath -Recurse -Force -ErrorAction SilentlyContinue
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }

--- a/tests/Invoke-DbaDbMirroring.Tests.ps1
+++ b/tests/Invoke-DbaDbMirroring.Tests.ps1
@@ -58,6 +58,10 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceCopy1, $TestConfig.InstanceCopy2 -Database $dbName
         $null = Remove-DbaEndpoint -SqlInstance $TestConfig.InstanceCopy1, $TestConfig.InstanceCopy2 -EndPoint $endpointName
 
+        # Seeding the mirror leaves the full backup and the log backup in the shared folder, and every
+        # test file that runs afterwards then reports them as leftovers of its own.
+        Get-ChildItem -Path $TestConfig.Temp -Filter "$dbName*" | Remove-Item -Force -ErrorAction SilentlyContinue
+
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 


### PR DESCRIPTION
Three test files left backup files behind in the lab. Found by running the full suite and checking the
environment after every test file.

The count is worth stating, because it is what makes this worth fixing rather than tidy-up: the environment
check reports every file it finds, so **one** leftover from the 34th test file made **709 of 742 files** in a
full run look like they had left something behind. That buries a real leftover from a later file in noise.

## Connect-DbaInstance

```powershell
$results = Backup-DbaDatabase -SqlInstance $server -Database msdb
if ($results.FullName) {
    Remove-Item -Path $results.FullName -ErrorAction SilentlyContinue
}
```

The cleanup was already there and looks correct, but it never worked against a remote instance. Without
`-Path` the backup lands in the default backup folder **of the instance**, so `$results.FullName` is a path on
the SQL Server. `Remove-Item` runs on the machine executing the tests, where that path does not exist, and
`-ErrorAction SilentlyContinue` swallows the failure. The backup stayed on the instance every time.

It now backs up to the shared temp folder, where the cleanup can actually reach the file. This test only cares
that `Connect-DbaInstance` clones the server object correctly, so where the backup goes is incidental.

## Copy-DbaDatabase

The file already said what should happen:

```powershell
# For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
$NetworkPath = $TestConfig.Temp
```

but the variable pointed at the shared temp folder itself and nothing ever deleted anything. It now creates a
directory per run and removes it in `AfterAll`, which is what the comment always described.

## Invoke-DbaDbMirroring

Seeding the mirror leaves a full backup and a log backup in the shared folder. `AfterAll` removed the mirror,
the databases and the endpoints, but not those two files.

## Testing

All three files pass and the environment check reports no leftovers afterwards, with the shared temp folder
empty at the end:

| | |
| --- | --- |
| `Connect-DbaInstance.Tests.ps1` | 28 passed / 1 skipped |
| `Copy-DbaDatabase.Tests.ps1` | 28 passed |
| `Invoke-DbaDbMirroring.Tests.ps1` | 2 passed |

The one warning `Copy-DbaDatabase.Tests.ps1` still writes (`Set-DbaDbOwner ... is not accessible`) is a
separate, real problem in its setup and is deliberately left visible rather than silenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
