### PR TITLE
Registered server commands - Leave the connection of the caller alone

### DIFF
--- a/private/functions/Disconnect-Regserver.ps1
+++ b/private/functions/Disconnect-Regserver.ps1
@@ -1,8 +1,22 @@
 function Disconnect-Regserver ($Server) {
+    <#
+    .SYNOPSIS
+        Internal function. Closes the connection behind a registered server object, but only if we opened it.
+
+    .DESCRIPTION
+        Takes any object of the registered server tree - a store, a group or a registered server - and walks up
+        to the RegisteredServersStore, which is the object that holds the connection.
+
+        The connection is only closed when Get-DbaRegServerStore opened it itself, which it records as
+        IsNewConnection on the store. A connection that was handed in belongs to the caller, and closing it takes
+        their session, their temp tables and their database context with it. See #10572.
+    #>
     $i = 0
-    do { $server = $server.Parent }
-    until ($null -ne $server.ServerConnection -or $i++ -gt 20)
-    if ($server.ServerConnection) {
-        $server.ServerConnection.Disconnect()
+    while ($null -ne $Server -and $null -eq $Server.ServerConnection -and $i++ -le 20) {
+        $Server = $Server.Parent
+    }
+
+    if ($Server.ServerConnection -and $Server.IsNewConnection) {
+        $Server.ServerConnection.Disconnect()
     }
 }

--- a/public/Add-DbaRegServerGroup.ps1
+++ b/public/Add-DbaRegServerGroup.ps1
@@ -151,9 +151,7 @@ function Add-DbaRegServerGroup {
                     $newgroup.Alter()
 
                     Get-DbaRegServerGroup -SqlInstance $currentInstance -Group (Get-RegServerGroupReverseParse -object $newgroup)
-                    if ($currentInstance.ConnectionContext) {
-                        $currentInstance.ConnectionContext.Disconnect()
-                    }
+                    Disconnect-RegServer -Server $newgroup
                 } catch {
                     Stop-Function -Message "Failed to add $reggroup" -ErrorRecord $_ -Continue
                 }

--- a/public/Get-DbaRegServer.ps1
+++ b/public/Get-DbaRegServer.ps1
@@ -219,7 +219,7 @@ function Get-DbaRegServer {
                 }
             } else {
                 $servers += ($serverstore.DatabaseEngineServerGroup.GetDescendantRegisteredServers())
-                $serverstore.ServerConnection.Disconnect()
+                Disconnect-RegServer -Server $serverstore
             }
 
             # save the $serverstore for later usage

--- a/public/Get-DbaRegServerGroup.ps1
+++ b/public/Get-DbaRegServerGroup.ps1
@@ -177,9 +177,7 @@ function Get-DbaRegServerGroup {
                     $groups = $serverstore.DatabaseEngineServerGroup.GetDescendantRegisteredServers().Parent | Where-Object Id -In $Id
                 }
             }
