### PR TITLE
Update-DbaMaintenanceSolution - Update the procedures in the database that was named and leave the connection of the caller alone

### DIFF
--- a/public/Update-DbaMaintenanceSolution.ps1
+++ b/public/Update-DbaMaintenanceSolution.ps1
@@ -128,8 +128,17 @@ function Update-DbaMaintenanceSolution {
         }
 
         foreach ($instance in $SqlInstance) {
+            # Connect-DbaInstance tells us whether it opened a connection for us. We must only close what we opened
+            # ourselves, because closing a connection of the caller takes their session with it. See #10554.
+            $isNewConnection = $false
+            $splatConnect = @{
+                SqlInstance              = $instance
+                SqlCredential            = $SqlCredential
+                NonPooledConnection      = $true
+                IsNewConnectionReference = [ref]$isNewConnection
+            }
             try {
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -NonPooledConnection
+                $server = Connect-DbaInstance @splatConnect
             } catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
@@ -181,8 +190,10 @@ function Update-DbaMaintenanceSolution {
                 }
             }
 
-            # Close non-pooled connection as this is not done automatically. If it is a reused Server SMO, connection will be opened again automatically on next request.
-            $null = $server | Disconnect-DbaInstance
+            if ($isNewConnection) {
+                # Close non-pooled connection as this is not done automatically.
+                $null = $server | Disconnect-DbaInstance
+            }
         }
     }
 }

--- a/public/Update-DbaMaintenanceSolution.ps1
+++ b/public/Update-DbaMaintenanceSolution.ps1
@@ -148,7 +148,15 @@ function Update-DbaMaintenanceSolution {
                 Stop-Function -Message "Database $Database not found on $instance. Skipping." -Target $instance -Continue
             }
 
