### PR TITLE
Add Find-DbaDbQueryStoreRegression

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -170,6 +170,7 @@
         'Find-DbaDbDisabledIndex',
         'Find-DbaDbDuplicateIndex',
         'Find-DbaDbGrowthEvent',
+        'Find-DbaDbQueryStoreRegression',
         'Find-DbaDbUnusedIndex',
         'Find-DbaInstance',
         'Find-DbaLoginInGroup',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -539,6 +539,7 @@ $script:xplat = @(
         'Get-DbaQueryExecutionTime',
         'Get-DbaTempdbUsage',
         'Find-DbaDbGrowthEvent',
+        'Find-DbaDbQueryStoreRegression',
         'Test-DbaLinkedServerConnection',
         'Get-DbaDbFile',
         'Get-DbaDbFileGrowth',

--- a/public/Find-DbaDbQueryStoreRegression.ps1
+++ b/public/Find-DbaDbQueryStoreRegression.ps1
@@ -1,0 +1,211 @@
+function Find-DbaDbQueryStoreRegression {
+    <#
+    .SYNOPSIS
+        Detects query performance regressions from Query Store runtime statistics using an
+        execution-weighted baseline.
+
+    .DESCRIPTION
+        Reads sys.query_store_runtime_stats and flags queries whose recent performance has
+        regressed against a historical baseline.
+
+        Rather than a naive average-vs-average comparison, each plan's historical duration is
+        weighted by execution count, and low-frequency / low-total-impact queries are filtered
+        out, so genuine regressions surface instead of noise from a handful of slow one-off
+        executions.
+
+        This command is read-only: it queries Query Store and returns objects. It does not force
+        plans, clear the store, or change any configuration.
+
+        Query Store must be enabled on the target database(s) (SQL Server 2016+).
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell
+        credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and
+        Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        The database(s) to process. If unspecified, all Query Store-enabled user databases are
+        processed.
+
+    .PARAMETER ExcludeDatabase
+        The database(s) to exclude.
+
+    .PARAMETER BaselineStartDaysAgo
+        Start of the historical baseline window, in days before now. Default: 7.
+
+    .PARAMETER BaselineEndDaysAgo
+        End of the historical baseline window, in days before now. Default: 1. The baseline
+        window is therefore BaselineStartDaysAgo..BaselineEndDaysAgo, and the current window is
+        BaselineEndDaysAgo..now.
+
+    .PARAMETER SlowdownThreshold
+        Minimum ratio of current duration to baseline duration for a query to be flagged.
+        Default: 1.5 (50% slower).
+
+    .PARAMETER MinExecutionCount
+        Minimum executions in the current window for a query to be considered. Default: 20.
+
+    .PARAMETER MinTotalDurationMs
+        Minimum total current duration in milliseconds (summed across executions) for a query to
+        be considered. Filters queries that are individually slow but negligible to the overall
+        workload. Default: 100.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a
+        friendly warning message. This avoids overwhelming you with "sea of red" exceptions, but
+        is inconvenient because it basically disables advanced scripting.
+
+        Using this switch turns this "nice by default" feature off and enables you to catch
+        exceptions with your own try/catch.
+
+    .NOTES
+        Tags: QueryStore, Performance, Diagnostic
+        Author: Deepesh Dhake
+
+        Website: https://dbatools.io
+        Copyright: (c) 2026 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Find-DbaDbQueryStoreRegression
+
+    .EXAMPLE
+        PS C:\> Find-DbaDbQueryStoreRegression -SqlInstance sql2017 -Database AdventureWorks
+
+        Finds queries in AdventureWorks that ran at least 50% slower in the last day versus the
+        prior 7-to-1-day baseline, considering only queries executed 20 or more times.
+
+    .EXAMPLE
+        PS C:\> Find-DbaDbQueryStoreRegression -SqlInstance sql2017 -Database Sales -SlowdownThreshold 2.0 -MinExecutionCount 50
+
+        Only flags queries in Sales that at least doubled in duration and ran 50 or more times.
+
+    .EXAMPLE
+        PS C:\> Get-DbaDatabase -SqlInstance sql2017 | Find-DbaDbQueryStoreRegression | Sort-Object SlowdownFactor -Descending
+
+        Pipes databases in and returns all regressions across the instance, worst first.
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [object[]]$Database,
+        [object[]]$ExcludeDatabase,
+        [int]$BaselineStartDaysAgo = 7,
+        [int]$BaselineEndDaysAgo = 1,
+        [double]$SlowdownThreshold = 1.5,
+        [int]$MinExecutionCount = 20,
+        [long]$MinTotalDurationMs = 100,
+        [switch]$EnableException
+    )
+
+    begin {
+        if ($BaselineEndDaysAgo -ge $BaselineStartDaysAgo) {
+            Stop-Function -Message "BaselineEndDaysAgo ($BaselineEndDaysAgo) must be smaller than BaselineStartDaysAgo ($BaselineStartDaysAgo). The baseline is the older window."
+            return
+        }
+
+        $minTotalDurationUs = $MinTotalDurationMs * 1000
+
+        # Regression is measured at the QUERY level: each query's executions are aggregated
+        # across ALL its plans within a window (weighted by execution count). This catches
+        # plan-flip regressions - the common case where a query degrades because the optimizer
+        # switched to a worse plan - which a plan-level comparison would miss.
+        $sql = "
+DECLARE @BaselineStart datetimeoffset = DATEADD(day, -$BaselineStartDaysAgo, SYSDATETIMEOFFSET());
+DECLARE @BaselineEnd   datetimeoffset = DATEADD(day, -$BaselineEndDaysAgo,   SYSDATETIMEOFFSET());
+DECLARE @CurrentStart  datetimeoffset = @BaselineEnd;
+
+WITH baseline AS (
+    SELECT q.query_id,
+        SUM(rs.avg_duration * rs.count_executions) * 1.0 / NULLIF(SUM(rs.count_executions), 0) AS baseline_duration,
+        SUM(rs.count_executions) AS baseline_exec_count,
+        COUNT(DISTINCT p.plan_id) AS baseline_plan_count
+    FROM sys.query_store_runtime_stats rs
+    JOIN sys.query_store_plan  p ON rs.plan_id = p.plan_id
+    JOIN sys.query_store_query q ON p.query_id = q.query_id
+    WHERE rs.last_execution_time >= @BaselineStart AND rs.last_execution_time < @BaselineEnd
+    GROUP BY q.query_id
+),
+current_perf AS (
+    SELECT q.query_id,
+        SUM(rs.avg_duration * rs.count_executions) * 1.0 / NULLIF(SUM(rs.count_executions), 0) AS current_duration,
+        SUM(rs.count_executions) AS current_exec_count,
+        SUM(rs.avg_duration * rs.count_executions) AS current_total_duration,
+        COUNT(DISTINCT p.plan_id) AS current_plan_count
+    FROM sys.query_store_runtime_stats rs
+    JOIN sys.query_store_plan  p ON rs.plan_id = p.plan_id
+    JOIN sys.query_store_query q ON p.query_id = q.query_id
+    WHERE rs.last_execution_time >= @CurrentStart
+    GROUP BY q.query_id
+)
+SELECT
+    c.query_id AS QueryId,
+    CAST(b.baseline_duration / 1000.0 AS DECIMAL(18,2)) AS BaselineDurationMs,
+    CAST(c.current_duration  / 1000.0 AS DECIMAL(18,2)) AS CurrentDurationMs,
+    CAST(c.current_duration * 1.0 / NULLIF(b.baseline_duration, 0) AS DECIMAL(10,2)) AS SlowdownFactor,
+    b.baseline_exec_count AS BaselineExecCount,
+    c.current_exec_count  AS CurrentExecCount,
+    CASE WHEN c.current_plan_count > b.baseline_plan_count OR c.current_plan_count > 1
+         THEN CAST(1 AS bit) ELSE CAST(0 AS bit) END AS PlanChanged
+FROM current_perf c
+JOIN baseline b ON c.query_id = b.query_id
+WHERE c.current_duration > b.baseline_duration * $SlowdownThreshold
+  AND c.current_exec_count > $MinExecutionCount
+  AND c.current_total_duration > $minTotalDurationUs
+ORDER BY SlowdownFactor DESC;"
+    }
+
+    process {
+        if (Test-FunctionInterrupt) { return }
+
+        foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 13
+            } catch {
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            $dbs = Get-DbaDatabase -SqlInstance $server -Database $Database -ExcludeDatabase $ExcludeDatabase -ExcludeSystem
+
+            foreach ($db in $dbs) {
+                Write-Message -Level Verbose -Message "Processing $($db.Name) on $instance"
+
+                if ($db.QueryStoreOptions.ActualState -eq 'Off') {
+                    Write-Message -Level Warning -Message "Query Store is not enabled on $($db.Name) on $instance, skipping"
+                    continue
+                }
+
+                try {
+                    $results = $db.Query($sql)
+                } catch {
+                    Stop-Function -Message "Failure executing Query Store analysis against $($db.Name) on $instance" -ErrorRecord $_ -Target $db -Continue
+                }
+
+                foreach ($row in $results) {
+                    [PSCustomObject]@{
+                        ComputerName      = $server.ComputerName
+                        InstanceName      = $server.ServiceName
+                        SqlInstance       = $server.DomainInstanceName
+                        Database          = $db.Name
+                        QueryId           = $row.QueryId
+                        BaselineDurationMs = $row.BaselineDurationMs
+                        CurrentDurationMs  = $row.CurrentDurationMs
+                        SlowdownFactor     = $row.SlowdownFactor
+                        PlanChanged        = [bool]$row.PlanChanged
+                        BaselineExecCount  = $row.BaselineExecCount
+                        CurrentExecCount   = $row.CurrentExecCount
+                    } | Select-DefaultView -Property SqlInstance, Database, QueryId, BaselineDurationMs, CurrentDurationMs, SlowdownFactor, PlanChanged, CurrentExecCount
+                }
+            }
+        }
+    }
+}

