### PR TITLE
Invoke-DbaQuery - Test the database the connection is on, not the one it was opened with

### DIFF
--- a/public/Invoke-DbaQuery.ps1
+++ b/public/Invoke-DbaQuery.ps1
@@ -496,11 +496,17 @@ function Invoke-DbaQuery {
                 # Again, here we are, but we cannot use the connection when an information is lost, which is that we are:
                 #   - Integrated Security=True
                 #   - using ConnectAsUser, ConnectAsUserName, ConnectAsUserPassword to "log on as a different user"
+                #
+                # The database is tested with ConnectionContext.CurrentDatabase, the database the connection is on
+                # right now, and not with ConnectionContext.DatabaseName, which is only the database the connection
+                # was opened with. The two differ as soon as anything runs a USE, and then reusing the connection
+                # runs the query in the wrong database. Connect-DbaInstance tests CurrentDatabase as well, so both
+                # commands now ask the same question.
 
                 $startedWithAnOpenConnection = # we want to bypass Connect-DbaInstance if
                 ($instance.InputObject.GetType().Name -eq "Server") -and # we have Server SMO object and
                 (-not $ReadOnly) -and # no readonly intent is requested and
-                (-not $Database -or $instance.InputObject.ConnectionContext.DatabaseName -eq $Database) -and # the database is not set or the currently connected and
+                (-not $Database -or $instance.InputObject.ConnectionContext.CurrentDatabase -eq $Database) -and # the database is not set or the connection is on it and
                 (-not $AppendConnectionString) -and # we don't use AppendConnectionString and
                 ($instance.InputObject.ConnectionContext.ConnectAsUserName -eq '') # we don't use a DIFFERENT operating system user than the current logged in
                 # Connect-DbaInstance tells us whether it opened a connection for us. We must only close what we opened

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -402,6 +402,41 @@ CREATE INDEX IX_Filtered ON dbo.$tableName(Name) WHERE IsDeleted = 0;
         $results.Column1 | Should -Be "NULL"
     }
 
+    Context "The connection is only reused when it is on the requested database (#10554)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $movedServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -Database tempdb -NonPooledConnection
+            $movedOwnSpid = $movedServer.ConnectionContext.ExecuteScalar("SELECT @@SPID")
+
+            # As long as the connection is still on tempdb, it is reused.
+            $reusedSpid = Invoke-DbaQuery -SqlInstance $movedServer -Database tempdb -Query "SELECT @@SPID AS spid" -As SingleValue
+
+            # A USE moves the connection to another database. ConnectionContext.DatabaseName still says tempdb,
+            # only ConnectionContext.CurrentDatabase knows that the connection is on master now.
+            $null = $movedServer.ConnectionContext.ExecuteNonQuery("USE [master]")
+            $movedDatabase = Invoke-DbaQuery -SqlInstance $movedServer -Database tempdb -Query "SELECT DB_NAME() AS dbname" -As SingleValue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $movedServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "reuses the connection while it is on the requested database" {
+            $reusedSpid | Should -Be $movedOwnSpid
+        }
+
+        It "runs in the requested database after the connection was moved away from it" {
+            $movedDatabase | Should -Be "tempdb"
+        }
+    }
+
     Context "Connections that were passed in are not closed (#10554)" {
         BeforeAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true


### PR DESCRIPTION
**Draft: needs more testing, and waits for #10559.**

## Why this waits

The change sends the connection-reuse case through `Connect-DbaInstance` in situations where it did not go there before. On `development` alone that would be unsafe, because the old disconnect logic then closes the connection of the caller - which is what #10559 fixes. So this is based on the branch of #10559 and only the second commit belongs here. GitHub retargets the pull request to `development` once #10559 is merged.

## What is wrong

To decide whether the connection that was passed in can be reused, the command compares `ConnectionContext.DatabaseName` with `-Database`. That property only holds the database the connection was *opened* with. `Connect-DbaInstance` asks the same question with `ConnectionContext.CurrentDatabase`, the database the connection is on *right now*.

The two differ as soon as anything runs a `USE` on the connection - which is exactly what the database-scoped SMO calls in #10555 do. The connection is then reused although it sits on another database, and the query silently runs in the wrong one:

```powershell
$server = Connect-DbaInstance -SqlInstance $instance -Database tempdb -NonPooledConnection
$null = $server.ConnectionContext.ExecuteNonQuery("USE [master]")
Invoke-DbaQuery -SqlInstance $server -Database tempdb -Query "SELECT DB_NAME() AS dbname"
```

```
after a stray USE [master]     : DatabaseName=[tempdb] CurrentDatabase=[master]
Invoke-DbaQuery -Database tempdb runs in: master
```

## Measured effect

Using `@@SPID` to see whether a connection was reused, on SQL Server 2022:

| Connection of the caller | `-Database <the database it is on>` before | after |
|---|---|---|
| non-pooled, open | reused, but through a needless trip into `Connect-DbaInstance` | reused directly |
| pooled, closed | new connection | new connection, unchanged - `CurrentDatabase` is empty while the connection is closed |

## Tests

Two assertions: the connection is still reused while it is on the requested database, and a query runs in the requested database after the connection was moved away from it. Reverting the one-line change makes the second one fail with `Expected: 'tempdb' But was: 'master'`, so it does test the change. With the change, `Invoke-DbaQuery` passes 31 of 31.

## What still needs testing before this leaves draft

- a full suite run, because `Invoke-DbaQuery` carries a large part of the module and the reuse path is used everywhere
- Azure SQL Database, where the database of a connection cannot be changed the same way
- availability group listeners together with `-ReadOnly`
- inputs that are not a Server object: `SqlConnection`, connection strings and registered servers
- the case where `CurrentDatabase` is empty because the connection has never been opened, which is unchanged behaviour but deserves a deliberate check rather than an assumption

---

*This text was created by Claude and reviewed by Andreas Jordan.*
