### PR TITLE
Connect-DbaInstance / Invoke-DbaQuery - Do not close connections of the caller and do not reuse them for the wrong database

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -157,6 +157,10 @@ function Connect-DbaInstance {
         Creates a dedicated administrator connection (DAC) for emergency access to SQL Server.
         Use this when SQL Server is unresponsive to regular connections, allowing you to diagnose and resolve critical issues. Remember to manually disconnect the connection when finished.
 
+    .PARAMETER IsNewConnectionReference
+        Reports whether a new connection was opened, by writing $true or $false into the referenced variable: pass a variable that already exists as [ref]$variable.
+        Use this when your command has to clean up after itself: only close a connection when this is $true, because a connection that was passed in belongs to the caller and closing it takes their session, their temp tables and their database context with it. When several instances are connected in one call, the value reflects the last connection that was returned.
+
     .PARAMETER DisableException
         Changes exception handling from throwing errors to displaying warnings.
         Use this in interactive sessions where you want graceful error handling instead of script-stopping exceptions, which is the default behavior for this command.
@@ -414,6 +418,7 @@ function Connect-DbaInstance {
         [ValidateSet('ActiveDirectoryIntegrated', 'ActiveDirectoryInteractive', 'ActiveDirectoryPassword', 'ActiveDirectoryServicePrincipal', 'ActiveDirectoryManagedIdentity', 'ActiveDirectoryDeviceCodeFlow')]
         [string]$AuthenticationType,
         [switch]$DedicatedAdminConnection,
+        [ref]$IsNewConnectionReference,
         [switch]$DisableException
     )
     begin {
@@ -1261,6 +1266,9 @@ function Connect-DbaInstance {
                     $null = Add-ConnectionHashValue -Key $server.ConnectionContext.ConnectionString -Value $server.ConnectionContext.SqlConnectionObject
                 }
                 Write-Message -Level Debug -Message "We return only SqlConnection in server.ConnectionContext.SqlConnectionObject"
+                if ($IsNewConnectionReference) {
+                    $IsNewConnectionReference.Value = $isNewConnection
+                }
                 $server.ConnectionContext.SqlConnectionObject
                 continue
             }
@@ -1313,6 +1321,9 @@ function Connect-DbaInstance {
             }
 
             Write-Message -Level Debug -Message "We return the server object"
+            if ($IsNewConnectionReference) {
+                $IsNewConnectionReference.Value = $isNewConnection
+            }
             $server
 
             if ($isNewConnection -and -not $DedicatedAdminConnection) {

--- a/public/Invoke-DbaQuery.ps1
+++ b/public/Invoke-DbaQuery.ps1
@@ -496,11 +496,17 @@ function Invoke-DbaQuery {
                 # Again, here we are, but we cannot use the connection when an information is lost, which is that we are:
                 #   - Integrated Security=True
                 #   - using ConnectAsUser, ConnectAsUserName, ConnectAsUserPassword to "log on as a different user"
+                #
+                # The database is tested with ConnectionContext.CurrentDatabase, the database the connection is on
+                # right now, and not with ConnectionContext.DatabaseName, which is only the database the connection
+                # was opened with. The two differ as soon as anything runs a USE, and then reusing the connection
+                # runs the query in the wrong database. Connect-DbaInstance tests CurrentDatabase as well, so both
+                # commands now ask the same question.
 
                 $startedWithAnOpenConnection = # we want to bypass Connect-DbaInstance if
                 ($instance.InputObject.GetType().Name -eq "Server") -and # we have Server SMO object and
                 (-not $ReadOnly) -and # no readonly intent is requested and
-                (-not $Database -or $instance.InputObject.ConnectionContext.DatabaseName -eq $Database) -and # the database is not set or the currently connected and
+                (-not $Database -or $instance.InputObject.ConnectionContext.CurrentDatabase -eq $Database) -and # the database is not set or the connection is on it and
                 (-not $AppendConnectionString) -and # we don't use AppendConnectionString and
                 ($instance.InputObject.ConnectionContext.ConnectAsUserName -eq '') # we don't use a DIFFERENT operating system user than the current logged in
                 # Connect-DbaInstance tells us whether it opened a connection for us. We must only close what we opened

--- a/public/Invoke-DbaQuery.ps1
+++ b/public/Invoke-DbaQuery.ps1
@@ -503,16 +503,21 @@ function Invoke-DbaQuery {
                 (-not $Database -or $instance.InputObject.ConnectionContext.DatabaseName -eq $Database) -and # the database is not set or the currently connected and
                 (-not $AppendConnectionString) -and # we don't use AppendConnectionString and
                 ($instance.InputObject.ConnectionContext.ConnectAsUserName -eq '') # we don't use a DIFFERENT operating system user than the current logged in
+                # Connect-DbaInstance tells us whether it opened a connection for us. We must only close what we opened
+                # ourselves, because closing a connection of the caller takes their session with it. As we might not
+                # call Connect-DbaInstance at all, we have to set the default here.
+                $isNewConnection = $false
                 if ($startedWithAnOpenConnection) {
                     Write-Message -Level Debug -Message "Current connection will be reused"
                     $server = $instance.InputObject
                 } else {
                     $connDbaInstanceParams = @{
-                        SqlInstance         = $instance
-                        SqlCredential       = $SqlCredential
-                        Database            = $Database
-                        NonPooledConnection = $true           # see #8491 for details, also #7725 is still relevant
-                        Verbose             = $false
+                        SqlInstance              = $instance
+                        SqlCredential            = $SqlCredential
+                        Database                 = $Database
+                        NonPooledConnection      = $true           # see #8491 for details, also #7725 is still relevant
+                        IsNewConnectionReference = [ref]$isNewConnection
+                        Verbose                  = $false
                     }
                     if ($ReadOnly) {
                         $connDbaInstanceParams.ApplicationIntent = "ReadOnly"
@@ -541,9 +546,11 @@ function Invoke-DbaQuery {
             } catch {
                 Stop-Function -Message "[$instance] Failed during execution" -ErrorRecord $_ -Target $instance -Continue
             }
-            # if the given connection started out open, don't close it.
-            if ($connDbaInstanceParams.NonPooledConnection -and -not $startedWithAnOpenConnection) {
-                # Close non-pooled connection as this is not done automatically. If it is a reused Server SMO, connection will be opened again automatically on next request.
+            # Only close the connection if Connect-DbaInstance opened a new one for us. Connect-DbaInstance returns the
+            # object that was passed in whenever nothing about it has to change, so testing our own parameters is not
+            # enough - see #10554.
+            if ($isNewConnection) {
+                # Close non-pooled connection as this is not done automatically.
                 $null = $server | Disconnect-DbaInstance -Verbose:$false
             }
         }

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -48,6 +48,7 @@ Describe $CommandName -Tag UnitTests {
                 "AccessToken",
                 "AuthenticationType",
                 "DedicatedAdminConnection",
+                "IsNewConnectionReference",
                 "DisableException"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
@@ -415,6 +416,46 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "sets StatementTimeout to 0" {
             $server.ConnectionContext.StatementTimeout | Should -Be 0
+        }
+    }
+
+    Context "IsNewConnectionVariable tells the caller whether a connection was opened" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # We predefine the variables so that a test fails if Connect-DbaInstance does not set them at all.
+            $newFromString = $null
+            $newFromServer = $null
+            $newFromCopy = $null
+
+            $serverFromString = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -NonPooledConnection -IsNewConnectionReference ([ref]$newFromString)
+            $serverFromServer = Connect-DbaInstance -SqlInstance $serverFromString -IsNewConnectionReference ([ref]$newFromServer)
+            # Asking for a different database forces Connect-DbaInstance to copy the connection context, so this is a new connection.
+            $serverFromCopy = Connect-DbaInstance -SqlInstance $serverFromString -Database tempdb -IsNewConnectionReference ([ref]$newFromCopy)
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            $null = $serverFromString, $serverFromCopy | Disconnect-DbaInstance
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "is true when the connection is opened from a string" {
+            $newFromString | Should -BeTrue
+        }
+
+        It "is false when the server object is passed back in" {
+            $newFromServer | Should -BeFalse
+        }
+
+        It "returns the object that was passed in when nothing has to change" {
+            [object]::ReferenceEquals($serverFromServer, $serverFromString) | Should -BeTrue
+        }
+
+        It "is true when the connection context has to be copied" {
+            $newFromCopy | Should -BeTrue
         }
     }
 

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -402,6 +402,41 @@ CREATE INDEX IX_Filtered ON dbo.$tableName(Name) WHERE IsDeleted = 0;
         $results.Column1 | Should -Be "NULL"
     }
 
+    Context "The connection is only reused when it is on the requested database (#10554)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $movedServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -Database tempdb -NonPooledConnection
+            $movedOwnSpid = $movedServer.ConnectionContext.ExecuteScalar("SELECT @@SPID")
+
+            # As long as the connection is still on tempdb, it is reused.
+            $reusedSpid = Invoke-DbaQuery -SqlInstance $movedServer -Database tempdb -Query "SELECT @@SPID AS spid" -As SingleValue
+
+            # A USE moves the connection to another database. ConnectionContext.DatabaseName still says tempdb,
+            # only ConnectionContext.CurrentDatabase knows that the connection is on master now.
+            $null = $movedServer.ConnectionContext.ExecuteNonQuery("USE [master]")
+            $movedDatabase = Invoke-DbaQuery -SqlInstance $movedServer -Database tempdb -Query "SELECT DB_NAME() AS dbname" -As SingleValue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $movedServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "reuses the connection while it is on the requested database" {
+            $reusedSpid | Should -Be $movedOwnSpid
+        }
+
+        It "runs in the requested database after the connection was moved away from it" {
+            $movedDatabase | Should -Be "tempdb"
+        }
+    }
+
     Context "Connections that were passed in are not closed (#10554)" {
         BeforeAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -401,4 +401,53 @@ CREATE INDEX IX_Filtered ON dbo.$tableName(Name) WHERE IsDeleted = 0;
         $results = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceMulti1 -Query "select cast(null as hierarchyid)"
         $results.Column1 | Should -Be "NULL"
     }
+
+    Context "Connections that were passed in are not closed (#10554)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -NonPooledConnection
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            # Naming the database the connection is already on is enough to take the path where the connection of the caller used to be closed.
+            $null = Invoke-DbaQuery -SqlInstance $callerServer -Database master -Query "SELECT 1"
+
+            # Every call with a string opens and closes a connection of its own, so we count the sessions to see that they are still closed.
+            $counterServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
+            $splatCountSessions = @{
+                SqlInstance  = $counterServer
+                Query        = "SELECT COUNT(*) FROM sys.dm_exec_sessions WHERE program_name = @clientName"
+                SqlParameter = @{ clientName = Get-DbatoolsConfigValue -FullName sql.connection.clientname }
+                As           = "SingleValue"
+            }
+            $sessionsBefore = Invoke-DbaQuery @splatCountSessions
+            foreach ($run in 1..5) {
+                $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceMulti1 -Query "SELECT 1"
+            }
+            $sessionsAfter = Invoke-DbaQuery @splatCountSessions
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer, $counterServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "leaves the connection of the caller open" {
+            $callerServer.ConnectionContext.IsOpen | Should -BeTrue
+        }
+
+        It "leaves the session of the caller intact, so the temp table is still there" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+
+        It "still closes the connections it opens itself (#6210)" {
+            # We allow for a little noise, because the tab expansion of dbatools connects in the background as well.
+            ($sessionsAfter - $sessionsBefore) | Should -BeLessThan 5
+        }
+    }
 }


### PR DESCRIPTION
Replaces #10559 and #10563, which have to ship together. Fixes the first part of #10554.

Both changes are about the connection a caller hands to `Invoke-DbaQuery`: the command must not close a connection it did not open, and it must not reuse one that is not on the requested database. Separately, each of them makes things worse, which is what this pull request is really about - see "Why they belong together" below.

## 1. Connect-DbaInstance reports whether it opened a connection

A command that connects and cleans up afterwards had no way to tell whether `Connect-DbaInstance` opened a connection for it or handed back the object it was given. `Invoke-DbaQuery` inferred it from its own parameters and closed the connection of the caller, taking the session with it:

```powershell
$server = Connect-DbaInstance -SqlInstance $instance -NonPooledConnection
$null = $server.ConnectionContext.ExecuteNonQuery("CREATE TABLE #t (id int)")
$null = Invoke-DbaQuery -SqlInstance $server -Database master -Query "SELECT 1"
$server.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #t")
# Invalid object name '#t'.
```

`Connect-DbaInstance` now reports this through `-IsNewConnectionReference`, and `Invoke-DbaQuery` only disconnects when it opened the connection itself. The value is the `$isNewConnection` the command already computes internally, so no connection logic changed, only its exposure - at both places that emit a server, including the `-SqlConnectionOnly` path.

It takes a `[ref]` and not a variable name because `$PSCmdlet.SessionState.PSVariable.Set()` never reaches a caller inside of dbatools: both share the module session state, so the value lands in the local scope of `Connect-DbaInstance`. `Set-Variable -Scope 1` does not help either, because from a module function the parent scope is the module scope.

## 2. Invoke-DbaQuery tests the database the connection is on

To decide whether the connection can be reused, the command compared `ConnectionContext.DatabaseName` - the database the connection was *opened* with - against `-Database`. `Connect-DbaInstance` asks the same question with `ConnectionContext.CurrentDatabase`, the database the connection is on *right now*. The two differ as soon as anything runs a `USE`, and the query then runs in the wrong database:

```powershell
$server = Connect-DbaInstance -SqlInstance $instance -Database tempdb -NonPooledConnection
$null = $server.ConnectionContext.ExecuteNonQuery("USE [master]")
Invoke-DbaQuery -SqlInstance $server -Database tempdb -Query "SELECT DB_NAME()"
# master
```

## Why they belong together

#10559 alone breaks `Install-DbaFirstResponderKit`, which is how this was found - its test file failed in CI and reproduces locally.

The command opens one connection with `-Database $Database`, and before signing the procedures it runs `Get-DbaLogin | Remove-DbaLogin`. SMO's `Login.Drop()` leaves that shared connection in `master` (`New-DbaLogin` does the same, `Get-DbaLogin` does not) - the defect described in #10555, here from SMO's own object scripting rather than from `$db.Query()`. Every later query for the user database is then reused onto a connection that sits in master, and signing fails with `Cannot alter the object 'sp_BlitzFirst', because it does not exist or you do not have permission`.

Today that is hidden: the disconnect from part 1 closes the connection in between, and the reconnect lands back on the catalog from the connection string. Measured on the three states:

```
=== development ===
after Remove-DbaLogin (SMO drops the login)    DB_NAME()=master
after Invoke-DbaQuery -Database master         DB_NAME()=dbatoolsci_frkrepair   <-- repaired by the disconnect
the next query against the database runs in: dbatoolsci_frkrepair

=== part 1 only ===
after Invoke-DbaQuery -Database master         DB_NAME()=master
the next query against the database runs in: master                            <-- broken

=== part 1 and part 2 ===
after Invoke-DbaQuery -Database master         DB_NAME()=master
the next query against the database runs in: dbatoolsci_frkrepair              <-- correct for the right reason
```

So part 1 removes a crutch and part 2 removes the need for it. `Install-DbaFirstResponderKit` passes 22 of 22 with both, and the install produces its 2 signed objects again.

## Tests

`Connect-DbaInstance`: the parameter list, and that the reference is `$true` for a string, `$false` when a server object is passed back in, `$true` when the connection context has to be copied, and that the same object comes back when nothing has to change.

`Invoke-DbaQuery`: the connection of the caller stays open and its temp table survives; connections the command opens itself are still closed, so #6210 does not come back; the connection is still reused while it is on the requested database; and a query runs in the requested database after the connection was moved away from it.

Reverting either production change makes the matching test fail, so both are covered by something that actually tests them.

Locally against SQL Server 2025 and 2022: `Connect-DbaInstance` 32 passed and 1 skipped (Azure), `Invoke-DbaQuery` 31 passed, `Install-DbaFirstResponderKit` 22 passed.

## Still worth checking in review

- Azure SQL Database, where the database of a connection cannot be changed the same way
- availability group listeners together with `-ReadOnly`
- inputs that are not a Server object: `SqlConnection`, connection strings and registered servers

---

*This text was created by Claude and reviewed by Andreas Jordan.*
