### PR TITLE
Copy-DbaAgentSchedule - Make -Force actually drop and recreate existing schedules

### DIFF
--- a/public/Copy-DbaAgentSchedule.ps1
+++ b/public/Copy-DbaAgentSchedule.ps1
@@ -165,25 +165,28 @@ function Copy-DbaAgentSchedule {
                         }
                         continue
                     } else {
-                        if ($Pscmdlet.ShouldProcess($destinstance, "Schedule [$scheduleName] has associated jobs. Skipping.")) {
-                            if ($destServer.JobServer.Jobs.JobSchedules.Name -contains $scheduleName) {
+                        # A schedule that is attached to a job at the destination cannot be dropped, so it cannot be overwritten even with -Force.
+                        # This has to be tested before ShouldProcess, otherwise the drop below would be unreachable in a normal run.
+                        if ($destServer.JobServer.Jobs.JobSchedules.Name -contains $scheduleName) {
+                            if ($Pscmdlet.ShouldProcess($destinstance, "Schedule [$scheduleName] has associated jobs. Skipping.")) {
                                 $copySharedScheduleStatus.Status = "Skipped"
                                 $copySharedScheduleStatus.Notes = "Schedule has associated jobs"
                                 $copySharedScheduleStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
                                 Write-Message -Level Verbose -Message "Schedule [$scheduleName] has associated jobs. Skipping."
                             }
                             continue
-                        } else {
-                            if ($Pscmdlet.ShouldProcess($destinstance, "Dropping schedule $scheduleName and recreating")) {
-                                try {
-                                    Write-Message -Level Verbose -Message "Dropping schedule $scheduleName"
-                                    $destServer.JobServer.SharedSchedules[$scheduleName].Drop()
-                                } catch {
-                                    $copySharedScheduleStatus.Status = "Failed"
-                                    $copySharedScheduleStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
-                                    Write-Message -Level Verbose -Message "Issue dropping schedule $scheduleName on $destinstance | $PSItem"
-                                    continue
-                                }
+                        }
+
+                        if ($Pscmdlet.ShouldProcess($destinstance, "Dropping schedule $scheduleName and recreating")) {
+                            try {
+                                Write-Message -Level Verbose -Message "Dropping schedule $scheduleName"
+                                $destServer.JobServer.SharedSchedules[$scheduleName].Drop()
+                            } catch {
+                                $copySharedScheduleStatus.Status = "Failed"
+                                $copySharedScheduleStatus.Notes = "Issue dropping schedule on destination"
+                                $copySharedScheduleStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+                                Write-Message -Level Verbose -Message "Issue dropping schedule $scheduleName on $destinstance | $PSItem"
+                                continue
                             }
                         }
                     }

--- a/tests/Copy-DbaAgentSchedule.Tests.ps1
+++ b/tests/Copy-DbaAgentSchedule.Tests.ps1
@@ -74,4 +74,131 @@ Describe $CommandName -Tag IntegrationTests {
             $schedule.ActiveStartTimeOfDay | Should -Be "01:00:00"
         }
     }
+
+    Context "When the destination schedule has no associated jobs and -Force is used" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # The same schedule name on both instances, but with different start times, so we can
+            # tell a real drop and recreate from a silent no-op. The destination copy has no jobs.
+            $splatSourceForceSchedule = @{
+                SqlInstance       = $TestConfig.InstanceCopy1
+                Schedule          = "dbatoolsci_ForceSchedule"
+                FrequencyType     = "Daily"
+                FrequencyInterval = "Everyday"
+                StartTime         = "010000"
+                Force             = $true
+            }
+            $null = New-DbaAgentSchedule @splatSourceForceSchedule
+
+            $splatDestForceSchedule = @{
+                SqlInstance       = $TestConfig.InstanceCopy2
+                Schedule          = "dbatoolsci_ForceSchedule"
+                FrequencyType     = "Daily"
+                FrequencyInterval = "Everyday"
+                StartTime         = "050000"
+                Force             = $true
+            }
+            $null = New-DbaAgentSchedule @splatDestForceSchedule
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+
+            $splatCopyForce = @{
+                Source      = $TestConfig.InstanceCopy1
+                Destination = $TestConfig.InstanceCopy2
+                Schedule    = "dbatoolsci_ForceSchedule"
+                Force       = $true
+            }
+            $forceResults = @(Copy-DbaAgentSchedule @splatCopyForce)
+            $forceSchedules = @(Get-DbaAgentSchedule -SqlInstance $TestConfig.InstanceCopy2 -Schedule dbatoolsci_ForceSchedule)
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = Remove-DbaAgentSchedule -SqlInstance $TestConfig.InstanceCopy1 -Schedule dbatoolsci_ForceSchedule -ErrorAction SilentlyContinue
+            $null = Remove-DbaAgentSchedule -SqlInstance $TestConfig.InstanceCopy2 -Schedule dbatoolsci_ForceSchedule -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Does not warn" {
+            $WarnVar | Should -BeNullOrEmpty
+        }
+
+        It "Reports the schedule as copied" {
+            $forceResults.Status | Should -Be "Successful"
+        }
+
+        It "Replaces the destination schedule with the source definition" {
+            $forceSchedules.ActiveStartTimeOfDay | Should -Be "01:00:00"
+        }
+
+        It "Leaves exactly one schedule with that name on the destination" {
+            $forceSchedules.Count | Should -Be 1
+        }
+    }
+
+    Context "When the destination schedule has associated jobs and -Force is used" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $splatSourceJobSchedule = @{
+                SqlInstance       = $TestConfig.InstanceCopy1
+                Schedule          = "dbatoolsci_JobSchedule"
+                FrequencyType     = "Daily"
+                FrequencyInterval = "Everyday"
+                StartTime         = "010000"
+                Force             = $true
+            }
+            $null = New-DbaAgentSchedule @splatSourceJobSchedule
+
+            # A schedule that a job uses cannot be dropped, so -Force must skip it and leave it alone.
+            $null = New-DbaAgentJob -SqlInstance $TestConfig.InstanceCopy2 -Job dbatoolsci_ScheduleJob
+            $splatDestJobSchedule = @{
+                SqlInstance       = $TestConfig.InstanceCopy2
+                Job               = "dbatoolsci_ScheduleJob"
+                Schedule          = "dbatoolsci_JobSchedule"
+                FrequencyType     = "Daily"
+                FrequencyInterval = "Everyday"
+                StartTime         = "050000"
+                Force             = $true
+            }
+            $null = New-DbaAgentSchedule @splatDestJobSchedule
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+
+            $splatCopyJobSchedule = @{
+                Source      = $TestConfig.InstanceCopy1
+                Destination = $TestConfig.InstanceCopy2
+                Schedule    = "dbatoolsci_JobSchedule"
+                Force       = $true
+            }
+            $jobScheduleResults = @(Copy-DbaAgentSchedule @splatCopyJobSchedule)
+            $jobSchedules = @(Get-DbaAgentSchedule -SqlInstance $TestConfig.InstanceCopy2 -Schedule dbatoolsci_JobSchedule)
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = Remove-DbaAgentJob -SqlInstance $TestConfig.InstanceCopy2 -Job dbatoolsci_ScheduleJob -KeepUnusedSchedule -ErrorAction SilentlyContinue
+            $null = Remove-DbaAgentSchedule -SqlInstance $TestConfig.InstanceCopy1 -Schedule dbatoolsci_JobSchedule -ErrorAction SilentlyContinue
+            $null = Remove-DbaAgentSchedule -SqlInstance $TestConfig.InstanceCopy2 -Schedule dbatoolsci_JobSchedule -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Does not warn" {
+            $WarnVar | Should -BeNullOrEmpty
+        }
+
+        It "Reports the schedule as skipped" {
+            $jobScheduleResults.Status | Should -Be "Skipped"
+            $jobScheduleResults.Notes | Should -Be "Schedule has associated jobs"
+        }
+
+        It "Leaves the destination schedule unchanged" {
+            $jobSchedules.ActiveStartTimeOfDay | Should -Be "05:00:00"
+        }
+    }
 }


