### PR TITLE
CI - Skip Azure migration tests on Dependabot pushes

### DIFF
--- a/.github/workflows/azure-migration-tests.yml
+++ b/.github/workflows/azure-migration-tests.yml
@@ -33,6 +33,10 @@ concurrency:
 
 jobs:
   azure-migration-tests:
+    # GitHub withholds repository secrets from Dependabot-triggered runs, so azure/login
+    # sees an empty VMSS_AZURE_CREDENTIALS and hard-fails. This file is one of the trigger
+    # paths above, so every Dependabot bump of an action used here would otherwise go red.
+    if: github.actor != 'dependabot[bot]'
     env:
       SMODefaultModuleName: dbatools
     runs-on: ubuntu-latest


### PR DESCRIPTION
`Run Azure Migration Tests` is the only red check on #10546, and it fails at **Authenticate existing Azure CI identity**:

```
Login failed with Error: Using auth-type: SERVICE_PRINCIPAL. Not all values are present.
Ensure 'client-id' and 'tenant-id' are supplied.
```

`secrets.VMSS_AZURE_CREDENTIALS` arrives empty because GitHub does not pass repository secrets to Dependabot-triggered runs. The workflow lists its own file in `paths:`, so any Dependabot bump of an action used here (this time `azure/login` v3.0.0 → v3.0.1) fires the whole 75-minute Azure job and then dies on the login step — a red X for a reason unrelated to the bump.

This adds a job-level actor guard so the job is skipped rather than failed, matching the `if: ... github.actor` style already used in `runner-boost.yml` and `claude-code-review.yml`. Nothing changes for human pushes.

`ps3-smoke.yml`, `runner-reconcile.yml` and `runner-scale-up.yml` also pin `azure/login`, but they only run on `schedule`/`workflow_dispatch`, so Dependabot never triggers them — this workflow is the only one that needed the guard.

Verified locally against both CI gates: `Test-GitHubActionsPins.ps1` and `Test-ActionlintWorkflows.ps1` pass.

After this merges, #10546 needs a `@dependabot rebase` so its branch picks up the guard — the `push` event runs the workflow file from the pushed branch, not from `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)