### PR TITLE
Invoke-DbaDbUpgrade - Leave the database context of the caller alone

### DIFF
--- a/public/Invoke-DbaDbUpgrade.ps1
+++ b/public/Invoke-DbaDbUpgrade.ps1
@@ -180,6 +180,10 @@ function Invoke-DbaDbUpgrade {
         foreach ($db in $InputObject) {
             # create objects to use in updates
             $server = $db.Parent
+
+            # Read before anything else runs, so that this is the database the caller was in and not one
+            # that a statement of this command left behind.
+            $callerDatabase = $server.ConnectionContext.CurrentDatabase
             $serverVersion = $server.VersionMajor
             Write-Message -Level Verbose -Message "SQL Server is using Version: $serverVersion"
 
@@ -228,12 +232,17 @@ function Invoke-DbaDbUpgrade {
                 $targetRecoveryTimeResult = "No change"
             }
 
+            # The maintenance statements below run in the database, so they go through the Invoke script
+            # method of the Database object rather than through SMO's own ExecuteNonQuery. Both issue a
+            # USE on the execution manager of the database, which is the connection context of the parent
+            # server and belongs to the caller, but only ours puts the previous database back afterwards.
+            # See #10555 and #10556.
             if (!($NoCheckDb)) {
                 Write-Message -Level Verbose -Message "Updating $db with DBCC CHECKDB DATA_PURITY"
                 If ($Pscmdlet.ShouldProcess($server, "Updating $db with DBCC CHECKDB DATA_PURITY")) {
                     $tsqlCheckDB = "DBCC CHECKDB ('$($db.Name)') WITH DATA_PURITY, NO_INFOMSGS"
                     try {
-                        $db.ExecuteNonQuery($tsqlCheckDB)
+                        $db.Invoke($tsqlCheckDB)
                         $DataPurityResult = "Success"
                     } catch {
                         Write-Message -Level Warning -Message "Failed run DBCC CHECKDB with DATA_PURITY on $db" -ErrorRecord $_ -Target $instance
@@ -249,7 +258,7 @@ function Invoke-DbaDbUpgrade {
                 If ($Pscmdlet.ShouldProcess($server, "Updating $db with DBCC UPDATEUSAGE")) {
                     $tsqlUpdateUsage = "DBCC UPDATEUSAGE ($db) WITH NO_INFOMSGS;"
                     try {
-                        $db.ExecuteNonQuery($tsqlUpdateUsage)
+                        $db.Invoke($tsqlUpdateUsage)
                         $UpdateUsageResult = "Success"
                     } catch {
                         Write-Message -Level Warning -Message "Failed to run DBCC UPDATEUSAGE on $db" -ErrorRecord $_ -Target $instance
@@ -266,7 +275,7 @@ function Invoke-DbaDbUpgrade {
                 If ($Pscmdlet.ShouldProcess($server, "Updating $db statistics")) {
                     $tsqlStats = "EXEC sp_updatestats;"
                     try {
-                        $db.ExecuteNonQuery($tsqlStats)
+                        $db.Invoke($tsqlStats)
                         $UpdateStatsResult = "Success"
                     } catch {
                         Write-Message -Level Warning -Message "Failed to run sp_updatestats on $db" -ErrorRecord $_ -Target $instance
@@ -280,21 +289,40 @@ function Invoke-DbaDbUpgrade {
 
             if (!($NoRefreshView)) {
                 Write-Message -Level Verbose -Message "Refreshing $db Views"
-                $dbViews = $db.Views | Where-Object IsSystemObject -eq $false
-                $RefreshViewResult = "Success"
-                foreach ($dbview in $dbviews) {
-                    $viewName = $dbView.Name
-                    $viewSchema = $dbView.Schema
-                    $fullName = $viewSchema + "." + $viewName
+                # Enumerating a database level collection like Views runs in the database as well: SMO issues
+                # a USE on the execution manager of the database, which is the connection context of the
+                # parent server, and never switches back. The Invoke calls above put the database back
+                # themselves, so this is the only place in the command that has to do it. See #10555.
+                try {
+                    $dbViews = $db.Views | Where-Object IsSystemObject -eq $false
+                    $RefreshViewResult = "Success"
+                    foreach ($dbview in $dbviews) {
+                        $viewName = $dbView.Name
+                        $viewSchema = $dbView.Schema
+                        $fullName = $viewSchema + "." + $viewName
 
-                    $tsqlupdateView = "EXECUTE sp_refreshview N'$fullName';  "
+                        $tsqlupdateView = "EXECUTE sp_refreshview N'$fullName';  "
 
-                    If ($Pscmdlet.ShouldProcess($server, "Refreshing view $fullName on $db")) {
+                        If ($Pscmdlet.ShouldProcess($server, "Refreshing view $fullName on $db")) {
+                            try {
+                                $db.Invoke($tsqlupdateView)
+                            } catch {
+                                Write-Message -Level Warning -Message "Failed update view $fullName on $db" -ErrorRecord $_ -Target $instance
+                                $RefreshViewResult = "Fail"
+                            }
+                        }
+                    }
+                } finally {
+                    if ($callerDatabase -and $server.ConnectionContext.CurrentDatabase -cne $callerDatabase) {
+                        # Case sensitive, because on a case sensitive instance AppDb and appdb are two
+                        # different databases and -ne would report them as equal and skip the restore.
+                        $escapedCallerDatabase = $callerDatabase.Replace("]", "]]")
                         try {
-                            $db.ExecuteNonQuery($tsqlupdateView)
+                            $null = $server.ConnectionContext.ExecuteNonQuery("USE [$escapedCallerDatabase]")
                         } catch {
-                            Write-Message -Level Warning -Message "Failed update view $fullName on $db" -ErrorRecord $_ -Target $instance
-                            $RefreshViewResult = "Fail"
+                            # Putting the database back is housekeeping and must never become the outcome of
+                            # the command, so this warns rather than throwing.
+                            Write-Message -Level Warning -Message "The database context could not be restored to [$callerDatabase]: $_"
                         }
                     }
                 }

--- a/tests/Invoke-DbaDbUpgrade.Tests.ps1
+++ b/tests/Invoke-DbaDbUpgrade.Tests.ps1
@@ -28,8 +28,165 @@ Describe $CommandName -Tag UnitTests {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/dataplat/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $setupServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+
+        # The command skips a database that is already at the compatibility level of the instance, so the
+        # test database is created one level below it. The level is asked of the instance instead of being
+        # hardcoded: every supported version accepts the level of the major version before it.
+        $instanceCompatibility = [Microsoft.SqlServer.Management.Smo.CompatibilityLevel]"Version$($setupServer.VersionMajor)0"
+        $previousCompatibility = [Microsoft.SqlServer.Management.Smo.CompatibilityLevel]"Version$($setupServer.VersionMajor - 1)0"
+
+        $upgradeDbName = "dbatoolsci_upgrade_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $setupServer -Name $upgradeDbName
+        $null = Set-DbaDbCompatibility -SqlInstance $setupServer -Database $upgradeDbName -Compatibility $previousCompatibility
+
+        # sp_refreshview only runs for a user view, so without one the fourth statement of the command
+        # would never execute and could not show whether it moves the connection.
+        $splatCreateView = @{
+            SqlInstance = $setupServer
+            Database    = $upgradeDbName
+            Query       = "CREATE TABLE dbo.dbatoolsci_table (id INT); EXEC ('CREATE VIEW dbo.dbatoolsci_view AS SELECT id FROM dbo.dbatoolsci_table');"
+        }
+        $null = Invoke-DbaQuery @splatCreateView
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $null = Remove-DbaDatabase -SqlInstance $setupServer -Database $upgradeDbName -ErrorAction SilentlyContinue
+        $null = $setupServer | Disconnect-DbaInstance
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "Upgrading a database leaves the connection of the caller alone (#10556)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which wipes the leak before it can be read.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $upgradeResult = Invoke-DbaDbUpgrade -SqlInstance $callerServer -Database $upgradeDbName
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "upgrades the database to the compatibility level of the instance" {
+            $upgradeResult.OriginalCompatibility | Should -Be $previousCompatibility.ToString().Replace("Version", "")
+            $upgradeResult.CurrentCompatibility | Should -Be $instanceCompatibility.ToString().Replace("Version", "")
+            $upgradeResult.Compatibility | Should -Be $instanceCompatibility.ToString().Replace("Version", "")
+        }
+
+        It "runs every maintenance step" {
+            # Only a statement that ran can move the connection, so a command that did nothing would pass
+            # the assertion below for the wrong reason.
+            $upgradeResult.DataPurity | Should -Be "Success"
+            $upgradeResult.UpdateUsage | Should -Be "Success"
+            $upgradeResult.UpdateStats | Should -Be "Success"
+            $upgradeResult.RefreshViews | Should -Be "Success"
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+
+        It "does not warn" {
+            $WarnVar | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "The database the caller was in is restored, not master (#10555)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $tempdbCallerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -Database tempdb -NonPooledConnection
+
+            # The database is at the level of the instance by now, so only -Force makes the maintenance
+            # statements run again. A fix that put the connection back to master instead of back to what
+            # the caller had would pass every assertion of the context above and fail here.
+            $forcedResult = Invoke-DbaDbUpgrade -SqlInstance $tempdbCallerServer -Database $upgradeDbName -Force
+
+            $tempdbContextAfter = $tempdbCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $tempdbCallerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "runs the maintenance steps again" {
+            $forcedResult.DataPurity | Should -Be "Success"
+            $forcedResult.UpdateUsage | Should -Be "Success"
+            $forcedResult.UpdateStats | Should -Be "Success"
+            $forcedResult.RefreshViews | Should -Be "Success"
+        }
+
+        It "leaves the connection in tempdb" {
+            $tempdbContextAfter | Should -Be "tempdb"
+        }
+    }
+
+    Context "The maintenance statements put the database back themselves (#10556)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $statementCallerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $statementContextBefore = $statementCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # -NoRefreshView is the case the restore around the view enumeration cannot cover, because with
+            # it the command never enumerates the views. Whatever the DBCC and stored procedure statements
+            # do to the connection has to be undone by the statements themselves.
+            $statementResult = Invoke-DbaDbUpgrade -SqlInstance $statementCallerServer -Database $upgradeDbName -NoRefreshView -Force
+
+            $statementContextAfter = $statementCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $statementCallerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "runs the statements it was not told to skip" {
+            $statementResult.DataPurity | Should -Be "Success"
+            $statementResult.UpdateUsage | Should -Be "Success"
+            $statementResult.UpdateStats | Should -Be "Success"
+            $statementResult.RefreshViews | Should -Be "Skipped"
+        }
+
+        It "leaves the connection in the database it was in" {
+            $statementContextAfter | Should -Be $statementContextBefore
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #10556)
 - [x] Pester test is included

This is also the first command of bucket B of #10555. It deliberately carries **no closing keyword for #10555**: that issue was closed by accident when #10580 merged, because "fixes #10555 in part" is read as a plain "fixes" by the linking parser. Buckets B and C are still open.

### Purpose

`Invoke-DbaDbUpgrade` handed the connection back pointing at the database it had just upgraded. This is the command from the provisioning script in #10555 that started the whole workstream, and it is a bucket B site, so the script method fix in #10579 does not reach it.

### Approach

Two independent causes, and fixing either one alone leaves the leak in place under some parameter combination.

**1. The four maintenance statements.** They ran through SMO's own `Database.ExecuteNonQuery`, which issues a `USE` on the execution manager of the database - the connection context of the parent server, which belongs to the caller - and never switches back. They go through our `Invoke` script method now, which since #10579 restores the previous database in a `finally`. The statements still run in the database they always ran in; nothing else about them changes.

**2. Enumerating `$db.Views` moves the connection just as well.** This one is worth flagging beyond this command, because it is not in the inventory on #10555 and it cannot be fixed by any script method - it is not a call we make, it is a property getter. Measured on SQL Server 2019 with `-NonPooledConnection`, reading `DB_NAME()` on the caller's connection afterwards:

```
db.Views                      master -> leaked
db.Tables                     master -> leaked
db.StoredProcedures           master -> leaked
db.Users                      master -> leaked
db.Schemas                    master -> leaked
db.Roles                      master -> leaked
db.FileGroups                 master -> leaked
db.Tables[0].Columns          master -> leaked
db.Size (a plain property)    master -> ok
db.Refresh()                  master -> ok
```

So the command reads the database of the caller **before any work starts** - not just before the view refresh, or a statement that already moved the connection would be recorded as "what the caller had" - and puts it back around the view refresh, in a `finally`, case sensitively, exactly as `Set-DbaTempDbConfig` does since #10580. A failing restore warns rather than throwing, so housekeeping can never become the outcome of the command.

### Tests

Three integration contexts in `tests/Invoke-DbaDbUpgrade.Tests.ps1`, all against a non-pooled connection, because a pooled one that closes between two calls reconnects at its default database and hides the leak:

- the upgrade itself, asserting the compatibility level really moved and that every maintenance step reported `Success` - a command that did nothing cannot leak, so without this the leak assertion would pass for the wrong reason
- the caller sitting in `tempdb` and using `-Force`, which fails for a fix that restores "to master" instead of restoring what the caller had
- `-NoRefreshView -Force`, the one case the restore around the view enumeration cannot cover, so the statements have to put the database back themselves

Verified to have teeth, in the lab against `SQL03\SQL2019`:

| state of the branch | result |
| --- | --- |
| both halves | 9 passed, 0 failed |
| `Invoke` reverted to `ExecuteNonQuery` | 1 failed (the `-NoRefreshView` context) |
| restore around the view enumeration removed | 2 failed (the other two contexts) |

### Commands to test

```powershell
$server = Connect-DbaInstance -SqlInstance $instance -NonPooledConnection
$null = Invoke-DbaDbUpgrade -SqlInstance $server -Database <a database below the compatibility level of the instance>
$server.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")   # master, was the upgraded database before
```

---

*This text was created by Claude and reviewed by Andreas Jordan.*
