### PR TITLE
Invoke-DbaAdvancedRestore - Leave the connection of the caller alone

### DIFF
--- a/public/Invoke-DbaAdvancedRestore.ps1
+++ b/public/Invoke-DbaAdvancedRestore.ps1
@@ -257,8 +257,17 @@ function Invoke-DbaAdvancedRestore {
         [switch]$EnableException
     )
     begin {
+        # Connect-DbaInstance tells us whether it opened a connection for us. We must only close what we opened
+        # ourselves, because closing a connection of the caller takes their session with it. Restore-DbaDatabase
+        # connects once and hands that server object down to here, so this is the connection of its caller. See #10554.
+        $isNewConnection = $false
+        $splatConnect = @{
+            SqlInstance              = $SqlInstance
+            SqlCredential            = $SqlCredential
+            IsNewConnectionReference = [ref]$isNewConnection
+        }
         try {
-            $server = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $server = Connect-DbaInstance @splatConnect
         } catch {
             Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
             return
@@ -531,7 +540,7 @@ function Invoke-DbaAdvancedRestore {
                             Write-Progress -id 1 -Activity "Restoring $database to $SqlInstance - Backup $BackupCnt of $($Backups.count)" -percentcomplete $outerProgress -status ([System.String]::Format("Progress: {0:N2} %", $outerProgress))
                         }
                     } catch {
-                        Write-Message -Level Verbose -Message "Failed, Closing Server connection"
+                        Write-Message -Level Verbose -Message "Failed to restore $database"
                         $restoreComplete = $False
                         $ExitError = $_.Exception.InnerException
                         Stop-Function -Message "Failed to restore db $database, stopping" -ErrorRecord $_ -Continue
@@ -598,17 +607,20 @@ function Invoke-DbaAdvancedRestore {
                         if ($restore.Devices.Count -gt 0) {
                             $restore.Devices.Clear()
                         }
-                        Write-Message -Level Verbose -Message "Closing Server connection"
-                        $server.ConnectionContext.Disconnect()
                     }
                 }
                 $BackupCnt++
             }
             Write-Progress -id 2 -Activity "Finished" -Completed
-            if ($server.ConnectionContext.exists) {
-                $server.ConnectionContext.Disconnect()
-            }
             Write-Progress -id 1 -Activity "Finished" -Completed
+        }
+
+        # This used to sit inside the loop above and be guarded by ConnectionContext.exists, which is not a
+        # property of a ServerConnection, so it was never reached. Now it runs once, and only for a connection
+        # that was opened here.
+        if ($isNewConnection) {
+            Write-Message -Level Verbose -Message "Closing the connection that was opened for the restore"
+            $server.ConnectionContext.Disconnect()
         }
     }
 }