### PR DESCRIPTION
fixes #10594.

## Problem

`-Force` on `Copy-DbaAgentSchedule` never dropped anything. It reported nothing, wrote no warning, and left the destination schedule as it was. Reported by @greenmtnsun in #10594 with a complete and correct control-flow analysis.

## Mechanism

In the `-Force` arm, the test for associated jobs was made *inside* a `ShouldProcess` call, and the `continue` after it was unconditional:

```powershell
if ($Pscmdlet.ShouldProcess($destinstance, "Schedule [$scheduleName] has associated jobs. Skipping.")) {
    if ($destServer.JobServer.Jobs.JobSchedules.Name -contains $scheduleName) { ...report Skipped... }
    continue                       # always, jobs or not
} else {
    if ($Pscmdlet.ShouldProcess($destinstance, "Dropping schedule $scheduleName and recreating")) { ...Drop()... }
}
```

`ShouldProcess` returns true on any normal run, so the `continue` fires and the `Drop()` in the `else` is unreachable. `if ($Force) { $ConfirmPreference = 'none' }` in the `begin` block makes that certain: with `-Force` the prompt cannot appear and cannot return false. The only route to `Drop()` was `-Force -Confirm`, answering **No** to "has associated jobs. Skipping." and then **Yes** to "Dropping schedule and recreating".

