### PR TITLE
Install-DbaMaintenanceSolution - Leave the connection of the caller alone

### DIFF
--- a/public/Install-DbaMaintenanceSolution.ps1
+++ b/public/Install-DbaMaintenanceSolution.ps1
@@ -456,8 +456,17 @@ function Install-DbaMaintenanceSolution {
         }
 
         foreach ($instance in $SqlInstance) {
+            # Connect-DbaInstance tells us whether it opened a connection for us. We must only close what we opened
+            # ourselves, because closing a connection of the caller takes their session with it. See #10554.
+            $isNewConnection = $false
+            $splatConnect = @{
+                SqlInstance              = $instance
+                SqlCredential            = $SqlCredential
+                NonPooledConnection      = $true
+                IsNewConnectionReference = [ref]$isNewConnection
+            }
             try {
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -NonPooledConnection
+                $server = Connect-DbaInstance @splatConnect
             } catch {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
@@ -558,7 +567,9 @@ function Install-DbaMaintenanceSolution {
 
                 if ($Pscmdlet.ShouldProcess($instance, "Dropping all objects created by Ola's Maintenance Solution")) {
                     Write-ProgressHelper -ExcludePercent -Message "Dropping objects created by Ola's Maintenance Solution"
-                    $null = $db.Invoke($cleanupQuery)
+                    # Invoke-DbaQuery names the database instead of running on the connection of the caller, which
+                    # $db.Invoke() would leave in that database. This is how the installation below runs as well.
+                    $null = Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $cleanupQuery -EnableException
                 }
 
                 # Remove Ola's Jobs
@@ -891,8 +902,10 @@ function Install-DbaMaintenanceSolution {
                 }
             }
 
-            # Close non-pooled connection as this is not done automatically. If it is a reused Server SMO, connection will be opened again automatically on next request.
-            $null = $server | Disconnect-DbaInstance
+            if ($isNewConnection) {
+                # Close non-pooled connection as this is not done automatically.
+                $null = $server | Disconnect-DbaInstance
+            }
         }
 
         Write-ProgressHelper -ExcludePercent -Message "Installation complete"

--- a/tests/Install-DbaMaintenanceSolution.Tests.ps1
+++ b/tests/Install-DbaMaintenanceSolution.Tests.ps1
@@ -193,6 +193,43 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 
+    Context "The connection of the caller is left alone (#10554)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -NonPooledConnection
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            # ReplaceExisting takes the code path that drops the existing objects, jobs are left out so that no
+            # SQL Agent command touches the connection - those are separate commands, see #10555.
+            $splatInstall = @{
+                SqlInstance     = $callerServer
+                Database        = "tempdb"
+                BackupLocation  = "NUL"
+                ReplaceExisting = $true
+            }
+            $null = Install-DbaMaintenanceSolution @splatInstall
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+
+        It "leaves the connection in the database it was on" {
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "master"
+        }
+    }
+
     Context "Additional backup parameters all enabled" {
         AfterEach {
             Invoke-DbaQuery -SqlInstance $TestConfig.InstanceMulti2 -Query $jobStep.Command -NoExec -EnableException


### PR DESCRIPTION
Fourth of the sites listed in #10554.

## The disconnect

The command closed its connection when it was done, without asking whether it had opened it. When a caller passes their own server object, `Connect-DbaInstance` hands the same object back, and the command then closed the connection of the caller, taking the session with it. It now only closes what it opened itself.

## The leak the disconnect was hiding

With `-ReplaceExisting`, the existing objects are dropped through `$db.Invoke($cleanupQuery)`, which runs on the connection of the caller and leaves it in that database - #10555. The disconnect covered that up, because the connection was closed right afterwards.

The installation of the scripts a few lines below already names the database:

```powershell
$null = Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $sql -EnableException
```

so the cleanup now does the same. Same statements, same database, and the connection of the caller is untouched.

## Tests

A new context installs with `-ReplaceExisting` through a connection the caller opened, and asserts that the session survives and that the connection is still on `master`. Each assertion covers one of the two changes, verified by putting each one back:

```
=== branch as committed (both fixes) ===
session survived: True
DB_NAME()       : master

=== with $db.Invoke() restored ===
session survived: True
DB_NAME()       : tempdb

=== with the disconnect guard removed ===
session survived: False
DB_NAME()       : master
```

Jobs are deliberately left out of that context (`-InstallJobs` not set), because the SQL Agent commands move the connection themselves - `New-DbaAgentJob` and `Remove-DbaAgentJob` are their own sites of #10555 and are not touched here.

`Install-DbaMaintenanceSolution` passes 52 of 52 against SQL Server 2025 and 2022, in 20 minutes.

---

*This text was created by Claude and reviewed by Andreas Jordan.*
