### PR TITLE
Import-DbaParquet - Release the parquet file when the import is done

### DIFF
--- a/public/Import-DbaParquet.ps1
+++ b/public/Import-DbaParquet.ps1
@@ -315,7 +315,12 @@ function Import-DbaParquet {
             param([string]$Path)
             $stream = [System.IO.File]::OpenRead($Path)
             try {
-                $reader = [Parquet.ParquetReader]::CreateAsync($stream).GetAwaiter().GetResult()
+                # leaveStreamOpen has to be passed as false. It defaults to true, which means disposing the
+                # reader leaves the file stream open and the file stays locked until the garbage collector
+                # finalizes it - so the imported file could not be deleted or overwritten for an arbitrary
+                # time after the import finished. All four arguments are passed because the overload that
+                # takes a stream can only be selected by its full signature.
+                $reader = [Parquet.ParquetReader]::CreateAsync($stream, $null, $false, [System.Threading.CancellationToken]::None).GetAwaiter().GetResult()
                 return $reader
             } catch {
                 $stream.Dispose()


### PR DESCRIPTION
Fixes #10542.

`Import-DbaParquet` kept the imported file locked after the import had finished, until the garbage collector
got around to finalizing the stream. How long that took varied from run to run, so a file could not reliably
be deleted, moved or overwritten right after importing it.

## Cause

`Get-ParquetReader` opens a file stream and passes it to Parquet.NET without saying what should happen to it:

```powershell
$reader = [Parquet.ParquetReader]::CreateAsync($stream).GetAwaiter().GetResult()
```

The overload in play is

```
CreateAsync(Stream input, ParquetOptions parquetOptions = null, Boolean leaveStreamOpen = True, CancellationToken cancellationToken)
```

`leaveStreamOpen` **defaults to true**, so disposing the reader deliberately leaves the stream open. The
command does dispose the reader, but nothing disposes the stream, so the handle lived until finalization.

`leaveStreamOpen` is now passed as `false`. All four arguments are passed explicitly because the stream
overload can only be selected by its full signature - with fewer arguments the `string filePath` overload is a
candidate too.

## Testing

The symptom that made this visible was a test that could not clean up after itself: on PowerShell 7 the Pester
run failed in `Remove-TestDrive` with `The process cannot access the file 'staging.ecdc_parquet_test.parquet'
because it is being used by another process`, while all 17 tests passed. It failed **about every other run**,
which is why it read as test flakiness rather than a defect.

| | before | after |
| --- | --- | --- |
| `Import-DbaParquet.Tests.ps1` on PowerShell 7.4, five consecutive runs | failed ~1 in 2 | **5 of 5 clean** |
| `Import-DbaParquet.Tests.ps1` on Windows PowerShell 5.1 | 17 of 17 | **17 of 17** |

No test change was needed - the test was right and the command was wrong.

> [!NOTE]
> This touches the same file as #10538 and #10541 but a different part of it. All three merge cleanly, verified
> by merging them locally and running the tests above against the combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
