### PR TITLE
Set-DbaDbQueryStoreOption - Refresh the Query Store options after changing them with T-SQL

### DIFF
--- a/public/Set-DbaDbQueryStoreOption.ps1
+++ b/public/Set-DbaDbQueryStoreOption.ps1
@@ -345,6 +345,12 @@ function Set-DbaDbQueryStoreOption {
 
                         if ($query -ne "") {
                             $null = $server.Query($query)
+                            # These options are changed with T-SQL rather than through SMO, so the SMO
+                            # object knows nothing about it and still holds what it read before. Without
+                            # this the command reports the values from before its own change, and leaves
+                            # the object of the caller saying the same. It is the treatment the SMO path
+                            # above already gets after its Alter. See #10561.
+                            $db.QueryStoreOptions.Refresh()
                         }
                     } catch {
                         Stop-Function -Message "Could not modify configuration." -Category InvalidOperation -InnerErrorRecord $_ -Target $db -Continue

--- a/tests/Set-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Set-DbaDbQueryStoreOption.Tests.ps1
@@ -37,6 +37,14 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
+    BeforeDiscovery {
+        # MaxPlansPerQuery and WaitStatsCaptureMode arrived with SQL Server 2017. The value decides a
+        # Skip, which Pester needs while it discovers the tests, so it cannot be read in BeforeAll.
+        $discoveryServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
+        $multi1VersionMajor = $discoveryServer.VersionMajor
+        $null = $discoveryServer | Disconnect-DbaInstance
+    }
+
     BeforeAll {
         Get-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1, $TestConfig.InstanceMulti2 | Where-Object Name -Match "dbatoolsci" | Remove-DbaDatabase
         New-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1, $TestConfig.InstanceMulti2 -Name dbatoolsciqs
@@ -142,6 +150,50 @@ Describe $CommandName -Tag IntegrationTests {
                 $resultsModel | Should -BeNullOrEmpty
                 $warnModel -join "`n" | Should -Match "Query Store cannot be read on model before SQL Server 2022"
             }
+        }
+    }
+
+    Context "When an option is changed that needs T-SQL" -Skip:($multi1VersionMajor -lt 14) {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # The database of the Describe rather than one of its own. A CREATE DATABASE here fails
+            # intermittently with "Could not obtain exclusive lock on database 'model'", because the tests
+            # above read Query Store on model and leave a session parked in it. That is #10584, which is
+            # not in development yet, and this Context does not need a database of its own anyway.
+            $refreshDbName = "dbatoolsciqs"
+
+            # The server object is kept, because the point of this is what the command leaves behind on it.
+            $refreshServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
+            $null = Set-DbaDbQueryStoreOption -SqlInstance $refreshServer -Database $refreshDbName -State ReadWrite
+
+            # MaxPlansPerQuery and WaitStatsCaptureMode are changed with ALTER DATABASE rather than through
+            # SMO, so the SMO object knows nothing about it and still holds what it read before. See #10561.
+            $resultsRefresh = Set-DbaDbQueryStoreOption -SqlInstance $refreshServer -Database $refreshDbName -MaxPlansPerQuery 555 -WaitStatsCaptureMode Off
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $refreshServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Returns the values it has just set" {
+            $resultsRefresh.MaxPlansPerQuery | Should -Be 555
+            $resultsRefresh.WaitStatsCaptureMode | Should -Be "Off"
+        }
+
+        It "Leaves the SMO object of the caller with the new values" {
+            $refreshServer.Databases[$refreshDbName].QueryStoreOptions.MaxPlansPerQuery | Should -Be 555
+        }
+
+        It "Really changed them on the instance" {
+            $verifyQuery = "SELECT max_plans_per_query AS MaxPlansPerQuery FROM sys.database_query_store_options"
+            (Invoke-DbaQuery -SqlInstance $TestConfig.InstanceMulti1 -Database $refreshDbName -Query $verifyQuery).MaxPlansPerQuery | Should -Be 555
         }
     }
 }


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #10561)
 - [x] Ran manual Pester test and has passed
 - [x] Pester test is included

### Purpose

`MaxPlansPerQuery`, `WaitStatsCaptureMode` and the four `CustomCapturePolicy*` options are changed with an `ALTER DATABASE` statement rather than through SMO. The SMO object knows nothing about that and still holds what it read before, so the command reported the values from **before its own change** and left the object of the caller saying the same:

```
returned by Set     : MaxPlansPerQuery=200
the instance has    : MaxPlansPerQuery=555
```

This is not the staleness that a reused connection brings with it. It happens on every call, including one where the command opens the connection itself, because the command reads `$db.QueryStoreOptions` before it runs the statement and that fills the cache.

`Copy-DbaDbQueryStoreOption` is fixed with it, because it copies the settings by calling this command.

### Approach

The SMO path a few lines above already does the right thing:

```powershell
$db.QueryStoreOptions.DesiredState = $State
$db.QueryStoreOptions.Alter()
$db.QueryStoreOptions.Refresh()
```

The T-SQL path now gets the same treatment, right after the statement:

```powershell
if ($query -ne "") {
    $null = $server.Query($query)
    $db.QueryStoreOptions.Refresh()
}
```

That is one round trip per database, and only for the calls that actually use one of these options. What a reused connection reports about changes made elsewhere is unaffected, as it should be.

### Commands to test

```powershell
$server = Connect-DbaInstance -SqlInstance $instance
$null = Set-DbaDbQueryStoreOption -SqlInstance $server -Database $dbName -State ReadWrite

Set-DbaDbQueryStoreOption -SqlInstance $server -Database $dbName -MaxPlansPerQuery 555 -WaitStatsCaptureMode Off |
    Select-Object MaxPlansPerQuery, WaitStatsCaptureMode      # 555 / Off, was 200 / On
```

### Tests

A `Context` that sets both options and expects:

- the returned object to carry them
- the SMO object of the caller to carry them, which is the part a `Get-` command cannot paper over
- the instance to really have them, which passes either way and says the T-SQL was never the problem

The first two fail against `development` with `Expected 555, but got 200`.

`Set-DbaDbQueryStoreOption`: 11 tests, all passing, no leftovers in the lab.

### Note on the test fixture

The new `Context` uses the database that the `Describe` already creates rather than one of its own. A `CREATE DATABASE` at that point fails intermittently with

```
Could not obtain exclusive lock on database 'model'. Retry the operation later.
```

because the tests above it read Query Store on `model` and leave a session parked in it. That is the leak #10584 fixes, which is not merged yet - worth knowing that it now reaches test files that have nothing to do with connection handling.

---

*This text was created by Claude and reviewed by Andreas Jordan.*
