### PR TITLE
Connect-DbaInstance - Give the cloned server ownership of its database connection

### DIFF
--- a/private/testing/Get-TestConfig.ps1
+++ b/private/testing/Get-TestConfig.ps1
@@ -25,6 +25,15 @@ function Get-TestConfig {
         ClusterStorage   = $null
         # ClusterWitness needs a file share witness.
         ClusterWitness   = $null
+        # The Azure SQL Database that the tests of the Azure code paths need. Azure SQL Database is the
+        # only engine that refuses to switch the database of an existing connection - it answers a USE
+        # with error 40508 - so a real one is the only place that branch can be covered. No CI
+        # environment has one, so these stay empty there and those tests skip themselves. A local
+        # configuration that has one sets all three: the server, a database on it, and a credential of a
+        # SQL Server login that can reach that database.
+        AzureSqlDbServer = $null
+        AzureSqlDbName   = $null
+        AzureSqlDbCred   = $null
     }
 
     if (Test-Path $LocalConfigPath) {

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -752,29 +752,52 @@ function Connect-DbaInstance {
                 } elseif ($copyContext) {
                     $isNewConnection = $true
                     $connContext = $inputObject.ConnectionContext.Copy()
+                    # A ServerConnection that was built from a SqlConnection has its connection string set
+                    # explicitly, and SMO then refuses to let some of its properties be assigned:
+                    #   Property <name> cannot be changed or read after a connection string has been set.
+                    # DatabaseName, NonPooledConnection and ServerInstance are all in that group, which is
+                    # why -Database, -NonPooledConnection and -DedicatedAdminConnection used to fail on a
+                    # server that was created from a SqlConnection. Those settings are collected here and
+                    # put into the connection string further down instead, where the same three are
+                    # Initial Catalog, Pooling and Data Source. No readable property tells the two kinds of
+                    # context apart - every one of them reads fine on both - so we find out by trying.
+                    $connectionStringKeyword = @{ }
                     if ($ApplicationIntent) {
                         $connContext.ApplicationIntent = $ApplicationIntent
                     }
                     if ($NonPooledConnection) {
-                        $connContext.NonPooledConnection = $true
+                        try {
+                            $connContext.NonPooledConnection = $true
+                        } catch {
+                            $connectionStringKeyword["Pooling"] = $false
+                        }
                     }
                     if (Test-Bound -Parameter StatementTimeout) {
                         $connContext.StatementTimeout = $StatementTimeout
                     }
-                    if ($DedicatedAdminConnection -and $inputObject.ConnectionContext.ServerInstance -notmatch '^ADMIN:') {
+                    if ($DedicatedAdminConnection -and $inputObject.ConnectionContext.ServerInstance -notmatch "^ADMIN:") {
                         if ($instance.IsLocalHost) {
                             # Use localhost to avoid multiple IP resolution on multi-homed servers (issue #10151)
-                            if ($instance.InstanceName -ne 'MSSQLSERVER') {
-                                $connContext.ServerInstance = "ADMIN:localhost\$($instance.InstanceName)"
+                            if ($instance.InstanceName -ne "MSSQLSERVER") {
+                                $dedicatedAdminServerInstance = "ADMIN:localhost\$($instance.InstanceName)"
                             } else {
-                                $connContext.ServerInstance = "ADMIN:localhost"
+                                $dedicatedAdminServerInstance = "ADMIN:localhost"
                             }
                             # Trust the server certificate because 'localhost' may not match the certificate CN (e.g., FQDN), issue #10254
                             $connContext.TrustServerCertificate = $true
                         } else {
-                            $connContext.ServerInstance = 'ADMIN:' + $connContext.ServerInstance
+                            $dedicatedAdminServerInstance = "ADMIN:$($connContext.ServerInstance)"
                         }
-                        $connContext.NonPooledConnection = $true
+                        try {
+                            $connContext.ServerInstance = $dedicatedAdminServerInstance
+                        } catch {
+                            $connectionStringKeyword["Data Source"] = $dedicatedAdminServerInstance
+                        }
+                        try {
+                            $connContext.NonPooledConnection = $true
+                        } catch {
+                            $connectionStringKeyword["Pooling"] = $false
+                        }
                     }
                     if ($Database) {
                         # We set DatabaseName instead of calling GetDatabaseConnection on purpose.
@@ -788,7 +811,32 @@ function Connect-DbaInstance {
                         # which is also what the connection string code paths of this command already do.
                         # It does not reset StatementTimeout either, so the save and restore that
                         # GetDatabaseConnection needed is gone with it.
-                        $connContext.DatabaseName = $Database
+                        try {
+                            $connContext.DatabaseName = $Database
+                        } catch {
+                            # Falling back to GetDatabaseConnection here would bring back the very leak this
+                            # change is about, so the database goes into the connection string instead. As
+                            # Initial Catalog it is part of the pool key, which is what setting DatabaseName
+                            # achieves as well, so the reason #9505 forced a non pooled connection still holds.
+                            $connectionStringKeyword["Initial Catalog"] = $Database
+                        }
+                    }
+                    if ($connectionStringKeyword.Count -gt 0) {
+                        $changedKeywords = $connectionStringKeyword.Keys -join ", "
+                        Write-Message -Level Debug -Message "Connection context does not accept property assignments, using the connection string for: $changedKeywords"
+                        # The copy has to be disconnected first: setting the connection string of an open
+                        # connection does not move it, and CurrentDatabase would silently stay where it was.
+                        # The copy is a session of its own - a different SPID than the server that was passed
+                        # in - so this does not touch the connection of the caller.
+                        $connContext.Disconnect()
+                        $connectionStringBuilder = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnectionStringBuilder -ArgumentList $connContext.ConnectionString
+                        foreach ($keyword in $connectionStringKeyword.Keys) {
+                            # PowerShell routes property assignments on a connection string builder through its
+                            # dictionary indexer, so the keyword has to be used rather than the property name:
+                            # $connectionStringBuilder.InitialCatalog fails with "Keyword not supported".
+                            $connectionStringBuilder[$keyword] = $connectionStringKeyword[$keyword]
+                        }
+                        $connContext.ConnectionString = $connectionStringBuilder.ConnectionString
                     }
                     $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $connContext
                     if ($Database -and $server.ConnectionContext.CurrentDatabase -ne $Database) {

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -777,10 +777,18 @@ function Connect-DbaInstance {
                         $connContext.NonPooledConnection = $true
                     }
                     if ($Database) {
-                        # Save StatementTimeout because it might be reset on GetDatabaseConnection
-                        $savedStatementTimeout = $connContext.StatementTimeout
-                        $connContext = $connContext.GetDatabaseConnection($Database, $false)
-                        $connContext.StatementTimeout = $savedStatementTimeout
+                        # We set DatabaseName instead of calling GetDatabaseConnection on purpose.
+                        # GetDatabaseConnection opens the connection on the copy we are holding and returns
+                        # a *different* ConnectionContext, so the server we build below never owns that
+                        # connection. Disconnect-DbaInstance can only reach the context of the server it is
+                        # given, so nothing ever closed it: the session stayed open for the life of the
+                        # process, holding a shared lock on the database. On model that is enough to make a
+                        # later CREATE DATABASE on the same instance fail on the exclusive lock.
+                        # Setting DatabaseName keeps the connection with the context we hand to the server,
+                        # which is also what the connection string code paths of this command already do.
+                        # It does not reset StatementTimeout either, so the save and restore that
+                        # GetDatabaseConnection needed is gone with it.
+                        $connContext.DatabaseName = $Database
                     }
                     $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $connContext
                     if ($Database -and $server.ConnectionContext.CurrentDatabase -ne $Database) {

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -752,138 +752,198 @@ function Connect-DbaInstance {
                 } elseif ($copyContext) {
                     $isNewConnection = $true
                     $connContext = $inputObject.ConnectionContext.Copy()
-                    # A ServerConnection that was built from a SqlConnection has its connection string set
-                    # explicitly, and SMO then refuses to let some of its properties be assigned:
-                    #   Property <name> cannot be changed or read after a connection string has been set.
-                    # DatabaseName, NonPooledConnection and ServerInstance are all in that group, which is
-                    # why -Database, -NonPooledConnection and -DedicatedAdminConnection used to fail on a
-                    # server that was created from a SqlConnection. Those settings are collected here and
-                    # put into the connection string further down instead, where the same three are
-                    # Initial Catalog, Pooling and Data Source. No readable property tells the two kinds of
-                    # context apart - every one of them reads fine on both - so we find out by trying.
-                    $connectionStringKeyword = @{ }
-                    $databaseNeedsSwitch = $false
-                    if ($ApplicationIntent) {
-                        $connContext.ApplicationIntent = $ApplicationIntent
-                    }
-                    if ($NonPooledConnection) {
-                        try {
-                            $connContext.NonPooledConnection = $true
-                        } catch {
-                            $connectionStringKeyword["Pooling"] = $false
+                    # From here on the copy owns a connection of its own: Copy() clones the underlying
+                    # SqlConnection and, when the source is open, hands back a copy that is open as well.
+                    # Only the server object built at the end of this block gives anyone a way to close it
+                    # again, because Disconnect-DbaInstance can reach nothing but the context of the server
+                    # it is given. Every path that leaves without building that server - a refusal below, a
+                    # failed connect, a failed database switch - therefore has to close the copy itself, or
+                    # it becomes exactly the orphaned session this whole code path exists to remove.
+                    $connContextTransferred = $false
+                    try {
+                        # A ServerConnection that was built from a SqlConnection has its connection string set
+                        # explicitly, and SMO then refuses to let some of its properties be assigned:
+                        #   Property <name> cannot be changed or read after a connection string has been set.
+                        # DatabaseName, NonPooledConnection and ServerInstance are all in that group, which is
+                        # why -Database, -NonPooledConnection and -DedicatedAdminConnection used to fail on a
+                        # server that was created from a SqlConnection. Those settings are collected here and
+                        # put into the connection string further down instead, where the same three are
+                        # Initial Catalog, Pooling and Data Source. No readable property tells the two kinds of
+                        # context apart - every one of them reads fine on both - so we find out by trying.
+                        $databaseNeedsSwitch = $false
+                        $connectionStringKeyword = @{ }
+                        if ($ApplicationIntent) {
+                            $connContext.ApplicationIntent = $ApplicationIntent
                         }
-                    }
-                    if (Test-Bound -Parameter StatementTimeout) {
-                        $connContext.StatementTimeout = $StatementTimeout
-                    }
-                    if ($DedicatedAdminConnection -and $inputObject.ConnectionContext.ServerInstance -notmatch "^ADMIN:") {
-                        if ($instance.IsLocalHost) {
-                            # Use localhost to avoid multiple IP resolution on multi-homed servers (issue #10151)
-                            if ($instance.InstanceName -ne "MSSQLSERVER") {
-                                $dedicatedAdminServerInstance = "ADMIN:localhost\$($instance.InstanceName)"
-                            } else {
-                                $dedicatedAdminServerInstance = "ADMIN:localhost"
+                        if ($NonPooledConnection) {
+                            try {
+                                $connContext.NonPooledConnection = $true
+                            } catch {
+                                $connectionStringKeyword["Pooling"] = $false
                             }
-                            # Trust the server certificate because 'localhost' may not match the certificate CN (e.g., FQDN), issue #10254
-                            $connContext.TrustServerCertificate = $true
-                        } else {
-                            $dedicatedAdminServerInstance = "ADMIN:$($connContext.ServerInstance)"
                         }
-                        try {
-                            $connContext.ServerInstance = $dedicatedAdminServerInstance
-                        } catch {
-                            $connectionStringKeyword["Data Source"] = $dedicatedAdminServerInstance
+                        if (Test-Bound -Parameter StatementTimeout) {
+                            $connContext.StatementTimeout = $StatementTimeout
+                        }
+                        if ($DedicatedAdminConnection -and $inputObject.ConnectionContext.ServerInstance -notmatch "^ADMIN:") {
                             if ($instance.IsLocalHost) {
-                                # TrustServerCertificate was assigned above, and on a context with a fixed
-                                # connection string that assignment does not reach the string - the property
-                                # reads back as True while the string still says False. Since the string is
-                                # what the new connection is built from, the same has to be put in there, or
-                                # the localhost DAC fails on a certificate that does not match. See #10254.
-                                $connectionStringKeyword["Trust Server Certificate"] = $true
+                                # Use localhost to avoid multiple IP resolution on multi-homed servers (issue #10151)
+                                if ($instance.InstanceName -ne "MSSQLSERVER") {
+                                    $dedicatedAdminServerInstance = "ADMIN:localhost\$($instance.InstanceName)"
+                                } else {
+                                    $dedicatedAdminServerInstance = "ADMIN:localhost"
+                                }
+                                # Trust the server certificate because 'localhost' may not match the certificate CN (e.g., FQDN), issue #10254
+                                $connContext.TrustServerCertificate = $true
+                            } else {
+                                $dedicatedAdminServerInstance = "ADMIN:$($connContext.ServerInstance)"
+                            }
+                            try {
+                                $connContext.ServerInstance = $dedicatedAdminServerInstance
+                            } catch {
+                                $connectionStringKeyword["Data Source"] = $dedicatedAdminServerInstance
+                                if ($instance.IsLocalHost) {
+                                    # TrustServerCertificate was assigned above, and on a context with a fixed
+                                    # connection string that assignment does not reach the string - the property
+                                    # reads back as True while the string still says False. Since the string is
+                                    # what the new connection is built from, the same has to be put in there, or
+                                    # the localhost DAC fails on a certificate that does not match. See #10254.
+                                    $connectionStringKeyword["Trust Server Certificate"] = $true
+                                }
+                            }
+                            try {
+                                $connContext.NonPooledConnection = $true
+                            } catch {
+                                $connectionStringKeyword["Pooling"] = $false
                             }
                         }
-                        try {
-                            $connContext.NonPooledConnection = $true
-                        } catch {
-                            $connectionStringKeyword["Pooling"] = $false
+                        if ($Database) {
+                            # We set DatabaseName instead of calling GetDatabaseConnection on purpose.
+                            # GetDatabaseConnection opens the connection on the copy we are holding and returns
+                            # a *different* ConnectionContext, so the server we build below never owns that
+                            # connection. Disconnect-DbaInstance can only reach the context of the server it is
+                            # given, so nothing ever closed it: the session stayed open for the life of the
+                            # process, holding a shared lock on the database. On model that is enough to make a
+                            # later CREATE DATABASE on the same instance fail on the exclusive lock.
+                            # Setting DatabaseName keeps the connection with the context we hand to the server,
+                            # which is also what the connection string code paths of this command already do.
+                            # It does not reset StatementTimeout either, so the save and restore that
+                            # GetDatabaseConnection needed is gone with it.
+                            try {
+                                $connContext.DatabaseName = $Database
+                            } catch {
+                                # A fixed connection string. Falling back to GetDatabaseConnection here would
+                                # bring back the very leak this change is about, so the database is either put
+                                # into the connection string or switched on the connection further down.
+                                $databaseNeedsSwitch = $true
+                            }
                         }
-                    }
-                    if ($Database) {
-                        # We set DatabaseName instead of calling GetDatabaseConnection on purpose.
-                        # GetDatabaseConnection opens the connection on the copy we are holding and returns
-                        # a *different* ConnectionContext, so the server we build below never owns that
-                        # connection. Disconnect-DbaInstance can only reach the context of the server it is
-                        # given, so nothing ever closed it: the session stayed open for the life of the
-                        # process, holding a shared lock on the database. On model that is enough to make a
-                        # later CREATE DATABASE on the same instance fail on the exclusive lock.
-                        # Setting DatabaseName keeps the connection with the context we hand to the server,
-                        # which is also what the connection string code paths of this command already do.
-                        # It does not reset StatementTimeout either, so the save and restore that
-                        # GetDatabaseConnection needed is gone with it.
-                        try {
-                            $connContext.DatabaseName = $Database
-                        } catch {
-                            # Falling back to GetDatabaseConnection here would bring back the very leak this
-                            # change is about. The database is switched on the connection of the copy further
-                            # down instead, which needs no new connection and therefore cannot lose anything.
-                            $databaseNeedsSwitch = $true
-                        }
-                    }
-                    if ($connectionStringKeyword.Count -gt 0) {
-                        # Rebuilding the connection string means opening a new connection from it, and that is
-                        # only safe when the string still carries what it takes to log in. Once a SqlConnection
-                        # has been opened with Persist Security Info=False, SqlClient hides the password, so
-                        # the string we can read back no longer has one and the new connection would fail with
-                        # "Login failed". Rejecting that is better than handing back a server that cannot be
-                        # used - and the caller can always pass the instance name and a SqlCredential instead.
+
+                        # Everything above that could not be assigned needs a new connection built from a
+                        # changed connection string. Work out here whether that is possible at all, because
+                        # opening a new connection means logging in again, and only a connection string that
+                        # still carries the whole login can do that.
                         $connectionStringBuilder = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnectionStringBuilder -ArgumentList $connContext.ConnectionString
-                        $usesSqlLogin = -not $connectionStringBuilder["Integrated Security"] -and $connectionStringBuilder["User ID"]
-                        if ($usesSqlLogin -and -not $connectionStringBuilder["Password"] -and -not $connContext.SqlConnectionObject.Credential) {
-                            Stop-Function -Message "Cannot apply the requested settings to [$instance]: they need a new connection, and the password of the SQL Server login is no longer readable from the connection that was passed in. Connect with the instance name and -SqlCredential instead, or pass a SqlConnection that uses Persist Security Info=True." -Target $instance -Continue
+                        if ($ApplicationIntent -and $connectionStringBuilder["ApplicationIntent"] -ne $ApplicationIntent) {
+                            # The property was assigned above without complaint, but on a fixed connection
+                            # string that assignment never reaches the string, and the string is what the login
+                            # is made with. SQL Server reads the intent at login time and routes on it then, so
+                            # a context that reports ReadOnly over a connection that logged in as ReadWrite is
+                            # simply wrong. Where the assignment did reach the string - every context that
+                            # accepts property assignments - the two match here and nothing is added, which is
+                            # what keeps this from forcing a new connection where none is needed.
+                            $connectionStringKeyword["ApplicationIntent"] = $ApplicationIntent
+                        }
+                        $authenticationMethod = [string]$connectionStringBuilder["Authentication"]
+                        if ($connectionStringBuilder["Integrated Security"] -or $connContext.SqlConnectionObject.AccessToken -or $connContext.SqlConnectionObject.AccessTokenCallback) {
+                            # Windows authentication needs no secret from the string, and an access token - or
+                            # the callback that fetches one - lives on the SqlConnection, where both survive
+                            # being given a new connection string.
+                            $connectionStringCanLogIn = $true
+                        } elseif ($authenticationMethod -in "ActiveDirectoryPassword", "ActiveDirectoryServicePrincipal") {
+                            # The only two Microsoft Entra methods that use a password of their own.
+                            $connectionStringCanLogIn = [bool]$connectionStringBuilder["Password"]
+                        } elseif ($authenticationMethod -ne "NotSpecified") {
+                            # Every other Entra method - managed identity, workload identity, default,
+                            # integrated, interactive, device code - is passwordless by design. Several of them
+                            # do put a client id in User ID, so User ID alone must not be read as a SQL Server
+                            # login, or these get rejected over a password they never had.
+                            $connectionStringCanLogIn = $true
+                        } else {
+                            # A SQL Server login, and both halves have to be in the string. Once a SqlConnection
+                            # has been opened with Persist Security Info=False, SqlClient hides the password,
+                            # and a SqlCredential is hidden the same way - ServerConnection.Copy() does not even
+                            # carry one over. So neither can be recovered from an open connection, and what is
+                            # left in the string would log in as nobody.
+                            $connectionStringCanLogIn = [bool]$connectionStringBuilder["User ID"] -and [bool]$connectionStringBuilder["Password"]
                         }
 
                         if ($databaseNeedsSwitch) {
-                            # A new connection is opened anyway, so the database belongs in the string. As
-                            # Initial Catalog it is part of the pool key, which is what setting DatabaseName
-                            # achieves as well, so the reason #9505 forced a non pooled connection still holds.
-                            $connectionStringKeyword["Initial Catalog"] = $Database
-                            $databaseNeedsSwitch = $false
+                            if ($connectionStringCanLogIn) {
+                                # A new connection can be built, so the database belongs in the string. As
+                                # Initial Catalog it is part of the pool key, which is what setting DatabaseName
+                                # achieves as well, so the reason #9505 forced a non pooled connection still
+                                # holds. This is also the only way that works on Azure SQL Database.
+                                $connectionStringKeyword["Initial Catalog"] = $Database
+                                $databaseNeedsSwitch = $false
+                            } elseif ($inputObject.ConnectionContext.DatabaseEngineEdition -in "SqlDatabase", "SqlDataWarehouse", "SqlOnDemand") {
+                                # Read the edition from the server that was passed in, never from the copy:
+                                # reading it there connects the copy, and every property of a connected context
+                                # is locked from then on, including the ones assigned above.
+                                # Azure SQL Database answers a USE with error 40508 and wants a new connection
+                                # for another database, so the switch below cannot work there. Refusing is the
+                                # honest answer - the alternative is a server object in the wrong database.
+                                Stop-Function -Message "Cannot change the database of [$instance] to [$Database]: it needs a new connection, because Azure SQL Database does not support switching the database of an existing one, and the authentication of the connection that was passed in cannot be reproduced from its connection string. Connect with the instance name and -SqlCredential, or with an access token, instead." -Target $instance -Continue
+                            }
                         }
-                        if ($ApplicationIntent) {
-                            # Assigned as a property above, which does not reach a fixed connection string
-                            # either, so the context would report ReadOnly while the connection routes as it
-                            # always did.
-                            $connectionStringKeyword["ApplicationIntent"] = $ApplicationIntent
-                        }
+                        if ($connectionStringKeyword.Count -gt 0) {
+                            if (-not $connectionStringCanLogIn) {
+                                # Refusing is better than handing back a server that cannot be used. The caller
+                                # can always connect with the instance name and a credential of its own.
+                                Stop-Function -Message "Cannot apply the requested settings to [$instance]: they need a new connection, and the authentication of the connection that was passed in cannot be reproduced from its connection string. Connect with the instance name and -SqlCredential, or with an access token, instead." -Target $instance -Continue
+                            }
 
-                        $changedKeywords = $connectionStringKeyword.Keys -join ", "
-                        Write-Message -Level Debug -Message "Connection context does not accept property assignments, using the connection string for: $changedKeywords"
-                        # The copy has to be disconnected first: setting the connection string of an open
-                        # connection does not move it. The copy is a session of its own - a different SPID
-                        # than the server that was passed in - so this does not touch the caller.
-                        $connContext.Disconnect()
-                        foreach ($keyword in $connectionStringKeyword.Keys) {
-                            # PowerShell routes property assignments on a connection string builder through its
-                            # dictionary indexer, so the keyword has to be used rather than the property name:
-                            # $connectionStringBuilder.InitialCatalog fails with "Keyword not supported".
-                            $connectionStringBuilder[$keyword] = $connectionStringKeyword[$keyword]
+                            $changedKeywords = $connectionStringKeyword.Keys -join ", "
+                            Write-Message -Level Debug -Message "Connection context does not accept property assignments, using the connection string for: $changedKeywords"
+                            # The copy has to be disconnected first: setting the connection string of an open
+                            # connection does not move it. The copy is a session of its own - a different SPID
+                            # than the server that was passed in - so this does not touch the caller.
+                            $connContext.Disconnect()
+                            foreach ($keyword in $connectionStringKeyword.Keys) {
+                                # PowerShell routes property assignments on a connection string builder through its
+                                # dictionary indexer, so the keyword has to be used rather than the property name:
+                                # $connectionStringBuilder.InitialCatalog fails with "Keyword not supported".
+                                $connectionStringBuilder[$keyword] = $connectionStringKeyword[$keyword]
+                            }
+                            $connContext.ConnectionString = $connectionStringBuilder.ConnectionString
                         }
-                        $connContext.ConnectionString = $connectionStringBuilder.ConnectionString
-                    }
-                    if ($databaseNeedsSwitch) {
-                        # Nothing else needs a new connection, so the database is switched on the one the copy
-                        # already holds. That keeps every part of the authentication that lives on the
-                        # SqlConnection rather than in its string, which rebuilding the string would lose.
-                        # The copy is a session of its own, so this is not the leak of #10555 - the caller
-                        # keeps its own database.
-                        if ($connContext.SqlConnectionObject.State -ne "Open") {
-                            $connContext.Connect()
+                        if ($databaseNeedsSwitch) {
+                            # No new connection can be built, but this engine takes a USE, so the database is
+                            # switched on the connection the copy already holds. That keeps every part of the
+                            # authentication that lives on the SqlConnection rather than in its string, which
+                            # rebuilding the string would lose. The copy is a session of its own, so this is not
+                            # the leak of #10555 - the caller keeps its own database.
+                            if ($connContext.SqlConnectionObject.State -ne "Open") {
+                                $connContext.Connect()
+                            }
+                            $connContext.SqlConnectionObject.ChangeDatabase($Database)
                         }
-                        $connContext.SqlConnectionObject.ChangeDatabase($Database)
-                    }
-                    $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $connContext
-                    if ($Database -and $server.ConnectionContext.CurrentDatabase -ne $Database) {
-                        Write-Message -Level Warning -Message "Changing connection context to database $Database was not successful. Current database is $($server.ConnectionContext.CurrentDatabase). Please open an issue on https://github.com/dataplat/dbatools/issues."
+                        $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $connContext
+                        $connContextTransferred = $true
+                        if ($Database -and $server.ConnectionContext.CurrentDatabase -ne $Database) {
+                            Write-Message -Level Warning -Message "Changing connection context to database $Database was not successful. Current database is $($server.ConnectionContext.CurrentDatabase). Please open an issue on https://github.com/dataplat/dbatools/issues."
+                        }
+                    } finally {
+                        if (-not $connContextTransferred) {
+                            # Nothing else can reach this connection any more, so it is closed here. Disconnect
+                            # must not throw on the way out of a failure, or it would replace the error that
+                            # brought us here with one about the cleanup.
+                            try {
+                                $connContext.Disconnect()
+                            } catch {
+                                Write-Message -Level Debug -Message "Disconnecting the copied connection context after a failed connect failed as well: $PSItem"
+                            }
+                        }
                     }
                 } else {
                     $server = $inputObject
@@ -1430,7 +1490,15 @@ function Connect-DbaInstance {
             if ($isNewConnection -and -not $DedicatedAdminConnection) {
                 if (-not $usesCredentialSspiProvider) {
                     # Register the connected instance, so that the TEPP updater knows it's been connected to and starts building the cache
-                    [Dataplat.Dbatools.TabExpansion.TabExpansionHost]::SetInstance($instance.FullSmoName.ToLowerInvariant(), $server.ConnectionContext.Copy(), ($server.ConnectionContext.FixedServerRoles -match "SysAdmin"))
+                    # Copy() clones an open connection as an open connection, and this copy is then kept for
+                    # the life of the process, where nothing can ever reach it to close it again. Whenever the
+                    # context is already open at this point - which is what switching the database on the
+                    # connection leaves behind - that parked a session per call that nothing could reuse or
+                    # close. Handing over a disconnected copy costs nothing: the updater connects when it
+                    # runs, and it is off by default.
+                    $teppConnectionContext = $server.ConnectionContext.Copy()
+                    $teppConnectionContext.Disconnect()
+                    [Dataplat.Dbatools.TabExpansion.TabExpansionHost]::SetInstance($instance.FullSmoName.ToLowerInvariant(), $teppConnectionContext, ($server.ConnectionContext.FixedServerRoles -match "SysAdmin"))
 
                     # Update cache for instance names
                     if ([Dataplat.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] -notcontains $instance.FullSmoName.ToLowerInvariant()) {

--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -762,6 +762,7 @@ function Connect-DbaInstance {
                     # Initial Catalog, Pooling and Data Source. No readable property tells the two kinds of
                     # context apart - every one of them reads fine on both - so we find out by trying.
                     $connectionStringKeyword = @{ }
+                    $databaseNeedsSwitch = $false
                     if ($ApplicationIntent) {
                         $connContext.ApplicationIntent = $ApplicationIntent
                     }
@@ -792,6 +793,14 @@ function Connect-DbaInstance {
                             $connContext.ServerInstance = $dedicatedAdminServerInstance
                         } catch {
                             $connectionStringKeyword["Data Source"] = $dedicatedAdminServerInstance
+                            if ($instance.IsLocalHost) {
+                                # TrustServerCertificate was assigned above, and on a context with a fixed
+                                # connection string that assignment does not reach the string - the property
+                                # reads back as True while the string still says False. Since the string is
+                                # what the new connection is built from, the same has to be put in there, or
+                                # the localhost DAC fails on a certificate that does not match. See #10254.
+                                $connectionStringKeyword["Trust Server Certificate"] = $true
+                            }
                         }
                         try {
                             $connContext.NonPooledConnection = $true
@@ -815,21 +824,44 @@ function Connect-DbaInstance {
                             $connContext.DatabaseName = $Database
                         } catch {
                             # Falling back to GetDatabaseConnection here would bring back the very leak this
-                            # change is about, so the database goes into the connection string instead. As
-                            # Initial Catalog it is part of the pool key, which is what setting DatabaseName
-                            # achieves as well, so the reason #9505 forced a non pooled connection still holds.
-                            $connectionStringKeyword["Initial Catalog"] = $Database
+                            # change is about. The database is switched on the connection of the copy further
+                            # down instead, which needs no new connection and therefore cannot lose anything.
+                            $databaseNeedsSwitch = $true
                         }
                     }
                     if ($connectionStringKeyword.Count -gt 0) {
+                        # Rebuilding the connection string means opening a new connection from it, and that is
+                        # only safe when the string still carries what it takes to log in. Once a SqlConnection
+                        # has been opened with Persist Security Info=False, SqlClient hides the password, so
+                        # the string we can read back no longer has one and the new connection would fail with
+                        # "Login failed". Rejecting that is better than handing back a server that cannot be
+                        # used - and the caller can always pass the instance name and a SqlCredential instead.
+                        $connectionStringBuilder = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnectionStringBuilder -ArgumentList $connContext.ConnectionString
+                        $usesSqlLogin = -not $connectionStringBuilder["Integrated Security"] -and $connectionStringBuilder["User ID"]
+                        if ($usesSqlLogin -and -not $connectionStringBuilder["Password"] -and -not $connContext.SqlConnectionObject.Credential) {
+                            Stop-Function -Message "Cannot apply the requested settings to [$instance]: they need a new connection, and the password of the SQL Server login is no longer readable from the connection that was passed in. Connect with the instance name and -SqlCredential instead, or pass a SqlConnection that uses Persist Security Info=True." -Target $instance -Continue
+                        }
+
+                        if ($databaseNeedsSwitch) {
+                            # A new connection is opened anyway, so the database belongs in the string. As
+                            # Initial Catalog it is part of the pool key, which is what setting DatabaseName
+                            # achieves as well, so the reason #9505 forced a non pooled connection still holds.
+                            $connectionStringKeyword["Initial Catalog"] = $Database
+                            $databaseNeedsSwitch = $false
+                        }
+                        if ($ApplicationIntent) {
+                            # Assigned as a property above, which does not reach a fixed connection string
+                            # either, so the context would report ReadOnly while the connection routes as it
+                            # always did.
+                            $connectionStringKeyword["ApplicationIntent"] = $ApplicationIntent
+                        }
+
                         $changedKeywords = $connectionStringKeyword.Keys -join ", "
                         Write-Message -Level Debug -Message "Connection context does not accept property assignments, using the connection string for: $changedKeywords"
                         # The copy has to be disconnected first: setting the connection string of an open
-                        # connection does not move it, and CurrentDatabase would silently stay where it was.
-                        # The copy is a session of its own - a different SPID than the server that was passed
-                        # in - so this does not touch the connection of the caller.
+                        # connection does not move it. The copy is a session of its own - a different SPID
+                        # than the server that was passed in - so this does not touch the caller.
                         $connContext.Disconnect()
-                        $connectionStringBuilder = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnectionStringBuilder -ArgumentList $connContext.ConnectionString
                         foreach ($keyword in $connectionStringKeyword.Keys) {
                             # PowerShell routes property assignments on a connection string builder through its
                             # dictionary indexer, so the keyword has to be used rather than the property name:
@@ -837,6 +869,17 @@ function Connect-DbaInstance {
                             $connectionStringBuilder[$keyword] = $connectionStringKeyword[$keyword]
                         }
                         $connContext.ConnectionString = $connectionStringBuilder.ConnectionString
+                    }
+                    if ($databaseNeedsSwitch) {
+                        # Nothing else needs a new connection, so the database is switched on the one the copy
+                        # already holds. That keeps every part of the authentication that lives on the
+                        # SqlConnection rather than in its string, which rebuilding the string would lose.
+                        # The copy is a session of its own, so this is not the leak of #10555 - the caller
+                        # keeps its own database.
+                        if ($connContext.SqlConnectionObject.State -ne "Open") {
+                            $connContext.Connect()
+                        }
+                        $connContext.SqlConnectionObject.ChangeDatabase($Database)
                     }
                     $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $connContext
                     if ($Database -and $server.ConnectionContext.CurrentDatabase -ne $Database) {

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -478,6 +478,17 @@ The lab those names describe needs more than a bare cluster: one cluster shared 
 
 Do not copy this exception to any other command family. It applies where the boundary is a Windows feature that no runner can provide, not where provisioning is merely inconvenient.
 
+### The other boundary CI does not have: Azure SQL Database
+
+The same shape, for the same reason. Azure SQL Database is the only engine that refuses to switch the database of a connection it has already opened - it answers a `USE` with error 40508 and wants a new connection whose `Initial Catalog` names the target. Azure SQL Managed Instance takes the `USE` like every other engine, so it does not stand in for one. Any code that changes the database of an existing connection is therefore correct everywhere CI can reach and wrong only here, which is how `Connect-DbaInstance` shipped a fallback that could not work on Azure SQL Database at all (#10584).
+
+No CI environment has one, so `Get-TestConfig` leaves `AzureSqlDbServer`, `AzureSqlDbName` and `AzureSqlDbCred` empty and the tests carry `-Skip:(-not $script:hasAzureSqlDb)`. A local configuration whose lab has an Azure SQL Database sets all three, and the tests then run for real.
+
+Two things keep that skip honest, and both are worth copying:
+
+- **Assert the engine first.** The Azure tests begin with an `It` that fails unless `DatabaseEngineEdition` is `SqlDatabase`. Pointed at anything else the rest would pass while proving nothing, because every other engine simply takes the `USE`.
+- **Assert the message, not just the failure.** Where the command has to refuse, the test also asserts that the error is *not* the raw "USE statement is not supported" - that is what fails if the code ever reaches `ChangeDatabase` again.
+
 ## TEST MANAGEMENT GUIDELINES
 
 The dbatools test suite must remain manageable in size while ensuring adequate coverage for important functionality.

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -13,6 +13,12 @@ BeforeDiscovery {
     # exercised where the instance really is local, which is the case on the CI runners and not in a lab
     # of remote instances. The value decides a Skip, so it has to exist at discovery time.
     $script:instanceIsLocalHost = ([DbaInstanceParameter]$TestConfig.InstanceMulti1).IsLocalHost
+    # Azure SQL Database is the only engine that refuses to switch the database of a connection it has
+    # already opened - it answers a USE with error 40508 and wants a new connection instead. Every branch
+    # that depends on that can therefore only be covered against a real one, which a lab configuration
+    # supplies through AzureSqlDbServer. Everywhere else these tests skip themselves. The value decides a
+    # Skip, so it has to exist at discovery time.
+    $script:hasAzureSqlDb = -not [string]::IsNullOrWhiteSpace($TestConfig.AzureSqlDbServer)
 }
 
 Describe $CommandName -Tag UnitTests {
@@ -560,6 +566,29 @@ Describe $CommandName -Tag IntegrationTests {
             $null = $serverClone | Disconnect-DbaInstance
         }
 
+        It "clones when using parameter ApplicationIntent" {
+            # ApplicationIntent is not one of the properties SMO refuses to assign, so this used to look
+            # like it worked: the property took the value and read it back. On a fixed connection string
+            # the assignment never reaches the string, and the string is what the login is made with -
+            # SQL Server reads the intent at login time and routes on it then. So the context reported
+            # ReadOnly over a connection that had logged in as ReadWrite, and with no other setting to
+            # apply, nothing rebuilt the string to correct it.
+            $serverClone = Connect-DbaInstance -SqlInstance $serverFromSqlConnection -ApplicationIntent ReadOnly
+            $cloneStringBuilder = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnectionStringBuilder -ArgumentList $serverClone.ConnectionContext.ConnectionString
+            $cloneStringBuilder["ApplicationIntent"] | Should -Be "ReadOnly"
+            $serverClone.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "master"
+            $null = $serverClone | Disconnect-DbaInstance
+        }
+
+        It "clones when using parameter Database together with ApplicationIntent" {
+            $serverClone = Connect-DbaInstance -SqlInstance $serverFromSqlConnection -Database tempdb -ApplicationIntent ReadOnly
+            $cloneStringBuilder = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnectionStringBuilder -ArgumentList $serverClone.ConnectionContext.ConnectionString
+            $cloneStringBuilder["ApplicationIntent"] | Should -Be "ReadOnly"
+            $cloneStringBuilder["Initial Catalog"] | Should -Be "tempdb"
+            $serverClone.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "tempdb"
+            $null = $serverClone | Disconnect-DbaInstance
+        }
+
         It "clones when using parameter DedicatedAdminConnection" {
             $serverClone = Connect-DbaInstance -SqlInstance $serverFromSqlConnection -DedicatedAdminConnection
             $serverClone.ConnectionContext.ConnectionString | Should -Match "ADMIN:"
@@ -621,13 +650,21 @@ Describe $CommandName -Tag IntegrationTests {
             $sqlAuthConnection.Open()
             $serverFromSqlAuth = Connect-DbaInstance -SqlInstance $sqlAuthConnection
 
+            # The session counting of the tests below goes through a connection of its own, opened once
+            # here. Passing an instance name to Get-DbaProcess instead would open a new connection on
+            # every call, and each of those registers itself with the tab expansion cache under the same
+            # instance key - which drops the reference to whatever was stored there before, and with it
+            # the leaked connection these tests are looking for. Counting would then hide the growth it
+            # is supposed to prove.
+            $serverForCounting = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
+
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         AfterAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-            $null = $serverFromSqlAuth | Disconnect-DbaInstance
+            $null = $serverFromSqlAuth, $serverForCounting | Disconnect-DbaInstance
             $sqlAuthConnection.Close()
             $null = Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login $sqlAuthLogin -Force -ErrorAction SilentlyContinue
 
@@ -651,7 +688,144 @@ Describe $CommandName -Tag IntegrationTests {
             # so rather than hand back something that fails on first use. Connect-DbaInstance throws by
             # default, which is why this is not a warning.
             { Connect-DbaInstance -SqlInstance $serverFromSqlAuth -Database tempdb -NonPooledConnection } |
-                Should -Throw -ExpectedMessage "*no longer readable*"
+                Should -Throw -ExpectedMessage "*cannot be reproduced from its connection string*"
+        }
+
+        It "keeps the session count flat over repeated refusals" {
+            # A refusal happens after the connection context has been copied, and Copy() clones an open
+            # connection as an open connection. Nothing but the returned server object can ever close that
+            # copy, so a refusal that simply returns leaves a session behind that nothing can reuse - the
+            # same orphaned connection this whole change is about, only on the failure path. Repeated on
+            # purpose: one sleeping pooled session is legitimate, growth is not.
+            $countPerCycle = @()
+            foreach ($cycle in 1..5) {
+                { Connect-DbaInstance -SqlInstance $serverFromSqlAuth -Database tempdb -NonPooledConnection } | Should -Throw
+                $countPerCycle += @(Get-DbaProcess -SqlInstance $serverForCounting -Login $sqlAuthLogin).Count
+            }
+            ($countPerCycle | Select-Object -Unique).Count | Should -Be 1
+        }
+
+        It "keeps the session count flat over repeated failed database switches" {
+            # The other way out of the same block: the copy exists and is open, and switching it to a
+            # database that does not exist throws from inside SMO rather than through Stop-Function.
+            $countPerCycle = @()
+            foreach ($cycle in 1..5) {
+                { Connect-DbaInstance -SqlInstance $serverFromSqlAuth -Database "dbatoolsci_does_not_exist_$cycle" } | Should -Throw
+                $countPerCycle += @(Get-DbaProcess -SqlInstance $serverForCounting -Login $sqlAuthLogin).Count
+            }
+            ($countPerCycle | Select-Object -Unique).Count | Should -Be 1
+        }
+
+        It "keeps the session count flat over repeated successful clones" {
+            # And the path that succeeds. This one switches the database on the connection the copy holds,
+            # which leaves that connection open, and an open connection was then copied a second time for
+            # the tab expansion cache and kept there for the life of the process. That copy was reachable
+            # by nothing, so every call parked another session: the count went 3, 4, 5, 6, 7, 8.
+            $countPerCycle = @()
+            foreach ($cycle in 1..5) {
+                $serverClone = Connect-DbaInstance -SqlInstance $serverFromSqlAuth -Database tempdb
+                $serverClone.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "tempdb"
+                $null = $serverClone | Disconnect-DbaInstance
+                $countPerCycle += @(Get-DbaProcess -SqlInstance $serverForCounting -Login $sqlAuthLogin).Count
+            }
+            ($countPerCycle | Select-Object -Unique).Count | Should -Be 1
+        }
+    }
+
+    Context "connection is properly cloned on Azure SQL Database" -Skip:(-not $script:hasAzureSqlDb) {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Azure SQL Database answers a USE with error 40508 and wants a new connection for another
+            # database. Every other engine, Azure SQL Managed Instance included, takes the USE, so the
+            # branch that switches the database on an existing connection looks correct everywhere else
+            # and is wrong only here. See #10584.
+            # A serverless database that has been idle is paused and takes up to a minute to wake up, so
+            # the first connection gets a generous timeout.
+            $splatAzureConnect = @{
+                SqlInstance    = $TestConfig.AzureSqlDbServer
+                Database       = $TestConfig.AzureSqlDbName
+                SqlCredential  = $TestConfig.AzureSqlDbCred
+                ConnectTimeout = 120
+            }
+            $serverAzure = Connect-DbaInstance @splatAzureConnect
+
+            # The same login again, but through a SqlConnection, which gives the server a fixed connection
+            # string and so takes the code path that cannot assign DatabaseName. Persist Security Info is
+            # on, so the password survives being read back and a new connection can be built from it.
+            $azurePassword = $TestConfig.AzureSqlDbCred.GetNetworkCredential().Password
+            $azureConnectionString = @(
+                "Data Source=$($TestConfig.AzureSqlDbServer)"
+                "Initial Catalog=$($TestConfig.AzureSqlDbName)"
+                "User ID=$($TestConfig.AzureSqlDbCred.UserName)"
+                "Password=$azurePassword"
+                "Encrypt=True"
+                "Persist Security Info=True"
+                "Connect Timeout=120"
+            ) -join ";"
+            $azureConnection = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnection -ArgumentList $azureConnectionString
+            $azureConnection.Open()
+            $serverAzureFromSqlConnection = Connect-DbaInstance -SqlInstance $azureConnection
+
+            # And once more with the password hidden, which is what an opened connection looks like by
+            # default. Nothing can rebuild a connection string from this one.
+            $azureHiddenConnectionString = $azureConnectionString -replace "Persist Security Info=True", "Persist Security Info=False"
+            $azureHiddenConnection = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnection -ArgumentList $azureHiddenConnectionString
+            $azureHiddenConnection.Open()
+            $serverAzureHiddenPassword = Connect-DbaInstance -SqlInstance $azureHiddenConnection
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $serverAzure, $serverAzureFromSqlConnection, $serverAzureHiddenPassword | Disconnect-DbaInstance
+            $azureConnection.Close()
+            $azureHiddenConnection.Close()
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "really is an Azure SQL Database, which is what makes this case different" {
+            # Guards the three tests below: against anything else they would pass without proving
+            # anything, because every other engine simply takes the USE.
+            $serverAzure.DatabaseEngineEdition | Should -Be "SqlDatabase"
+        }
+
+        It "clones when using parameter Database" {
+            $serverClone = Connect-DbaInstance -SqlInstance $serverAzure -Database master
+            $serverClone.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "master"
+            $serverAzure.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be $TestConfig.AzureSqlDbName
+            $null = $serverClone | Disconnect-DbaInstance
+        }
+
+        It "clones when using parameter Database from a server that was created from a SqlConnection" {
+            # The regression: a fixed connection string cannot take DatabaseName, and switching the
+            # database on the connection instead is exactly what Azure SQL Database refuses. The database
+            # has to go into the connection string as Initial Catalog, which is also the only thing that
+            # gives it the right connection pool.
+            $serverClone = Connect-DbaInstance -SqlInstance $serverAzureFromSqlConnection -Database master
+            $serverClone.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "master"
+            $serverClone.ConnectionContext.ExecuteScalar("select suser_sname()") | Should -Be $TestConfig.AzureSqlDbCred.UserName
+            $serverAzureFromSqlConnection.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be $TestConfig.AzureSqlDbName
+            $null = $serverClone | Disconnect-DbaInstance
+        }
+
+        It "refuses rather than trying to switch the database on the connection" {
+            # No new connection can be built here, because the password is gone, and the fallback that
+            # every other engine uses cannot work on Azure SQL Database. The command has to say so. The
+            # last assertion is the one with teeth: it fails if the code ever reaches ChangeDatabase,
+            # which answers with "USE statement is not supported to switch between databases".
+            $errorRecord = $null
+            try {
+                $null = Connect-DbaInstance -SqlInstance $serverAzureHiddenPassword -Database master
+            } catch {
+                $errorRecord = $PSItem
+            }
+            $errorRecord | Should -Not -BeNullOrEmpty
+            $errorRecord.Exception.Message | Should -BeLike "*Azure SQL Database does not support switching the database*"
+            $errorRecord.Exception.Message | Should -Not -BeLike "*USE statement is not supported*"
         }
     }
 

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -740,15 +740,30 @@ Describe $CommandName -Tag IntegrationTests {
             # database. Every other engine, Azure SQL Managed Instance included, takes the USE, so the
             # branch that switches the database on an existing connection looks correct everywhere else
             # and is wrong only here. See #10584.
-            # A serverless database that has been idle is paused and takes up to a minute to wake up, so
-            # the first connection gets a generous timeout.
+            # A serverless database that has been idle is paused and takes up to a minute to wake up. A
+            # generous ConnectTimeout does not cover that: while the database resumes, Azure does not
+            # keep the attempt waiting, it answers it right away with error 40613 "Database ... is not
+            # currently available. Please retry the connection later." So the first connection is
+            # retried until the database is up, and only an error that says something else is thrown
+            # immediately.
             $splatAzureConnect = @{
                 SqlInstance    = $TestConfig.AzureSqlDbServer
                 Database       = $TestConfig.AzureSqlDbName
                 SqlCredential  = $TestConfig.AzureSqlDbCred
                 ConnectTimeout = 120
             }
-            $serverAzure = Connect-DbaInstance @splatAzureConnect
+            $azureResumeAttempt = 0
+            while ($null -eq $serverAzure) {
+                $azureResumeAttempt++
+                try {
+                    $serverAzure = Connect-DbaInstance @splatAzureConnect
+                } catch {
+                    if ($azureResumeAttempt -ge 10 -or $PSItem.Exception.Message -notmatch "is not currently available") {
+                        throw
+                    }
+                    Start-Sleep -Seconds 15
+                }
+            }
 
             # The same login again, but through a SqlConnection, which gives the server a fixed connection
             # string and so takes the code path that cannot assign DatabaseName. Persist Security Info is
@@ -780,9 +795,17 @@ Describe $CommandName -Tag IntegrationTests {
         AfterAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-            $null = $serverAzure, $serverAzureFromSqlConnection, $serverAzureHiddenPassword | Disconnect-DbaInstance
-            $azureConnection.Close()
-            $azureHiddenConnection.Close()
+            # The BeforeAll can fail partway through - an Azure SQL Database that stays unavailable is the
+            # realistic case - and then the variables below it were never assigned. Calling a method on
+            # one of them throws from the teardown, and Pester reports that null reference on every test
+            # of the block instead of the error that really happened.
+            $null = $serverAzure, $serverAzureFromSqlConnection, $serverAzureHiddenPassword | Where-Object { $null -ne $PSItem } | Disconnect-DbaInstance
+            if ($azureConnection) {
+                $azureConnection.Close()
+            }
+            if ($azureHiddenConnection) {
+                $azureHiddenConnection.Close()
+            }
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -540,6 +540,21 @@ Describe $CommandName -Tag IntegrationTests {
             $serverClone.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "tempdb"
         }
 
+        It "hands the clone a connection that Disconnect-DbaInstance can close" {
+            # The clone used to be built with GetDatabaseConnection, which opened the connection on an
+            # intermediate copy and returned a different context. The clone therefore did not own its
+            # connection and Disconnect-DbaInstance closed nothing, so every call left a session parked
+            # in the database holding a shared lock on it.
+            $countBefore = @(Get-DbaProcess -SqlInstance $server -Database tempdb | Where-Object Program -match "dbatools").Count
+
+            $serverParked = Connect-DbaInstance -SqlInstance $server -Database tempdb
+            $serverParked.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "tempdb"
+            $null = $serverParked | Disconnect-DbaInstance
+
+            $countAfter = @(Get-DbaProcess -SqlInstance $server -Database tempdb | Where-Object Program -match "dbatools").Count
+            $countAfter | Should -Be $countBefore
+        }
+
         It "clones when using parameter ApplicationIntent" {
             $serverClone = Connect-DbaInstance -SqlInstance $server -ApplicationIntent ReadOnly
             $server.ConnectionContext.ApplicationIntent | Should -BeNullOrEmpty

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -565,6 +565,64 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 
+    Context "connection is properly cloned from an open SQL authenticated SqlConnection" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Once a SqlConnection has been opened with Persist Security Info=False, SqlClient hides the
+            # password: the connection string that can be read back no longer carries one. Anything that
+            # rebuilds the connection string from it therefore produces a connection that cannot log in,
+            # so the database has to be switched on the connection that already exists. See #10584.
+            $sqlAuthLogin = "dbatoolsci_clone_$(Get-Random)"
+            $sqlAuthPassword = "dbatools.IO_$(Get-Random)"
+            $splatSqlAuthLogin = @{
+                SqlInstance = $TestConfig.InstanceMulti1
+                Login       = $sqlAuthLogin
+                Password    = (ConvertTo-SecureString -String $sqlAuthPassword -AsPlainText -Force)
+                Force       = $true
+            }
+            $null = New-DbaLogin @splatSqlAuthLogin
+            $null = Set-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login $sqlAuthLogin -AddRole sysadmin
+
+            $sqlAuthConnectionString = "Data Source=$($TestConfig.InstanceMulti1);Initial Catalog=master;User ID=$sqlAuthLogin;Password=$sqlAuthPassword;Persist Security Info=False;Encrypt=False;Trust Server Certificate=True"
+            $sqlAuthConnection = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnection -ArgumentList $sqlAuthConnectionString
+            $sqlAuthConnection.Open()
+            $serverFromSqlAuth = Connect-DbaInstance -SqlInstance $sqlAuthConnection
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $serverFromSqlAuth | Disconnect-DbaInstance
+            $sqlAuthConnection.Close()
+            $null = Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1 -Login $sqlAuthLogin -Force -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "hides the password from the connection string, which is what makes this case hard" {
+            $serverFromSqlAuth.ConnectionContext.ConnectionString | Should -Not -Match "Password="
+        }
+
+        It "clones when using parameter Database" {
+            $serverClone = Connect-DbaInstance -SqlInstance $serverFromSqlAuth -Database tempdb
+            $serverClone.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "tempdb"
+            $serverClone.ConnectionContext.ExecuteScalar("select suser_sname()") | Should -Be $sqlAuthLogin
+            $serverFromSqlAuth.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "master"
+            $null = $serverClone | Disconnect-DbaInstance
+        }
+
+        It "refuses instead of returning a server that cannot log in" {
+            # This one needs a new connection, and the password for it is gone, so the command has to say
+            # so rather than hand back something that fails on first use. Connect-DbaInstance throws by
+            # default, which is why this is not a warning.
+            { Connect-DbaInstance -SqlInstance $serverFromSqlAuth -Database tempdb -NonPooledConnection } |
+                Should -Throw -ExpectedMessage "*no longer readable*"
+        }
+    }
+
     Context "connection is properly cloned from an existing connection" {
         BeforeAll {
             $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
@@ -598,7 +656,9 @@ Describe $CommandName -Tag IntegrationTests {
                 $countPerCycle += @(Get-DbaProcess -SqlInstance $server -Database tempdb | Where-Object Program -match "dbatools").Count
             }
 
-            $countPerCycle[-1] | Should -Be $countPerCycle[0]
+            # Every cycle has to land on the same number, not just the first and the last. A sequence like
+            # 4, 5, 4, 5, 4 starts and ends the same way and still means the pool is churning.
+            ($countPerCycle | Select-Object -Unique).Count | Should -Be 1
         }
 
         It "clones when using parameter ApplicationIntent" {

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -7,6 +7,12 @@ param(
 
 BeforeDiscovery {
     $script:hasCredentialSspiProvider = $null -ne ("Dataplat.Dbatools.Connection.NetworkCredentialSspiContextProvider" -as [type])
+    # A dedicated admin connection to an instance on the machine running the tests takes a different path
+    # than one to a remote instance: it goes to ADMIN:localhost and forces TrustServerCertificate, because
+    # the certificate of the instance does not have to match "localhost" (#10254). That path can only be
+    # exercised where the instance really is local, which is the case on the CI runners and not in a lab
+    # of remote instances. The value decides a Skip, so it has to exist at discovery time.
+    $script:instanceIsLocalHost = ([DbaInstanceParameter]$TestConfig.InstanceMulti1).IsLocalHost
 }
 
 Describe $CommandName -Tag UnitTests {
@@ -562,6 +568,32 @@ Describe $CommandName -Tag IntegrationTests {
             $dacQuery = "SELECT COUNT(*) FROM sys.dm_exec_sessions AS s JOIN sys.endpoints AS e ON e.endpoint_id = s.endpoint_id WHERE e.is_admin_endpoint = 1 AND s.session_id = @@SPID"
             $serverClone.ConnectionContext.ExecuteScalar($dacQuery) | Should -Be 1
             $null = $serverClone | Disconnect-DbaInstance
+        }
+
+        It "keeps the forced certificate trust of a local dedicated admin connection" -Skip:(-not $script:instanceIsLocalHost) {
+            # A local DAC goes to ADMIN:localhost and forces TrustServerCertificate, because the
+            # certificate of the instance does not have to match "localhost" (#10254). On a context whose
+            # connection string is fixed, assigning that property succeeds and reads back as True while
+            # the string still says False - and the string is what the new connection is built from. So
+            # the trust has to be put into the string as well, or the local DAC fails on the certificate.
+            # Starts from Trust Server Certificate=False on purpose: with True the assertion would pass
+            # even if the command did nothing at all.
+            $localDacConnectionString = "Data Source=$($TestConfig.InstanceMulti1);Integrated Security=True;Encrypt=False;Trust Server Certificate=False"
+            [Microsoft.Data.SqlClient.SqlConnection]$localDacConnection = $localDacConnectionString
+            $serverForLocalDac = Connect-DbaInstance -SqlInstance $localDacConnection
+            try {
+                $serverClone = Connect-DbaInstance -SqlInstance $serverForLocalDac -DedicatedAdminConnection
+
+                # Read back through a builder rather than matching the string: a connection string builder
+                # keeps the spelling it was given, so the same setting reads as "Trust Server Certificate"
+                # or "TrustServerCertificate" depending on how the caller wrote it.
+                $cloneStringBuilder = New-Object -TypeName Microsoft.Data.SqlClient.SqlConnectionStringBuilder -ArgumentList $serverClone.ConnectionContext.ConnectionString
+                $cloneStringBuilder["Trust Server Certificate"] | Should -BeTrue
+                $cloneStringBuilder["Data Source"] | Should -Match "^ADMIN:localhost"
+                $null = $serverClone | Disconnect-DbaInstance
+            } finally {
+                $null = $serverForLocalDac | Disconnect-DbaInstance
+            }
         }
     }
 

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -525,6 +525,46 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 
+    Context "connection is properly cloned from a connection that was created from a SqlConnection" {
+        BeforeAll {
+            # A ServerConnection that was built from a SqlConnection has its connection string set, and
+            # SMO then refuses assignments to DatabaseName, NonPooledConnection and ServerInstance, so
+            # cloning such a server has to go through the connection string instead. CI never noticed
+            # because it covers SqlConnection to Server and Server to another Database, but never the
+            # two of them chained. See #10584.
+            [Microsoft.Data.SqlClient.SqlConnection]$sqlConnectionToClone = "Data Source=$($TestConfig.InstanceMulti1);Integrated Security=True;Encrypt=False;Trust Server Certificate=True"
+            $serverFromSqlConnection = Connect-DbaInstance -SqlInstance $sqlConnectionToClone
+        }
+
+        AfterAll {
+            $null = $serverFromSqlConnection | Disconnect-DbaInstance
+        }
+
+        It "clones when using parameter Database" {
+            $serverClone = Connect-DbaInstance -SqlInstance $serverFromSqlConnection -Database tempdb
+            $serverClone.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "tempdb"
+            $serverFromSqlConnection.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "master"
+            $null = $serverClone | Disconnect-DbaInstance
+        }
+
+        It "clones when using parameter Database together with NonPooledConnection" {
+            $serverClone = Connect-DbaInstance -SqlInstance $serverFromSqlConnection -Database tempdb -NonPooledConnection
+            $serverClone.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "tempdb"
+            $serverClone.ConnectionContext.ConnectionString | Should -Match "Pooling=False"
+            $null = $serverClone | Disconnect-DbaInstance
+        }
+
+        It "clones when using parameter DedicatedAdminConnection" {
+            $serverClone = Connect-DbaInstance -SqlInstance $serverFromSqlConnection -DedicatedAdminConnection
+            $serverClone.ConnectionContext.ConnectionString | Should -Match "ADMIN:"
+            # The connection context cannot be asked here, because ServerInstance is one of the properties
+            # that cannot be assigned on such a context, so ask the session which endpoint it is on.
+            $dacQuery = "SELECT COUNT(*) FROM sys.dm_exec_sessions AS s JOIN sys.endpoints AS e ON e.endpoint_id = s.endpoint_id WHERE e.is_admin_endpoint = 1 AND s.session_id = @@SPID"
+            $serverClone.ConnectionContext.ExecuteScalar($dacQuery) | Should -Be 1
+            $null = $serverClone | Disconnect-DbaInstance
+        }
+    }
+
     Context "connection is properly cloned from an existing connection" {
         BeforeAll {
             $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
@@ -545,20 +585,33 @@ Describe $CommandName -Tag IntegrationTests {
             # intermediate copy and returned a different context. The clone therefore did not own its
             # connection and Disconnect-DbaInstance closed nothing, so every call left a session parked
             # in the database holding a shared lock on it.
-            $countBefore = @(Get-DbaProcess -SqlInstance $server -Database tempdb | Where-Object Program -match "dbatools").Count
+            # Repeated on purpose. With pooling, a sleeping session that stays behind is legitimate - it
+            # belongs to the pool and the next call reuses it. What must not happen is that their number
+            # grows with every call, which is what an orphaned connection looks like: nothing can reuse
+            # it and nothing can close it. Against the old implementation the count went up on almost
+            # every cycle, so a single cycle is not enough to tell the two apart.
+            $countPerCycle = @()
+            foreach ($cycle in 1..5) {
+                $serverParked = Connect-DbaInstance -SqlInstance $server -Database tempdb
+                $serverParked.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "tempdb"
+                $null = $serverParked | Disconnect-DbaInstance
+                $countPerCycle += @(Get-DbaProcess -SqlInstance $server -Database tempdb | Where-Object Program -match "dbatools").Count
+            }
 
-            $serverParked = Connect-DbaInstance -SqlInstance $server -Database tempdb
-            $serverParked.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "tempdb"
-            $null = $serverParked | Disconnect-DbaInstance
-
-            $countAfter = @(Get-DbaProcess -SqlInstance $server -Database tempdb | Where-Object Program -match "dbatools").Count
-            $countAfter | Should -Be $countBefore
+            $countPerCycle[-1] | Should -Be $countPerCycle[0]
         }
 
         It "clones when using parameter ApplicationIntent" {
             $serverClone = Connect-DbaInstance -SqlInstance $server -ApplicationIntent ReadOnly
             $server.ConnectionContext.ApplicationIntent | Should -BeNullOrEmpty
             $serverClone.ConnectionContext.ApplicationIntent | Should -Be "ReadOnly"
+        }
+
+        It "clones when using parameter Database together with NonPooledConnection" {
+            $serverClone = Connect-DbaInstance -SqlInstance $server -Database tempdb -NonPooledConnection
+            $serverClone.ConnectionContext.ExecuteScalar("select db_name()") | Should -Be "tempdb"
+            $serverClone.ConnectionContext.NonPooledConnection | Should -Be $true
+            $null = $serverClone | Disconnect-DbaInstance
         }
 
         It "clones when using parameter NonPooledConnection" {


### PR DESCRIPTION
## Overview

*Added 2026-08-23, after several rounds of review grew this beyond what the original description below covers. Nothing was removed - the original text follows unchanged.*

### The problem

Passing an existing server object back into `Connect-DbaInstance` together with a different `-Database` returned a server whose connection **nothing could ever close**.

```powershell
$server = Connect-DbaInstance -SqlInstance $instance
$clone  = Connect-DbaInstance -SqlInstance $server -Database model
$clone | Disconnect-DbaInstance     # closed nothing
```

The session stayed open for the life of the process, sitting in the target database and holding a shared lock on it. On `model` that is enough to make the next `CREATE DATABASE` on that instance fail:

```
Could not obtain exclusive lock on database 'model'. Retry the operation later.
```

which surfaced as an intermittent failure in whatever test file happened to run next, with nothing pointing back at the cause. In the full suite of 2026-08-15, 69 files failed with `Timeout expired ... prior to obtaining a connection from the pool`.

**Why it happened:** the code called `ConnectionContext.Copy().GetDatabaseConnection($Database, $false)`. `GetDatabaseConnection` opens the connection on the intermediate copy and returns a *different* context. The server handed back therefore never owned the connection that had been opened, and `Disconnect-DbaInstance` can only reach the context of the server it is given.

### What this pull request changes

All of it is in the one branch of `Connect-DbaInstance` that clones an existing server object.

1. **Ownership.** The database is set on the copy the returned server will own, instead of through `GetDatabaseConnection`. Disconnecting now closes what was opened. Sessions stop accumulating: repeated connect and disconnect cycles went from `4, 5, 4, 5, 5, 6, 6, 7` to flat.

2. **Servers built from a raw `SqlConnection`.** Such a server has a fixed connection string, and SMO refuses to assign `DatabaseName`, `NonPooledConnection` or `ServerInstance` on it, so `-Database`, `-NonPooledConnection` and `-DedicatedAdminConnection` used to fail outright. Those settings now go into the connection string instead, where they are `Initial Catalog`, `Pooling` and `Data Source`.

3. **Never hand back a server that cannot log in.** Building a new connection means logging in again, and only a connection string that still carries the whole login can do that. Once a `SqlConnection` has been opened with `Persist Security Info=False`, SqlClient hides the password - and a `SqlCredential` is not copied over at all. Where the login cannot be reproduced, the command switches the database on the connection that already exists, and where even that is impossible it refuses with a clear message rather than returning something that fails on first use.

4. **Azure SQL Database.** It is the only engine that refuses to switch the database of a connection it has already opened - it answers a `USE` with error 40508 and wants a new connection instead. It gets one, or an explicit error. Azure SQL Managed Instance is not grouped with it, because it takes the `USE`.

5. **`-ApplicationIntent`.** On a fixed connection string, assigning the property succeeded silently without reaching the string - and the string is what the login is made with. The context reported `ReadOnly` over a connection that had logged in as `ReadWrite`. It goes into the connection string now.

6. **Failure paths release their connection.** `Copy()` clones an open connection as an open connection. Any exit that did not build a server object - a refusal, a failed connect, a failed database switch - left one behind that nothing could reach.

7. **The tab expansion cache** was handed an open copy and keeps it for the life of the process. Whenever the context was already open, every call parked another session: `3, 4, 5, 6, 7, 8`. It gets a disconnected copy now.

### What it does not change

Connecting from a plain instance name behaves exactly as before - that path never had the problem. The reasons behind the four earlier fixes to this line (#6904, #7548, #8025, #9505) are each preserved or provably no longer needed. #9505's non pooled connection mattered because a pooled one could come from an already dropped database, and putting the database in as `Initial Catalog` makes it part of the pool key, which achieves the same thing.

### Evidence

- `Connect-DbaInstance.Tests.ps1`: 51 tests, 49 pass, 2 skip - the local dedicated admin connection in a lab of remote instances, and the SSPI provider
- Reverting the source and keeping the tests makes **8 of them fail**, each with the defect it guards
- Commands that use this path - `Invoke-DbaQuery`, `Remove-DbaDbData`, `New-DbaLogin`, `Get-DbaUserPermission` and eight more: 96 tests, no failures
- CI: 20 pass, 1 skipping, 0 failures

The Azure SQL Database cases run against a real Azure SQL Database in a lab configuration and skip where none is configured, which is every CI environment.

---

When an existing server object is passed in together with a different `-Database`, the connection context is copied and the database connection was then created with `GetDatabaseConnection`:

```powershell
$connContext = $connContext.GetDatabaseConnection($Database, $false)
```

`GetDatabaseConnection` opens the connection on the intermediate copy and returns a *different* `ConnectionContext`, so the server object that is handed back never owns that connection. `Disconnect-DbaInstance` can only reach the context of the server it is given, so nothing ever closed it.

The session therefore stayed open for the life of the process, sitting in the target database and holding a shared `DATABASE` lock on it. On `model` that is enough to make a later `CREATE DATABASE` on the same instance fail:

```
Could not obtain exclusive lock on database 'model'. Retry the operation later.
CREATE DATABASE failed.
```

which surfaced as an intermittent failure in whatever test file happened to run next, with no connection to the command that caused it.

## Where the connection goes

Running the steps of the old code one at a time and counting sessions on the instance after each:

```
0. server connection only                         sessions=1  [62:master]
1. after ConnectionContext.Copy()                 sessions=1
2. after setting NonPooledConnection              sessions=1
3. after GetDatabaseConnection(model)             sessions=2  [62:master, 64:master]
4. after New-Object Smo.Server                    sessions=2
5. after reading CurrentDatabase [model]          sessions=2
6. after Disconnect-DbaInstance                   sessions=2   <-- closes nothing
7. after disconnecting the intermediate copy      sessions=1   <-- this owned it
```

Step 3 opens the connection on the copy. Step 3 also reassigns `$connContext`, which drops the only reference to the object that owns it. Step 6 shows the consequence: the server we return has nothing to close. Step 7 shows who did own it - and that disconnecting the copy is not a usable fix either, because that is the working connection.

## The change

Setting `DatabaseName` on the copy keeps the connection with the context that the returned server owns, so `Disconnect-DbaInstance` closes it. This is also what the connection string paths of this command already do, so the server object path now behaves like the others.

## History of the line, and why each earlier fix still holds

The line has been touched four times, and none of the reasons are lost by this change:

| PR | What it did | Status now |
| --- | --- | --- |
| #6904 (2020) | Introduced it in the new code path, as `ConnectionContext.Copy().GetDatabaseConnection($Database)`, next to a `# TODO: Do we have to check if its the same database?` | Not a fix for a reported bug, it was the chosen implementation |
| #7548, fixes #7546 (2021) | Moved the call to be the **last** change to the copied context, because `GetDatabaseConnection` opens the connection and later property assignments would come too late | Dissolved. Setting `DatabaseName` does not open a connection - the trace above shows nothing opens until the first query. The assignment is kept in the same last position anyway |
| #8025 (2021) | Added a save and restore around it, because `GetDatabaseConnection` resets `StatementTimeout` | No longer needed and removed. `StatementTimeout` is set earlier on the copy and simply stays. `clones when using parameter StatementTimeout` covers it |
| #9505 (2024) | Added the second argument, `GetDatabaseConnection($Database, $false)`, to force a non-pooled connection. Without it, `Backup-DbaDatabase` got **a cached connection to an already dropped database** and the context change silently did not happen. Also added the warning when `CurrentDatabase` does not match | Verified not to regress, see below. The warning is kept |

#9505 is the one worth care, because `$false` forced a non-pooled connection and setting `DatabaseName` does not. It holds because `DatabaseName` puts `Initial Catalog` into the connection string, so the database is part of the pool key: a pooled connection then comes from that database's pool instead of being taken from the original database's pool and switched.

Replaying the exact #9505 scenario against this change - create a database, connect with it as context, drop it, then ask for a clone on `master`:

```
1. connected with -Database dbatoolsci_ctx_853144975 -> CurrentDatabase = dbatoolsci_ctx_853144975
2. dropped dbatoolsci_ctx_853144975
3. clone with -Database master -> CurrentDatabase = master
   warning raised          : none
   a query really runs in  : master
```

And with pooling left on everywhere, which is the case `$false` used to opt out of:

```
base NonPooledConnection = False
clone CurrentDatabase    = tempdb
clone NonPooledConnection= False
query runs in            = tempdb
original still in        = master
warning raised           : none
```

The test #9505 added, `clones when using Backup-DabInstace`, is still in the suite and passes.

## Measured

The clearest way to see it is to repeat the call. Eight cycles of connect to a database from an existing server object, each followed by `Disconnect-DbaInstance`, counting the module's sessions on the instance after every cycle:

**Before** - sessions accumulate without bound, and every new one sits in the target database:

```
cycle 1: 4 sessions [58:master, 60:model, 61:master, 64:model]
cycle 2: 5 sessions [58:master, 60:model, 61:master, 64:model, 73:model]
cycle 3: 4 sessions [...]
cycle 4: 5 sessions [...]
cycle 5: 5 sessions [...]
cycle 6: 6 sessions [58:master, 60:model, 61:master, 64:model, 73:model, 76:model]
cycle 7: 6 sessions [...]
cycle 8: 7 sessions [58:master, 60:model, 61:master, 64:model, 73:model, 76:model, 77:model]
```

**After** - flat, and the same spids are reused every cycle:

```
cycle 1: 3 sessions [58:master, 60:model, 61:master]
cycle 2: 3 sessions [58:master, 60:model, 61:master]
...
cycle 8: 3 sessions [58:master, 60:model, 61:master]
```

That is the difference between an orphaned non-pooled connection, which nothing can ever reuse or close, and a pooled one that goes back to the pool on disconnect. The sessions that remain after the fix are the pool's: they stay `sleeping`, they are reused by the next call, and their number does not grow. Connecting from a plain instance name behaves the same way in both versions, which is why that path never had the problem.

At suite scale the same difference: the full 744 file run of 2026-08-15 had 69 files failing with `Timeout expired ... prior to obtaining a connection from the pool`, and the same run with this fix had **zero**.

Commands that read a per database view through `Invoke-DbaQuery -Database` stop leaking without being touched. `Get-DbaDbQueryStoreOption -Database model` went from three leaked sessions, one of them in `model`, to one leaked session and none in `model`.

## Tests

`tests/Connect-DbaInstance.Tests.ps1` gets a regression test that connects to a database, disconnects again and asserts the session count is back where it started. It was verified to fail against the old implementation (`Expected 4, but got 5`) and to be the only test that fails there.

Run against SQL Server 2025, including the commands that use this path:

| File | Result |
| --- | --- |
| `Connect-DbaInstance` | 33 passed, 1 skipped |
| `Invoke-DbaQuery` | 31 passed |
| `Remove-DbaDbData` | 13 passed |
| `Get-DbaUserPermission` | 6 passed |
| `Get-DbaDbRecoveryModel` | 6 passed |
| `Get-DbaDbQueryStoreOption` | 4 passed |
| `Disconnect-DbaInstance`, `Remove-DbaDbAsymmetricKey`, `Remove-DbaDbCertificate`, `Remove-DbaDbEncryptionKey` | all passed |

106 tests, no failures.

---

*This text was created by Claude and reviewed by Andreas Jordan.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

