### PR TITLE
Issue skill - Read the issue body and its comments in one call

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -13,8 +13,10 @@ The two failure modes this skill exists to prevent: **fixing something that `dev
 ## 1. Read the whole issue
 
 ```
-gh issue view <number> --comments
+gh issue view <number> --json number,title,state,author,body,labels,createdAt,comments
 ```
+
+Use the `--json` form, not `gh issue view <number> --comments`. Those two views are disjoint: the plain view prints the body and no comments, `--comments` prints the comments and no body. On an issue with no comments yet — which is most new reports — `--comments` prints nothing at all and looks like a broken `gh`. The `--json` form always returns both in one call.
 
 Also check whether someone is already on it:
 


### PR DESCRIPTION
Step 1 of the issue skill told the agent to read the issue with:

```
gh issue view <number> --comments
```

That view is not additive. The two forms are disjoint:

| Command | Body | Comments |
| --- | --- | --- |
| `gh issue view 10549` | 70 lines | none |
| `gh issue view 10549 --comments` | none | 36 lines |
| `gh issue view 10550 --comments` | none | issue has no comments, so **nothing at all** |

A fresh bug report normally has no comments yet, which is exactly when this skill runs. `gh` then prints nothing and exits 0. That looks like a broken `gh` rather than an empty comment list, and the natural reaction is to retry with `--repo`, then in another shell, then start ruling out pagers and encodings, none of which can matter. It cost a few minutes on #10550 before the `--json` fallback happened to work.

The fix is the `--json` form, which returns the body and the comments together in one call, plus a short note explaining the trap so nobody switches the command back:

```
gh issue view <number> --json number,title,state,author,body,labels,createdAt,comments
```

Verified against dataplat/dbatools#10549 (has comments) and #10550 (has none). No command code is touched, so there is nothing for CI to test here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
