### PR TITLE
Testing Get-DbaDbQueryStoreOption - Create the database before anything has read model

### DIFF
--- a/tests/Get-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Get-DbaDbQueryStoreOption.Tests.ps1
@@ -37,7 +37,24 @@ Describe $CommandName -Tag IntegrationTests {
 
         $serverSingle = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
 
+        # Created here rather than in the Context that uses it, because the Contexts below read Query Store
+        # on model and leave a session parked in it, and the next CREATE DATABASE then fails with
+        # "Could not obtain exclusive lock on database 'model'". That is the leak of #10584, and until it
+        # is merged the only way past it is to create the database before anything has touched model.
+        $queryStoreDbName = "dbatoolsci_qso_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $queryStoreDbName
+        $null = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database $queryStoreDbName -State ReadWrite
+
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $queryStoreDbName -ErrorAction SilentlyContinue
+
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
@@ -76,19 +93,8 @@ Describe $CommandName -Tag IntegrationTests {
         BeforeAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-            $queryStoreDbName = "dbatoolsci_qso_$(Get-Random)"
-            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $queryStoreDbName
-            $null = Set-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database $queryStoreDbName -State ReadWrite
-
+            # The database itself comes from the BeforeAll of the Describe, see the note there.
             $resultsFromSmo = Get-DbaDbQueryStoreOption -SqlInstance $TestConfig.InstanceSingle -Database $queryStoreDbName
-
-            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-        }
-
-        AfterAll {
-            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-
-            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $queryStoreDbName -ErrorAction SilentlyContinue
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, test only)
 - [x] Ran manual Pester test and has passed
 - [x] Pester test is included

### Purpose

`development` is red. The `Context` that #10592 added to `Get-DbaDbQueryStoreOption.Tests.ps1` creates its database *after* the Contexts that read Query Store on `model`, and those leave a session parked there. On the runners the next `CREATE DATABASE` cannot get the lock:

```
Get-DbaDbQueryStoreOption > When a value is available from SMO > ...
  Block Error: Could not obtain exclusive lock on database 'model'. Retry the operation later.
  CREATE DATABASE failed. Some file names listed could not be created.
```

Three attempts, all three the same. It passed in the lab because the run there happened to win the lock, which is exactly what makes this kind of failure easy to merge by accident.

### Approach

The database is created in the `BeforeAll` of the `Describe`, which runs before any `Context`, and removed in a new `AfterAll`. Nothing else changes - no assertion is touched.

### The cause, and why this is a workaround

The parked session is the connection leak that **#10584** fixes: `Invoke-DbaQuery -SqlInstance $server -Database model`, which `Get-DbaDbQueryStoreOption` uses per database, orphaned a non-pooled connection that nothing could close. Once that is merged, the ordering here stops mattering - but a test should not depend on the order of its Contexts either way, so this is worth having regardless.

This is the third sighting of the same race:

- `Get-DbaDbRecoveryModel` failing intermittently in a lab run, diagnosed to a session parked in `model`
- this failure
- `Set-DbaDbCompatibility.Tests.ps1`, which already carries `Get-DbaProcess -Database model | Stop-DbaProcess` in its `BeforeAll` - someone hit it before and worked around it the same way

The same care was taken in the `Set-DbaDbQueryStoreOption` test of #10593, which is why that one did not break.

### Tests

`Get-DbaDbQueryStoreOption`: 7 tests, all passing, no leftovers in the lab.

---

*This text was created by Claude and reviewed by Andreas Jordan.*
