### PR TITLE
Database context - Run server level statements on the connection

### DIFF
--- a/private/functions/Get-LoginPasswordHash.ps1
+++ b/private/functions/Get-LoginPasswordHash.ps1
@@ -63,7 +63,9 @@ function Get-LoginPasswordHash {
             $hashedPass = $server.ConnectionContext.ExecuteScalar($sql)
         } catch {
             try {
-                $hashedPassDt = $server.Databases["master"].ExecuteWithResults($sql)
+                # Same query as above, so it runs on the connection as well. Going through the master
+                # database would leave the connection of the caller there. See #10555.
+                $hashedPassDt = $server.ConnectionContext.ExecuteWithResults($sql)
                 $hashedPass = $hashedPassDt.Tables[0].Rows[0].Item(0)
             } catch {
                 Stop-Function -Message "Failed to retrieve password hash for login $($Login.Name)" -ErrorRecord $_ -Target $Login -Continue

--- a/private/functions/Get-OfflineSqlFileStructure.ps1
+++ b/private/functions/Get-OfflineSqlFileStructure.ps1
@@ -27,7 +27,9 @@ Internal function. Returns dictionary object that contains file structures for S
 
     if ($filestream) {
         $sql = "SELECT COALESCE(SERVERPROPERTY('FilestreamConfiguredLevel'),0) AS fs"
-        $fscheck = $server.databases['master'].ExecuteWithResults($sql)
+        # SERVERPROPERTY does not depend on the current database, so this runs on the connection. Going
+        # through the master database would leave the connection of the caller there. See #10555.
+        $fscheck = $server.ConnectionContext.ExecuteWithResults($sql)
         if ($fscheck.tables.fs -eq 0) { return $false }
     }
 

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -21,7 +21,7 @@ function Connect-DbaInstance {
 
         To execute SQL commands directly: $server.ConnectionContext.ExecuteReader($sql) or $server.ConnectionContext.ExecuteNonQuery($sql)
 
-        Run statements through the connection context rather than through a database object. A database object executes on the same connection and leaves it in that database, which changes the database of every later command that reuses the connection.
+        For statements that do not depend on a particular database, use the connection context rather than a database object. A database object executes on the same connection and leaves it in that database, which changes the database of every later command that reuses the connection. A statement that does need a database still has to say so, because the connection context runs it in whatever database the session currently happens to be in.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -19,7 +19,9 @@ function Connect-DbaInstance {
         https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnectionstringbuilder.aspx
         https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnection.aspx
 
-        To execute SQL commands directly: $server.ConnectionContext.ExecuteReader($sql) or $server.Databases['master'].ExecuteNonQuery($sql)
+        To execute SQL commands directly: $server.ConnectionContext.ExecuteReader($sql) or $server.ConnectionContext.ExecuteNonQuery($sql)
+
+        Run statements through the connection context rather than through a database object. A database object executes on the same connection and leaves it in that database, which changes the database of every later command that reuses the connection.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.

--- a/public/Export-DbaLogin.ps1
+++ b/public/Export-DbaLogin.ps1
@@ -390,7 +390,9 @@ function Export-DbaLogin {
                             try {
                                 $hashedPass = $server.ConnectionContext.ExecuteScalar($sql)
                             } catch {
-                                $hashedPassDt = $server.Databases['master'].ExecuteWithResults($sql)
+                                # Same query as above, so it runs on the connection as well. Going through the
+                                # master database would leave the connection of the caller there. See #10555.
+                                $hashedPassDt = $server.ConnectionContext.ExecuteWithResults($sql)
                                 $hashedPass = $hashedPassDt.Tables[0].Rows[0].Item(0)
                             }
 

--- a/public/Get-DbaDbDetachedFileInfo.ps1
+++ b/public/Get-DbaDbDetachedFileInfo.ps1
@@ -130,7 +130,9 @@ function Get-DbaDbDetachedFileInfo {
             $collationsql = "SELECT name FROM fn_helpcollations() WHERE COLLATIONPROPERTY(name, N'COLLATIONID')  = $collationid"
 
             try {
-                $dataset = $server.databases['master'].ExecuteWithResults($collationsql)
+                # fn_helpcollations is available in every database, so this runs on the connection. Going
+                # through the master database would leave the connection of the caller there. See #10555.
+                $dataset = $server.ConnectionContext.ExecuteWithResults($collationsql)
                 $collation = "$($dataset.Tables[0].Rows[0].Item(0))"
             } catch {
                 $collation = $collationid

--- a/public/New-DbaLogin.ps1
+++ b/public/New-DbaLogin.ps1
@@ -327,7 +327,9 @@ function New-DbaLogin {
                         try {
                             $hashedPass = $sourceServer.ConnectionContext.ExecuteScalar($sql)
                         } catch {
-                            $hashedPassDt = $sourceServer.Databases['master'].ExecuteWithResults($sql)
+                            # Same query as above, so it runs on the connection as well. Going through the
+                            # master database would leave the connection of the caller there. See #10555.
+                            $hashedPassDt = $sourceServer.ConnectionContext.ExecuteWithResults($sql)
                             $hashedPass = $hashedPassDt.Tables[0].Rows[0].Item(0)
                         }
 

--- a/public/Remove-DbaAgentJob.ps1
+++ b/public/Remove-DbaAgentJob.ps1
@@ -136,8 +136,10 @@ function Remove-DbaAgentJob {
                         $dropSchedule = 0
                     }
                     Write-Message -Level SomewhatVerbose -Message "Removing job"
-                    $dropJobQuery = ("EXEC dbo.sp_delete_job @job_name = '{0}', @delete_history = {1}, @delete_unused_schedule = {2}" -f $currentJob.Name.Replace("'", "''"), $dropHistory, $dropSchedule)
-                    $server.Databases['msdb'].ExecuteNonQuery($dropJobQuery)
+                    # The procedure is named in full so that it does not need the connection to be in msdb.
+                    # Going through the msdb database would leave the connection of the caller there. See #10555.
+                    $dropJobQuery = ("EXEC msdb.dbo.sp_delete_job @job_name = '{0}', @delete_history = {1}, @delete_unused_schedule = {2}" -f $currentJob.Name.Replace("'", "''"), $dropHistory, $dropSchedule)
+                    $server.ConnectionContext.ExecuteNonQuery($dropJobQuery)
                     $server.JobServer.Jobs.Refresh()
                     Remove-TeppCacheItem -SqlInstance $server -Type job -Name $currentJob.Name
                     [PSCustomObject]@{

--- a/public/Set-DbaTempDbConfig.ps1
+++ b/public/Set-DbaTempDbConfig.ps1
@@ -170,6 +170,26 @@ function Set-DbaTempDbConfig {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
+            # Unlike the other sites in #10555, this command cannot avoid moving the database context:
+            # FILEPROPERTY and DBCC SHRINKFILE only report on and work on the current database, so tempdb
+            # has to be the current database for both. It puts the database of the caller back instead,
+            # which is what this does at each of the two places that move it.
+            $callerDatabase = $server.ConnectionContext.CurrentDatabase
+            $restoreCallerDatabase = {
+                if ($callerDatabase -and $server.ConnectionContext.CurrentDatabase -cne $callerDatabase) {
+                    # Case sensitive, because on a case sensitive instance AppDb and appdb are two
+                    # different databases and -ne would report them as equal and skip the restore.
+                    $escapedCallerDatabase = $callerDatabase.Replace("]", "]]")
+                    try {
+                        $null = $server.ConnectionContext.ExecuteNonQuery("USE [$escapedCallerDatabase]")
+                    } catch {
+                        # Putting the database back is housekeeping and must never become the outcome of
+                        # the command, so this warns rather than throwing.
+                        Write-Message -Level Warning -Message "The database context could not be restored to [$callerDatabase]: $_"
+                    }
+                }
+            }
+
             $cores = $server.Processors
             if ($cores -gt 8) {
                 $cores = 8
@@ -201,7 +221,14 @@ function Set-DbaTempDbConfig {
                     Stop-Function -Message $invalidPathFound -Continue
                 }
             } else {
-                $Filepath = $server.Databases['tempdb'].Query('SELECT physical_name AS PhysicalName FROM sys.database_files WHERE file_id = 1').PhysicalName
+                # sys.master_files is a server level view, so the path of a tempdb file can be read
+                # without making tempdb the current database. See #10555.
+                $dataFilePathQuery = @"
+SELECT physical_name
+FROM sys.master_files
+WHERE database_id = DB_ID('tempdb') AND file_id = 1
+"@
+                $Filepath = $server.ConnectionContext.ExecuteScalar($dataFilePathQuery)
                 $DataPath = Split-Path $Filepath
             }
 
@@ -212,7 +239,13 @@ function Set-DbaTempDbConfig {
                     Stop-Function -Message "$LogPath is an invalid path." -Continue
                 }
             } else {
-                $Filepath = $server.Databases['tempdb'].Query('SELECT physical_name AS PhysicalName FROM sys.database_files WHERE file_id = 2').PhysicalName
+                # Server level as well, see the comment on the data file path above.
+                $logFilePathQuery = @"
+SELECT physical_name
+FROM sys.master_files
+WHERE database_id = DB_ID('tempdb') AND file_id = 2
+"@
+                $Filepath = $server.ConnectionContext.ExecuteScalar($logFilePathQuery)
                 $LogPath = Split-Path $Filepath
             }
             Write-Message -Message "Using log path: $LogPath." -Level Verbose
@@ -235,6 +268,10 @@ FROM sys.database_files
 WHERE type = 0
 ORDER BY file_id;
 "@))
+            # FILEPROPERTY only reports on the current database - outside tempdb it silently returns NULL
+            # rather than failing - so this one has to run in tempdb and the caller gets its database back.
+            & $restoreCallerDatabase
+
             $CurrentFileCount = $tempdbFiles.Count
             $filesToRemove = @()
             $filesToKeep = @($tempdbFiles)
@@ -361,7 +398,15 @@ ORDER BY file_id;
                         # ALTER DATABASE does not depend on the current database, so this runs on the
                         # connection. Going through the master database would leave the connection of the
                         # caller there. See #10555.
-                        $server.ConnectionContext.ExecuteNonQuery($sql)
+                        # The batches built for -Force are the exception: they carry an explicit
+                        # USE [tempdb], because DBCC SHRINKFILE empties a file of the current database
+                        # only. So the database of the caller is put back once the batches have run,
+                        # in a finally, because a reconfiguration that fails half way moves it just as much.
+                        try {
+                            $server.ConnectionContext.ExecuteNonQuery($sql)
+                        } finally {
+                            & $restoreCallerDatabase
+                        }
                         Write-Message -Level Verbose -Message "tempdb successfully reconfigured."
 
                         [PSCustomObject]@{

--- a/public/Set-DbaTempDbConfig.ps1
+++ b/public/Set-DbaTempDbConfig.ps1
@@ -358,7 +358,10 @@ ORDER BY file_id;
             } else {
                 if ($Pscmdlet.ShouldProcess($instance, "Executing query and informing that a restart is required.")) {
                     try {
-                        $server.Databases['master'].ExecuteNonQuery($sql)
+                        # ALTER DATABASE does not depend on the current database, so this runs on the
+                        # connection. Going through the master database would leave the connection of the
+                        # caller there. See #10555.
+                        $server.ConnectionContext.ExecuteNonQuery($sql)
                         Write-Message -Level Verbose -Message "tempdb successfully reconfigured."
 
                         [PSCustomObject]@{

--- a/tests/Get-DbaDbDetachedFileInfo.Tests.ps1
+++ b/tests/Get-DbaDbDetachedFileInfo.Tests.ps1
@@ -64,4 +64,38 @@ Describe $CommandName -Tag IntegrationTests {
             $results.LogFiles | Should -Not -BeNullOrEmpty
         }
     }
+
+    Context "The connection of the caller keeps its database (#10555)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # The collation lookup used to run through the master database, which leaves the connection of
+            # the caller there. Only a non-pooled connection shows it, because SMO reopens a pooled one at
+            # its default database.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -Database msdb -NonPooledConnection
+            $callerResult = Get-DbaDbDetachedFileInfo -SqlInstance $callerServer -Path $path
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still reads the detached file" {
+            $callerResult.Name | Should -Be $dbname
+        }
+
+        It "still resolves the collation" {
+            $callerResult.Collation | Should -Not -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was on" {
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "msdb"
+        }
+    }
 }

--- a/tests/Get-DbaDbDetachedFileInfo.Tests.ps1
+++ b/tests/Get-DbaDbDetachedFileInfo.Tests.ps1
@@ -29,6 +29,10 @@ Describe $CommandName -Tag IntegrationTests {
         $dbname = "dbatoolsci_detatch_$random"
         $server.Query("CREATE DATABASE $dbname")
         $path = (Get-DbaDbFile -SqlInstance $TestConfig.InstanceSingle -Database $dbname | Where-Object PhysicalName -like "*.mdf").PhysicalName
+        # Remembered before the database is detached, so that the collation the command resolves can be
+        # compared against the real one. The command falls back to the numeric collation id when the lookup
+        # fails, and that is not null either, so only an exact comparison can tell the two apart.
+        $expectedCollation = $server.Databases[$dbname].Collation
         Detach-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbname -Force
     }
 
@@ -90,8 +94,11 @@ Describe $CommandName -Tag IntegrationTests {
             $callerResult.Name | Should -Be $dbname
         }
 
-        It "still resolves the collation" {
-            $callerResult.Collation | Should -Not -BeNullOrEmpty
+        It "still resolves the collation to its name" {
+            # Not just "not empty": the command catches every failure of the lookup and falls back to the
+            # numeric collation id, which is not empty either, so this assertion would pass even if the
+            # changed call always threw.
+            $callerResult.Collation | Should -Be $expectedCollation
         }
 
         It "leaves the connection in the database it was on" {

--- a/tests/Remove-DbaAgentJob.Tests.ps1
+++ b/tests/Remove-DbaAgentJob.Tests.ps1
@@ -159,4 +159,38 @@ Describe $CommandName -Tag IntegrationTests {
             (Get-DbaAgentJob -SqlInstance $TestConfig.InstanceSingle -Job dbatoolsci_testjob_validation) | Should -Not -BeNullOrEmpty
         }
     }
+
+    Context "The connection of the caller keeps its database (#10555)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextJobName = "dbatoolsci_testjob_context"
+            $null = New-DbaAgentJob -SqlInstance $TestConfig.InstanceSingle -Job $contextJobName
+
+            # sp_delete_job used to be run through the msdb database, which leaves the connection of the
+            # caller there. Only a non-pooled connection shows it, because SMO reopens a pooled one at its
+            # default database.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $null = Remove-DbaAgentJob -SqlInstance $callerServer -Job $contextJobName
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Get-DbaAgentJob -SqlInstance $TestConfig.InstanceSingle -Job $contextJobName | Remove-DbaAgentJob -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still removes the job" {
+            Get-DbaAgentJob -SqlInstance $TestConfig.InstanceSingle -Job $contextJobName | Should -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was on" {
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "master"
+        }
+    }
 }

--- a/tests/Set-DbaTempDbConfig.Tests.ps1
+++ b/tests/Set-DbaTempDbConfig.Tests.ps1
@@ -144,11 +144,21 @@ Describe $CommandName -Tag IntegrationTests {
             $allocationTableName = "dbatoolsci_tempdb_reduction_$(Get-Random)"
             $allocationRowCount = 15000
 
+            # A connection of its own that starts in msdb, so the tests can assert that the command puts the
+            # database of the caller back. It has to be non-pooled: SMO reopens a pooled connection at its
+            # default database, which hides the leak. msdb rather than master, because restoring to master
+            # would pass an assertion and still be wrong. See #10555.
+            $tempdbContextServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -Database msdb -NonPooledConnection
+
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            if ($null -ne $tempdbContextServer) {
+                $null = $tempdbContextServer | Disconnect-DbaInstance
+            }
 
             if ($null -ne $tempdbReductionServer -and $null -ne $allocationTableName) {
                 $tempdbReductionServer.Databases["tempdb"].ExecuteNonQuery("IF OBJECT_ID(N'dbo.$allocationTableName', N'U') IS NOT NULL DROP TABLE dbo.[$allocationTableName];")
@@ -284,8 +294,13 @@ CROSS JOIN sys.all_objects AS second_source;
             $capacityResult | Should -BeNullOrEmpty
             ($capacityWarning -join " ") | Should -Match "exceeds the requested target capacity"
 
+            # Run the reduction through the connection that starts in msdb, so that the assertion below can
+            # show that the command leaves the database of the caller where it found it. This is the path
+            # that moves it twice: reading tempdb through FILEPROPERTY, which only reports on the current
+            # database, and then the batches, which carry an explicit USE [tempdb] because DBCC SHRINKFILE
+            # empties a file of the current database only.
             $splatReduce = @{
-                SqlInstance     = $tempdbReductionServer
+                SqlInstance     = $tempdbContextServer
                 DataFileCount   = $originalDataFileCount
                 DataFileSize    = $expandedTotalDataFileSize
                 DataPath        = $tempdbReductionDataPath
@@ -296,6 +311,8 @@ CROSS JOIN sys.all_objects AS second_source;
             }
             $reduceResult = Set-DbaTempDbConfig @splatReduce
             $reduceResult.DataFileCount | Should -Be $originalDataFileCount
+
+            $tempdbContextServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "msdb"
 
             $reducedFiles = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0)
             $reducedFiles.Count | Should -Be $originalDataFileCount


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #10555 in part)
 - [x] Ran manual Pester test and has passed
 - [x] Pester test is included

### Purpose

Step two of #10555, and the half that needs no new mechanism, so it is independent of #10579.

Ten call sites went through a database object only because they needed *somewhere* to run a statement. The execution manager of an SMO database is the connection context of the parent server, so each of them issued a `USE` and left the connection of the caller in `master` or `msdb`. None of the statements needed a database context at all.

The clearest example is [`Export-DbaLogin.ps1:391-393`](https://github.com/dataplat/dbatools/blob/development/public/Export-DbaLogin.ps1#L391-L393), where the primary path was already right and only the fallback was not:

```powershell
$hashedPass = $server.ConnectionContext.ExecuteScalar($sql)          # fine
} catch {
    $hashedPassDt = $server.Databases['master'].ExecuteWithResults($sql)   # same query, leaks
```

### Approach

Each statement now runs on the connection itself, so there is no context to put back:

| Command | Statement | Why no database is needed |
|---|---|---|
| `Export-DbaLogin`, `New-DbaLogin`, `Get-LoginPasswordHash` | password hash from `sys.sql_logins` / `sys.server_principals` | server level catalog views; the primary path already used the connection |
| `Get-DbaDbDetachedFileInfo` | `fn_helpcollations()` | available in every database |
| `Get-OfflineSqlFileStructure` | `SERVERPROPERTY(...)` | does not depend on the current database |
| `Set-DbaTempDbConfig` | `ALTER DATABASE tempdb ...` | does not depend on the current database |
| `Remove-DbaAgentJob` | `sp_delete_job` | named in full as `msdb.dbo.sp_delete_job` |

Only the last one changes a statement. Verified that the three part name works and leaves the context alone:

```
context before : master
3-part sp_delete_job: worked
context after  : master
job still there: False
```

Also verified that `ConnectionContext.ExecuteNonQuery` takes the string array `Set-DbaTempDbConfig` hands it, which is the one signature difference between the two receivers.

The help of `Connect-DbaInstance` recommended the pattern this removes:

> To execute SQL commands directly: `$server.ConnectionContext.ExecuteReader($sql)` or `$server.Databases['master'].ExecuteNonQuery($sql)`

It now points at the connection context and says why.

### Tests

Regression contexts for the two sites that a test can actually reach, both asserting on a `-NonPooledConnection`, because SMO reopens a pooled one at its default database and hides the leak:

- `Remove-DbaAgentJob` still removes the job and leaves the connection where it was
- `Get-DbaDbDetachedFileInfo` still reads the file and resolves the collation, and leaves a connection that was on `msdb` on `msdb`

The other sites have no reachable test, and it is worth being explicit about why rather than adding a test that proves nothing:

- the three password hash sites are `catch` fallbacks for `ExecuteScalar`, which does not fail on a supported SQL Server, so the changed line does not run
- `Get-OfflineSqlFileStructure` has **no callers anywhere in the module**; the change is correct but the function is dead code
- `Set-DbaTempDbConfig` reaches its changed line only by really reconfiguring tempdb. The existing `Set-DbaTempDbConfig` tests do execute that path, so it is exercised, but a context assertion cannot pass yet - see below.

Test files run: `Export-DbaLogin` (20), `New-DbaLogin` (15), `Get-DbaDbDetachedFileInfo` (9), `Remove-DbaAgentJob` (12 + 1 skipped), `Sync-DbaLoginPassword` (9), all passing.

### Set-DbaTempDbConfig is only half fixed by this

It also reads tempdb through `$server.Databases['tempdb'].Query(...)` in three places, which is the script method fix in #10579. Measured on this branch, the connection still ends up in tempdb from those calls even when the command stops before the line changed here:

```
context before : msdb
command failed: Current tempdb ... is not suitable to be reconfigured ...
context after  : tempdb
```

So the command is free of the leak only once both changes are in, and a context test for it belongs with the second one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