-            if ($serverstore.ServerConnection) {
-                $serverstore.ServerConnection.Disconnect()
-            }
+            Disconnect-RegServer -Server $serverstore
 
             foreach ($groupobject in $groups) {
                 Add-Member -Force -InputObject $groupobject -MemberType NoteProperty -Name ComputerName -Value $serverstore.ComputerName

--- a/public/Get-DbaRegServerStore.ps1
+++ b/public/Get-DbaRegServerStore.ps1
@@ -48,7 +48,9 @@ function Get-DbaRegServerStore {
         - RegisteredServers: Collection of registered servers at the root level
 
         Properties excluded from default display (internal/technical properties):
-        - ServerConnection, DomainInstanceName, DomainName, Urn, Properties, Metadata, Parent, ConnectionContext, PropertyMetadataChanged, PropertyChanged, ParentServer
+        - ServerConnection, DomainInstanceName, DomainName, Urn, Properties, Metadata, Parent, ConnectionContext, PropertyMetadataChanged, PropertyChanged, ParentServer, IsNewConnection
+
+        IsNewConnection records whether the connection behind the store was opened here or handed in by the caller. The registered server commands use it to decide whether they may close the connection when they are done.
 
         All SMO RegisteredServersStore properties are accessible using Select-Object *, including the excluded properties if needed for advanced operations.
 
@@ -72,8 +74,17 @@ function Get-DbaRegServerStore {
     )
     process {
         foreach ($instance in $SqlInstance) {
+            # Connect-DbaInstance tells us whether it opened a connection for us. The whole registered server
+            # family closes the connection through Disconnect-RegServer, which reads the answer back off the
+            # store, so that only a connection this module opened is ever closed. See #10572.
+            $isNewConnection = $false
+            $splatConnect = @{
+                SqlInstance              = $instance
+                SqlCredential            = $SqlCredential
+                IsNewConnectionReference = [ref]$isNewConnection
+            }
             try {
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance @splatConnect
             } catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
@@ -88,7 +99,8 @@ function Get-DbaRegServerStore {
             Add-Member -Force -InputObject $store -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
             Add-Member -Force -InputObject $store -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
             Add-Member -Force -InputObject $store -MemberType NoteProperty -Name ParentServer -value $server
-            Select-DefaultView -InputObject $store -ExcludeProperty ServerConnection, DomainInstanceName, DomainName, Urn, Properties, Metadata, Parent, ConnectionContext, PropertyMetadataChanged, PropertyChanged, ParentServer
+            Add-Member -Force -InputObject $store -MemberType NoteProperty -Name IsNewConnection -value $isNewConnection
+            Select-DefaultView -InputObject $store -ExcludeProperty ServerConnection, DomainInstanceName, DomainName, Urn, Properties, Metadata, Parent, ConnectionContext, PropertyMetadataChanged, PropertyChanged, ParentServer, IsNewConnection
         }
 
         # Magic courtesy of Mathias Jessen and David Shifflet

--- a/public/Move-DbaRegServer.ps1
+++ b/public/Move-DbaRegServer.ps1
@@ -126,7 +126,7 @@ function Move-DbaRegServer {
                 try {
                     $null = $parentserver.ServerConnection.ExecuteNonQuery($regserver.ScriptMove($movetogroup).GetScript())
                     Get-DbaRegServer -SqlInstance $server -Name $regserver.Name -ServerName $regserver.ServerName
-                    $parentserver.ServerConnection.Disconnect()
+                    Disconnect-RegServer -Server $parentserver
                 } catch {
                     Stop-Function -Message "Failed to move $($regserver.Name) to $Group on $($regserver.SqlInstance)" -ErrorRecord $_ -Continue
                 }

--- a/public/Move-DbaRegServerGroup.ps1
+++ b/public/Move-DbaRegServerGroup.ps1
@@ -130,7 +130,7 @@ function Move-DbaRegServerGroup {
                     Write-Message -Level Verbose -Message "Executing $($regservergroup.ScriptMove($groupobject).GetScript())"
                     $null = $parentserver.ServerConnection.ExecuteNonQuery($regservergroup.ScriptMove($groupobject).GetScript())
                     Get-DbaRegServerGroup -SqlInstance $server -Group $newname
-                    $parentserver.ServerConnection.Disconnect()
+                    Disconnect-RegServer -Server $parentserver
                 } catch {
                     Stop-Function -Message "Failed to move $($regserver.Name) to $NewGroup on $($regserver.SqlInstance)" -ErrorRecord $_ -Continue
                 }

--- a/public/Remove-DbaRegServerGroup.ps1
+++ b/public/Remove-DbaRegServerGroup.ps1
@@ -115,7 +115,7 @@ function Remove-DbaRegServerGroup {
                 # try to avoid 'Collection was modified after the enumerator was instantiated' issue
                 if ($regservergroup.ID) {
                     $null = $parentserver.ServerConnection.ExecuteNonQuery($regservergroup.ScriptDrop().GetScript())
-                    $parentserver.ServerConnection.Disconnect()
+                    Disconnect-RegServer -Server $parentserver
                 } else {
                     $regservergroup.Drop()
                 }

--- a/tests/Add-DbaRegServerGroup.Tests.ps1
+++ b/tests/Add-DbaRegServerGroup.Tests.ps1
@@ -108,4 +108,39 @@ Describe $CommandName -Tag IntegrationTests {
             $results.SqlInstance | Should -Not -BeNullOrEmpty
         }
     }
+
+    Context "The connection of the caller is left alone (#10572)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Only a non-pooled connection can show this. SMO silently reopens a pooled connection, so the test
+            # would pass even with the disconnect this is about.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $callerGroupName = "dbatoolsci-caller-group"
+            $callerResult = Add-DbaRegServerGroup -SqlInstance $callerServer -Name $callerGroupName
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still adds the group" {
+            $callerResult.Name | Should -Be $callerGroupName
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+    }
 }

--- a/tests/Get-DbaRegServer.Tests.ps1
+++ b/tests/Get-DbaRegServer.Tests.ps1
@@ -197,4 +197,44 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Property Comparisons will come later when we have the commands
     }
+
+    Context "The connection of the caller is left alone (#10572)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # This context brings its own registered server, because the one of the context above is cleaned up
+            # by the time this runs.
+            $callerRegSrvName = "dbatoolsci-caller-server"
+            $null = Add-DbaRegServer -SqlInstance $TestConfig.InstanceSingle -ServerName $callerRegSrvName -Name $callerRegSrvName
+
+            # Only a non-pooled connection can show this. SMO silently reopens a pooled connection, so the test
+            # would pass even with the disconnect this is about.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $callerResult = Get-DbaRegServer -SqlInstance $callerServer
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            Get-DbaRegServer -SqlInstance $TestConfig.InstanceSingle -Name $callerRegSrvName | Remove-DbaRegServer -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still returns the registered servers" {
+            $callerResult.Name | Should -Contain $callerRegSrvName
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+    }
 }

