### PR TITLE
Set-DbaPrivilege - Write secedit's working database to temp, not cwd

### DIFF
--- a/public/Set-DbaPrivilege.ps1
+++ b/public/Set-DbaPrivilege.ps1
@@ -112,12 +112,16 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                         }
                         if ($SQLServiceAccounts.count -ge 1) {
                             Write-Message -Level Verbose -Message "Setting Privileges on $Computer"
-                            Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -Verbose -ArgumentList $ResolveAccountToSID, $SQLServiceAccounts, $SQLPerServiceSIDs, $Type -ScriptBlock {
+                            # A random token keeps this invocation's secedit database from colliding with
+                            # (or being deleted by) another concurrent Set-DbaPrivilege run against the same computer.
+                            $dbToken = Get-Random
+                            Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -Verbose -ArgumentList $ResolveAccountToSID, $SQLServiceAccounts, $SQLPerServiceSIDs, $Type, $dbToken -ScriptBlock {
                                 [CmdletBinding()]
                                 param ($ResolveAccountToSID,
                                     $SQLServiceAccounts,
                                     $SQLPerServiceSIDs,
-                                    $Type
+                                    $Type,
+                                    $DbToken
                                 )
                                 . ([ScriptBlock]::Create($ResolveAccountToSID))
                                 $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
@@ -254,15 +258,21 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                                         }
                                     }
                                 }
-                                $null = secedit /configure /cfg $tempfile /db $temp\secedit.sdb /areas USER_RIGHTS /overwrite /quiet
+                                $null = secedit /configure /cfg $tempfile /db $temp\secedit-$DbToken.sdb /areas USER_RIGHTS /overwrite /quiet
                             }
                             Write-Message -Level Verbose -Message "Removing secpol file on $computer"
-                            Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ScriptBlock {
+                            Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ArgumentList $dbToken -ScriptBlock {
+                                param ($DbToken)
                                 $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("")
                                 Remove-Item $temp\secpolByDbatools.cfg -Force > $NULL
                                 # secedit's /configure /db creates a database file plus a matching .jfm journal
                                 # file next to it; both live in $temp now instead of leaking into the caller's cwd.
-                                Remove-Item $temp\secedit.sdb, $temp\secedit.jfm -Force -ErrorAction SilentlyContinue > $NULL
+                                $splatRemoveSeceditDb = @{
+                                    Path        = "$temp\secedit-$DbToken.sdb", "$temp\secedit-$DbToken.jfm"
+                                    Force       = $true
+                                    ErrorAction = "SilentlyContinue"
+                                }
+                                Remove-Item @splatRemoveSeceditDb > $NULL
                             }
                         } else {
                             Write-Message -Level Warning -Message "No SQL Service Accounts found on $Computer"

--- a/public/Set-DbaPrivilege.ps1
+++ b/public/Set-DbaPrivilege.ps1
@@ -254,10 +254,16 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                                         }
                                     }
                                 }
-                                $null = secedit /configure /cfg $tempfile /db secedit.sdb /areas USER_RIGHTS /overwrite /quiet
+                                $null = secedit /configure /cfg $tempfile /db $temp\secedit.sdb /areas USER_RIGHTS /overwrite /quiet
                             }
                             Write-Message -Level Verbose -Message "Removing secpol file on $computer"
-                            Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ScriptBlock { $temp = ([System.IO.Path]::GetTempPath()).TrimEnd(""); Remove-Item $temp\secpolByDbatools.cfg -Force > $NULL }
+                            Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ScriptBlock {
+                                $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("")
+                                Remove-Item $temp\secpolByDbatools.cfg -Force > $NULL
+                                # secedit's /configure /db creates a database file plus a matching .jfm journal
+                                # file next to it; both live in $temp now instead of leaking into the caller's cwd.
+                                Remove-Item $temp\secedit.sdb, $temp\secedit.jfm -Force -ErrorAction SilentlyContinue > $NULL
+                            }
                         } else {
                             Write-Message -Level Warning -Message "No SQL Service Accounts found on $Computer"
                         }

