### PR TITLE
Database context - Put the database back in the Query and Invoke script methods

### DIFF
--- a/tests/InModule.TypeExtensions.Tests.ps1
+++ b/tests/InModule.TypeExtensions.Tests.ps1
@@ -15,7 +15,14 @@ Describe $CommandName -Tag IntegrationTests {
         # caught. The collation decides it, not the version, so this is asked of the instance rather than
         # assumed. On a case insensitive instance the scenario cannot be built at all and the Context skips.
         $caseDiscoveryServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
-        $instanceIsCaseSensitive = $caseDiscoveryServer.Collation -match "_CS_"
+        # Asked as a behaviour rather than matched against the collation name. The _BIN and _BIN2
+        # collations are case sensitive too and carry no _CS_, so a name match would skip this whole
+        # scenario on a binary collation instance. Comparing a name in sys.databases asks the exact
+        # question instead, because that column carries the collation of the instance - the one that
+        # database names are compared with. DB_NAME(1) is master, so the comparison needs no string
+        # literal of its own.
+        $caseProbeQuery = "SELECT CASE WHEN EXISTS (SELECT 1 FROM sys.databases WHERE name = UPPER(DB_NAME(1))) THEN 0 ELSE 1 END"
+        $instanceIsCaseSensitive = [bool]$caseDiscoveryServer.ConnectionContext.ExecuteScalar($caseProbeQuery)
         $null = $caseDiscoveryServer | Disconnect-DbaInstance
     }
 