--- a/tests/Get-DbaRegServerGroup.Tests.ps1
+++ b/tests/Get-DbaRegServerGroup.Tests.ps1
@@ -132,4 +132,38 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Property Comparisons will come later when we have the commands
     }
+
+    Context "The connection of the caller is left alone (#10572)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Only a non-pooled connection can show this. SMO silently reopens a pooled connection, so the test
+            # would pass even with the disconnect this is about.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $callerResult = Get-DbaRegServerGroup -SqlInstance $callerServer -Id 1
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still returns the group" {
+            $callerResult.Name | Should -Be "DatabaseEngineServerGroup"
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+    }
 }

--- a/tests/Get-DbaRegServerStore.Tests.ps1
+++ b/tests/Get-DbaRegServerStore.Tests.ps1
@@ -28,4 +28,37 @@ Describe $CommandName -Tag IntegrationTests {
             $results.DisplayName | Should -Be "Central Management Servers"
         }
     }
+
+    Context "The store records who owns the connection (#10572)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # This is what the whole registered server family reads to decide whether it may close the
+            # connection when it is done.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $storeFromName = Get-DbaRegServerStore -SqlInstance $TestConfig.InstanceSingle
+            $storeFromServer = Get-DbaRegServerStore -SqlInstance $callerServer
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "reports a connection it opened itself as its own" {
+            $storeFromName.IsNewConnection | Should -BeTrue
+        }
+
+        It "reports a connection of the caller as not its own" {
+            $storeFromServer.IsNewConnection | Should -BeFalse
+        }
+    }
 }

--- a/tests/Move-DbaRegServer.Tests.ps1
+++ b/tests/Move-DbaRegServer.Tests.ps1
@@ -89,4 +89,49 @@ Describe $CommandName -Tag IntegrationTests {
         $results = Get-DbaRegServer -SqlInstance $TestConfig.InstanceSingle -Group $testGroupHR | Move-DbaRegServer -Group $testGroupFinance
         $results.Count | Should -Be 2
     }
