### PR TITLE
Get-DbaDbExtentDiff - Leave the connection of the caller alone

### DIFF
--- a/public/Get-DbaDbExtentDiff.ps1
+++ b/public/Get-DbaDbExtentDiff.ps1
@@ -105,8 +105,17 @@ function Get-DbaDbExtentDiff {
     process {
 
         foreach ($instance in $SqlInstance) {
+            # Connect-DbaInstance tells us whether it opened a connection for us. We must only close what we opened
+            # ourselves, because closing a connection of the caller takes their session with it. See #10554.
+            $isNewConnection = $false
+            $splatConnect = @{
+                SqlInstance              = $instance
+                SqlCredential            = $SqlCredential
+                NonPooledConnection      = $true
+                IsNewConnectionReference = [ref]$isNewConnection
+            }
             try {
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -NonPooledConnection
+                $server = Connect-DbaInstance @splatConnect
             } catch {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
@@ -133,14 +142,17 @@ function Get-DbaDbExtentDiff {
             #Available from 2016 SP2
             if ($server.Version -ge [version]'13.0.5026') {
                 foreach ($db in $sourcedbs) {
+                    # The database is named in the query instead of running the query in the database, because
+                    # running it in the database leaves the connection there and it belongs to the caller. See #10555.
+                    $dbNameEscaped = $db.Name.Replace("]", "]]")
                     $DBCCPageQueryDMV = "
                         SELECT
                         SUM(total_page_count) / 8 AS [ExtentsTotal],
                         SUM(modified_extent_page_count) / 8 AS [ExtentsChanged],
                         100.0 * SUM(modified_extent_page_count)/SUM(total_page_count) AS [ChangedPerc]
-                        FROM sys.dm_db_file_space_usage
+                        FROM [$dbNameEscaped].sys.dm_db_file_space_usage
                     "
-                    $DBCCPageResults = $server.Query($DBCCPageQueryDMV, $db.Name)
+                    $DBCCPageResults = $server.Query($DBCCPageQueryDMV)
                     [PSCustomObject]@{
                         ComputerName   = $server.ComputerName
                         InstanceName   = $server.ServiceName
@@ -187,8 +199,10 @@ function Get-DbaDbExtentDiff {
                 }
             }
 
-            # Close non-pooled connection as this is not done automatically. If it is a reused Server SMO, connection will be opened again automatically on next request.
-            $null = $server | Disconnect-DbaInstance
+            if ($isNewConnection) {
+                # Close non-pooled connection as this is not done automatically.
+                $null = $server | Disconnect-DbaInstance
+            }
         }
     }
 }

--- a/tests/Get-DbaDbExtentDiff.Tests.ps1
+++ b/tests/Get-DbaDbExtentDiff.Tests.ps1
@@ -70,6 +70,35 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 
+    Context "The connection of the caller is left alone (#10554)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $null = Get-DbaDbExtentDiff -SqlInstance $callerServer -Database $dbname
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+
+        It "leaves the connection in the database it was on" {
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "master"
+        }
+    }
+
     Context "Gets Changed Extents for Single Database" {
         BeforeAll {
             $singleDbResults = Get-DbaDbExtentDiff -SqlInstance $TestConfig.InstanceSingle -Database $dbname


### PR DESCRIPTION
Second of the sites listed in #10554, after #10564 brought the mechanism.

## The disconnect

The command opened its connection with `-NonPooledConnection` and closed it at the end, without asking whether it had opened it. When a caller passes their own server object, `Connect-DbaInstance` hands the same object back and the command then closed the connection of the caller, which takes the session with it. It now only closes what it opened itself, via `-IsNewConnectionReference`.

## The leak the disconnect was hiding

This is the part worth a second look. The extents query ran *in* the examined database:

```powershell
$DBCCPageResults = $server.Query($DBCCPageQueryDMV, $db.Name)
```

That two argument form routes through `$server.Databases[$Database].ExecuteWithResults()`, and SMO leaves the connection in that database - the defect in #10555. Until now the disconnect covered it up: the connection was closed right afterwards, and the reconnect landed back on the database from the connection string. Removing the disconnect without touching the query would have left the connection of the caller in whichever database was examined last.

So the query now names the database instead of running in it:

```sql
FROM [$dbNameEscaped].sys.dm_db_file_space_usage
```

Verified that this returns the same numbers as the context switch, per database:

```
master   three-part=71     with context switch=71
msdb     three-part=297    with context switch=297
tempdb   three-part=512    with context switch=512
```

The branch for SQL Server 2016 before SP2 needs no change: it queries `master.sys.master_files` and runs `DBCC PAGE` with the database as an argument, neither of which moves the connection.

## Tests

Two assertions on a connection the caller opened: the session survives the call, and the connection is still on the database it was on. Each one covers one of the two changes - reverting the disconnect guard fails the first, reverting the query change fails the second with `Expected: 'master' But was: 'dbatoolsci_test_1751040644'`.

`Get-DbaDbExtentDiff` passes 9 of 9 against SQL Server 2019.

---

*This text was created by Claude and reviewed by Andreas Jordan.*