@@ -142,9 +149,17 @@ Describe $CommandName -Tag IntegrationTests {
         BeforeAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
+            # One database and one connection per test. The scenario is spent once it has run: the restore
+            # fails because the previous database went offline, so the connection is left in master, and a
+            # second call from the same connection would have master as its previous database and restore
+            # it without trouble.
             $offlineDbName = "dbatoolsci_typeext_offline_$(Get-Random)"
             $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $offlineDbName
             $offlineServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName -NonPooledConnection
+
+            $offlineStopDbName = "dbatoolsci_typeext_offlinestop_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $offlineStopDbName
+            $offlineStopServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -Database $offlineStopDbName -NonPooledConnection
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
@@ -152,9 +167,11 @@ Describe $CommandName -Tag IntegrationTests {
         AfterAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-            $null = $offlineServer | Disconnect-DbaInstance
-            $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName -Online -Force -ErrorAction SilentlyContinue
-            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName -ErrorAction SilentlyContinue
+            $null = $offlineServer, $offlineStopServer | Disconnect-DbaInstance
+            foreach ($offlineDatabase in $offlineDbName, $offlineStopDbName) {
+                $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDatabase -Online -Force -ErrorAction SilentlyContinue
+                $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $offlineDatabase -ErrorAction SilentlyContinue
+            }
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
@@ -171,6 +188,28 @@ Describe $CommandName -Tag IntegrationTests {
             { $offlineServer.Databases["master"].Invoke($offlineStatement) } | Should -Not -Throw
 
             (Get-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName).Status | Should -Be "OFFLINE"
+        }
+
+        It "returns normally even when the caller turned warnings into terminating errors" {
+            # The same scenario with $WarningPreference = Stop, which is the one setting that can hand the
+            # outcome of the call back to the housekeeping after all: Write-Warning obeys the preference of
+            # the caller, and Stop makes it throw. The statement would have succeeded and the caller would
+            # still see an exception - and where the statement itself failed, that exception would replace
+            # its error. The wrapper neutralises the preference for its own warning, so this returns.
+            # The test above still proves that a caller asking for silence gets silence, which is why the
+            # preference is not simply forced to Continue.
+            $WarningPreference = "Stop"
+            $offlineStatement = "ALTER DATABASE [$offlineStopDbName] SET OFFLINE WITH ROLLBACK IMMEDIATE"
+
+            # Unlike the test above, the caller has not asked for silence here, so the warning is written -
+            # and it cannot be asserted on, because a script method writes to the host and neither
+            # -WarningVariable nor a redirection inside the method can reach it. It is merged into the
+            # output stream so that it does not land in the run, where the harness reads every warning as
+            # a defect. That does not soften the test: a preference of Stop throws before anything is
+            # written at all, which is how this fails against the unguarded code.
+            { $null = $offlineStopServer.Databases["master"].Invoke($offlineStatement) 3>&1 } | Should -Not -Throw
+
+            (Get-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineStopDbName).Status | Should -Be "OFFLINE"
         }
     }
 

--- a/tests/InModule.TypeExtensions.Tests.ps1
+++ b/tests/InModule.TypeExtensions.Tests.ps1
@@ -1,0 +1,122 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "InModule.TypeExtensions",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag IntegrationTests {
+    # The Query and Invoke script methods of Server and Database in xml\dbatools.Types.ps1xml run through
+    # the execution manager of a database, which is the connection context of the parent server and belongs
+    # to the caller. SMO issues a USE and never switches back, so the methods put the database back. See #10555.
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $contextDbName = "dbatoolsci_typeext_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "The database context of the caller survives the script methods (#10555)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Only a non-pooled connection can show this. SMO reopens a pooled connection at its default
+            # database, which hides the leak.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "leaves the database context alone in Database.Query" {
+            $null = $callerServer.Databases[$contextDbName].Query("SELECT 1")
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "master"
+        }
+
+        It "leaves the database context alone in Database.Invoke" {
+            $null = $callerServer.Databases[$contextDbName].Invoke("SELECT 1")
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "master"
+        }
+
+        It "leaves the database context alone in Server.Query with a database" {
+            $null = $callerServer.Query("SELECT 1", $contextDbName)
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "master"
+        }
+
+        It "leaves the database context alone in Server.Invoke with a database" {
+            $null = $callerServer.Invoke("SELECT 1", $contextDbName)
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "master"
+        }
+
+        It "still runs the query in the database that was asked for" {
+            $callerServer.Databases[$contextDbName].Query("SELECT DB_NAME() AS dbname").dbname | Should -Be $contextDbName
+            $callerServer.Query("SELECT DB_NAME() AS dbname", $contextDbName).dbname | Should -Be $contextDbName
+        }
+
+        It "still returns every table when AllTables is used" {
+            $allTables = $callerServer.Databases[$contextDbName].Query("SELECT 1 AS a; SELECT 2 AS b", $true)
+            $allTables.Count | Should -Be 2
+        }
+
+        It "keeps the session, so temporary objects survive" {
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+            $null = $callerServer.Databases[$contextDbName].Query("SELECT 1")
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+
+        It "puts the database back even when the query fails" {
+            { $callerServer.Databases[$contextDbName].Query("SELECT * FROM dbatoolsci_does_not_exist") } | Should -Throw
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "master"
+        }
+    }
+
+    Context "The database the caller was on is restored, not master (#10555)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # A connection that starts out somewhere other than master. Restoring to master would pass the
+            # tests above and still be wrong here.
+            $msdbServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -Database msdb -NonPooledConnection
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $msdbServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "leaves the connection in msdb after Database.Query" {
+            $null = $msdbServer.Databases[$contextDbName].Query("SELECT 1")
+            $msdbServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "msdb"
+        }
+
+        It "leaves the connection in msdb after Server.Query with a database" {
+            $null = $msdbServer.Query("SELECT 1", $contextDbName)
+            $msdbServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "msdb"
+        }
+    }
+}