+
+    Context "The connection of the caller is left alone (#10572)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $callerRegSrvName = "dbatoolsci-caller-server"
+            $callerTargetName = "dbatoolsci-caller-target"
+            $null = Add-DbaRegServerGroup -SqlInstance $TestConfig.InstanceSingle -Name $callerTargetName
+            $null = Add-DbaRegServer -SqlInstance $TestConfig.InstanceSingle -ServerName $callerRegSrvName -Name $callerRegSrvName
+
+            # Only a non-pooled connection can show this. SMO silently reopens a pooled connection, so the test
+            # would pass even with the disconnect this is about.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+
+            # The marker is created after the lookup on purpose, because Get-DbaRegServer closes the connection
+            # too. This test has to measure the command under test, not its input.
+            $callerInputObject = Get-DbaRegServer -SqlInstance $callerServer -Name $callerRegSrvName
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $callerResult = Move-DbaRegServer -InputObject $callerInputObject -Group $callerTargetName
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            Get-DbaRegServer -SqlInstance $TestConfig.InstanceSingle -Name $callerRegSrvName | Remove-DbaRegServer -ErrorAction SilentlyContinue
+            Get-DbaRegServerGroup -SqlInstance $TestConfig.InstanceSingle -Group $callerTargetName | Remove-DbaRegServerGroup -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still moves the registered server" {
+            $callerResult.Parent.Name | Should -Be $callerTargetName
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+    }
 }

--- a/tests/Move-DbaRegServerGroup.Tests.ps1
+++ b/tests/Move-DbaRegServerGroup.Tests.ps1
@@ -67,4 +67,48 @@ Describe $CommandName -Tag IntegrationTests {
             $results.Parent.Name | Should -Be "DatabaseEngineServerGroup"
         }
     }
+
+    Context "The connection of the caller is left alone (#10572)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $callerGroupName = "dbatoolsci-caller-group"
+            $callerTargetName = "dbatoolsci-caller-target"
+            $null = Add-DbaRegServerGroup -SqlInstance $TestConfig.InstanceSingle -Name $callerGroupName
+            $null = Add-DbaRegServerGroup -SqlInstance $TestConfig.InstanceSingle -Name $callerTargetName
+
+            # Only a non-pooled connection can show this. SMO silently reopens a pooled connection, so the test
+            # would pass even with the disconnect this is about.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+
+            # The marker is created after the lookup on purpose, because Get-DbaRegServerGroup closes the
+            # connection too. This test has to measure the command under test, not its input.
+            $callerInputObject = Get-DbaRegServerGroup -SqlInstance $callerServer -Group $callerGroupName
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $callerResult = Move-DbaRegServerGroup -InputObject $callerInputObject -NewGroup $callerTargetName
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            Get-DbaRegServerGroup -SqlInstance $TestConfig.InstanceSingle -Group $callerTargetName | Remove-DbaRegServerGroup -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still moves the group" {
+            $callerResult.Parent.Name | Should -Be $callerTargetName
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+    }
 }

--- a/tests/Remove-DbaRegServer.Tests.ps1
+++ b/tests/Remove-DbaRegServer.Tests.ps1
@@ -81,4 +81,46 @@ Describe $CommandName -Tag IntegrationTests {
             $results.Status | Should -Be "Dropped"
         }
     }
+
+    Context "The connection of the caller is left alone (#10572)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $callerRegSrvName = "dbatoolsci-caller-server"
+            $null = Add-DbaRegServer -SqlInstance $TestConfig.InstanceSingle -ServerName $callerRegSrvName -Name $callerRegSrvName
+
+            # Only a non-pooled connection can show this. SMO silently reopens a pooled connection, so the test
+            # would pass even with the disconnect this is about.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+
+            # The marker is created after the lookup on purpose, because Get-DbaRegServer closes the connection
+            # too. This test has to measure the command under test, not its input.
+            $callerInputObject = Get-DbaRegServer -SqlInstance $callerServer -Name $callerRegSrvName
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $callerResult = Remove-DbaRegServer -InputObject $callerInputObject
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            Get-DbaRegServer -SqlInstance $TestConfig.InstanceSingle -Name $callerRegSrvName | Remove-DbaRegServer -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still drops the registered server" {
+            $callerResult.Status | Should -Be "Dropped"
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+    }
 }

--- a/tests/Remove-DbaRegServerGroup.Tests.ps1
+++ b/tests/Remove-DbaRegServerGroup.Tests.ps1
@@ -69,4 +69,45 @@ Describe $CommandName -Tag IntegrationTests {
             $results.Name | Should -Be "dbatoolsci-third"
         }
     }