--- a/tests/Invoke-DbaAdvancedRestore.Tests.ps1
+++ b/tests/Invoke-DbaAdvancedRestore.Tests.ps1
@@ -184,8 +184,145 @@ Describe $CommandName -Tag UnitTests {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/dataplat/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        # For all the backups that we want to clean up after the test, we create a directory that we can delete at the end.
+        $backupPath = "$($TestConfig.Temp)\$CommandName-$(Get-Random)"
+        $null = New-Item -Path $backupPath -ItemType Directory
+
+        # A full and a log backup, so that the restore runs more than one backup file. The disconnect this is
+        # about sat inside the loop over the backup files, so a single file would not show the whole of it.
+        $restoreDbName = "dbatoolsci_advrestore_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $restoreDbName -RecoveryModel Full
+        $null = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $restoreDbName -BackupDirectory $backupPath -Type Full
+        $null = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $restoreDbName -BackupDirectory $backupPath -Type Log
+
+        # The history is what Restore-DbaDatabase builds before it hands over, so the tests below can call the
+        # command the same way it does.
+        $backupHistory = Get-DbaBackupInformation -SqlInstance $TestConfig.InstanceSingle -Path $backupPath |
+            Select-DbaBackupInformation |
+            Format-DbaBackupInformation |
+            Test-DbaBackupInformation -SqlInstance $TestConfig.InstanceSingle -WithReplace
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $restoreDbName -ErrorAction SilentlyContinue
+        Remove-Item -Path $backupPath -Recurse -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "The connection of the caller is left alone (#10554)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Only a non-pooled connection can show this. SMO silently reopens a pooled connection, so the test
+            # would pass even with the disconnect after every backup file.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $splatRestore = @{
+                SqlInstance = $callerServer
+                WithReplace = $true
+            }
+            $callerResult = $backupHistory | Invoke-DbaAdvancedRestore @splatRestore
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "restores every backup file" {
+            $callerResult.Count | Should -BeGreaterThan 1
+            $callerResult.RestoreComplete | Should -Not -Contain $false
+        }
+
+        It "leaves the connection open" {
+            $callerServer.ConnectionContext.IsOpen | Should -BeTrue
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+
+        It "leaves the connection in the database it was on" {
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "master"
+        }
+    }
+
+    Context "The connection of the caller of Restore-DbaDatabase is left alone (#10554)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Restore-DbaDatabase connects once and hands that server object down, so this is the connection that
+            # gets closed in practice.
+            $restoreCallerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $null = $restoreCallerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $splatRestoreDatabase = @{
+                SqlInstance = $restoreCallerServer
+                Path        = $backupPath
+                WithReplace = $true
+            }
+            $restoreCallerResult = Restore-DbaDatabase @splatRestoreDatabase
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $restoreCallerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "restores every backup file" {
+            $restoreCallerResult.RestoreComplete | Should -Not -Contain $false
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $restoreCallerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+    }
+
+    Context "The command still closes the connection it opens itself" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Passing the name instead of a server object is the other side of the guard: the command opens the
+            # connection here, so it is the one that has to close it again.
+            $splatRestoreByName = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                WithReplace = $true
+            }
+            $ownResult = $backupHistory | Invoke-DbaAdvancedRestore @splatRestoreByName
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "restores every backup file" {
+            $ownResult.RestoreComplete | Should -Not -Contain $false
+        }
+
+        It "does not warn" {
+            $WarnVar | Should -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #10554 in part)
 - [x] Ran manual Pester test and has passed
 - [x] Pester test is included

### Purpose

Last command of the inventory in #10554, and the one with the widest reach: `Restore-DbaDatabase` connects once and hands that server object down to here, so the connection that gets closed is the one its caller passed in.

```powershell
Write-Message -Level Verbose -Message "Closing Server connection"
$server.ConnectionContext.Disconnect()
```

That sits in the `finally` of the loop over the backup files, so it fires **after every single backup file**. Verified on SQL Server 2019 with `Connect-DbaInstance -NonPooledConnection` and a temp table as the session marker:

```
=== Restore-DbaDatabase with a connection of the caller ===
  before: IsOpen True, database master
  after Restore-DbaDatabase
    IsOpen          : False
    session survived: False

=== Invoke-DbaAdvancedRestore directly with a connection of the caller ===
  before: IsOpen True
  after Invoke-DbaAdvancedRestore
    IsOpen          : False
    session survived: False
```

### Approach

`Connect-DbaInstance` reports through `IsNewConnectionReference` whether it opened the connection, and only a connection opened here is closed.

The per-backup-file disconnect is gone rather than guarded. Reconnecting between the files of one restore chain serves nothing - SMO opens the connection again for the next file anyway.

The disconnect at the end of the loop over the databases was guarded by `$server.ConnectionContext.exists`:

```powershell
if ($server.ConnectionContext.exists) {
    $server.ConnectionContext.Disconnect()
}
```

`exists` is not a property of a `ServerConnection`, so the condition was always `$null` and the block never ran. It now runs once, after all databases are done, and only for a connection this command opened itself.

Two things checked while in there and deliberately left alone:

- `$server.ConnectionContext.Connect()` after killing processes or dropping the database is idempotent on an open connection and does not lose the session, so it stays as it is.
- The progress bars in this command are odd in places, but they belong to the separate progress-bar cleanup and are not touched here.

The only other change is the verbose message in the `catch`, which said the server connection was being closed - the `catch` has never done that.

### Commands to test

```powershell
$server = Connect-DbaInstance -SqlInstance $instance -NonPooledConnection
$null = $server.ConnectionContext.ExecuteNonQuery("CREATE TABLE #t (id int)")
$null = Restore-DbaDatabase -SqlInstance $server -Path $backupFolder -WithReplace
$server.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #t")   # 0, was: Invalid object name '#t'
```

### Tests

`tests\Invoke-DbaAdvancedRestore.Tests.ps1` had unit tests only. Three integration contexts were added on `InstanceSingle`, all against a full plus a log backup so that the restore really runs more than one backup file - a single file would not show the disconnect that sat inside that loop:

- the command called with a server object of the caller leaves the connection open, the session intact and the database context unchanged, and still restores every file
- `Restore-DbaDatabase` with a server object of the caller does the same, which is the path this reaches in practice
- called with an instance name, the command still opens and closes its own connection, restores every file and does not warn

14 tests, all passing. Against `development` 3 of them fail, covering both the direct call and the `Restore-DbaDatabase` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
