### PR TITLE
Copy-DbaSsisCatalog - Require SQL Server 2012 on the destination, as the help already promises

### DIFF
--- a/public/Copy-DbaSsisCatalog.ps1
+++ b/public/Copy-DbaSsisCatalog.ps1
@@ -313,7 +313,7 @@ function Copy-DbaSsisCatalog {
         }
         foreach ($destinstance in $Destination) {
             try {
-                $destinationConnection = Connect-DbaInstance -SqlInstance $destinstance -SqlCredential $DestinationSqlCredential -MinimumVersion 1
+                $destinationConnection = Connect-DbaInstance -SqlInstance $destinstance -SqlCredential $DestinationSqlCredential -MinimumVersion 11
             } catch {
                 Stop-Function -Message "Error occurred while establishing connection to $destinstance" -Category ConnectionError -ErrorRecord $_ -Target $destinstance -Continue
             }
@@ -321,14 +321,14 @@ function Copy-DbaSsisCatalog {
             try {
                 Get-RemoteIntegrationService -Computer $destinstance.ComputerName
             } catch {
-                Stop-Function -Message "An error occurred when checking the destination for Integration Services. Is Integration Services installed?" -Target $destinstance -ErrorRecord $_
+                Stop-Function -Message "An error occurred when checking the destination for Integration Services. Is Integration Services installed?" -Target $destinstance -ErrorRecord $_ -Continue
             }
 
             try {
                 $destinationStoreConnection = New-Object Microsoft.SqlServer.Management.Sdk.Sfc.SqlStoreConnection $destinationConnection.ConnectionContext.SqlConnectionObject
                 $destinationSSIS = New-Object Microsoft.SqlServer.Management.IntegrationServices.IntegrationServices $destinationStoreConnection
             } catch {
-                Stop-Function -Message "There was an error connecting to the destination integration services." -Target $destinationCon -ErrorRecord $_
+                Stop-Function -Message "There was an error connecting to the destination integration services." -Target $destinationConnection -ErrorRecord $_ -Continue
             }
 
             $destinationCatalog = $destinationSSIS.Catalogs | Where-Object {


### PR DESCRIPTION
Found while counting version gates for #10600, and small enough to fix rather than leave in the tally.

## What was wrong

`public/Copy-DbaSsisCatalog.ps1:316` connected to the destination with `-MinimumVersion 1`:

```powershell
$destinationConnection = Connect-DbaInstance -SqlInstance $destinstance -SqlCredential $DestinationSqlCredential -MinimumVersion 1
```

Every instance satisfies 1, so the guard did nothing. Line 287 connects to the source with `-MinimumVersion 11`, and the help for both `-Source` and `-Destination` says "Requires sysadmin privileges and SQL Server 2012 or higher". A dropped digit, invisible to review because the line still reads like a version check.

The SSISDB catalog is a 2012 feature, so a pre-2012 destination failed later and less clearly - `New-Object ...IntegrationServices` against a server with no catalog support, rather than "SQL Server version 11 required".

## Two more in the same loop

Both within three lines of the first, so they belong in this PR rather than a follow-up:

- The catch for the destination integration services passed `-Target $destinationCon`, a variable that is never assigned anywhere in the command. The connection is `$destinationConnection`, so the error record carried a null target.
- Neither that catch nor the Integration Services check used `-Continue`, although both sit inside `foreach ($destinstance in $Destination)` and the connection catch three lines above does use it. Without `-Continue`, `Stop-Function` warned and execution fell straight through to the next statement, which then worked on a null `$destinationSSIS` - so one bad destination produced a confusing second error instead of moving on to the next instance.

## Testing

This command cannot be integration tested here, and I would rather say so than imply otherwise:

- It refuses to run on PowerShell Core (`begin` block, line 129), and the lab and the container workflow both run PowerShell 7.
- No CI scenario provisions an SSISDB catalog, so there is no boundary to test against.
- Exercising the corrected guard needs a destination older than SQL Server 2012, and the oldest instance in the lab is 2019.

So the existing unit test is unchanged - the parameter surface did not move - and the change was verified by reading the two call sites against each other and against the help. The file parses clean and passes the repository style check.

If a maintainer with an SSIS lab wants to confirm the destination guard before this merges, the check is `Copy-DbaSsisCatalog -Source <2012+> -Destination <pre-2012>`, which should now refuse with `SQL Server version 11 required - ... not supported.`

*This text was created by Claude and reviewed by Andreas Jordan.*