+
+    Context "The connection of the caller is left alone (#10572)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $callerGroupName = "dbatoolsci-caller-group"
+            $null = Add-DbaRegServerGroup -SqlInstance $TestConfig.InstanceSingle -Name $callerGroupName
+
+            # Only a non-pooled connection can show this. SMO silently reopens a pooled connection, so the test
+            # would pass even with the disconnect this is about.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+
+            # The marker is created after the lookup on purpose, because Get-DbaRegServerGroup closes the
+            # connection too. This test has to measure the command under test, not its input.
+            $callerInputObject = Get-DbaRegServerGroup -SqlInstance $callerServer -Group $callerGroupName
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            $callerResult = Remove-DbaRegServerGroup -InputObject $callerInputObject
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still drops the group" {
+            $callerResult.Status | Should -Be "Dropped"
+        }
+
+        It "leaves the connection open, so the session survives" {
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+    }
 }


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #10572)
 - [x] Ran manual Pester test and has passed
 - [x] Pester test is included

### Purpose

Seven sites in the registered server commands closed a connection they did not open. **Two of them are `Get-` commands**, so merely reading registered servers ended the session of the connection that was handed in - temp tables, `SET` options, session context - and the connection was silently reopened afterwards, so nothing looked wrong.

Measured on SQL Server 2019 with a temp table as the marker and `Get-DbaDatabase` as a control:

```
Get-DbaRegServerGroup                      session survived: False
Get-DbaRegServer                           session survived: False
Add-DbaRegServerGroup                      session survived: False
Move-DbaRegServerGroup                     session survived: False
Move-DbaRegServer                          session survived: False
Remove-DbaRegServer                        session survived: False
Remove-DbaRegServerGroup                   session survived: False
Get-DbaRegServerStore (control)            session survived: True
Get-DbaDatabase (control)                  session survived: True
```

This is the family that the inventory in #10554 missed, because the grep behind it matched `Disconnect-DbaInstance` and `ConnectionContext.Disconnect()` but not the generic `.Disconnect()` these use.

### Approach

One fix, not seven. Removing the disconnect in `Add-DbaRegServerGroup` alone would change nothing, because it calls `Get-DbaRegServerGroup`, which disconnects as well - anything short of a decision covering the whole family leaves the symptom in place.

`Get-DbaRegServerStore` is where the connection is obtained, so it is where the answer is known. It asks `Connect-DbaInstance` through `IsNewConnectionReference` and records the result as `IsNewConnection` on the store.

A note property is safe **here**, unlike on a server object: the store is built fresh on every call and is never handed back to `Connect-DbaInstance`, so nothing can re-stamp it. That was the objection to a note property in #10554, and it does not apply to this object.

`Disconnect-Regserver` becomes the single place that acts on it. It already walked up the parents to find the connection; it now also accepts the store itself, and closes the connection only when the store says we opened it:

```powershell
$i = 0
while ($null -ne $Server -and $null -eq $Server.ServerConnection -and $i++ -le 20) {
    $Server = $Server.Parent
}

if ($Server.ServerConnection -and $Server.IsNewConnection) {
    $Server.ServerConnection.Disconnect()
}
```

The six sites that closed the connection by hand now go through it too, so there is one place left in the family that can close a connection.

### Commands to test

```powershell
$server = Connect-DbaInstance -SqlInstance $instance -NonPooledConnection
$null = $server.ConnectionContext.ExecuteNonQuery("CREATE TABLE #marker (id INT)")

$null = Get-DbaRegServerGroup -SqlInstance $server -Id 1

$server.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #marker")   # 0, was: Invalid object name '#marker'
```

### Tests

One regression context per fixed command, all on `InstanceSingle`, in the shape used for #10554: connect with `-NonPooledConnection`, create a temp table, call the command with that server object, assert the command still did its work and the temp table is still there. A pooled connection passes either way, so the tests have to be non-pooled.

`Get-DbaRegServerStore.Tests.ps1` covers the mechanism itself: `IsNewConnection` is `$true` for an instance name and `$false` for a connection of the caller.

For the commands that take an `-InputObject`, the marker is created **after** the lookup on purpose. `Get-DbaRegServer` and `Get-DbaRegServerGroup` close the connection too, so a marker created before the lookup would measure them instead of the command under test.

53 tests across the eight files, all passing. Against `development` every one of the eight files fails on exactly its new assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
