### PR TITLE
Import-DbaBinaryFile - Work with a connection that is already open

### DIFF
--- a/public/Import-DbaBinaryFile.ps1
+++ b/public/Import-DbaBinaryFile.ps1
@@ -235,7 +235,17 @@ function Import-DbaBinaryFile {
                         Write-Message -Level Verbose -Message "Statement: $Statement"
                         $cmd = $server.ConnectionContext.SqlConnectionObject.CreateCommand()
                         $cmd.CommandText = $Statement
-                        $cmd.Connection.Open()
+                        # The connection belongs to the caller, so it is only opened and closed again if it was
+                        # closed to begin with. Opening an open connection throws, and closing the connection of
+                        # the caller takes their session with it. See #10554.
+                        # The connection belongs to the caller, so it is only opened and closed again if it was
+                        # closed to begin with. Opening an open connection throws, and closing the connection of
+                        # the caller takes their session with it. See #10554.
+                        $openedConnection = $false
+                        if ($cmd.Connection.State -ne [System.Data.ConnectionState]::Open) {
+                            $cmd.Connection.Open()
+                            $openedConnection = $true
+                        }
 
                         $datatype = ($tbl.Columns | Where-Object Name -eq $BinaryColumn).DataType
                         Write-Message -Level Verbose -Message "Binary column datatype is $datatype"
@@ -246,7 +256,9 @@ function Import-DbaBinaryFile {
                         $null = $cmd.ExecuteScalar()
 
                         try {
-                            $cmd.Connection.Close()
+                            if ($openedConnection) {
+                                $cmd.Connection.Close()
+                            }
                             $cmd.Dispose()
                             $filestream.Close()
                             $filestream.Dispose()
@@ -276,7 +288,6 @@ function Import-DbaBinaryFile {
                             $binaryreader.Close()
                             $binaryreader.Dispose()
                         }
-                        $null = $server | Disconnect-DbaInstance
                     }
                 }
             }

--- a/tests/Import-DbaBinaryFile.Tests.ps1
+++ b/tests/Import-DbaBinaryFile.Tests.ps1
@@ -29,3 +29,84 @@ Describe $CommandName -Tag UnitTests {
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $dbName = "dbatoolsci_binaryfile_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $dbName
+
+        $splatTable = @{
+            SqlInstance = $TestConfig.InstanceSingle
+            Database    = $dbName
+            Query       = "CREATE TABLE dbo.BinaryFiles (FileName nvarchar(255), FileData varbinary(max))"
+        }
+        $null = Invoke-DbaQuery @splatTable
+
+        # Two files, because the command used to close the connection after every single one of them.
+        $importPath = "$($TestConfig.Temp)\$CommandName-$(Get-Random)"
+        $null = New-Item -Path $importPath -ItemType Directory
+        Set-Content -Path "$importPath\first.txt" -Value "first file"
+        Set-Content -Path "$importPath\second.txt" -Value "second file"
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbName
+        Remove-Item -Path $importPath -Recurse -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "Importing through a connection of the caller (#10554)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            # The connection is in use and therefore open, which is what the command has to cope with.
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $splatImport = @{
+                SqlInstance = $callerServer
+                Database    = $dbName
+                Table       = "BinaryFiles"
+                Path        = $importPath
+            }
+            $importResults = Import-DbaBinaryFile @splatImport
+
+            $splatCount = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbName
+                Query       = "SELECT COUNT(*) FROM dbo.BinaryFiles"
+                As          = "SingleValue"
+            }
+            $importedRows = Invoke-DbaQuery @splatCount
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "imports every file" {
+            $importResults.Status | Should -Be "Success", "Success"
+            $importedRows | Should -Be 2
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+    }
+}


### PR DESCRIPTION
Fifth of the sites listed in #10554, and it turned out to be more than a stray disconnect.

## What was wrong

The command opens the `SqlConnection` of the server object for every file:

```powershell
$cmd.Connection.Open()
```

and closes the whole connection again in the `finally`:

```powershell
$null = $server | Disconnect-DbaInstance
```

`$server` comes from the table that was piped in (`$tbl.Parent.Parent`), so the command never opened that connection in the first place.

Two consequences. A connection that is already open - the normal state of a connection someone is working with - makes the command fail outright:

```
Import-DbaBinaryFile : The connection was not closed. The connection's current state is open.
```

And in the case where it does work, the session of the caller is gone afterwards, because the connection was closed and silently reopened.

The disconnect could not simply be deleted: it is what makes the loop over several files work, because the next `Open()` needs a closed connection.

## What this changes

The connection is opened only when it was closed, closed again only when this command opened it, and the disconnect is gone.

## Tests

The command had no integration tests at all. There is now a context that imports two files through a connection the caller opened and holds open:

- both files are imported and the rows are in the table
- the session of the caller survives

With the unconditional `Open()` back in place, the whole context fails with the error above, so the tests cover the change.

`Import-DbaBinaryFile` passes 3 of 3 against SQL Server 2019.

## Not in here

`Add-DbaRegServerGroup` was meant to be in this pull request as the second deletion. While testing it, the session of the caller still died after removing its disconnect, because the registered server commands share a second mechanism - `$serverstore.ServerConnection.Disconnect()` in `Get-DbaRegServer` and `Get-DbaRegServerGroup`, `$parentserver.ServerConnection.Disconnect()` in the `Move-*` and `Remove-*` commands, and the private `Disconnect-RegServer`. That family needs one coherent fix rather than a single deletion, and my inventory in #10554 missed it. I will add it there.

---

*This text was created by Claude and reviewed by Andreas Jordan.*