--- a/public/Find-DbaDbQueryStoreRegression.ps1
+++ b/public/Find-DbaDbQueryStoreRegression.ps1
@@ -37,6 +37,10 @@ function Find-DbaDbQueryStoreRegression {
     .PARAMETER ExcludeDatabase
         The database(s) to exclude.
 
+    .PARAMETER InputObject
+        Database objects piped in from Get-DbaDatabase. Use this to narrow the analysis with the
+        full Get-DbaDatabase filter set before the Query Store statistics are read.
+
     .PARAMETER BaselineStartDaysAgo
         Start of the historical baseline window, in days before now. Default: 7.
 
@@ -76,6 +80,27 @@ function Find-DbaDbQueryStoreRegression {
     .LINK
         https://dbatools.io/Find-DbaDbQueryStoreRegression
 
+    .OUTPUTS
+        PSCustomObject
+
+        Returns one object per query flagged as regressed, ordered by SlowdownFactor descending
+        within each database. Nothing is returned for a database with no regression.
+
+        Default display properties (via Select-DefaultView):
+        - SqlInstance: The full SQL Server instance name (computer\instance)
+        - Database: Name of the database the query ran in
+        - QueryId: The Query Store query_id, usable with sys.query_store_query and the Query Store reports
+        - BaselineDurationMs: Execution-weighted average duration over the baseline window, in milliseconds
+        - CurrentDurationMs: Execution-weighted average duration over the current window, in milliseconds
+        - SlowdownFactor: CurrentDurationMs divided by BaselineDurationMs
+        - PlanChanged: True when the query ran under more plans in the current window than in the baseline, or under more than one plan in the current window
+        - CurrentExecCount: Number of executions in the current window
+
+        Additional properties available:
+        - ComputerName: The computer name of the SQL Server instance
+        - InstanceName: The SQL Server instance name
+        - BaselineExecCount: Number of executions in the baseline window
+
     .EXAMPLE
         PS C:\> Find-DbaDbQueryStoreRegression -SqlInstance sql2017 -Database AdventureWorks
 
@@ -94,11 +119,13 @@ function Find-DbaDbQueryStoreRegression {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory, ValueFromPipeline)]
+        [parameter(ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
         [int]$BaselineStartDaysAgo = 7,
         [int]$BaselineEndDaysAgo = 1,
         [double]$SlowdownThreshold = 1.5,
@@ -167,36 +194,60 @@ ORDER BY SlowdownFactor DESC;"
     process {
         if (Test-FunctionInterrupt) { return }
 
-        foreach ($instance in $SqlInstance) {
-            try {
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 13
-            } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+        if (-not $SqlInstance -and -not $InputObject) {
+            Stop-Function -Message "You must specify SqlInstance or pipe in databases from Get-DbaDatabase"
+            return
+        }
+
+        # Each instance is resolved to its databases and analyzed before the next one connects, so a
+        # connection failure later in the list never withholds results already gathered. Piped
+        # databases take the same path in a single pass with nothing to connect to.
+        if ($SqlInstance) {
+            $targets = $SqlInstance
+        } else {
+            $targets = @($null)
+        }
+
+        foreach ($target in $targets) {
+            if ($target) {
+                try {
+                    $server = Connect-DbaInstance -SqlInstance $target -SqlCredential $SqlCredential -MinimumVersion 13
+                } catch {
+                    Stop-Function -Message "Error occurred while establishing connection to $target" -Category ConnectionError -ErrorRecord $_ -Target $target -Continue
+                }
+
+                $databases = Get-DbaDatabase -SqlInstance $server -Database $Database -ExcludeDatabase $ExcludeDatabase -ExcludeSystem
+            } else {
+                $databases = $InputObject
             }
 
-            $dbs = Get-DbaDatabase -SqlInstance $server -Database $Database -ExcludeDatabase $ExcludeDatabase -ExcludeSystem
+            foreach ($db in $databases) {
+                $server = $db.Parent
+                Write-Message -Level Verbose -Message "Processing $($db.Name) on $server"
 
-            foreach ($db in $dbs) {
-                Write-Message -Level Verbose -Message "Processing $($db.Name) on $instance"
+                # Piped databases bypass Connect-DbaInstance and its -MinimumVersion check.
+                if ($server.VersionMajor -lt 13) {
+                    Stop-Function -Message "Query Store requires SQL Server 2016 or later, $server is version $($server.VersionMajor)" -Target $db -Continue
+                }
 
-                if ($db.QueryStoreOptions.ActualState -eq 'Off') {
-                    Write-Message -Level Warning -Message "Query Store is not enabled on $($db.Name) on $instance, skipping"
+                if ($db.QueryStoreOptions.ActualState -eq "Off") {
+                    Write-Message -Level Warning -Message "Query Store is not enabled on $($db.Name) on $server, skipping"
                     continue
                 }
 
                 try {
                     $results = $db.Query($sql)
                 } catch {
-                    Stop-Function -Message "Failure executing Query Store analysis against $($db.Name) on $instance" -ErrorRecord $_ -Target $db -Continue
+                    Stop-Function -Message "Failure executing Query Store analysis against $($db.Name) on $server" -ErrorRecord $_ -Target $db -Continue
                 }
 
                 foreach ($row in $results) {
                     [PSCustomObject]@{
-                        ComputerName      = $server.ComputerName
-                        InstanceName      = $server.ServiceName
-                        SqlInstance       = $server.DomainInstanceName
-                        Database          = $db.Name
-                        QueryId           = $row.QueryId
+                        ComputerName       = $server.ComputerName
+                        InstanceName       = $server.ServiceName
+                        SqlInstance        = $server.DomainInstanceName
+                        Database           = $db.Name
+                        QueryId            = $row.QueryId
                         BaselineDurationMs = $row.BaselineDurationMs
                         CurrentDurationMs  = $row.CurrentDurationMs
                         SlowdownFactor     = $row.SlowdownFactor

--- a/tests/Find-DbaDbQueryStoreRegression.Tests.ps1
+++ b/tests/Find-DbaDbQueryStoreRegression.Tests.ps1
@@ -1,19 +1,21 @@
-#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
 param(
-    $ModuleName = "dbatools",
-    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+    $ModuleName  = "dbatools",
+    $CommandName = "Find-DbaDbQueryStoreRegression",
+    $PSDefaultParameterValues = $TestConfig.Defaults
 )
 
-Describe "Find-DbaDbQueryStoreRegression" -Tag "UnitTests" {
+Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
-        BeforeAll {
-            $command = Get-Command Find-DbaDbQueryStoreRegression
-            $expected = $TestConfig.CommonParameters
-            $expected += @(
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
                 "SqlInstance",
                 "SqlCredential",
                 "Database",
                 "ExcludeDatabase",
+                "InputObject",
                 "BaselineStartDaysAgo",
                 "BaselineEndDaysAgo",
                 "SlowdownThreshold",
@@ -21,32 +23,82 @@ Describe "Find-DbaDbQueryStoreRegression" -Tag "UnitTests" {
                 "MinTotalDurationMs",
                 "EnableException"
             )
-        }
-
-        It "Has parameter: <_>" -ForEach $expected {
-            $command | Should -HaveParameter $PSItem
-        }
-
-        It "Should have exactly the number of expected parameters ($($expected.Count))" {
-            $hasparms = $command.Parameters.Values.Name
-            Compare-Object -ReferenceObject $expected -DifferenceObject $hasparms | Should -BeNullOrEmpty
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
 }
 
-Describe "Find-DbaDbQueryStoreRegression" -Tag "IntegrationTests" {
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
-        # Integration tests require a SQL Server 2016+ instance with Query Store enabled
-        # and workload history. These run in the dbatools CI environment against the
-        # configured test instances ($TestConfig.instance2 / instance3).
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        # A regression cannot be staged in a test run: the baseline window is measured in whole
+        # days before now, so statistics written during the run never land in it. These tests
+        # cover what does not need history - the window validation, the Query Store-off skip,
+        # piped database input and a clean empty result from a freshly enabled Query Store.
+        $qsOnDb = "dbatoolsci_qsreg_on_$(Get-Random)"
+        $qsOffDb = "dbatoolsci_qsreg_off_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $qsOnDb, $qsOffDb
+        $null = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database $qsOnDb -State ReadWrite
+        # SQL Server 2022 enables Query Store on new databases by default, so "off" has to be set, not assumed.
+        $null = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database $qsOffDb -State Off
+
+        # Give Query Store something to record so an empty result means "no regression", not "nothing ran".
+        $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $qsOnDb -Query "SELECT TOP 1 name FROM sys.objects"
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
-    Context "Command returns expected object shape" {
-        It "Returns objects with a SlowdownFactor property when regressions exist" -Skip {
-            # Skipped in the template; enable against an instance with a known regression.
-            $results = Find-DbaDbQueryStoreRegression -SqlInstance $TestConfig.instance2 -Database tempdb
-            $results | Should -Not -BeNullOrEmpty
-            $results[0].PSObject.Properties.Name | Should -Contain "SlowdownFactor"
+    AfterAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $qsOnDb, $qsOffDb -ErrorAction SilentlyContinue
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "Input validation" {
+        It "Rejects a baseline end that is not older than the baseline start" {
+            $splatWindow = @{
+                SqlInstance          = $TestConfig.InstanceSingle
+                Database             = $qsOnDb
+                BaselineStartDaysAgo = 1
+                BaselineEndDaysAgo   = 7
+                EnableException      = $true
+            }
+            { Find-DbaDbQueryStoreRegression @splatWindow } | Should -Throw "*must be smaller than BaselineStartDaysAgo*"
+        }
+
+        It "Requires either SqlInstance or piped databases" {
+            { Find-DbaDbQueryStoreRegression -EnableException } | Should -Throw "*You must specify SqlInstance or pipe in databases*"
+        }
+    }
+
+    Context "Reading Query Store" {
+        It "Warns and returns nothing when Query Store is off" {
+            $results = Find-DbaDbQueryStoreRegression -SqlInstance $TestConfig.InstanceSingle -Database $qsOffDb -WarningVariable warnOff 3> $null
+            $results | Should -BeNullOrEmpty
+            $warnOff | Should -Match "Query Store is not enabled on $qsOffDb"
+        }
+
+        It "Returns no regression and no warning for a freshly enabled Query Store" {
+            $results = Find-DbaDbQueryStoreRegression -SqlInstance $TestConfig.InstanceSingle -Database $qsOnDb -WarningVariable warnOn 3> $null
+            $results | Should -BeNullOrEmpty
+            $warnOn | Should -BeNullOrEmpty
+        }
+
+        It "Processes databases piped in from Get-DbaDatabase" {
+            # The Query Store-off warning names the database, which proves the piped object was
+            # the one processed rather than the result being vacuously empty.
+            $results = Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $qsOnDb, $qsOffDb | Find-DbaDbQueryStoreRegression -WarningVariable warnPipe 3> $null
+            $results | Should -BeNullOrEmpty
+            @($warnPipe).Count | Should -Be 1
+            $warnPipe | Should -Match "Query Store is not enabled on $qsOffDb"
+        }
+
+        It "Processes an instance piped in from Connect-DbaInstance" {
+            $results = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle | Find-DbaDbQueryStoreRegression -Database $qsOffDb -WarningVariable warnServer 3> $null
+            $results | Should -BeNullOrEmpty
+            @($warnServer).Count | Should -Be 1
+            $warnServer | Should -Match "Query Store is not enabled on $qsOffDb"
         }
     }
 }

--- a/tests/Find-DbaDbQueryStoreRegression.Tests.ps1
+++ b/tests/Find-DbaDbQueryStoreRegression.Tests.ps1
@@ -1,0 +1,52 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0"}
+param(
+    $ModuleName = "dbatools",
+    $PSDefaultParameterValues = ($TestConfig = Get-TestConfig).Defaults
+)
+
+Describe "Find-DbaDbQueryStoreRegression" -Tag "UnitTests" {
+    Context "Parameter validation" {
+        BeforeAll {
+            $command = Get-Command Find-DbaDbQueryStoreRegression
+            $expected = $TestConfig.CommonParameters
+            $expected += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Database",
+                "ExcludeDatabase",
+                "BaselineStartDaysAgo",
+                "BaselineEndDaysAgo",
+                "SlowdownThreshold",
+                "MinExecutionCount",
+                "MinTotalDurationMs",
+                "EnableException"
+            )
+        }
+
+        It "Has parameter: <_>" -ForEach $expected {
+            $command | Should -HaveParameter $PSItem
+        }
+
+        It "Should have exactly the number of expected parameters ($($expected.Count))" {
+            $hasparms = $command.Parameters.Values.Name
+            Compare-Object -ReferenceObject $expected -DifferenceObject $hasparms | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe "Find-DbaDbQueryStoreRegression" -Tag "IntegrationTests" {
+    BeforeAll {
+        # Integration tests require a SQL Server 2016+ instance with Query Store enabled
+        # and workload history. These run in the dbatools CI environment against the
+        # configured test instances ($TestConfig.instance2 / instance3).
+    }
+
+    Context "Command returns expected object shape" {
+        It "Returns objects with a SlowdownFactor property when regressions exist" -Skip {
+            # Skipped in the template; enable against an instance with a known regression.
+            $results = Find-DbaDbQueryStoreRegression -SqlInstance $TestConfig.instance2 -Database tempdb
+            $results | Should -Not -BeNullOrEmpty
+            $results[0].PSObject.Properties.Name | Should -Contain "SlowdownFactor"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
- [x] New feature (non-breaking change, adds functionality)
- [x] Unit test is included

### Purpose

dbatools has strong Query Store *configuration* coverage
(Get/Set/Copy-DbaDbQueryStoreOption, Test-DbaDbQueryStore) but nothing in-module
that *analyzes* Query Store runtime statistics to find performance regressions.
This command fills that gap.

The concept and the `Find-` verb were checked with @niphlod in the #dbatools
Slack channel before building.

### Approach

`Find-DbaDbQueryStoreRegression` reads sys.query_store_runtime_stats and flags
queries that have regressed, using an execution-weighted baseline: each query's
historical duration is weighted by execution count over a baseline window, then
compared against a current window, filtering out low-frequency and low-total-duration
noise.

Detection is at the **query level** (aggregating across plans), not the plan level.
This is deliberate — it catches plan-flip regressions, the common case where a query
degrades because the optimizer switched to a worse plan, which a plan-level comparison
would miss. A `PlanChanged` column flags those cases.

It is read-only (queries DMVs, returns objects, changes nothing) and requires
SQL Server 2016+.

### Commands to test

Find-DbaDbQueryStoreRegression -SqlInstance sql2019 -Database YourDb
Find-DbaDbQueryStoreRegression -SqlInstance sql2019 -Database YourDb -SlowdownThreshold 2.0 -MinExecutionCount 50