### PR TITLE
Export-DbaInstance - Script us_english custom errors before their translations

### DIFF
--- a/public/Export-DbaInstance.ps1
+++ b/public/Export-DbaInstance.ps1
@@ -339,7 +339,13 @@ function Export-DbaInstance {
                     if ($Exclude -notcontains 'CustomErrors') {
                         Write-Message -Level Verbose -Message "Exporting custom errors (user defined messages)"
                         Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Exporting custom errors (user defined messages)"
-                        $null = Get-DbaCustomError -SqlInstance $server -EnableException:$EnableException | Export-DbaScript -FilePath "$exportPath\customererrors.sql" -BatchSeparator $BatchSeparator -ScriptingOptionsObject $ScriptingOption -NoPrefix:$NoPrefix -EnableException:$EnableException
+                        # sp_addmessage rejects a localized message whose us_english version does not exist yet,
+                        # and SMO returns the messages sorted by language name. So we script all us_english
+                        # messages first, the same way Copy-DbaCustomError orders them.
+                        $allCustomErrors = @(Get-DbaCustomError -SqlInstance $server -EnableException:$EnableException)
+                        $orderedCustomErrors = @($allCustomErrors | Where-Object Language -eq "us_english")
+                        $orderedCustomErrors += $allCustomErrors | Where-Object Language -ne "us_english"
+                        $null = $orderedCustomErrors | Export-DbaScript -FilePath "$exportPath\customererrors.sql" -BatchSeparator $BatchSeparator -ScriptingOptionsObject $ScriptingOption -NoPrefix:$NoPrefix -EnableException:$EnableException
                         Get-ChildItem -ErrorAction Ignore -Path "$exportPath\customererrors.sql"
                     }
 

--- a/tests/Export-DbaInstance.Tests.ps1
+++ b/tests/Export-DbaInstance.Tests.ps1
@@ -433,6 +433,15 @@ Describe $CommandName -Tag IntegrationTests {
         $null = Invoke-DbaQuery -SqlInstance $testServer -Database master -Query "EXEC sp_addmessage 250000, 16, N'Sample error message1'"
         $null = Invoke-DbaQuery -SqlInstance $testServer -Database master -Query "EXEC sp_addmessage 250001, 16, N'Sample error message2'"
 
+        # A second language for one of the custom errors. sp_addmessage only accepts a localized message
+        # when the us_english version of that message id already exists, so the export has to script the
+        # us_english messages first. The language name is built from a char code to keep this file ASCII.
+        $frenchLanguage = "Fran" + [char]0xE7 + "ais"
+        $addFrenchCustomErrorQuery = @"
+EXEC sp_addmessage 250000, 16, N'Exemple de message1', @lang = '$frenchLanguage'
+"@
+        $null = Invoke-DbaQuery -SqlInstance $testServer -Database master -Query $addFrenchCustomErrorQuery
+
         # credentials
         New-DbaCredential -SqlInstance $testServer -Name "dbatools1$random" -Identity "dbatools1$random" -SecurePassword (ConvertTo-SecureString -String "dbatools1" -AsPlainText -Force)
         New-DbaCredential -SqlInstance $testServer -Name "dbatools2$random" -Identity "dbatools2$random" -SecurePassword (ConvertTo-SecureString -String "dbatools2" -AsPlainText -Force)
@@ -511,9 +520,15 @@ Describe $CommandName -Tag IntegrationTests {
         Get-DbaRegServer -SqlInstance $testServer | Where-Object Name -Match dbatoolsci | Remove-DbaRegServer
         Get-DbaRegServerGroup -SqlInstance $testServer | Where-Object Name -Match dbatoolsci | Remove-DbaRegServerGroup
 
-        # custom error message
-        $null = Invoke-DbaQuery -SqlInstance $testServer -Database master -Query "EXEC sp_dropmessage 250000"
-        $null = Invoke-DbaQuery -SqlInstance $testServer -Database master -Query "EXEC sp_dropmessage 250001"
+        # custom error messages
+        # The replay test drops them all and lets the exported script recreate them, so we drop whatever
+        # is still there instead of two fixed ids. Dropping with "all" also removes the localized versions.
+        foreach ($leftoverCustomErrorId in @(Get-DbaCustomError -SqlInstance $testServer | Select-Object -ExpandProperty ID | Sort-Object -Unique)) {
+            $dropCustomErrorQuery = @"
+EXEC sp_dropmessage $leftoverCustomErrorId, 'all'
+"@
+            $null = Invoke-DbaQuery -SqlInstance $testServer -Database master -Query $dropCustomErrorQuery
+        }
 
         # credentials
         $null = Invoke-DbaQuery -SqlInstance $testServer -Database master -Query "DROP CREDENTIAL [dbatools1$random]"
@@ -748,6 +763,59 @@ Describe $CommandName -Tag IntegrationTests {
 
         $results.FullName | Should -Exist
         $results.Length | Should -BeGreaterThan 0
+    }
+
+    # This has to stay the last test, because it drops all custom errors of the instance and relies on
+    # the exported script to recreate them.
+    It "Exports custom errors in an order that can be replayed" {
+        $splatExportCustomErrors = @{
+            SqlInstance = $testServer
+            Path        = $exportDir
+            Exclude     = @(
+                "AgentServer",
+                "Audits",
+                "AvailabilityGroups",
+                "BackupDevices",
+                "CentralManagementServer",
+                "Credentials",
+                "DatabaseMail",
+                "Databases",
+                "Endpoints",
+                "ExtendedEvents",
+                "LinkedServers",
+                "Logins",
+                "PolicyManagement",
+                "ReplicationSettings",
+                "ResourceGovernor",
+                "ServerAuditSpecifications",
+                "ServerRoles",
+                "SpConfigure",
+                "SysDbUserObjects",
+                "SystemTriggers",
+                "OleDbProvider"
+            )
+        }
+        $results = Export-DbaInstance @splatExportCustomErrors
+
+        $customErrorFile = $results | Where-Object Name -eq "customererrors.sql"
+        $customErrorFile | Should -Not -BeNullOrEmpty
+
+        # sp_addmessage refuses a message that is already there, so the instance has to be empty before
+        # the exported script can be replayed. A successful replay puts the messages back for AfterAll.
+        foreach ($exportedCustomErrorId in @(Get-DbaCustomError -SqlInstance $testServer | Select-Object -ExpandProperty ID | Sort-Object -Unique)) {
+            $dropExportedCustomErrorQuery = @"
+EXEC sp_dropmessage $exportedCustomErrorId, 'all'
+"@
+            $null = Invoke-DbaQuery -SqlInstance $testServer -Database master -Query $dropExportedCustomErrorQuery -EnableException
+        }
+
+        # Before the fix the localized message was scripted first and this failed with
+        # "You must add the us_english version of this message before you can add the ... version."
+        { Invoke-DbaQuery -SqlInstance $testServer -Database master -File $customErrorFile.FullName -EnableException } | Should -Not -Throw
+
+        $replayedCustomError = Get-DbaCustomError -SqlInstance $testServer | Where-Object ID -eq 250000
+        $replayedCustomError.Language | Should -Contain "us_english"
+        $replayedCustomError.Language | Should -Contain $frenchLanguage
     }
 
     # placeholder for a future test with availability groups


### PR DESCRIPTION
Fixes #10550. Reported and correctly diagnosed by @tivivi63.

## Problem

`Export-DbaInstance` writes `customererrors.sql` with the localized version of a message before its `us_english` original, so the generated script cannot be replayed:

```
You must add the us_english version of this message before you can add the 'Francais' version.
```

## Mechanism

`sp_addmessage` only accepts a localized message once the `us_english` version of that message id exists. `Get-DbaCustomError` enumerates `$server.UserDefinedMessages`, which SMO returns sorted by message id and then by language *name*, so `Francais` comes out before `us_english`. `Export-DbaInstance` piped that straight into `Export-DbaScript`, preserving the wrong order.

Reproduced on the current `development` source against SQL Server 2019 (15.0.4430.1); the ordering comes from the SMO collection, not from the server version.

## What changed

`public/Export-DbaInstance.ps1` orders the messages before scripting them, the same way `Copy-DbaCustomError` already does:

```powershell
$allCustomErrors = @(Get-DbaCustomError -SqlInstance $server -EnableException:$EnableException)
$orderedCustomErrors = @($allCustomErrors | Where-Object Language -eq "us_english")
$orderedCustomErrors += $allCustomErrors | Where-Object Language -ne "us_english"
```

## What deliberately did not change

I swept every command that touches user defined messages:

| Command | Verdict |
| --- | --- |
| `Copy-DbaCustomError` | Already puts `us_english` first, unchanged |
| `Remove-DbaCustomError` | Already handles the mirror rule on drop, unchanged |
| `Start-DbaMigration`, `Sync-DbaAvailabilityGroup` | Both go through `Copy-DbaCustomError`, unchanged |
| `Get-DbaCustomError` | Still returns the plain SMO order. It is the only caller-visible ordering in the module and no other `Get-Dba*` command imposes one, so the fix belongs in the export |

## Tests

`tests/Export-DbaInstance.Tests.ps1` now creates a French translation for one of the custom errors it already sets up, and the new test exports, drops every custom error on the instance and replays the exported script.

The `AfterAll` block drops whatever custom errors are still present instead of two fixed ids, so a failed replay does not leave the instance dirty.

Run against a SQL Server 2019 instance:

* with the fix: 29 passed, 0 failed, 1 skipped (the policies test skips on pwsh)
* with the fix reverted: the new test fails with exactly the error from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