--- a/public/Set-DbaPrivilege.ps1
+++ b/public/Set-DbaPrivilege.ps1
@@ -92,9 +92,21 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                     $null = Test-ElevationRequirement -ComputerName $Computer -Continue
                     if (Test-PSRemoting -ComputerName $Computer) {
                         Write-Message -Level Verbose -Message "Exporting Privileges on $Computer"
-                        Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ScriptBlock {
-                            $temp = ([System.IO.Path]::GetTempPath()).TrimEnd(""); secedit /export /cfg $temp\secpolByDbatools.cfg > $NULL;
+                        # A random token keeps this invocation's secedit cfg/db/jfm files from colliding with
+                        # (or being deleted by) another concurrent Set-DbaPrivilege run against the same computer.
+                        $seceditRunToken = Get-Random
+                        $exportPrivilegesScriptBlock = {
+                            param ($ExportRunToken)
+                            $temp = ([System.IO.Path]::GetTempPath()).TrimEnd(""); secedit /export /cfg $temp\secpolByDbatools-$ExportRunToken.cfg > $NULL;
                         }
+                        $splatExportPrivileges = @{
+                            Raw          = $true
+                            ComputerName = $computer
+                            Credential   = $Credential
+                            ArgumentList = $seceditRunToken
+                            ScriptBlock  = $exportPrivilegesScriptBlock
+                        }
+                        Invoke-Command2 @splatExportPrivileges
 
                         $SQLServiceAccounts = @()
                         $SQLPerServiceSIDs = @()
@@ -112,20 +124,17 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                         }
                         if ($SQLServiceAccounts.count -ge 1) {
                             Write-Message -Level Verbose -Message "Setting Privileges on $Computer"
-                            # A random token keeps this invocation's secedit database from colliding with
-                            # (or being deleted by) another concurrent Set-DbaPrivilege run against the same computer.
-                            $dbToken = Get-Random
-                            Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -Verbose -ArgumentList $ResolveAccountToSID, $SQLServiceAccounts, $SQLPerServiceSIDs, $Type, $dbToken -ScriptBlock {
+                            $setPrivilegesScriptBlock = {
                                 [CmdletBinding()]
                                 param ($ResolveAccountToSID,
                                     $SQLServiceAccounts,
                                     $SQLPerServiceSIDs,
                                     $Type,
-                                    $DbToken
+                                    $ConfigureRunToken
                                 )
                                 . ([ScriptBlock]::Create($ResolveAccountToSID))
                                 $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
-                                $tempfile = "$temp\secpolByDbatools.cfg"
+                                $tempfile = "$temp\secpolByDbatools-$ConfigureRunToken.cfg"
                                 if ('BatchLogon' -in $Type) {
                                     $BLline = Get-Content $tempfile | Where-Object { $_ -match "SeBatchLogonRight" }
                                     ForEach ($acc in $SQLServiceAccounts) {
@@ -258,22 +267,39 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                                         }
                                     }
                                 }
-                                $null = secedit /configure /cfg $tempfile /db $temp\secedit-$DbToken.sdb /areas USER_RIGHTS /overwrite /quiet
+                                $null = secedit /configure /cfg $tempfile /db $temp\secedit-$ConfigureRunToken.sdb /areas USER_RIGHTS /overwrite /quiet
                             }
+                            $splatSetPrivileges = @{
+                                Raw          = $true
+                                ComputerName = $computer
+                                Credential   = $Credential
+                                Verbose      = $true
+                                ArgumentList = $ResolveAccountToSID, $SQLServiceAccounts, $SQLPerServiceSIDs, $Type, $seceditRunToken
+                                ScriptBlock  = $setPrivilegesScriptBlock
+                            }
+                            Invoke-Command2 @splatSetPrivileges
+
                             Write-Message -Level Verbose -Message "Removing secpol file on $computer"
-                            Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ArgumentList $dbToken -ScriptBlock {
-                                param ($DbToken)
+                            $removeSecpolScriptBlock = {
+                                param ($CleanupRunToken)
                                 $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("")
-                                Remove-Item $temp\secpolByDbatools.cfg -Force > $NULL
                                 # secedit's /configure /db creates a database file plus a matching .jfm journal
                                 # file next to it; both live in $temp now instead of leaking into the caller's cwd.
-                                $splatRemoveSeceditDb = @{
-                                    Path        = "$temp\secedit-$DbToken.sdb", "$temp\secedit-$DbToken.jfm"
+                                $splatRemoveSeceditFiles = @{
+                                    Path        = "$temp\secpolByDbatools-$CleanupRunToken.cfg", "$temp\secedit-$CleanupRunToken.sdb", "$temp\secedit-$CleanupRunToken.jfm"
                                     Force       = $true
                                     ErrorAction = "SilentlyContinue"
                                 }
-                                Remove-Item @splatRemoveSeceditDb > $NULL
+                                Remove-Item @splatRemoveSeceditFiles > $NULL
                             }
+                            $splatRemoveSecpolFile = @{
+                                Raw          = $true
+                                ComputerName = $computer
+                                Credential   = $Credential
+                                ArgumentList = $seceditRunToken
+                                ScriptBlock  = $removeSecpolScriptBlock
+                            }
+                            Invoke-Command2 @splatRemoveSecpolFile
                         } else {
                             Write-Message -Level Warning -Message "No SQL Service Accounts found on $Computer"
                         }

--- a/tests/Set-DbaPrivilege.Tests.ps1
+++ b/tests/Set-DbaPrivilege.Tests.ps1
@@ -167,6 +167,8 @@ Describe $CommandName -Tag IntegrationTests {
                 Remove-Item @splatRemoveRevertArtifacts
             }
         }
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Does not leave secedit artifacts behind" {

--- a/tests/Set-DbaPrivilege.Tests.ps1
+++ b/tests/Set-DbaPrivilege.Tests.ps1
@@ -55,7 +55,7 @@ InModuleScope dbatools {
                     return
                 }
 
-                if ($ArgumentList.Count -gt 0) {
+                if ($ScriptBlock.ToString() -match "secedit /configure") {
                     & $ScriptBlock @ArgumentList
                     $script:capturedPolicyContent = Get-Content -Path $script:policyFile
                     return
@@ -87,6 +87,12 @@ InModuleScope dbatools {
     }
 }
 
+<#
+    Integration test should appear below and are custom to the command you are writing.
+    Read https://github.com/dataplat/dbatools/blob/development/contributing.md#tests
+    for more guidence.
+#>
+
 Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
@@ -102,46 +108,90 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
         # Revert the grant unless the user already held the privilege before the test: strip the
         # SID position-independently (secedit re-sorts the SID list on export) and re-apply.
         if (-not $hadCreateGlobalObjects) {
-            $tempPath = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
-            $revertCfg = "$tempPath\secpolRevertByDbatoolsci.cfg"
-            $null = secedit /export /cfg $revertCfg
-            $revertContent = Get-Content -Path $revertCfg | ForEach-Object {
-                if ($PSItem -match "^SeCreateGlobalPrivilege") {
-                    ($PSItem -replace ("\*" + [regex]::Escape($currentSid) + ",?"), "") -replace ",\s*$", ""
-                } else {
-                    $PSItem
+            $revertTempPath = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
+            $revertBaseName = "secpolRevertByDbatoolsci-$(Get-Random)"
+            $revertCfg = "$revertTempPath\$revertBaseName.cfg"
+            $revertDb = "$revertTempPath\$revertBaseName.sdb"
+            $revertJfm = "$revertTempPath\$revertBaseName.jfm"
+
+            try {
+                $null = secedit /export /cfg $revertCfg
+                if ($LASTEXITCODE -ne 0) {
+                    throw "secedit /export failed with exit code $LASTEXITCODE while reverting CreateGlobalObjects for $currentUser"
                 }
+
+                $revertContent = Get-Content -Path $revertCfg | ForEach-Object {
+                    if ($PSItem -match "^SeCreateGlobalPrivilege") {
+                        ($PSItem -replace ("\*" + [regex]::Escape($currentSid) + "(,|$)"), "") -replace ",\s*$", ""
+                    } else {
+                        $PSItem
+                    }
+                }
+
+                $splatWriteRevertCfg = @{
+                    Path     = $revertCfg
+                    Value    = $revertContent
+                    Encoding = "Unicode"
+                }
+                Set-Content @splatWriteRevertCfg
+
+                $null = secedit /configure /cfg $revertCfg /db $revertDb /areas USER_RIGHTS /overwrite /quiet
+                if ($LASTEXITCODE -ne 0) {
+                    throw "secedit /configure failed with exit code $LASTEXITCODE while reverting CreateGlobalObjects for $currentUser"
+                }
+            } finally {
+                $splatRemoveRevertArtifacts = @{
+                    Path        = $revertCfg, $revertDb, $revertJfm
+                    Force       = $true
+                    ErrorAction = "SilentlyContinue"
+                }
+                Remove-Item @splatRemoveRevertArtifacts
             }
-            Set-Content -Path $revertCfg -Value $revertContent -Encoding Unicode
-            $null = secedit /configure /cfg $revertCfg /db "$tempPath\secpolRevertByDbatoolsci.sdb" /areas USER_RIGHTS /overwrite /quiet
-            Remove-Item -Path $revertCfg, "$tempPath\secpolRevertByDbatoolsci.sdb" -Force -ErrorAction SilentlyContinue
         }
     }
 
     Context "Does not leave secedit artifacts behind" {
-        It "Does not create secedit.sdb or secedit.jfm in the working directory" {
+        It "Writes secedit's working database to temp, not the working directory, and cleans it up" {
             $workingDirectory = (Get-Location).Path
+            $artifactTempPath = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
 
-            $splatSetPrivilege = @{
-                ComputerName = $env:COMPUTERNAME
-                Type         = "CreateGlobalObjects"
-                User         = $currentUser
-                Confirm      = $false
+            # Watch temp for the working database secedit creates for /db, so this test proves the
+            # file was actually routed to temp during the run, not just absent from cwd afterward.
+            $seceditWatcher = New-Object -TypeName System.IO.FileSystemWatcher
+            $seceditWatcher.Path = $artifactTempPath
+            $seceditWatcher.Filter = "secedit-*.sdb"
+            $seceditWatcher.EnableRaisingEvents = $true
+            $seceditWatcherSourceId = "SetDbaPrivilegeSeceditDbCreated-$(Get-Random)"
+            $null = Register-ObjectEvent -InputObject $seceditWatcher -EventName Created -SourceIdentifier $seceditWatcherSourceId
+
+            try {
+                $splatGrantCreateGlobalObjects = @{
+                    ComputerName    = $env:COMPUTERNAME
+                    Type            = "CreateGlobalObjects"
+                    User            = $currentUser
+                    Confirm         = $false
+                    EnableException = $true
+                }
+                $null = Set-DbaPrivilege @splatGrantCreateGlobalObjects
+
+                $seceditDbCreatedEvents = Get-Event -SourceIdentifier $seceditWatcherSourceId -ErrorAction SilentlyContinue
+                $seceditDbCreatedEvents | Should -Not -BeNullOrEmpty -Because "secedit's /db database should be created under $artifactTempPath while Set-DbaPrivilege runs"
+
+                Get-ChildItem -Path $workingDirectory -Filter "secedit-*.sdb" -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+                Get-ChildItem -Path $workingDirectory -Filter "secedit-*.jfm" -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+                Get-ChildItem -Path $artifactTempPath -Filter "secedit-*.sdb" -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+                Get-ChildItem -Path $artifactTempPath -Filter "secedit-*.jfm" -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+            } finally {
+                Unregister-Event -SourceIdentifier $seceditWatcherSourceId -ErrorAction SilentlyContinue
+                Remove-Event -SourceIdentifier $seceditWatcherSourceId -ErrorAction SilentlyContinue
+                $seceditWatcher.Dispose()
             }
-            $null = Set-DbaPrivilege @splatSetPrivilege 3>$null
-
-            Join-Path -Path $workingDirectory -ChildPath "secedit.sdb" | Should -Not -Exist
-            Join-Path -Path $workingDirectory -ChildPath "secedit.jfm" | Should -Not -Exist
-        }
-
-        It "Does not leave secedit.sdb or secedit.jfm behind in the temp directory either" {
-            $tempPath = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
-
-            Join-Path -Path $tempPath -ChildPath "secedit.sdb" | Should -Not -Exist
-            Join-Path -Path $tempPath -ChildPath "secedit.jfm" | Should -Not -Exist
         }
     }
 }

--- a/tests/Set-DbaPrivilege.Tests.ps1
+++ b/tests/Set-DbaPrivilege.Tests.ps1
@@ -34,7 +34,7 @@ InModuleScope dbatools {
         }
 
         BeforeEach {
-            $script:policyFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "secpolByDbatools.cfg"
+            $script:policyFile = $null
             $script:capturedPolicyContent = $null
 
             Mock Test-ElevationRequirement { $true }
@@ -46,6 +46,12 @@ InModuleScope dbatools {
                     $ScriptBlock,
                     $ArgumentList
                 )
+
+                # Set-DbaPrivilege passes the same per-run token to every call it makes (export,
+                # configure, cleanup); it is always the last element so this reads it regardless of
+                # whether $ArgumentList is that lone token or the configure call's 5-element list.
+                $runToken = if ($ArgumentList -is [array]) { $ArgumentList[-1] } else { $ArgumentList }
+                $script:policyFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "secpolByDbatools-$runToken.cfg"
 
                 if ($ScriptBlock.ToString() -match "secedit /export /cfg") {
                     Set-Content -Path $script:policyFile -Value @(
@@ -98,10 +104,15 @@ Describe $CommandName -Tag IntegrationTests {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
+        # Guards the AfterAll revert: only trust $hadCreateGlobalObjects once we know it was
+        # actually captured. If this block throws partway through, $preTestStateCaptured stays
+        # $false and AfterAll leaves the machine alone instead of guessing at the prior state.
+        $preTestStateCaptured = $false
         $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
         $currentSid = ([System.Security.Principal.NTAccount]$currentUser).Translate([System.Security.Principal.SecurityIdentifier]).Value
         $privilegeBefore = Get-DbaPrivilege -ComputerName $env:COMPUTERNAME 3>$null | Where-Object User -eq $currentUser
         $hadCreateGlobalObjects = $privilegeBefore.CreateGlobalObjects -eq $true
+        $preTestStateCaptured = $true
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
@@ -113,7 +124,9 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Revert the grant unless the user already held the privilege before the test: strip the
         # SID position-independently (secedit re-sorts the SID list on export) and re-apply.
-        if (-not $hadCreateGlobalObjects) {
+        # Skip entirely if BeforeAll never confirmed the prior state - reverting on an unknown
+        # state risks stripping a privilege the user genuinely held before this test ran.
+        if ($preTestStateCaptured -and -not $hadCreateGlobalObjects) {
             $revertTempPath = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
             $revertBaseName = "secpolRevertByDbatoolsci-$(Get-Random)"
             $revertCfg = "$revertTempPath\$revertBaseName.cfg"
@@ -168,7 +181,12 @@ Describe $CommandName -Tag IntegrationTests {
             $seceditWatcher.Filter = "secedit-*.sdb"
             $seceditWatcher.EnableRaisingEvents = $true
             $seceditWatcherSourceId = "SetDbaPrivilegeSeceditDbCreated-$(Get-Random)"
-            $null = Register-ObjectEvent -InputObject $seceditWatcher -EventName Created -SourceIdentifier $seceditWatcherSourceId
+            $splatRegisterSeceditWatcher = @{
+                InputObject      = $seceditWatcher
+                EventName        = "Created"
+                SourceIdentifier = $seceditWatcherSourceId
+            }
+            $null = Register-ObjectEvent @splatRegisterSeceditWatcher
 
             try {
                 $splatGrantCreateGlobalObjects = @{
@@ -180,13 +198,32 @@ Describe $CommandName -Tag IntegrationTests {
                 }
                 $null = Set-DbaPrivilege @splatGrantCreateGlobalObjects
 
-                $seceditDbCreatedEvents = Get-Event -SourceIdentifier $seceditWatcherSourceId -ErrorAction SilentlyContinue
-                $seceditDbCreatedEvents | Should -Not -BeNullOrEmpty -Because "secedit's /db database should be created under $artifactTempPath while Set-DbaPrivilege runs"
+                # FileSystemWatcher delivers Created events on a background thread and queues them
+                # asynchronously, so even though Set-DbaPrivilege above has already returned, the event
+                # may not have reached the PowerShell event queue yet - wait for it instead of polling once.
+                $seceditDbCreatedEvent = Wait-Event -SourceIdentifier $seceditWatcherSourceId -Timeout 10
+                $seceditDbCreatedEvent | Should -Not -BeNullOrEmpty -Because "secedit's /db database should be created under $artifactTempPath while Set-DbaPrivilege runs"
 
-                Get-ChildItem -Path $workingDirectory -Filter "secedit-*.sdb" -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
-                Get-ChildItem -Path $workingDirectory -Filter "secedit-*.jfm" -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
-                Get-ChildItem -Path $artifactTempPath -Filter "secedit-*.sdb" -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
-                Get-ChildItem -Path $artifactTempPath -Filter "secedit-*.jfm" -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+                # Track the exact file(s) the watcher actually saw created, instead of re-scanning temp
+                # with the same wildcard afterward - a re-scan can't tell this invocation's artifact
+                # apart from a leftover or a concurrent Set-DbaPrivilege run against the same computer.
+                $observedSeceditDbPaths = (Get-Event -SourceIdentifier $seceditWatcherSourceId).SourceEventArgs.FullPath | Select-Object -Unique
+                $observedSeceditDbPaths | Should -Not -BeNullOrEmpty -Because "the watcher event should carry the created database's path"
+
+                foreach ($observedSeceditDbPath in $observedSeceditDbPaths) {
+                    $observedSeceditJfmPath = [System.IO.Path]::ChangeExtension($observedSeceditDbPath, "jfm")
+                    Test-Path -Path $observedSeceditDbPath | Should -BeFalse -Because "$observedSeceditDbPath should have been cleaned up after Set-DbaPrivilege ran"
+                    Test-Path -Path $observedSeceditJfmPath | Should -BeFalse -Because "$observedSeceditJfmPath should have been cleaned up after Set-DbaPrivilege ran"
+                }
+
+                # Legacy regression guard: earlier versions of Set-DbaPrivilege wrote a hardcoded
+                # secedit.sdb/secedit.jfm pair (no per-run token) straight into the working directory.
+                $splatCheckWorkingDirectoryArtifacts = @{
+                    Path        = $workingDirectory
+                    Include     = "secedit-*.sdb", "secedit-*.jfm", "secedit.sdb", "secedit.jfm"
+                    ErrorAction = "SilentlyContinue"
+                }
+                Get-ChildItem @splatCheckWorkingDirectoryArtifacts | Should -BeNullOrEmpty
             } finally {
                 Unregister-Event -SourceIdentifier $seceditWatcherSourceId -ErrorAction SilentlyContinue
                 Remove-Event -SourceIdentifier $seceditWatcherSourceId -ErrorAction SilentlyContinue

--- a/tests/Set-DbaPrivilege.Tests.ps1
+++ b/tests/Set-DbaPrivilege.Tests.ps1
@@ -86,8 +86,62 @@ InModuleScope dbatools {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/dataplat/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+        $currentSid = ([System.Security.Principal.NTAccount]$currentUser).Translate([System.Security.Principal.SecurityIdentifier]).Value
+        $privilegeBefore = Get-DbaPrivilege -ComputerName $env:COMPUTERNAME 3>$null | Where-Object User -eq $currentUser
+        $hadCreateGlobalObjects = $privilegeBefore.CreateGlobalObjects -eq $true
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # Revert the grant unless the user already held the privilege before the test: strip the
+        # SID position-independently (secedit re-sorts the SID list on export) and re-apply.
+        if (-not $hadCreateGlobalObjects) {
+            $tempPath = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
+            $revertCfg = "$tempPath\secpolRevertByDbatoolsci.cfg"
+            $null = secedit /export /cfg $revertCfg
+            $revertContent = Get-Content -Path $revertCfg | ForEach-Object {
+                if ($PSItem -match "^SeCreateGlobalPrivilege") {
+                    ($PSItem -replace ("\*" + [regex]::Escape($currentSid) + ",?"), "") -replace ",\s*$", ""
+                } else {
+                    $PSItem
+                }
+            }
+            Set-Content -Path $revertCfg -Value $revertContent -Encoding Unicode
+            $null = secedit /configure /cfg $revertCfg /db "$tempPath\secpolRevertByDbatoolsci.sdb" /areas USER_RIGHTS /overwrite /quiet
+            Remove-Item -Path $revertCfg, "$tempPath\secpolRevertByDbatoolsci.sdb" -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context "Does not leave secedit artifacts behind" {
+        It "Does not create secedit.sdb or secedit.jfm in the working directory" {
+            $workingDirectory = (Get-Location).Path
+
+            $splatSetPrivilege = @{
+                ComputerName = $env:COMPUTERNAME
+                Type         = "CreateGlobalObjects"
+                User         = $currentUser
+                Confirm      = $false
+            }
+            $null = Set-DbaPrivilege @splatSetPrivilege 3>$null
+
+            Join-Path -Path $workingDirectory -ChildPath "secedit.sdb" | Should -Not -Exist
+            Join-Path -Path $workingDirectory -ChildPath "secedit.jfm" | Should -Not -Exist
+        }
+
+        It "Does not leave secedit.sdb or secedit.jfm behind in the temp directory either" {
+            $tempPath = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
+
+            Join-Path -Path $tempPath -ChildPath "secedit.sdb" | Should -Not -Exist
+            Join-Path -Path $tempPath -ChildPath "secedit.jfm" | Should -Not -Exist
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A user reported that `Set-DbaPrivilege` leaves `secedit.sdb` and `secedit.jfm` behind in the current working directory after it runs.

Root cause: the command calls `secedit /configure /cfg $tempfile /db secedit.sdb /areas USER_RIGHTS /overwrite /quiet`. `/db` takes a bare, relative filename, which `secedit.exe` resolves against the process's current directory - not `$env:TEMP` - so the working database (and its `.jfm` journal file) land wherever the caller's shell happened to be.

- `public/Set-DbaPrivilege.ps1`: `secedit`'s three working files - the exported `.cfg`, the `/db` database `.sdb`, and its `.jfm` journal - all now live under an absolute `$temp` path, named with a single `Get-Random` token generated once per invocation and threaded through the export, configure, and cleanup `Invoke-Command2` calls via splatted `-ArgumentList`. Tokenizing all three (not just the `.sdb`/`.jfm` pair) matters: two `Set-DbaPrivilege` runs against the same computer at the same time would otherwise still collide on, or delete, each other's shared `.cfg` file and apply the wrong privileges. Cleanup removes all three tokenized files alongside the working database.
- `tests/Set-DbaPrivilege.Tests.ps1`: added a real (non-mocked) `IntegrationTests` `Describe` block. A single combined test grants `CreateGlobalObjects`, watches temp with a `FileSystemWatcher` (via a bounded `Wait-Event`) to positively confirm the tokenized `.sdb` database is actually created under temp during the run, tracks the exact path(s) observed and confirms they're gone afterward, and separately checks the working directory for both the tokenized pattern and the legacy hardcoded `secedit.sdb`/`secedit.jfm` names (so a regression back to the pre-fix filename would still be caught). `AfterAll` reverts the granted privilege unless the user already held it, only doing so once `BeforeAll` has actually confirmed the prior state, validating `secedit`'s exit code, and cleaning up its own scratch files in a `finally` block.

This same bug also exists in the compiled C# port (`dbatools.library`, `SetDbaPrivilegeCommand.cs`) - see the companion PR at dataplat/dbatools.library.

### Follow-up fixes from automated review (2 rounds)

- Fixed the pre-existing `Invoke-Command2` mock in the `Set-DbaPrivilege regressions` unit test, which discriminated "set privileges" vs. "cleanup" calls by `$ArgumentList.Count`, and later derives the same per-run token dbatools now uses so its fabricated `.cfg` path matches what the real scriptblock reads/writes.
- Fixed a SID-removal regex in the integration test's `AfterAll` that could match a SID as a string-prefix of a different, longer SID sharing the same prefix.
- Splatted every `Invoke-Command2`/`Register-ObjectEvent`/`Get-ChildItem` call that grew to 3+ parameters, with purpose-specific variable names for the per-run token in each scope (`seceditRunToken`, `ExportRunToken`, `ConfigureRunToken`, `CleanupRunToken`) instead of reusing one name across scopes.
- Guarded the `AfterAll` revert on a `$preTestStateCaptured` flag so a `BeforeAll` failure can't be misread as "user didn't already have the privilege" and trigger an unwanted revert.
- Replaced an immediate post-call `Get-Event` with a bounded `Wait-Event`, since `FileSystemWatcher` delivers `Created` events asynchronously and a same-tick poll can race the event queue.

## Verification limitation

My local shell isn't elevated, and both `secedit.exe` and dbatools' own `Test-ElevationRequirement` check require Administrator rights for a localhost target. I confirmed:
- AST parse of both changed files is clean.
- The `UnitTests`-tagged tests (parameter validation + the `Mock`-based regression test) pass locally.
- The new `IntegrationTests` test fails locally, but only for the expected/honest reason: `Set-DbaPrivilege` throws `Console not elevated, but elevation is required...` via its own `Test-ElevationRequirement` check, and the `AfterAll` revert fails with `secedit /export failed with exit code 740` (`ERROR_ELEVATION_REQUIRED`) for the same reason. Neither the `FileSystemWatcher` assertion nor the `/db` path fix has been exercised end-to-end on my machine - that needs a run on the elevated self-hosted CI runner to be conclusive.

## Test plan

- [ ] CI runs `Set-DbaPrivilege` `IntegrationTests` on the elevated self-hosted runner and the new test passes
- [x] `UnitTests` pass locally
- [x] AST parse clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
