### PR TITLE
Get-DbaDbQueryStoreOption - Read from SMO what SMO carries, and query only the rest

### DIFF
--- a/public/Get-DbaDbQueryStoreOption.ps1
+++ b/public/Get-DbaDbQueryStoreOption.ps1
@@ -128,10 +128,15 @@ function Get-DbaDbQueryStoreOption {
                 Write-Message -Level Verbose -Message "Processing $($db.Name) on $instance"
                 $qso = $db.QueryStoreOptions
 
-                if ($server.VersionMajor -eq 14) {
-                    $QueryStoreOptions = Invoke-DbaQuery -SqlInstance $server -Database $db.Name -Query "SELECT max_plans_per_query AS MaxPlansPerQuery, wait_stats_capture_mode_desc AS WaitStatsCaptureMode FROM sys.database_query_store_options;" -As PSObject
-                } elseif ($server.VersionMajor -ge 15) {
-                    $QueryStoreOptions = Invoke-DbaQuery -SqlInstance $server -Database $db.Name -Query "SELECT max_plans_per_query AS MaxPlansPerQuery, wait_stats_capture_mode_desc AS WaitStatsCaptureMode, capture_policy_execution_count AS CustomCapturePolicyExecutionCount, capture_policy_stale_threshold_hours AS CustomCapturePolicyStaleThresholdHours, capture_policy_total_compile_cpu_time_ms AS CustomCapturePolicyTotalCompileCPUTimeMS, capture_policy_total_execution_cpu_time_ms AS CustomCapturePolicyTotalExecutionCPUTimeMS FROM sys.database_query_store_options;" -As PSObject
+                # Only values that the SMO object does not carry are read from the catalog view. The four
+                # CustomCapturePolicy ones are not properties of QueryStoreOptions at all, so they have to
+                # be added. MaxPlansPerQuery and WaitStatsCaptureMode are, and used to be queried here as
+                # well - on SQL Server 2019 and later the result was then thrown away, and on SQL Server
+                # 2017 it was added over the real property, which turns it into a note property that no
+                # longer follows a Refresh of the object. SMO is the single source for those two now, on
+                # every version. See #10562.
+                if ($server.VersionMajor -ge 15) {
+                    $QueryStoreOptions = Invoke-DbaQuery -SqlInstance $server -Database $db.Name -Query "SELECT capture_policy_execution_count AS CustomCapturePolicyExecutionCount, capture_policy_stale_threshold_hours AS CustomCapturePolicyStaleThresholdHours, capture_policy_total_compile_cpu_time_ms AS CustomCapturePolicyTotalCompileCPUTimeMS, capture_policy_total_execution_cpu_time_ms AS CustomCapturePolicyTotalExecutionCPUTimeMS FROM sys.database_query_store_options;" -As PSObject
                 }
 
                 Add-Member -Force -InputObject $qso -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
@@ -142,8 +147,6 @@ function Get-DbaDbQueryStoreOption {
                 if ($server.VersionMajor -eq 13) {
                     Select-DefaultView -InputObject $qso -Property ComputerName, InstanceName, SqlInstance, Database, ActualState, DataFlushIntervalInSeconds, StatisticsCollectionIntervalInMinutes, MaxStorageSizeInMB, CurrentStorageSizeInMB, QueryCaptureMode, SizeBasedCleanupMode, StaleQueryThresholdInDays
                 } elseif ($server.VersionMajor -eq 14) {
-                    Add-Member -Force -InputObject $qso -MemberType NoteProperty -Name MaxPlansPerQuery -Value $QueryStoreOptions.MaxPlansPerQuery
-                    Add-Member -Force -InputObject $qso -MemberType NoteProperty -Name WaitStatsCaptureMode -Value $QueryStoreOptions.WaitStatsCaptureMode
                     Select-DefaultView -InputObject $qso -Property ComputerName, InstanceName, SqlInstance, Database, ActualState, DataFlushIntervalInSeconds, StatisticsCollectionIntervalInMinutes, MaxStorageSizeInMB, CurrentStorageSizeInMB, QueryCaptureMode, SizeBasedCleanupMode, StaleQueryThresholdInDays, MaxPlansPerQuery, WaitStatsCaptureMode
                 } elseif ($server.VersionMajor -ge 15) {
                     Add-Member -Force -InputObject $qso -MemberType NoteProperty -Name CustomCapturePolicyExecutionCount -Value $QueryStoreOptions.CustomCapturePolicyExecutionCount

--- a/tests/Get-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Get-DbaDbQueryStoreOption.Tests.ps1
@@ -22,6 +22,15 @@ Describe $CommandName -Tag UnitTests {
     }
 }
 Describe $CommandName -Tag IntegrationTests {
+    BeforeDiscovery {
+        # MAX_PLANS_PER_QUERY arrived with SQL Server 2017, so the scenario below cannot be built before
+        # that. The value decides a Skip, which Pester needs while it discovers the tests, so it cannot be
+        # read in BeforeAll.
+        $discoveryServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+        $instanceVersionMajor = $discoveryServer.VersionMajor
+        $null = $discoveryServer | Disconnect-DbaInstance
+    }
+
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
@@ -60,6 +69,48 @@ Describe $CommandName -Tag IntegrationTests {
             $resultsSweep = Get-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -WarningVariable warnSweep
             $resultsSweep.Database | Should -Not -Contain "model"
             $warnSweep | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "When a value is available from SMO" -Skip:($instanceVersionMajor -lt 14) {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $queryStoreDbName = "dbatoolsci_qso_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $queryStoreDbName
+            $null = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database $queryStoreDbName -State ReadWrite
+
+            $resultsFromSmo = Get-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database $queryStoreDbName
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $queryStoreDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Leaves MaxPlansPerQuery and WaitStatsCaptureMode as the properties of the SMO object" {
+            # Both are real properties of QueryStoreOptions. Adding them with Add-Member replaces the
+            # property with a note property on the object of the caller - one that keeps its value even
+            # after the object is refreshed - so only values SMO does not carry may be added that way.
+            # See #10562. This guards the rule rather than a fix: on SQL Server 2019 and later the two
+            # were queried and then discarded, so nothing observable changed there. It is SQL Server 2017
+            # where they used to be added over the real property, and the lab has no 2017 instance.
+            (Get-Member -InputObject $resultsFromSmo -Name MaxPlansPerQuery).MemberType | Should -Be "Property"
+            (Get-Member -InputObject $resultsFromSmo -Name WaitStatsCaptureMode).MemberType | Should -Be "Property"
+        }
+
+        It "Still reports both of them" {
+            $resultsFromSmo.MaxPlansPerQuery | Should -Not -BeNullOrEmpty
+            $resultsFromSmo.WaitStatsCaptureMode | Should -Not -BeNullOrEmpty
+        }
+
+        It "Adds the CustomCapturePolicy values, which SMO does not carry" -Skip:($instanceVersionMajor -lt 15) {
+            (Get-Member -InputObject $resultsFromSmo -Name CustomCapturePolicyExecutionCount).MemberType | Should -Be "NoteProperty"
         }
     }
 }


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #10562)
 - [x] Ran manual Pester test and has passed
 - [x] Pester test is included

### Purpose

`MaxPlansPerQuery` and `WaitStatsCaptureMode` are properties of the SMO `QueryStoreOptions` object, and the command queried them from `sys.database_query_store_options` as well:

- On **SQL Server 2019 and later** the queried values were then thrown away. Six columns were fetched, four were added to the output, and those two were left to the SMO object. The query paid for two columns nobody read.
- On **SQL Server 2017** they were added with `Add-Member`, which is worse than it looks.

### Why Add-Member is the wrong tool for these two

Adding a note property over a **real** property does not add anything, it replaces it on the object of the caller - and the note property keeps its value even after the object is refreshed:

```
member kind before Get   : Property
member kind after Get    : NoteProperty
value after SMO Refresh  : 200   (the instance has 999)
```

The four `CustomCapturePolicy*` values are a different case: they are not properties of `QueryStoreOptions` at all, so adding them hides nothing.

```
--- before Get, on development ---
MaxPlansPerQuery                         Property
WaitStatsCaptureMode                     Property
CustomCapturePolicyExecutionCount        <none>
CustomCapturePolicyStaleThresholdHours   <none>
```

### Approach

The catalog view is read only for what SMO does not carry, which is the four `CustomCapturePolicy*` values. SMO is the single source for the other two on every version, and the SQL Server 2017 query is gone entirely, saving a round trip there.

Refreshing inside a `Get-` command was rejected in #10560 and is not revisited here.

### What changes for users

**Nothing on SQL Server 2019 and later.** Those two already came from SMO; only the two unread columns are gone from the query.

**On SQL Server 2017** they now come from SMO like every other value in the output, so a connection that has read them before reports what it read then - exactly as it already does for `MaxStorageSizeInMB`, `StaleQueryThresholdInDays` and the rest. In exchange, the command no longer replaces a live property on the caller's object with a frozen copy.

### Tests

Assertions that `MaxPlansPerQuery` and `WaitStatsCaptureMode` stay properties of the SMO object, and that `CustomCapturePolicyExecutionCount` is a note property, which is the rule this PR follows.

**Being explicit about what that test proves:** it guards the rule, it is not a regression test. It cannot fail on SQL Server 2019 and later, because nothing observable changed there, and the change that *is* observable is on SQL Server 2017, which the lab used for this work does not have - the open question on #10562. If someone applies `Add-Member` to these two again on any version, it fails.

`Get-DbaDbQueryStoreOption`: 7 tests, all passing, no leftovers in the lab.

---

*This text was created by Claude and reviewed by Andreas Jordan.*
