### PR TITLE
Testing Get-DbaRandomizedValue - Decide emptiness without a culture sensitive comparison

### DIFF
--- a/tests/Get-DbaRandomizedValue.Tests.ps1
+++ b/tests/Get-DbaRandomizedValue.Tests.ps1
@@ -114,7 +114,13 @@ Describe $CommandName -Tag IntegrationTests {
                 # and Random/SByte can return 0, and both are a returned value rather than nothing at all.
                 $typeValue = @(Get-DbaRandomizedValue @splatRandomValue)
 
-                if ($typeValue.Count -gt 0 -and "$($typeValue[0])" -ne "") {
+                # Measure the string instead of comparing it to "". PowerShell compares strings culture
+                # sensitively, so a string of a single ignorable character - a soft hyphen, a zero width
+                # mark, one of the C0 controls - compares equal to the empty string. Random/Chars returns
+                # five characters out of the whole range and lands on such a character as the first one
+                # about once in five hundred calls, and the type was then reported as returning nothing
+                # at all. Measured on 2026-08-24 after the full suite failed on exactly that.
+                if ($typeValue.Count -gt 0 -and "$($typeValue[0])".Length -gt 0) {
                     $typeResults[$typeKey] = "value"
                 } elseif ($typeWarning) {
                     $typeResults[$typeKey] = "message"


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, test only)
 - [x] Ran manual Pester test and has passed
 - [x] Pester test is included

### Purpose

`Get-DbaRandomizedValue.Tests.ps1` fails about once every few full suite runs, always the same way:

```
Get-DbaRandomizedValue > Every randomizer type > Never returns nothing without saying why
  Expected $null or empty, but got 'Random/Chars'.
```

That reads as "the command returned nothing and did not say why", which is what the test exists to catch. The command is innocent. Over 500 repeat calls, `Random/Chars` returned five characters every single time.

### The cause

The `BeforeAll` classifies each randomizer type by what came back:

```powershell
if ($typeValue.Count -gt 0 -and "$($typeValue[0])" -ne "") {
```

PowerShell compares strings **culture sensitively**, and that comparison ignores characters the collation considers ignorable - a soft hyphen, a zero width mark, the C0 controls. A string consisting only of such a character therefore compares equal to `""`:

```powershell
PS> ("$([char]0x00AD)") -eq ""
True
PS> [string]::Equals("$([char]0x00AD)", "", [System.StringComparison]::Ordinal)
False
PS> ("$([char]0x00AD)").Length
1
```

`Random/Chars` draws five characters out of the whole range, so its first character lands on one of these roughly once in five hundred calls. Measured, not reasoned: 500 calls returned five characters each, and the first character stringified as "empty" once.

Every other randomizer type is safe by luck - they return numbers, names, dates and the like - so the type named in the failure will always be `Random/Chars`.

### Approach

Measure the string rather than compare it:

```powershell
if ($typeValue.Count -gt 0 -and "$($typeValue[0])".Length -gt 0) {
```

A comment records why, because `-ne ""` is the obvious thing to write here and will be written again otherwise. No assertion changes, and the command is untouched.

### Tests

`Get-DbaRandomizedValue`: 9 tests, all passing. The failure is intermittent by nature, so the fix is demonstrated directly instead: with a value whose first character is a soft hyphen, the old check classifies it as nothing and the new one as a value.

---

*This text was created by Claude and reviewed by Andreas Jordan.*