-            $installedProcedures = Get-DbaModule -SqlInstance $server -Database $Database | Where-Object Name -in 'CommandExecute', 'DatabaseBackup', 'DatabaseIntegrityCheck', 'IndexOptimize'
+            # The names are read with a query that names the database. Get-DbaModule would run on the connection of
+            # the caller and leave it in that database, and this command used to rely on exactly that to find the
+            # right database further down. See #10555.
+            $splatInstalledProcedures = @{
+                SqlInstance = $server
+                Database    = $Database
+                Query       = "SELECT name FROM sys.procedures"
+            }
+            $installedProcedures = (Invoke-DbaQuery @splatInstalledProcedures).name | Where-Object { $PSItem -in "CommandExecute", "DatabaseBackup", "DatabaseIntegrityCheck", "IndexOptimize" }
 
             foreach ($solutionName in $Solution) {
                 if ($solutionName -in 'Backup', 'IntegrityCheck') {
@@ -168,7 +176,7 @@ function Update-DbaMaintenanceSolution {
                         Results      = $null
                     }
 
-                    if ($procedureName -notin $installedProcedures.Name) {
+                    if ($procedureName -notin $installedProcedures) {
                         $output.Results = 'Procedure not installed'
                     } else {
                         $file = Get-ChildItem -Path $localCachedCopy -Recurse -File "$procedureName.sql"
@@ -177,7 +185,7 @@ function Update-DbaMaintenanceSolution {
                         } else {
                             Write-Message -Level Verbose -Message "Updating $procedureName from $($file.FullName)."
                             try {
-                                $null = Invoke-DbaQuery -SqlInstance $server -File $file
+                                $null = Invoke-DbaQuery -SqlInstance $server -Database $Database -File $file
                                 $output.IsUpdated = $true
                                 $output.Results = 'Updated'
                             } catch {

--- a/tests/Update-DbaMaintenanceSolution.Tests.ps1
+++ b/tests/Update-DbaMaintenanceSolution.Tests.ps1
@@ -51,6 +51,36 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
+    Context "The connection of the caller is left open (#10554)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $splatUpdate = @{
+                SqlInstance = $callerServer
+                Database    = $databaseName
+                Solution    = "CommandExecute"
+            }
+            $null = Update-DbaMaintenanceSolution @splatUpdate
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+    }
+
     It "downloads the current GitHub source before checking installed procedures" {
         $results = Update-DbaMaintenanceSolution -SqlInstance $TestConfig.InstanceSingle -Database $databaseName -Solution CommandExecute -Force -EnableException
 

--- a/tests/Update-DbaMaintenanceSolution.Tests.ps1
+++ b/tests/Update-DbaMaintenanceSolution.Tests.ps1
@@ -51,19 +51,52 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
-    Context "The connection of the caller is left open (#10554)" {
+    Context "The update runs in the named database and the connection of the caller is left alone (#10554)" {
         BeforeAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Own database, so that the expectations of the other tests about $databaseName still hold.
+            $contextDbName = "dbatoolsci_maintenance_context_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+
+            # A stub of the procedure, so that the command sees it as installed and takes the update path.
+            $splatStub = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $contextDbName
+                Query       = "CREATE PROCEDURE dbo.CommandExecute AS SELECT 1"
+            }
+            $null = Invoke-DbaQuery @splatStub
+
+            # Remember whether master already has one, so that the cleanup cannot remove a real installation.
+            $splatMasterBefore = @{
+                SqlInstance  = $TestConfig.InstanceSingle
+                Database     = "master"
+                Query        = "SELECT COUNT(*) FROM sys.procedures WHERE name = @procName"
+                SqlParameter = @{ procName = "CommandExecute" }
+                As           = "SingleValue"
+            }
+            $masterHadProcedure = (Invoke-DbaQuery @splatMasterBefore) -gt 0
 
             $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
             $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
 
             $splatUpdate = @{
                 SqlInstance = $callerServer
-                Database    = $databaseName
+                Database    = $contextDbName
                 Solution    = "CommandExecute"
             }
-            $null = Update-DbaMaintenanceSolution @splatUpdate
+            $updateResult = Update-DbaMaintenanceSolution @splatUpdate
+
+            $splatUpdatedDefinition = @{
+                SqlInstance  = $TestConfig.InstanceSingle
+                Database     = $contextDbName
+                Query        = "SELECT definition FROM sys.sql_modules WHERE object_id = OBJECT_ID(@procName)"
+                SqlParameter = @{ procName = "dbo.CommandExecute" }
+                As           = "SingleValue"
+            }
+            $updatedDefinition = Invoke-DbaQuery @splatUpdatedDefinition
+
+            $masterHasProcedureNow = (Invoke-DbaQuery @splatMasterBefore) -gt 0
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
@@ -73,11 +106,38 @@ Describe $CommandName -Tag IntegrationTests {
 
             $null = $callerServer | Disconnect-DbaInstance
 
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName
+
+            if (-not $masterHadProcedure -and $masterHasProcedureNow) {
+                $splatCleanupMaster = @{
+                    SqlInstance = $TestConfig.InstanceSingle
+                    Database    = "master"
+                    Query       = "DROP PROCEDURE dbo.CommandExecute"
+                }
+                $null = Invoke-DbaQuery @splatCleanupMaster
+            }
+
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "reports the procedure as updated" {
+            $updateResult.IsUpdated | Should -BeTrue
+        }
+
+        It "updates the procedure in the database that was named" {
+            $updatedDefinition | Should -Match "@DatabaseContext"
+        }
+
+        It "does not create the procedure in the database the connection is on" {
+            $masterHasProcedureNow | Should -Be $masterHadProcedure
         }
 
         It "leaves the connection open, so the session survives" {
             { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+
+        It "leaves the connection in the database it was on" {
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "master"
         }
     }
 
@@ -92,3 +152,4 @@ Describe $CommandName -Tag IntegrationTests {
         $WarnVar | Should -Match "Force still suppresses confirmation prompts"
     }
 }
+


### PR DESCRIPTION
Third of the sites listed in #10554, and it fixes #10569 as well - the two belong together, see below.

## The disconnect

The command closed its connection when it was done, without asking whether it had opened it. When a caller passes their own server object, `Connect-DbaInstance` hands the same object back, and the command then closed the connection of the caller, taking the session with it. It now only closes what it opened itself.

## The database the update runs in

The command executed the update script without naming a database:

```powershell
$null = Invoke-DbaQuery -SqlInstance $server -File $file
```

The scripts of the maintenance solution carry no `USE` statement, so the procedures were updated in whatever database the connection happened to be on. That was the right one only by accident: `Get-DbaModule` on the line above runs `$server.Query($sql, $db.name)`, and SMO leaves the connection in the database it queried - #10555.

```
connected                     : DB_NAME()=master
after Get-DbaModule -Database : DB_NAME()=dbatoolsci_olactx
procedure landed in dbatoolsci_olactx     : 1
procedure landed in master                : 0
```

Two things follow from that. The obvious one: the moment `Get-DbaModule` stops leaking, this command starts updating `master` and reports `Updated` while doing it. The less obvious one: as long as the leak is what makes it work, no test of the target database can fail, so the fix cannot be covered.

Both halves are explicit now. The installed procedures are read with a query that names the database - the command only ever used the four names - and the update names the database as well. `Get-DbaModule` is untouched: its query uses `DB_NAME()` and unqualified catalog views, so fixing it belongs to that command.

## Tests

A context with its own database, called through a connection that sits on `master`:

- the procedure is reported as updated
- its definition in the named database is Ola's, not the stub that was there before
- `master` has no `CommandExecute` afterwards that it did not have before
- the session of the caller survives
- the connection of the caller is still on `master`

Reverting the `-Database` on the update fails two of them:

```
updates the procedure in the database that was named
  Expected regular expression '@DatabaseContext' to match 'CREATE PROCEDURE dbo.CommandExecute AS SELECT 1', but it did not match.
does not create the procedure in the database the connection is on
  Expected $false, but got $true.
```

and reverting the disconnect guard fails the session test. `Update-DbaMaintenanceSolution` passes 7 of 7 against SQL Server 2019.

---

*This text was created by Claude and reviewed by Andreas Jordan.*
