### PR TITLE
Connect-DbaInstance - Report whether a new connection was opened

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -157,6 +157,10 @@ function Connect-DbaInstance {
         Creates a dedicated administrator connection (DAC) for emergency access to SQL Server.
         Use this when SQL Server is unresponsive to regular connections, allowing you to diagnose and resolve critical issues. Remember to manually disconnect the connection when finished.
 
+    .PARAMETER IsNewConnectionReference
+        Reports whether a new connection was opened, by writing $true or $false into the referenced variable: pass a variable that already exists as [ref]$variable.
+        Use this when your command has to clean up after itself: only close a connection when this is $true, because a connection that was passed in belongs to the caller and closing it takes their session, their temp tables and their database context with it. When several instances are connected in one call, the value reflects the last connection that was returned.
+
     .PARAMETER DisableException
         Changes exception handling from throwing errors to displaying warnings.
         Use this in interactive sessions where you want graceful error handling instead of script-stopping exceptions, which is the default behavior for this command.
@@ -414,6 +418,7 @@ function Connect-DbaInstance {
         [ValidateSet('ActiveDirectoryIntegrated', 'ActiveDirectoryInteractive', 'ActiveDirectoryPassword', 'ActiveDirectoryServicePrincipal', 'ActiveDirectoryManagedIdentity', 'ActiveDirectoryDeviceCodeFlow')]
         [string]$AuthenticationType,
         [switch]$DedicatedAdminConnection,
+        [ref]$IsNewConnectionReference,
         [switch]$DisableException
     )
     begin {
@@ -1261,6 +1266,9 @@ function Connect-DbaInstance {
                     $null = Add-ConnectionHashValue -Key $server.ConnectionContext.ConnectionString -Value $server.ConnectionContext.SqlConnectionObject
                 }
                 Write-Message -Level Debug -Message "We return only SqlConnection in server.ConnectionContext.SqlConnectionObject"
+                if ($IsNewConnectionReference) {
+                    $IsNewConnectionReference.Value = $isNewConnection
+                }
                 $server.ConnectionContext.SqlConnectionObject
                 continue
             }
@@ -1313,6 +1321,9 @@ function Connect-DbaInstance {
             }
 
             Write-Message -Level Debug -Message "We return the server object"
+            if ($IsNewConnectionReference) {
+                $IsNewConnectionReference.Value = $isNewConnection
+            }
             $server
 
             if ($isNewConnection -and -not $DedicatedAdminConnection) {

--- a/public/Invoke-DbaQuery.ps1
+++ b/public/Invoke-DbaQuery.ps1
@@ -503,16 +503,21 @@ function Invoke-DbaQuery {
                 (-not $Database -or $instance.InputObject.ConnectionContext.DatabaseName -eq $Database) -and # the database is not set or the currently connected and
                 (-not $AppendConnectionString) -and # we don't use AppendConnectionString and
                 ($instance.InputObject.ConnectionContext.ConnectAsUserName -eq '') # we don't use a DIFFERENT operating system user than the current logged in
+                # Connect-DbaInstance tells us whether it opened a connection for us. We must only close what we opened
+                # ourselves, because closing a connection of the caller takes their session with it. As we might not
+                # call Connect-DbaInstance at all, we have to set the default here.
+                $isNewConnection = $false
                 if ($startedWithAnOpenConnection) {
                     Write-Message -Level Debug -Message "Current connection will be reused"
                     $server = $instance.InputObject
                 } else {
                     $connDbaInstanceParams = @{
-                        SqlInstance         = $instance
-                        SqlCredential       = $SqlCredential
-                        Database            = $Database
-                        NonPooledConnection = $true           # see #8491 for details, also #7725 is still relevant
-                        Verbose             = $false
+                        SqlInstance              = $instance
+                        SqlCredential            = $SqlCredential
+                        Database                 = $Database
+                        NonPooledConnection      = $true           # see #8491 for details, also #7725 is still relevant
+                        IsNewConnectionReference = [ref]$isNewConnection
+                        Verbose                  = $false
                     }
                     if ($ReadOnly) {
                         $connDbaInstanceParams.ApplicationIntent = "ReadOnly"
@@ -541,9 +546,11 @@ function Invoke-DbaQuery {
             } catch {
                 Stop-Function -Message "[$instance] Failed during execution" -ErrorRecord $_ -Target $instance -Continue
             }
-            # if the given connection started out open, don't close it.
-            if ($connDbaInstanceParams.NonPooledConnection -and -not $startedWithAnOpenConnection) {
-                # Close non-pooled connection as this is not done automatically. If it is a reused Server SMO, connection will be opened again automatically on next request.
+            # Only close the connection if Connect-DbaInstance opened a new one for us. Connect-DbaInstance returns the
+            # object that was passed in whenever nothing about it has to change, so testing our own parameters is not
+            # enough - see #10554.
+            if ($isNewConnection) {
+                # Close non-pooled connection as this is not done automatically.
                 $null = $server | Disconnect-DbaInstance -Verbose:$false
             }
         }

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -48,6 +48,7 @@ Describe $CommandName -Tag UnitTests {
                 "AccessToken",
                 "AuthenticationType",
                 "DedicatedAdminConnection",
+                "IsNewConnectionReference",
                 "DisableException"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
@@ -415,6 +416,46 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "sets StatementTimeout to 0" {
             $server.ConnectionContext.StatementTimeout | Should -Be 0
+        }
+    }
+
+    Context "IsNewConnectionVariable tells the caller whether a connection was opened" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # We predefine the variables so that a test fails if Connect-DbaInstance does not set them at all.
+            $newFromString = $null
+            $newFromServer = $null
+            $newFromCopy = $null
+
+            $serverFromString = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -NonPooledConnection -IsNewConnectionReference ([ref]$newFromString)
+            $serverFromServer = Connect-DbaInstance -SqlInstance $serverFromString -IsNewConnectionReference ([ref]$newFromServer)
+            # Asking for a different database forces Connect-DbaInstance to copy the connection context, so this is a new connection.
+            $serverFromCopy = Connect-DbaInstance -SqlInstance $serverFromString -Database tempdb -IsNewConnectionReference ([ref]$newFromCopy)
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            $null = $serverFromString, $serverFromCopy | Disconnect-DbaInstance
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "is true when the connection is opened from a string" {
+            $newFromString | Should -BeTrue
+        }
+
+        It "is false when the server object is passed back in" {
+            $newFromServer | Should -BeFalse
+        }
+
+        It "returns the object that was passed in when nothing has to change" {
+            [object]::ReferenceEquals($serverFromServer, $serverFromString) | Should -BeTrue
+        }
+
+        It "is true when the connection context has to be copied" {
+            $newFromCopy | Should -BeTrue
         }
     }
 

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -401,4 +401,53 @@ CREATE INDEX IX_Filtered ON dbo.$tableName(Name) WHERE IsDeleted = 0;
         $results = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceMulti1 -Query "select cast(null as hierarchyid)"
         $results.Column1 | Should -Be "NULL"
     }
+
+    Context "Connections that were passed in are not closed (#10554)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -NonPooledConnection
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            # Naming the database the connection is already on is enough to take the path where the connection of the caller used to be closed.
+            $null = Invoke-DbaQuery -SqlInstance $callerServer -Database master -Query "SELECT 1"
+
+            # Every call with a string opens and closes a connection of its own, so we count the sessions to see that they are still closed.
+            $counterServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
+            $splatCountSessions = @{
+                SqlInstance  = $counterServer
+                Query        = "SELECT COUNT(*) FROM sys.dm_exec_sessions WHERE program_name = @clientName"
+                SqlParameter = @{ clientName = Get-DbatoolsConfigValue -FullName sql.connection.clientname }
+                As           = "SingleValue"
+            }
+            $sessionsBefore = Invoke-DbaQuery @splatCountSessions
+            foreach ($run in 1..5) {
+                $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceMulti1 -Query "SELECT 1"
+            }
+            $sessionsAfter = Invoke-DbaQuery @splatCountSessions
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer, $counterServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "leaves the connection of the caller open" {
+            $callerServer.ConnectionContext.IsOpen | Should -BeTrue
+        }
+
+        It "leaves the session of the caller intact, so the temp table is still there" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+
+        It "still closes the connections it opens itself (#6210)" {
+            # We allow for a little noise, because the tab expansion of dbatools connects in the background as well.
+            ($sessionsAfter - $sessionsBefore) | Should -BeLessThan 5
+        }
+    }
 }


### PR DESCRIPTION
First step of #10554. Adds the ownership signal and uses it in `Invoke-DbaQuery`; the other seven sites follow in their own pull requests.

## What was wrong

A command that connects and cleans up afterwards had no way to tell whether `Connect-DbaInstance` opened a connection for it or handed back the object the caller passed in. `Invoke-DbaQuery` inferred it from its own parameters:

```powershell
if ($connDbaInstanceParams.NonPooledConnection -and -not $startedWithAnOpenConnection) {
    $null = $server | Disconnect-DbaInstance -Verbose:$false
}
```

`Connect-DbaInstance` only copies the connection context when something about it actually has to change, so it frequently returns the very object that was passed in - and then this closed the caller's connection. With `-NonPooledConnection` that takes the session with it:

```powershell
$server = Connect-DbaInstance -SqlInstance $instance -NonPooledConnection
$null = $server.ConnectionContext.ExecuteNonQuery("CREATE TABLE #t (id int)")
$null = Invoke-DbaQuery -SqlInstance $server -Database master -Query "SELECT 1"
$server.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #t")
# Invalid object name '#t'.
```

## What this changes

`Connect-DbaInstance` gets `-IsNewConnectionReference`, which reports whether it opened a new connection, and `Invoke-DbaQuery` only disconnects when it did.

The value is already known internally as `$isNewConnection`: `$false` for Server and SqlConnection inputs, `$true` for string, connection string and RegisteredServer inputs, and `$true` when a connection context has to be copied. Only its exposure is new; no connection logic changed. Both places that emit a server set it, including the `-SqlConnectionOnly` path.

## Why a reference and not a variable name

The plan in the issue proposed `-IsNewConnectionVariable` written through `$PSCmdlet.SessionState.PSVariable.Set()`. That works for a caller outside of dbatools, but not for a caller inside it, which is exactly the case that matters here. Both commands share the module session state, so the value lands in the local scope of `Connect-DbaInstance` instead of the scope of the calling command:

```
external caller, name : set via SessionState
in-module caller, name : unset
in-module caller, ref  : set via ref
```

`Set-Variable -Scope 1` does not help either - from a module function the parent scope is the module scope, not the caller. A `[ref]` behaves the same way in both cases, so that is what the parameter takes.

The first test run caught this: with the variable-name version, `Invoke-DbaQuery` never learned that it owned its connections and the new session-count test failed with five leaked sessions. That test is in this pull request.

## Tests

- `Connect-DbaInstance`: the parameter list, plus four assertions that the reference is `$true` for a string, `$false` when a server object is passed back in, `$true` when the context has to be copied, and that the same object comes back when nothing has to change
- `Invoke-DbaQuery`: the caller's connection stays open and its temp table survives, and the connections the command opens itself are still closed, so #6210 does not come back

Both files pass against SQL Server 2025 and 2022: `Connect-DbaInstance` 32 passed, 1 skipped (Azure), `Invoke-DbaQuery` 29 passed.

---

*This text was created by Claude and reviewed by Andreas Jordan.*
