### PR TITLE
Invoke-DbaDbDecryptObject - reject ambiguous ciphertext chunks

### DIFF
--- a/private/functions/ConvertFrom-EncryptedObjectChunk.ps1
+++ b/private/functions/ConvertFrom-EncryptedObjectChunk.ps1
@@ -15,13 +15,16 @@ function ConvertFrom-EncryptedObjectChunk {
         so a byte for byte comparison against a created object cannot reach this code with more than one
         chunk. The multi chunk behaviour of this function is covered by its unit tests and by nothing else.
 
-        Two mistakes are easy to make here and both produce text of exactly the right length, which is the
-        one failure mode that the rest of the suite cannot see:
+        Three mistakes are easy to make here and all can produce output that looks more trustworthy than it
+        is:
 
         - Concatenating in the order the rows were read rather than in colid order swaps the parts of a
           definition around.
         - Deriving one keystream for the whole object leaves the first chunk readable and everything after
           it mojibake. colid is an input to the key, so every chunk has its own keystream.
+        - Accepting the same colid twice can combine the current row with a stale or duplicate physical row.
+          The page reader is deliberately defensive, but this is the final boundary before decryption and
+          must reject an ambiguous chunk set rather than concatenate both versions.
 
         This function is used by the following public functions:
         - Invoke-DbaDbDecryptObject
@@ -60,8 +63,22 @@ function ConvertFrom-EncryptedObjectChunk {
     )
 
     $scriptBuilder = New-Object System.Text.StringBuilder
+    $seenColId = New-Object System.Collections.Hashtable
 
     foreach ($piece in ($Chunk | Sort-Object -Property ColId)) {
+        # There is only one sys.sysobjvalues row for a given (object id, colid). Seeing the same colid twice
+        # means the input is ambiguous, for example because a stale physical row was harvested along with
+        # the current one. Concatenating both can still yield plausible text, so fail before producing any
+        # definition instead.
+        if ($seenColId.ContainsKey([int]$piece.ColId)) {
+            throw "Object $ObjectId contains more than one ciphertext chunk with colid $($piece.ColId), so it is not safe to decrypt."
+        }
+        $seenColId[[int]$piece.ColId] = $true
+
+        if ($null -eq $piece.Cipher) {
+            throw "Chunk $($piece.ColId) of object $ObjectId has no ciphertext."
+        }
+
         # The definition is UCS-2, so a chunk's ciphertext has to be an even number of bytes. An odd length
         # means a bad in row slice or a bad off row reassembly, and the decode below would silently drop the
         # trailing byte and hand back plausible text, so it is refused here instead.

--- a/tests/Invoke-DbaDbDecryptObject.Hardening.Tests.ps1
+++ b/tests/Invoke-DbaDbDecryptObject.Hardening.Tests.ps1
@@ -1,0 +1,89 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+
+Describe "Invoke-DbaDbDecryptObject hardening" -Tag UnitTests {
+    BeforeAll {
+        $dbatoolsModule = $null
+        foreach ($candidate in @(Get-Module dbatools | Where-Object ModuleType -eq "Script")) {
+            $hasPrivateFunction = $false
+            try {
+                $hasPrivateFunction = & $candidate { [bool](Get-Command ConvertFrom-EncryptedObjectChunk -ErrorAction SilentlyContinue) }
+            } catch {
+                $hasPrivateFunction = $false
+            }
+            if ($hasPrivateFunction) {
+                $dbatoolsModule = $candidate
+                break
+            }
+        }
+        if ($null -eq $dbatoolsModule) {
+            throw "No loaded dbatools script module exposes ConvertFrom-EncryptedObjectChunk."
+        }
+
+        $familyGuid = [guid]"7e11756e-abe9-11d2-896a-00c04fd9374a"
+        $objectId = 1253579504
+
+        function New-TestCipherChunk {
+            param(
+                [int]$ColId,
+                [string]$Text
+            )
+
+            $plainText = [System.Text.Encoding]::Unicode.GetBytes($Text)
+            $keystreamParams = @{
+                FamilyGuid = $familyGuid
+                ObjectId   = $objectId
+                ColId      = $ColId
+                Length     = $plainText.Length
+            }
+            $keystream = & $dbatoolsModule { param($p) Get-EncryptedObjectKeystream @p } $keystreamParams
+
+            $cipher = New-Object byte[] $plainText.Length
+            for ($offset = 0; $offset -lt $plainText.Length; $offset++) {
+                $cipher[$offset] = $plainText[$offset] -bxor $keystream[$offset]
+            }
+
+            [PSCustomObject]@{
+                ColId  = $ColId
+                Cipher = $cipher
+            }
+        }
+
+        function Convert-TestCipherChunk {
+            param([object[]]$Chunk)
+
+            $params = @{
+                FamilyGuid = $familyGuid
+                ObjectId   = $objectId
+                Chunk      = $Chunk
+            }
+            & $dbatoolsModule { param($p) ConvertFrom-EncryptedObjectChunk @p } $params
+        }
+    }
+
+    It "refuses duplicate colids rather than concatenating ambiguous ciphertext" {
+        $chunk = @(
+            (New-TestCipherChunk -ColId 1 -Text "SELECT 1;"),
+            (New-TestCipherChunk -ColId 1 -Text "SELECT 2;")
+        )
+
+        { Convert-TestCipherChunk -Chunk $chunk } | Should -Throw -ExpectedMessage "*more than one ciphertext chunk with colid 1*"
+    }
+
+    It "refuses a chunk whose ciphertext is null" {
+        $chunk = @(
+            [PSCustomObject]@{
+                ColId  = 1
+                Cipher = $null
+            }
+        )
+
+        { Convert-TestCipherChunk -Chunk $chunk } | Should -Throw -ExpectedMessage "*has no ciphertext*"
+    }
+
+    It "still decrypts a valid chunk exactly" {
+        $text = "CREATE PROCEDURE dbo.Valid WITH ENCRYPTION AS SELECT 1;"
+        $chunk = @(New-TestCipherChunk -ColId 1 -Text $text)
+
+        Convert-TestCipherChunk -Chunk $chunk | Should -BeExactly $text
+    }
+}

--- a/tests/Invoke-DbaDbDecryptObject.Hardening.Tests.ps1
+++ b/tests/Invoke-DbaDbDecryptObject.Hardening.Tests.ps1
@@ -1,6 +1,11 @@
 #Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName = "dbatools",
+    $CommandName = "Invoke-DbaDbDecryptObject",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
 
-Describe "Invoke-DbaDbDecryptObject hardening" -Tag UnitTests {
+Describe "$CommandName hardening" -Tag UnitTests {
     BeforeAll {
         $dbatoolsModule = $null
         foreach ($candidate in @(Get-Module dbatools | Where-Object ModuleType -eq "Script")) {


### PR DESCRIPTION
## Summary

Follow-up hardening after #10581.

The raw-page reader is intentionally defensive because stale or malformed physical records can otherwise look plausible. This adds a final invariant at the decryption boundary: one object may not contain the same `colid` more than once, and a chunk may not arrive without ciphertext.

A duplicate `(object id, colid)` is ambiguous. Concatenating both values can combine current ciphertext with a stale or duplicate physical row and still produce output that looks trustworthy, so the command now refuses that object instead of returning a definition.

## Changes

- Reject duplicate `colid` values in `ConvertFrom-EncryptedObjectChunk`.
- Reject null ciphertext at the same boundary rather than relying only on the caller to filter it.
- Add unit tests for duplicate chunks, null ciphertext, and the valid byte-exact path.

## Scope

This is deliberately narrow. The review after #10581 also identified broader defensive ideas around export-path containment, allocated/ghost page filtering, slot-pointer bounds, and the database-wide `dm_db_database_page_allocations(..., 'DETAILED')` fallback. Those touch legacy export behavior or undocumented physical-page assumptions and should be handled separately with targeted fixtures rather than folded into this small invariant fix.

## Type of Change

- [x] Bug fix / hardening
- [x] Unit tests
- [ ] Breaking change

Follow-up to #10581.