### PR TITLE
Set-DbaDbQueryStoreOption - Run the ALTER DATABASE statements on the server connection

### DIFF
--- a/public/Set-DbaDbQueryStoreOption.ps1
+++ b/public/Set-DbaDbQueryStoreOption.ps1
@@ -344,7 +344,7 @@ function Set-DbaDbQueryStoreOption {
                         $db.Refresh()
 
                         if ($query -ne "") {
-                            $db.Query($query, $dbName)
+                            $null = $server.Query($query)
                         }
                     } catch {
                         Stop-Function -Message "Could not modify configuration." -Category InvalidOperation -InnerErrorRecord $_ -Target $db -Continue


### PR DESCRIPTION
Fixes #10557.

`$db.Query($query, $dbName)` had two problems in one line:

- The second parameter of the `Database.Query` script method is `$AllTables`, not a database name - the `($Query, $Database)` signature belongs to `Server.Query`. The database name landed in `$AllTables`, made it truthy, and the method returned `.Tables` instead of `.Tables[0]`.
- The call ran on the caller's connection context. SMO issues a `USE [database]` for it that is never undone, so the command handed the connection back pointing at the configured database (see #10555 for the general pattern).

The statements collected in `$query` are all `ALTER DATABASE [...] SET QUERY_STORE = ...` and do not need the database context, so they now run on the server connection. Note that `$server.Query($query, $dbName)` would not have fixed anything - that overload routes through `$this.Databases[$Database].ExecuteWithResults(...)` and leaks identically.

Verified against SQL Server 2022:

- `-MaxPlansPerQuery 250 -WaitStatsCaptureMode Off` and `-CaptureMode Custom -CustomCapturePolicyExecutionCount 5` are applied and read back correctly
- `DB_NAME()` on the caller's connection stays `master` after the call, on a pooled connection - which is where the leak was visible before
- existing tests pass: `Set-DbaDbQueryStoreOption` 8/8, `Get-DbaDbQueryStoreOption` 4/4

No test added, by request.

Unrelated observation while verifying, worth its own issue: on SQL Server 2019 and later the object returned by the command reports `MaxPlansPerQuery` and `WaitStatsCaptureMode` from the cached SMO object rather than from the instance, so it showed 200/On while an independent `Get-DbaDbQueryStoreOption` correctly showed 250/Off. Same behaviour in released 2.8.4, so it predates this change.

---

*This text was created by Claude and reviewed by Andreas Jordan.*