--- a/tests/InModule.TypeExtensions.Tests.ps1
+++ b/tests/InModule.TypeExtensions.Tests.ps1
@@ -9,6 +9,16 @@ Describe $CommandName -Tag IntegrationTests {
     # The Query and Invoke script methods of Server and Database in xml\dbatools.Types.ps1xml run through
     # the execution manager of a database, which is the connection context of the parent server and belongs
     # to the caller. SMO issues a USE and never switches back, so the methods put the database back. See #10555.
+    BeforeDiscovery {
+        # Two databases whose names differ only in case can only exist on an instance with a case sensitive
+        # collation, and that is the only place where a case insensitive comparison in the restore can be
+        # caught. The collation decides it, not the version, so this is asked of the instance rather than
+        # assumed. On a case insensitive instance the scenario cannot be built at all and the Context skips.
+        $caseDiscoveryServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+        $instanceIsCaseSensitive = $caseDiscoveryServer.Collation -match "_CS_"
+        $null = $caseDiscoveryServer | Disconnect-DbaInstance
+    }
+
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
@@ -78,10 +88,18 @@ Describe $CommandName -Tag IntegrationTests {
             $allTables.Count | Should -Be 2
         }
 
-        It "keeps the session, so temporary objects survive" {
+        It "runs on the session of the caller and not on a copy of the connection" {
+            # Checking the temporary table through the caller afterwards proves nothing: it never left the
+            # caller's session, so a copied connection context would pass that too. The wrapper itself has
+            # to see the table, and its SPID has to be the caller's. ConnectionContext.Copy() plus
+            # GetDatabaseConnection() was the other candidate for this fix and fails both assertions.
+            $callerSpid = $callerServer.ConnectionContext.ExecuteScalar("SELECT @@SPID")
             $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
-            $null = $callerServer.Databases[$contextDbName].Query("SELECT 1")
-            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+
+            $wrapperResult = $callerServer.Databases[$contextDbName].Query("SELECT @@SPID AS spid, (SELECT COUNT(*) FROM #dbatoolsci_marker) AS marker")
+
+            $wrapperResult.spid | Should -Be $callerSpid
+            $wrapperResult.marker | Should -Be 0
         }
 
         It "puts the database back even when the query fails" {
@@ -117,6 +135,86 @@ Describe $CommandName -Tag IntegrationTests {
         It "leaves the connection in msdb after Server.Query with a database" {
             $null = $msdbServer.Query("SELECT 1", $contextDbName)
             $msdbServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "msdb"
+        }
+    }
+
+    Context "A failing restore does not become the outcome of the call (#10555)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $offlineDbName = "dbatoolsci_typeext_offline_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $offlineDbName
+            $offlineServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName -NonPooledConnection
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $offlineServer | Disconnect-DbaInstance
+            $null = Set-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName -Online -Force -ErrorAction SilentlyContinue
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "returns normally when the statement made the previous database unreachable" {
+            # The wrapper moves the connection to master to run this, and the USE that would put it back
+            # cannot work afterwards, because by then the database it names is offline. Restoring is
+            # housekeeping and must not turn a statement that succeeded into an exception: a caller reading
+            # that as "it did not run" might well run it a second time. The wrapper warns instead, which a
+            # script method can only write to the host, so the preference is set rather than captured.
+            $WarningPreference = "SilentlyContinue"
+            $offlineStatement = "ALTER DATABASE [$offlineDbName] SET OFFLINE WITH ROLLBACK IMMEDIATE"
+
+            { $offlineServer.Databases["master"].Invoke($offlineStatement) } | Should -Not -Throw
+
+            (Get-DbaDbState -SqlInstance $TestConfig.InstanceSingle -Database $offlineDbName).Status | Should -Be "OFFLINE"
+        }
+    }
+
+    Context "Databases whose names differ only in case are told apart (#10579)" -Skip:(-not $instanceIsCaseSensitive) {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $caseSuffix = Get-Random
+            $caseDbMixed = "dbatoolsci_CaseCtx$caseSuffix"
+            $caseDbLower = "dbatoolsci_casectx$caseSuffix"
+
+            # The two names may differ only in case, but their files may not: NTFS is case insensitive, so
+            # names derived from the database name collide, first the mdf and then the ldf. So the second
+            # database is created under a name of its own and renamed afterwards, which keeps its files
+            # apart and needs no explicit file paths.
+            $caseDbTemporary = "dbatoolsci_casetmp$caseSuffix"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $caseDbMixed
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $caseDbTemporary
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query "ALTER DATABASE [$caseDbTemporary] MODIFY NAME = [$caseDbLower]"
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            foreach ($caseDbName in $caseDbMixed, $caseDbLower, $caseDbTemporary) {
+                $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $caseDbName -ErrorAction SilentlyContinue
+            }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "restores the database of the caller when the two names differ only in case" {
+            # A case insensitive comparison reports the two as equal and skips the restore, so the caller is
+            # left in the wrong database - the very leak this change is about, on a valid configuration.
+            $caseCaller = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -Database $caseDbMixed -NonPooledConnection
+            try {
+                $null = $caseCaller.Databases[$caseDbLower].Query("SELECT 1")
+
+                $caseCaller.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -BeExactly $caseDbMixed
+            } finally {
+                $null = $caseCaller | Disconnect-DbaInstance
+            }
         }
     }
 }

--- a/xml/dbatools.Types.ps1xml
+++ b/xml/dbatools.Types.ps1xml
@@ -36,6 +36,12 @@ try {
             # renaming it, revoking access - would otherwise throw here although it succeeded, and the
             # caller would read that as "it did not run" and might do it a second time. A query that
             # failed would have its own error replaced by this one, which is just as misleading.
+            # Write-Warning obeys the caller's $WarningPreference, and Stop turns it into a terminating
+            # error - which would hand the outcome of the call back to the housekeeping, the very thing
+            # this catch exists to prevent. Inquire stops just as dead where nobody can answer it. Only
+            # those two are neutralised, and only for this one call: a caller that asked for silence
+            # still gets silence, which passing -WarningAction Continue would have taken away.
+            if ($WarningPreference -notin "SilentlyContinue", "Continue") { $WarningPreference = "Continue" }
             Write-Warning "The database context could not be restored to [$previousDatabase]: $($_.Exception.Message)"
         }
     }