A second consequence of the same shape: a destination schedule with no attached jobs emitted no `MigrationObject` at all, because the reporting block was inside the jobs test while the `continue` was outside it.

This is a regression from 9f67479581 (2018-07-18, "hid object output in whatif"). That commit wrapped the associated-jobs test in `ShouldProcess`, and the `else` that had belonged to the jobs test ended up attached to the new `ShouldProcess` instead — "no associated jobs, drop it" became "user declined the prompt, drop it". The commit title makes clear that was not the intent.

## What changed

The associated-jobs test is the outer condition again, matching the pre-2018 shape and matching how `Copy-DbaAgentJobCategory` writes the same `-Force` pattern today:

- attached to a job → report `Skipped` / `Schedule has associated jobs` and `continue` (the "cannot be overwritten, even with Force" case the help describes)
- otherwise → `ShouldProcess("Dropping schedule ... and recreating")`, drop, and fall through to the existing create block

Reporting stays *inside* `ShouldProcess` so `-WhatIf` still suppresses object output, which is what 9f67479581 and #8846 were after. The failed-drop status now also sets `Notes`, which it did not before.

## What deliberately did not change

- The non-`-Force` arm.
- The `-WhatIf` object-output suppression.
- The skip behaviour for schedules a job uses — those still cannot be overwritten, as `.PARAMETER Force` documents.
- No other command. I swept every `Copy-Dba*` and `Start-DbaMigration` for an `else` hanging off a `ShouldProcess` at the same nesting level. The three other hits are false positives — their `else` belongs to `if ($force -eq $false)` or `if ($UseLastBackup)`. `Copy-DbaAgentSchedule` was the only one.

## Tests

Two new integration contexts in `tests/Copy-DbaAgentSchedule.Tests.ps1`. Both create the same schedule name on source and destination with **different start times**, so a real drop and recreate is distinguishable from a silent no-op:

- destination schedule with no jobs, `-Force` → status `Successful`, destination start time becomes the source's, exactly one schedule left
- destination schedule attached to a job, `-Force` → status `Skipped` with `Schedule has associated jobs`, destination start time unchanged

Run against the lab (`InstanceCopy1` = SQL03\SQL2022, `InstanceCopy2` = SQL04\SQL2025): **11/11 passed**, no warnings, lab left clean.

Reverting only `public/Copy-DbaAgentSchedule.ps1` and re-running reproduces the report exactly:

```
FAILED  Reports the schedule as copied
        Expected 'Successful', but got $null.
FAILED  Replaces the destination schedule with the source definition
        Expected '01:00:00', but got 05:00:00.
```

---
created by Claude and reviewed by Andreas Jordan