### PR TITLE
Testing Backup-DbaDatabase - Restore model after the all-databases backup test

### DIFF
--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -81,7 +81,52 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "Properly backups all databases" {
         BeforeAll {
+            # This backs up every database of the instance, so it also takes a full backup of model.
+            # As model is in the full recovery model, that backup starts its log chain, and because no
+            # log backup ever follows, the log can never be reused and grows a little on every run of
+            # this file. That growth is in the file size, so a restart does not undo it, and once the
+            # log passes 32 MB it breaks New-DbaDatabase.Tests.ps1, which asserts the exact log size
+            # of a new database on the same instance. So we record the state here and restore it below.
+            $queryModelStateBefore = @"
+SELECT d.recovery_model_desc AS RecoveryModel, f.size * 8 AS LogSizeKb
+FROM sys.databases AS d
+JOIN sys.master_files AS f ON f.database_id = d.database_id AND f.type = 1
+WHERE d.name = N'model'
+"@
+            $modelStateBefore = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceCopy1 -Database master -Query $queryModelStateBefore
+
             $results = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceCopy1
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Break the log chain that the full backup of model started and give the log its original
+            # size back. Switching to the simple recovery model is what makes the log reusable again -
+            # without it the shrink cannot release anything, because the log still waits for a log
+            # backup, and the file even grows instead.
+            if ($modelStateBefore.RecoveryModel -ne "SIMPLE") {
+                $modelLogSizeMb = [Math]::Max(1, [Math]::Floor($modelStateBefore.LogSizeKb / 1024))
+
+                $queryBreakLogChain = @"
+ALTER DATABASE model SET RECOVERY SIMPLE WITH NO_WAIT;
+"@
+                # DBCC SHRINKFILE resolves the logical file name in the current database, so this has to run in model.
+                $queryShrinkModelLog = @"
+CHECKPOINT;
+DBCC SHRINKFILE (N'modellog', $modelLogSizeMb) WITH NO_INFOMSGS;
+"@
+                $queryRestoreRecoveryModel = @"
+ALTER DATABASE model SET RECOVERY $($modelStateBefore.RecoveryModel) WITH NO_WAIT;
+"@
+
+                $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceCopy1 -Database master -Query $queryBreakLogChain
+                $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceCopy1 -Database model -Query $queryShrinkModelLog
+                $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceCopy1 -Database master -Query $queryRestoreRecoveryModel
+            }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should return a database name, specifically master" {
@@ -534,7 +579,6 @@ go
     }
 
     Context "Test Backup Encryption with Certificate" {
-        # TODO: Should the master key be created at lab startup like in instance3?
         BeforeAll {
             $securePass = ConvertTo-SecureString "MyStrongPassword123!" -AsPlainText -Force
             $cert = New-DbaDbCertificate -SqlInstance $TestConfig.InstanceCopy2 -Database master -Name BackupCertt -Subject BackupCertt


### PR DESCRIPTION
The context "Properly backups all databases" backs up every database of `InstanceCopy1`, so it also takes a full backup of `model`. As `model` is in the full recovery model, that backup starts its log chain, and because no log backup ever follows, the log can never be reused and grows a little on every run of this file.

That growth is in the file size, so a restart does not undo it. It surfaces much later as a completely unrelated failure: a new database's log is never smaller than `model`'s, so `New-DbaDatabase.Tests.ps1` fails its log size assertion once `model`'s log passes 32 MB. In our lab `model` had reached 72 MB and the failure looked like this, on an instance where the other assertions of the same test passed:

```
New-DbaDatabase.When creating databases.creates one new database on two servers
  $instance3.Databases[$newDbName].LogFiles["$($newDbName)_log"].Size | Should -Be 32768
  Expected 32768, but got 73728.
```

`InstanceCopy1` and `InstanceMulti2` are the same instance in our configuration, which is why this file damages that one.

## The fix

The context's `BeforeAll` now records `model`'s recovery model and log size before the backup, and a new `AfterAll` restores both.

Switching to the simple recovery model is what makes the log reusable again. Without it the shrink cannot release anything, because the log still waits for a log backup, and the file even grows instead - a plain `DBCC SHRINKFILE` took our `model` log from 72 MB to 136 MB. `DBCC SHRINKFILE` also resolves the logical file name in the current database, so it has to run in `model` while the two `ALTER DATABASE` statements run from `master`.

The original recovery model is restored rather than a hardcoded `FULL`, and the whole block is skipped when `model` is already in the simple recovery model, so there is nothing to break.

This also removes a `TODO` that is answered: the master key it asks about is created on every lab instance at startup.

## Verification

- `Backup-DbaDatabase.Tests.ps1` passes unchanged: 48 passed, 2 skipped, 0 failed, the same counts as before.
- `model` is left exactly as found: full recovery model, `log_reuse_wait_desc` `NOTHING`, log at its original 8 MB, and `last_log_backup_lsn` back to `NULL`, so the chain is really closed and not just the file shrunk.
- `New-DbaDatabase.Tests.ps1` passes 13/13 again once `model` is repaired.

---

*This text was created by Claude and reviewed by Andreas Jordan.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