@@ -63,6 +69,8 @@ try {
         try {
             $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
         } catch {
+            # See the comment on Query above for why the warning preference is neutralised first.
+            if ($WarningPreference -notin "SilentlyContinue", "Continue") { $WarningPreference = "Continue" }
             Write-Warning "The database context could not be restored to [$previousDatabase]: $($_.Exception.Message)"
         }
     }
@@ -101,6 +109,8 @@ try {
                 try {
                     $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
                 } catch {
+                    # See the comment on Database.Query for why the warning preference is neutralised first.
+                    if ($WarningPreference -notin "SilentlyContinue", "Continue") { $WarningPreference = "Continue" }
                     Write-Warning "The database context could not be restored to [$previousDatabase]: $($_.Exception.Message)"
                 }
             }
@@ -148,6 +158,8 @@ try {
                 try {
                     $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
                 } catch {
+                    # See the comment on Database.Query for why the warning preference is neutralised first.
+                    if ($WarningPreference -notin "SilentlyContinue", "Continue") { $WarningPreference = "Continue" }
                     Write-Warning "The database context could not be restored to [$previousDatabase]: $($_.Exception.Message)"
                 }
             }

--- a/xml/dbatools.Types.ps1xml
+++ b/xml/dbatools.Types.ps1xml
@@ -22,9 +22,22 @@ try {
     if ($AllTables) { ($this.ExecuteWithResults($Query)).Tables }
     else { ($this.ExecuteWithResults($Query)).Tables[0] }
 } finally {
-    if ($previousDatabase -and $connectionContext.CurrentDatabase -ne $previousDatabase) {
+    # The comparison is case sensitive on purpose. Database names use the collation of the instance, so
+    # on a case sensitive instance AppDb and appdb are two different databases, and -ne would report
+    # them as equal and skip the restore. It cannot restore needlessly: both sides are read from the
+    # same property, so the same database always spells itself the same way.
+    if ($previousDatabase -and $connectionContext.CurrentDatabase -cne $previousDatabase) {
         $escapedDatabase = $previousDatabase.Replace("]", "]]")
-        $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+        try {
+            $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+        } catch {
+            # Putting the database back is housekeeping and must never become the outcome of the call.
+            # A query that makes the previous database unreachable - taking it offline, dropping it,
+            # renaming it, revoking access - would otherwise throw here although it succeeded, and the
+            # caller would read that as "it did not run" and might do it a second time. A query that
+            # failed would have its own error replaced by this one, which is just as misleading.
+            Write-Warning "The database context could not be restored to [$previousDatabase]: $($_.Exception.Message)"
+        }
     }
 }
 </Script>
@@ -44,9 +57,14 @@ $previousDatabase = $connectionContext.CurrentDatabase
 try {
     $this.ExecuteNonQuery($Command)
 } finally {
-    if ($previousDatabase -and $connectionContext.CurrentDatabase -ne $previousDatabase) {
+    # See the comment on Query above for why this is case sensitive and why a failing restore only warns.
+    if ($previousDatabase -and $connectionContext.CurrentDatabase -cne $previousDatabase) {
         $escapedDatabase = $previousDatabase.Replace("]", "]]")
-        $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+        try {
+            $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+        } catch {
+            Write-Warning "The database context could not be restored to [$previousDatabase]: $($_.Exception.Message)"
+        }
     }
 }
 </Script>
@@ -77,9 +95,14 @@ try {
         try {
             $dataSet = $this.Databases[$Database].ExecuteWithResults($Query)
         } finally {
-            if ($previousDatabase -and $connectionContext.CurrentDatabase -ne $previousDatabase) {
+            # See the comment on Database.Query for why this is case sensitive and why a failing restore only warns.
+            if ($previousDatabase -and $connectionContext.CurrentDatabase -cne $previousDatabase) {
                 $escapedDatabase = $previousDatabase.Replace("]", "]]")
-                $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+                try {
+                    $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+                } catch {
+                    Write-Warning "The database context could not be restored to [$previousDatabase]: $($_.Exception.Message)"
+                }
             }
         }
     } else {
@@ -119,9 +142,14 @@ try {
         try {
             $this.Databases[$Database].ExecuteNonQuery($Command)
         } finally {
-            if ($previousDatabase -and $connectionContext.CurrentDatabase -ne $previousDatabase) {
+            # See the comment on Database.Query for why this is case sensitive and why a failing restore only warns.
+            if ($previousDatabase -and $connectionContext.CurrentDatabase -cne $previousDatabase) {
                 $escapedDatabase = $previousDatabase.Replace("]", "]]")
-                $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+                try {
+                    $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+                } catch {
+                    Write-Warning "The database context could not be restored to [$previousDatabase]: $($_.Exception.Message)"
+                }
             }
         }
     } else {

--- a/xml/dbatools.Types.ps1xml
+++ b/xml/dbatools.Types.ps1xml
@@ -12,8 +12,21 @@ param (
     $AllTables = $false
 )
 
-if ($AllTables) { ($this.ExecuteWithResults($Query)).Tables }
-else { ($this.ExecuteWithResults($Query)).Tables[0] }
+# ExecuteWithResults does not run on a private connection: the execution manager of a database is the
+# connection context of the parent server, which belongs to the caller. It issues a USE and never switches
+# back, so the previous database is put back here. See #10555.
+$connectionContext = $this.Parent.ConnectionContext
+$previousDatabase = $connectionContext.CurrentDatabase
+
+try {
+    if ($AllTables) { ($this.ExecuteWithResults($Query)).Tables }
+    else { ($this.ExecuteWithResults($Query)).Tables[0] }
+} finally {
+    if ($previousDatabase -and $connectionContext.CurrentDatabase -ne $previousDatabase) {
+        $escapedDatabase = $previousDatabase.Replace("]", "]]")
+        $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+    }
+}
 </Script>
 </ScriptMethod>
 <ScriptMethod>
@@ -22,7 +35,20 @@ else { ($this.ExecuteWithResults($Query)).Tables[0] }
 param (
     $Command
 )
-$this.ExecuteNonQuery($Command)
+
+# See the comment on Query above: this leaves the connection of the caller in this database, so the
+# previous database is put back afterwards. See #10555.
+$connectionContext = $this.Parent.ConnectionContext
+$previousDatabase = $connectionContext.CurrentDatabase
+
+try {
+    $this.ExecuteNonQuery($Command)
+} finally {
+    if ($previousDatabase -and $connectionContext.CurrentDatabase -ne $previousDatabase) {
+        $escapedDatabase = $previousDatabase.Replace("]", "]]")
+        $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+    }
+}
 </Script>
 </ScriptMethod>
 </Members>
@@ -43,7 +69,19 @@ param (
 
 try {
     if ($Database) {
-        $dataSet = $this.Databases[$Database].ExecuteWithResults($Query)
+        # Going through the database object leaves the connection of the caller in that database, so the
+        # previous database is put back afterwards. This does not go through Database.Query, so it needs the
+        # same treatment of its own. See #10555.
+        $connectionContext = $this.ConnectionContext
+        $previousDatabase = $connectionContext.CurrentDatabase
+        try {
+            $dataSet = $this.Databases[$Database].ExecuteWithResults($Query)
+        } finally {
+            if ($previousDatabase -and $connectionContext.CurrentDatabase -ne $previousDatabase) {
+                $escapedDatabase = $previousDatabase.Replace("]", "]]")
+                $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+            }
+        }
     } else {
         $dataSet = $this.ConnectionContext.ExecuteWithResults($Query)
     }
@@ -74,7 +112,18 @@ param (
 
 try {
     if ($Database) {
-        $this.Databases[$Database].ExecuteNonQuery($Command)
+        # See the comment on Query above: this does not go through Database.Invoke either, so the previous
+        # database is put back here as well. See #10555.
+        $connectionContext = $this.ConnectionContext
+        $previousDatabase = $connectionContext.CurrentDatabase
+        try {
+            $this.Databases[$Database].ExecuteNonQuery($Command)
+        } finally {
+            if ($previousDatabase -and $connectionContext.CurrentDatabase -ne $previousDatabase) {
+                $escapedDatabase = $previousDatabase.Replace("]", "]]")
+                $null = $connectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+            }
+        }
     } else {
         $this.ConnectionContext.ExecuteNonQuery($Command)
     }


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #10555 in part)
 - [x] Ran manual Pester test and has passed
 - [x] Pester test is included

## Overview

*Added 2026-08-23, after two rounds of review added to what the original description below covers. Nothing was removed - the original text follows unchanged.*

### The problem

The `Query` and `Invoke` script methods on `Server` and `Database` move the caller's connection into another database and leave it there.

```powershell
$server = Connect-DbaInstance -SqlInstance $instance      # connection is in master
$server.Query("SELECT 1", "msdb")
$server.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")   # msdb, not master
```

The execution manager of a database object is the connection context of the parent server, which belongs to the caller - not a private connection. SMO issues a `USE` to run the statement and never switches back, so everything that runs on that connection afterwards silently runs in the wrong database. Four methods do this: `Database.Query`, `Database.Invoke`, and the `-Database` overloads of `Server.Query` and `Server.Invoke`.

### What this pull request changes

Each of the four remembers the current database and puts it back afterwards. The rest of the change is about the ways that goes wrong.

1. **The comparison that decides whether to restore is case sensitive.** Database names use the collation of the instance, so on a case sensitive instance `AppDb` and `appdb` are two different databases, and a case insensitive `-ne` reported them as equal and skipped the restore - leaving the caller in the wrong database, which is the very thing this fixes. It cannot restore needlessly: both sides are read from the same property, so one database always spells itself the same way.

2. **The name is escaped**, so a database with a `]` in its name cannot break the statement.

3. **Restoring never becomes the outcome of the call.** A statement that makes the previous database unreachable - taking it offline, dropping it, renaming it, revoking access - succeeds, and then the `USE` that would put the context back cannot work. Throwing there would tell the caller "it did not run" about a statement that ran, and a caller that retries would run it twice. Where the statement itself failed, the restore error would replace its error. So the restore warns instead of throwing.

4. **The warning cannot terminate the call either.** `Write-Warning` obeys the caller's `$WarningPreference`, and `Stop` turns it into a terminating error - which would hand the outcome back to the housekeeping after all. `Inquire` does the same where nothing can answer the prompt. Both are neutralised for that one warning. Suppression is deliberately left alone, so a caller who asked for silence still gets silence.

### Evidence

- `InModule.TypeExtensions.Tests.ps1` against a case **insensitive** instance: 13 tests, 12 pass, 1 skips
- The same file against a case **sensitive** instance: **13 pass, 0 skip**
- Every new test verified to fail against the old code, with the specific error it guards
- 16 test files of commands that use these wrappers: 186 tests, 184 pass, 2 skip, 0 fail
- CI: 20 pass, 1 skipping, 0 failures

### Two things worth knowing, because they shaped the tests

- **A warning written inside a ps1xml script method goes straight to the host.** It can be suppressed by the caller's preference, but it cannot be captured - not with `-WarningVariable`, not with `3>&1`, which returns zero objects. So the tests assert on behaviour, never on warning text.
- **Two databases whose names differ only in case need distinct file names.** NTFS is case insensitive, so the derived `.mdf` and then `.ldf` collide. `New-DbaDatabase` cannot express that, so the fixture creates the second database under a name of its own and renames it.

### What is covered where

The case sensitive scenario cannot be built at all on a case insensitive instance, so it skips there - which is every CI instance. Whether the instance is case sensitive is asked of the instance as a behaviour, not matched against the collation name, because `_BIN` and `_BIN2` are case sensitive too and carry no `_CS_`. The lab has no binary collation instance, so that case is handled by construction rather than demonstrated.

---

### Purpose

Step one of #10555: the mechanism, on its own.

The `Query` and `Invoke` script methods of `Server` and `Database` in [`xml/dbatools.Types.ps1xml`](https://github.com/dataplat/dbatools/blob/development/xml/dbatools.Types.ps1xml) do not run on a private connection. The execution manager of an SMO database **is** the connection context of the parent server, which belongs to the caller, so they issue a `USE` and never switch back:

```
call                                       result    DB_NAME() afterwards
$db.Query()                                LEAKED    dbatoolsci_wrap
$db.Invoke()                               LEAKED    dbatoolsci_wrap
$server.Query(sql) - one argument          ok        master
$server.Query(sql, db) - two arguments     LEAKED    dbatoolsci_wrap
$server.Invoke(sql, db) - two arguments    LEAKED    dbatoolsci_wrap
```

These four methods are reached from roughly 68 database-scoped `.Query()` / `.Invoke()` call sites plus 45 two-argument `$server.Query($sql, $db)` calls across 28 files, so this one file is the cheapest place in the module to fix it.

### Approach

Each method remembers `ConnectionContext.CurrentDatabase` and puts it back in a `finally`, so a query that throws restores the context as well.

**The `Server` pair needs its own copy of that.** `Server.Query` and `Server.Invoke` call `$this.Databases[$Database].ExecuteWithResults(...)` directly and never go through the `Database` methods, so fixing `Database.Query` alone does not reach them. That is four edits, not two - the issue body assumed otherwise.

**Restoring, not copying.** `ConnectionContext.Copy().GetDatabaseConnection($name)` also works, and was the other candidate, but it is a different session:

```
=== copied connection context ===
    query ran in          : dbatoolsci_ctx  on SPID 64      <-- caller is on SPID 62
    copy sees temp table  : no (separate session)

=== remember and put back ===
    query ran in          : dbatoolsci_ctx  on SPID 62
    caller temp table     : still there
```

A copy cannot see the temp tables or `SET` options of the caller and opens a connection per call, which would be a silent behaviour change for any command that builds session state and then queries through the wrapper. Restoring keeps the session and costs one round trip, and only when the database actually moved.

**The caller's database is restored, not master.** A connection sitting in `msdb` is returned to `msdb`. Restoring to master would have passed every other test and still been wrong - and it matters, because the Agent commands move the context to `msdb` rather than `master`.

The database name is escaped for the `USE`, so a database containing `]` in its name is handled.

### Commands to test

```powershell
$server = Connect-DbaInstance -SqlInstance $instance -NonPooledConnection
$null = $server.Databases["SomeDatabase"].Query("SELECT 1")
$server.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")   # master, was: SomeDatabase
```

### Tests

`tests\InModule.TypeExtensions.Tests.ps1`, following the existing `InModule.*` naming for test files that are not the test of a single command. 10 tests on `InstanceSingle`:

- each of the four methods leaves the database context alone
- the query still runs in the database that was asked for, and `AllTables` still returns every table
- the session is kept, so a temporary object created before the call is still there afterwards
- a failing query still puts the database back
- a caller connected to `msdb` is returned to `msdb`, not to master

All 10 pass. Against `development` 7 of them fail; the 3 that pass are the correctness assertions, which are there to catch the fix breaking something rather than to prove the bug.

Because this reaches every command that uses the wrappers, 15 further test files of wrapper-using commands were run on top: `Find-DbaSimilarTable`, `Get-DbaCpuRingBuffer`, `Get-DbaDatabase`, `Get-DbaDbFeatureUsage`, `Get-DbaDbFile`, `Get-DbaDbSnapshot`, `Get-DbaDbVirtualLogFile`, `Get-DbaHelpIndex`, `Get-DbaInstanceInstallDate`, `Get-DbaModule`, `Get-DbaSchemaChangeHistory`, `Install-DbaWhoIsActive`, `Invoke-DbaDbClone`, `New-DbaLinkedServer`, `Set-DbaDbFileGrowth`. 104 tests, no failures.

### What this does not fix

Only the script methods. The other two sources in #10555 are untouched and still leak:

- the 35 direct `$db.ExecuteNonQuery(...)` / `$db.ExecuteWithResults(...)` call sites, which are SMO's own methods and cannot be shadowed
- SMO's own `Create()` and `Drop()` of server-level objects

`Invoke-DbaDbUpgrade` (#10556) is in the first of those groups. Verified against a database forced to compatibility level 100 so the upgrade really ran - it went to 150 and the connection was still left in the upgraded database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

