### PR TITLE
Database context - Add Restore-DatabaseContext and fix eighteen commands

### DIFF
--- a/private/functions/Restore-DatabaseContext.ps1
+++ b/private/functions/Restore-DatabaseContext.ps1
@@ -74,6 +74,18 @@ function Restore-DatabaseContext {
     try {
         $null = $Server.ConnectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
     } catch {
-        Write-Message -Level Warning -Message "The database context could not be restored to [$Database]: $_"
+        # A caller can promote warnings to terminating errors or interactive prompts. Housekeeping must
+        # never replace the outcome of the command, so only interrupting preferences are neutralised.
+        # Silent warning preferences remain silent.
+        if ($WarningPreference -notin "SilentlyContinue", "Ignore", "Continue") {
+            $WarningPreference = "Continue"
+        }
+
+        $splatMessage = @{
+            Level   = "Warning"
+            Message = "The database context could not be restored to [$Database]: $_"
+        }
+
+        Write-Message @splatMessage
     }
 }

--- a/private/functions/Restore-DatabaseContext.ps1
+++ b/private/functions/Restore-DatabaseContext.ps1
@@ -1,0 +1,79 @@
+function Restore-DatabaseContext {
+    <#
+    .SYNOPSIS
+        Puts the current database of a connection back where the caller had it.
+
+    .DESCRIPTION
+        Database scoped SMO work moves the current database of the connection and never moves it back:
+        the execution manager of a Database object is the connection context of the parent server, which
+        belongs to the caller, and SMO issues a USE on it. That happens for ExecuteNonQuery and
+        ExecuteWithResults on a Database object, for Create and Drop of most server level objects, and for
+        enumerating any database level collection such as Views, Tables or Users. See #10555.
+
+        A command that cannot avoid moving the context calls this to put it back. Read
+        ConnectionContext.CurrentDatabase before the command starts its work, so the value is the database
+        the caller was in and not one that a statement of the command left behind, and call this from a
+        finally so a failing statement still puts the database back.
+
+        Putting the database back is housekeeping and must never become the outcome of the command, so a
+        failing restore warns instead of throwing. A query that makes the previous database unreachable -
+        taking it offline, dropping it, renaming it, revoking access - would otherwise report a failure
+        although the command succeeded.
+
+    .PARAMETER Server
+        The server object whose connection was moved. This is the object the caller passed in or that the
+        command connected with, not a copy.
+
+    .PARAMETER Database
+        The name of the database to go back to, read from ConnectionContext.CurrentDatabase before the work
+        started. Nothing happens when it is empty, so a command may pass a value it never managed to read.
+
+    .NOTES
+        Tags: Connection, Database
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2026 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .OUTPUTS
+        None. The current database of the connection is changed as a side effect.
+
+    .EXAMPLE
+        PS C:\> $callerDatabase = $server.ConnectionContext.CurrentDatabase
+        PS C:\> try {
+        PS C:\>     $views = $db.Views
+        PS C:\> } finally {
+        PS C:\>     Restore-DatabaseContext -Server $server -Database $callerDatabase
+        PS C:\> }
+
+        Enumerating the views leaves the connection in that database. This puts the database of the caller
+        back, whatever the enumeration did.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [Microsoft.SqlServer.Management.Smo.Server]$Server,
+        [string]$Database
+    )
+
+    if (-not $Database) {
+        return
+    }
+
+    # The comparison is case sensitive on purpose. Database names use the collation of the instance, so on
+    # a case sensitive instance AppDb and appdb are two different databases, and -eq would report them as
+    # equal and skip the restore. It cannot restore needlessly: both sides are read from the same property,
+    # so the same database always spells itself the same way.
+    if ($Server.ConnectionContext.CurrentDatabase -ceq $Database) {
+        return
+    }
+
+    $escapedDatabase = $Database.Replace("]", "]]")
+
+    try {
+        $null = $Server.ConnectionContext.ExecuteNonQuery("USE [$escapedDatabase]")
+    } catch {
+        Write-Message -Level Warning -Message "The database context could not be restored to [$Database]: $_"
+    }
+}

--- a/private/functions/Update-SqlPermission.ps1
+++ b/private/functions/Update-SqlPermission.ps1
@@ -305,7 +305,10 @@ function Update-SqlPermission {
                 if ($Pscmdlet.ShouldProcess($destination, "Adding $newDbUsername to $dbName.")) {
                     $sql = $SourceServer.Databases[$dbName].Users[$dbUsername].Script() | Out-String
                     try {
-                        $destDb.ExecuteNonQuery($sql.Replace("[$dbUsername]", "[$newDbUsername]").Replace("[$loginName]", "[$newLoginName]"))
+                        # Through the Invoke script method and not through ExecuteNonQuery of SMO: both run
+                        # the statement in that database by issuing a USE on the connection context of the
+                        # parent server, but only ours puts the previous database back. See #10555.
+                        $destDb.Invoke($sql.Replace("[$dbUsername]", "[$newDbUsername]").Replace("[$loginName]", "[$newLoginName]"))
                         Write-Message -Level Verbose -Message "Adding user $newDbUsername (login: $newLoginName) to $dbName successfully performed."
                     } catch {
                         Stop-Function -Message "Failed to add $newDbUsername (login: $newLoginName) to $dbName on $destination." -Target $db -ErrorRecord $_
@@ -343,7 +346,8 @@ function Update-SqlPermission {
                     $scriptOptions.IncludeIfNotExists = $true
                     $userScript = Export-DbaUser -SqlInstance $SourceServer -Database $dbName -User $dbUsername -Passthru -Template -ScriptingOptionsObject $scriptOptions -EnableException:$EnableException
                     $userScript = $userScript.Replace('{templateUser}', $newDbUsername)
-                    $destDb.ExecuteNonQuery($userScript)
+                    # See the comment above: the Invoke script method puts the database back afterwards.
+                    $destDb.Invoke($userScript)
                 }
             } else {
                 # Database Roles: db_owner, db_datareader, etc

--- a/public/ConvertTo-DbaXESession.ps1
+++ b/public/ConvertTo-DbaXESession.ps1
@@ -155,7 +155,12 @@ function ConvertTo-DbaXESession {
 
             try {
                 Write-Message -Level Verbose -Message "Executing SQL in tempdb."
-                $results = $tempdb.ExecuteWithResults($sql).Tables.Rows.SqlString
+                # Through the Query script method and not through ExecuteWithResults of SMO: both run the
+                # statement in tempdb by issuing a USE on the connection context of the parent server, which
+                # belongs to the caller, but only ours puts the previous database back. See #10555.
+                # The second argument asks for every result set: the conversion procedure returns the script
+                # in more than one of them, and Query returns only the first without it.
+                $results = $tempdb.Query($sql, $true).Rows.SqlString
             } catch {
                 Stop-Function -Message "Issue creating, dropping or executing sp_SQLskills_ConvertTraceToExtendedEvents in tempdb on $server." -Target $server -ErrorRecord $_
             }
@@ -167,7 +172,8 @@ function ConvertTo-DbaXESession {
             } else {
                 Write-Message -Level Verbose -Message "Creating XE Session $name."
                 try {
-                    $tempdb.ExecuteNonQuery($results)
+                    # See the comment above: the Invoke script method puts the database back afterwards.
+                    $tempdb.Invoke($results)
                 } catch {
                     Stop-Function -Message "Issue creating extended event $name on $server." -Target $server -ErrorRecord $_
                 }

--- a/public/Copy-DbaDatabase.ps1
+++ b/public/Copy-DbaDatabase.ps1
@@ -408,8 +408,14 @@ function Copy-DbaDatabase {
                 # Add support for Full Text Catalogs in SQL Server 2005 and below
                 if ($sourceServer.VersionMajor -lt 10) {
                     try {
-                        $fttable = $null = $sourceServer.Databases[$dbName].ExecuteWithResults('sp_help_fulltext_catalogs')
-                        $allrows = $fttable.Tables[0].rows
+                        # This used to read "$fttable = $null = ...", which assigns $null to $fttable, so
+                        # $allrows was always empty and no full text catalog was ever copied.
+                        # The Query script method runs the procedure in that database like ExecuteWithResults
+                        # of SMO does, by issuing a USE on the connection context of the parent server, which
+                        # belongs to the caller - but it puts the previous database back. It returns the rows,
+                        # so there is no table to unwrap. See #10555.
+                        $fttable = $sourceServer.Databases[$dbName].Query("sp_help_fulltext_catalogs")
+                        $allrows = $fttable
                     } catch {
                         # Nothing, it's just not enabled
                         # here to avoid an empty catch
@@ -1006,7 +1012,11 @@ function Copy-DbaDatabase {
                 $sql = "SELECT db.Name AS dbname, type_desc AS FileType, mf.Name, Physical_Name AS filename FROM sys.master_files mf INNER JOIN sys.databases db ON db.database_id = mf.database_id"
             }
 
-            $dbFileTable = $sourceServer.Databases['master'].ExecuteWithResults($sql)
+            # Read on the server connection and not through the master database: the statement queries
+            # sys.master_files and never needed a database context, and going through the Database object
+            # would move the connection of the caller into master. See #10555. ExecuteWithResults of the
+            # connection context returns the same DataSet, which the Select calls below rely on.
+            $dbFileTable = $sourceServer.ConnectionContext.ExecuteWithResults($sql)
 
             if ($destServer.VersionMajor -eq 8) {
                 $sql = "SELECT DB_NAME (dbid) AS dbname, name, filename, CASE WHEN groupid = 0 THEN 'LOG' ELSE 'ROWS' END AS filetype FROM sysaltfiles"
@@ -1014,7 +1024,8 @@ function Copy-DbaDatabase {
                 $sql = "SELECT db.Name AS dbname, type_desc AS FileType, mf.Name, Physical_Name AS filename FROM sys.master_files mf INNER JOIN sys.databases db ON db.database_id = mf.database_id"
             }
 
-            $remoteDbFileTable = $destServer.Databases['master'].ExecuteWithResults($sql)
+            # See the comment above - the same for the destination.
+            $remoteDbFileTable = $destServer.ConnectionContext.ExecuteWithResults($sql)
 
             $fileStructure = Get-SqlFileStructure -sourceserver $sourceServer -destserver $destServer -databaselist $databaseList -ReuseSourceFolderStructure $ReuseSourceFolderStructure
 

--- a/public/Copy-DbaDatabase.ps1
+++ b/public/Copy-DbaDatabase.ps1
@@ -1454,6 +1454,15 @@ function Copy-DbaDatabase {
                             If ($Pscmdlet.ShouldProcess($destServer.Name, "Setting db owner to $dbowner for $destinationDbName")) {
                                 # needed because the newly restored database doesn't show up
                                 $destServer.Databases.Refresh()
+                                # Refresh() on the collection only updates its membership. A database that
+                                # already existed on the destination - a copy with -WithReplace or -Continue -
+                                # keeps the property values SMO cached while the restore had it inaccessible,
+                                # and Set-DbaDbOwner would then skip it as not accessible. Refreshing the
+                                # object itself rereads those values.
+                                $destDb = $destServer.Databases[$destinationDbName]
+                                if ($destDb) {
+                                    $destDb.Refresh()
+                                }
                                 $dbOwner = $sourceServer.Databases[$dbName].Owner
                                 if ($null -eq $dbOwner -or $destServer.Logins.Name -notcontains $dbOwner) {
                                     $dbOwner = Get-SaLoginName -SqlInstance $destServer

--- a/public/Copy-DbaLogin.ps1
+++ b/public/Copy-DbaLogin.ps1
@@ -566,50 +566,67 @@ function Copy-DbaLogin {
             $sourceServer = $loginObject.Parent
             $sourceVersionMajor = $sourceServer.VersionMajor
 
-            foreach ($destinstance in $Destination) {
-                try {
-                    $destServer = Connect-DbaInstance -SqlInstance $destinstance -SqlCredential $DestinationSqlCredential -AzureUnsupported
-                } catch {
-                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $destinstance -Continue
-                }
+            # Copying a login drops and creates server level objects and syncs its permissions through the
+            # database level collections of both servers, all of which moves the connection into another
+            # database and never moves it back. The database of each caller connection is put back
+            # afterwards. See #10555.
+            $sourceCallerDatabase = $sourceServer.ConnectionContext.CurrentDatabase
 
-                $destVersionMajor = $destServer.VersionMajor
-                if ($sourceVersionMajor -gt 10 -and $destVersionMajor -lt 11) {
-                    Stop-Function -Message "Login migration from version $sourceVersionMajor to $destVersionMajor is not supported." -Target $sourceServer
-                }
-
-                if ($sourceVersionMajor -lt 8 -or $destVersionMajor -lt 8) {
-                    Stop-Function -Message "SQL Server 7 and below are not supported." -Target $sourceServer
-                }
-
-                if ($destserver.ConnectionContext.TrueLogin -notin $destserver.Logins.Name -and $Force) {
-                    if ($Login -or $ExcludeLogin -or $InputObject) {
-                        Write-Message -Level Verbose -Message "Force was used and $($destserver.ConnectionContext.TrueLogin) not found in logins list but an explicit Login or ExcludeLogin was specified, so we trust you won't drop the group that allows $($destserver.ConnectionContext.TrueLogin) access. Proceeding."
-                    } else {
-                        Stop-Function -Message "Force was used, no explicit -Login or -ExcludeLogin was specified and $($destserver.ConnectionContext.TrueLogin) cannot be found in the logins list. It may be part of a group. This will likely result in you being locked out of the server. To use Force, $($destserver.ConnectionContext.TrueLogin) must be added directly to logins before proceeding." -Target $destserver
-                        continue
+            try {
+                foreach ($destinstance in $Destination) {
+                    try {
+                        $destServer = Connect-DbaInstance -SqlInstance $destinstance -SqlCredential $DestinationSqlCredential -AzureUnsupported
+                    } catch {
+                        Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $destinstance -Continue
                     }
-                }
 
-                Write-Message -Level Verbose -Message "Attempting Login Migration."
-                Copy-Login -sourceserver $sourceServer -destserver $destServer -Login $loginObject -Exclude $ExcludeLogin
+                    # See the comment above - the same for the connection of the destination.
+                    $destCallerDatabase = $destServer.ConnectionContext.CurrentDatabase
 
-                if ($SyncSaName) {
-                    $sa = $sourceServer.Logins | Where-Object id -eq 1
-                    $destSa = $destServer.Logins | Where-Object id -eq 1
-                    $saName = $sa.Name
-                    if ($saName -ne $destSa.name) {
-                        Write-Message -Level Verbose -Message "Changing sa username to match source ($saName)."
-                        if ($Pscmdlet.ShouldProcess($destinstance, "Changing sa username to match source ($saName)")) {
-                            try {
-                                $destSa.Rename($saName)
-                                $destSa.Alter()
-                            } catch {
-                                Write-Message -Level Verbose -Message "Could not change sa username to match source ($saName) on $destinstance | $PSItem"
+                    try {
+                        $destVersionMajor = $destServer.VersionMajor
+                        if ($sourceVersionMajor -gt 10 -and $destVersionMajor -lt 11) {
+                            Stop-Function -Message "Login migration from version $sourceVersionMajor to $destVersionMajor is not supported." -Target $sourceServer
+                        }
+
+                        if ($sourceVersionMajor -lt 8 -or $destVersionMajor -lt 8) {
+                            Stop-Function -Message "SQL Server 7 and below are not supported." -Target $sourceServer
+                        }
+
+                        if ($destserver.ConnectionContext.TrueLogin -notin $destserver.Logins.Name -and $Force) {
+                            if ($Login -or $ExcludeLogin -or $InputObject) {
+                                Write-Message -Level Verbose -Message "Force was used and $($destserver.ConnectionContext.TrueLogin) not found in logins list but an explicit Login or ExcludeLogin was specified, so we trust you won't drop the group that allows $($destserver.ConnectionContext.TrueLogin) access. Proceeding."
+                            } else {
+                                Stop-Function -Message "Force was used, no explicit -Login or -ExcludeLogin was specified and $($destserver.ConnectionContext.TrueLogin) cannot be found in the logins list. It may be part of a group. This will likely result in you being locked out of the server. To use Force, $($destserver.ConnectionContext.TrueLogin) must be added directly to logins before proceeding." -Target $destserver
+                                continue
                             }
                         }
+
+                        Write-Message -Level Verbose -Message "Attempting Login Migration."
+                        Copy-Login -sourceserver $sourceServer -destserver $destServer -Login $loginObject -Exclude $ExcludeLogin
+
+                        if ($SyncSaName) {
+                            $sa = $sourceServer.Logins | Where-Object id -eq 1
+                            $destSa = $destServer.Logins | Where-Object id -eq 1
+                            $saName = $sa.Name
+                            if ($saName -ne $destSa.name) {
+                                Write-Message -Level Verbose -Message "Changing sa username to match source ($saName)."
+                                if ($Pscmdlet.ShouldProcess($destinstance, "Changing sa username to match source ($saName)")) {
+                                    try {
+                                        $destSa.Rename($saName)
+                                        $destSa.Alter()
+                                    } catch {
+                                        Write-Message -Level Verbose -Message "Could not change sa username to match source ($saName) on $destinstance | $PSItem"
+                                    }
+                                }
+                            }
+                        }
+                    } finally {
+                        Restore-DatabaseContext -Server $destServer -Database $destCallerDatabase
                     }
                 }
+            } finally {
+                Restore-DatabaseContext -Server $sourceServer -Database $sourceCallerDatabase
             }
         }
     }

--- a/public/Find-DbaDbDisabledIndex.ps1
+++ b/public/Find-DbaDbDisabledIndex.ps1
@@ -137,32 +137,40 @@ function Find-DbaDbDisabledIndex {
             }
 
             if ($databases.Count -gt 0) {
-                foreach ($db in $databases.name) {
+                # Working through a Database object moves the connection into that database and never moves it
+                # back - the query below runs there, and so does every enumeration of a database level
+                # collection. The database of the caller is put back when the work is done. See #10555.
+                $callerDatabase = $server.ConnectionContext.CurrentDatabase
+                try {
+                    foreach ($db in $databases.name) {
 
-                    if ($ExcludeDatabase -contains $db -or $null -eq $server.Databases[$db]) {
-                        continue
-                    }
-
-                    try {
-                        if ($PSCmdlet.ShouldProcess($db, "Getting disabled indexes")) {
-                            Write-Message -Level Verbose -Message "Getting indexes from database '$db'."
-                            Write-Message -Level Debug -Message "SQL Statement: $sql"
-                            $disabledIndex = $server.Databases[$db].ExecuteWithResults($sql)
-
-                            if ($disabledIndex.Tables[0].Rows.Count -gt 0) {
-                                $results = $disabledIndex.Tables[0];
-                                if ($results.Count -gt 0 -or !([string]::IsNullOrEmpty($results))) {
-                                    foreach ($index in $results) {
-                                        $index
-                                    }
-                                }
-                            } else {
-                                Write-Message -Level Verbose -Message "No Disabled indexes found"
-                            }
+                        if ($ExcludeDatabase -contains $db -or $null -eq $server.Databases[$db]) {
+                            continue
                         }
-                    } catch {
-                        Stop-Function -Message "Issue gathering indexes" -Category InvalidOperation -InnerErrorRecord $_ -Target $db
+
+                        try {
+                            if ($PSCmdlet.ShouldProcess($db, "Getting disabled indexes")) {
+                                Write-Message -Level Verbose -Message "Getting indexes from database '$db'."
+                                Write-Message -Level Debug -Message "SQL Statement: $sql"
+                                $disabledIndex = $server.Databases[$db].Query($sql)
+
+                                if (@($disabledIndex).Count -gt 0) {
+                                    $results = $disabledIndex;
+                                    if ($results.Count -gt 0 -or !([string]::IsNullOrEmpty($results))) {
+                                        foreach ($index in $results) {
+                                            $index
+                                        }
+                                    }
+                                } else {
+                                    Write-Message -Level Verbose -Message "No Disabled indexes found"
+                                }
+                            }
+                        } catch {
+                            Stop-Function -Message "Issue gathering indexes" -Category InvalidOperation -InnerErrorRecord $_ -Target $db
+                        }
                     }
+                } finally {
+                    Restore-DatabaseContext -Server $server -Database $callerDatabase
                 }
             } else {
                 Write-Message -Level Verbose -Message "There are no databases to analyse."

--- a/public/Find-DbaObject.ps1
+++ b/public/Find-DbaObject.ps1
@@ -233,37 +233,19 @@ function Find-DbaObject {
                 $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
             }
 
-            foreach ($db in $dbs) {
-                Write-Message -Level Verbose -Message "Searching object names in database $db on $instance"
+            # Working through a Database object moves the connection into that database and never moves it
+            # back - the query below runs there, and so does every enumeration of a database level
+            # collection. The database of the caller is put back when the work is done. See #10555.
+            $callerDatabase = $server.ConnectionContext.CurrentDatabase
+            try {
+                foreach ($db in $dbs) {
+                    Write-Message -Level Verbose -Message "Searching object names in database $db on $instance"
 
-                Write-Message -Level Debug -Message $sqlObjects
-                $objectRows = $db.ExecuteWithResults($sqlObjects).Tables.Rows
+                    Write-Message -Level Debug -Message $sqlObjects
+                    $objectRows = $db.Query($sqlObjects)
 
-                foreach ($row in $objectRows) {
-                    if ($row.ObjectName -match $Pattern) {
-                        [PSCustomObject]@{
-                            ComputerName = $server.ComputerName
-                            SqlInstance  = $server.ServiceName
-                            Database     = $db.Name
-                            Schema       = $row.SchemaName
-                            Name         = $row.ObjectName
-                            ObjectType   = $row.ObjectType
-                            MatchType    = "ObjectName"
-                            ColumnName   = $null
-                            CreateDate   = $row.CreateDate
-                            LastModified = $row.LastModified
-                        }
-                    }
-                }
-
-                if ($IncludeColumns) {
-                    Write-Message -Level Verbose -Message "Searching column names in database $db on $instance"
-
-                    Write-Message -Level Debug -Message $sqlColumns
-                    $columnRows = $db.ExecuteWithResults($sqlColumns).Tables.Rows
-
-                    foreach ($row in $columnRows) {
-                        if ($row.ColumnName -match $Pattern) {
+                    foreach ($row in $objectRows) {
+                        if ($row.ObjectName -match $Pattern) {
                             [PSCustomObject]@{
                                 ComputerName = $server.ComputerName
                                 SqlInstance  = $server.ServiceName
@@ -271,14 +253,40 @@ function Find-DbaObject {
                                 Schema       = $row.SchemaName
                                 Name         = $row.ObjectName
                                 ObjectType   = $row.ObjectType
-                                MatchType    = "ColumnName"
-                                ColumnName   = $row.ColumnName
+                                MatchType    = "ObjectName"
+                                ColumnName   = $null
                                 CreateDate   = $row.CreateDate
                                 LastModified = $row.LastModified
                             }
                         }
                     }
+
+                    if ($IncludeColumns) {
+                        Write-Message -Level Verbose -Message "Searching column names in database $db on $instance"
+
+                        Write-Message -Level Debug -Message $sqlColumns
+                        $columnRows = $db.Query($sqlColumns)
+
+                        foreach ($row in $columnRows) {
+                            if ($row.ColumnName -match $Pattern) {
+                                [PSCustomObject]@{
+                                    ComputerName = $server.ComputerName
+                                    SqlInstance  = $server.ServiceName
+                                    Database     = $db.Name
+                                    Schema       = $row.SchemaName
+                                    Name         = $row.ObjectName
+                                    ObjectType   = $row.ObjectType
+                                    MatchType    = "ColumnName"
+                                    ColumnName   = $row.ColumnName
+                                    CreateDate   = $row.CreateDate
+                                    LastModified = $row.LastModified
+                                }
+                            }
+                        }
+                    }
                 }
+            } finally {
+                Restore-DatabaseContext -Server $server -Database $callerDatabase
             }
         }
     }

--- a/public/Find-DbaOrphanedFile.ps1
+++ b/public/Find-DbaOrphanedFile.ps1
@@ -294,12 +294,20 @@ function Find-DbaOrphanedFile {
             $dbfiletable.Tables[0].TableName = "data"
 
             # Add support for Full Text Catalogs in Sql Server 2005 and below
-            if ($server.VersionMajor -lt 10) {
+            # The version is read from the server this function was given and not from the $server of the
+            # caller, which it used to reach into from here.
+            if ($smoserver.VersionMajor -lt 10) {
                 $databaselist = $smoserver.Databases | Select-Object -Property Name, IsFullTextEnabled
                 foreach ($db in $databaselist | Where-Object IsFullTextEnabled) {
                     $database = $db.Name
-                    $fttable = $null = $smoserver.Databases[$database].ExecuteWithResults('sp_help_fulltext_catalogs')
-                    foreach ($ftc in $fttable.Tables[0].Rows) {
+                    # This used to read "$fttable = $null = ...", which assigns $null to $fttable and threw
+                    # the catalogs away, so no full text catalog path was ever added below.
+                    # The Query script method is used instead of ExecuteWithResults of SMO because both run
+                    # the procedure in that database by issuing a USE on the connection context of the parent
+                    # server, which belongs to the caller, and only ours puts the previous database back.
+                    # It returns the rows, so there is no table to unwrap. See #10555.
+                    $fttable = $smoserver.Databases[$database].Query("sp_help_fulltext_catalogs")
+                    foreach ($ftc in $fttable) {
                         $null = $ftfiletable.Rows.Add($ftc.Path)
                     }
                 }
@@ -360,7 +368,8 @@ function Find-DbaOrphanedFile {
                 $userpaths = $Path | ForEach-Object { $_.TrimEnd("\") } | Sort-Object -Unique
             }
             $sql = Get-SQLDirTreeQuery -SqlPathList $sqlpaths -UserPathList $userpaths -FileTypes $fileTypeComparison -SystemFiles $systemfiles -Recurse:$Recurse -ServerMajorVersion $server.VersionMajor
-            $dirtreefiles = $server.Databases['master'].ExecuteWithResults($sql).Tables[0] | ForEach-Object {
+            # Through the Query script method, which puts the database of the caller back afterwards. See #10555.
+            $dirtreefiles = $server.Databases["master"].Query($sql) | ForEach-Object {
                 [PSCustomObject]@{
                     FullPath   = $_.Fullpath
                     Comparison = [IO.Path]::GetFullPath($(Format-Path $_.Fullpath))

--- a/public/Find-DbaStoredProcedure.ps1
+++ b/public/Find-DbaStoredProcedure.ps1
@@ -149,47 +149,55 @@ function Find-DbaStoredProcedure {
 
             $totalcount = 0
             $dbcount = $dbs.count
-            foreach ($db in $dbs) {
-                Write-Message -Level Verbose -Message "Searching on database $db"
+            # Working through a Database object moves the connection into that database and never moves it
+            # back - the query below runs there, and so does every enumeration of a database level
+            # collection. The database of the caller is put back when the work is done. See #10555.
+            $callerDatabase = $server.ConnectionContext.CurrentDatabase
+            try {
+                foreach ($db in $dbs) {
+                    Write-Message -Level Verbose -Message "Searching on database $db"
 
-                Write-Message -Level Debug -Message $sql
-                $rows = $db.ExecuteWithResults($sql).Tables.Rows
-                $sproccount = 0
+                    Write-Message -Level Debug -Message $sql
+                    $rows = $db.Query($sql)
+                    $sproccount = 0
 
-                foreach ($row in $rows) {
-                    $totalcount++; $sproccount++; $everyserverspcount++
+                    foreach ($row in $rows) {
+                        $totalcount++; $sproccount++; $everyserverspcount++
 
-                    $procSchema = $row.ProcSchema
-                    $proc = $row.Name
+                        $procSchema = $row.ProcSchema
+                        $proc = $row.Name
 
-                    Write-Message -Level Verbose -Message "Looking in stored procedure: $procSchema.$proc textBody for $pattern"
-                    if ($row.TextBody -match $Pattern) {
-                        $sp = $db.StoredProcedures | Where-Object { $_.Schema -eq $procSchema -and $_.Name -eq $proc }
+                        Write-Message -Level Verbose -Message "Looking in stored procedure: $procSchema.$proc textBody for $pattern"
+                        if ($row.TextBody -match $Pattern) {
+                            $sp = $db.StoredProcedures | Where-Object { $_.Schema -eq $procSchema -and $_.Name -eq $proc }
 
-                        $StoredProcedureText = $row.TextBody
-                        $splitOn = [string[]]@("`r`n", "`r", "`n" )
-                        $spTextFound = $StoredProcedureText.Split( $splitOn , [System.StringSplitOptions]::None ) |
-                            Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
+                            $StoredProcedureText = $row.TextBody
+                            $splitOn = [string[]]@("`r`n", "`r", "`n" )
+                            $spTextFound = $StoredProcedureText.Split( $splitOn , [System.StringSplitOptions]::None ) |
+                                Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
-                        [PSCustomObject]@{
-                            ComputerName             = $server.ComputerName
-                            SqlInstance              = $server.ServiceName
-                            Database                 = $db.Name
-                            DatabaseId               = $db.ID
-                            Schema                   = $sp.Schema
-                            Name                     = $sp.Name
-                            Owner                    = $sp.Owner
-                            IsSystemObject           = $sp.IsSystemObject
-                            CreateDate               = $sp.CreateDate
-                            LastModified             = $sp.DateLastModified
-                            StoredProcedureTextFound = $spTextFound -join [System.Environment]::NewLine
-                            StoredProcedure          = $sp
-                            StoredProcedureFullText  = $StoredProcedureText
-                        } | Select-DefaultView -ExcludeProperty StoredProcedure, StoredProcedureFullText
+                            [PSCustomObject]@{
+                                ComputerName             = $server.ComputerName
+                                SqlInstance              = $server.ServiceName
+                                Database                 = $db.Name
+                                DatabaseId               = $db.ID
+                                Schema                   = $sp.Schema
+                                Name                     = $sp.Name
+                                Owner                    = $sp.Owner
+                                IsSystemObject           = $sp.IsSystemObject
+                                CreateDate               = $sp.CreateDate
+                                LastModified             = $sp.DateLastModified
+                                StoredProcedureTextFound = $spTextFound -join [System.Environment]::NewLine
+                                StoredProcedure          = $sp
+                                StoredProcedureFullText  = $StoredProcedureText
+                            } | Select-DefaultView -ExcludeProperty StoredProcedure, StoredProcedureFullText
+                        }
                     }
-                }
 
-                Write-Message -Level Verbose -Message "Evaluated $sproccount stored procedures in $db"
+                    Write-Message -Level Verbose -Message "Evaluated $sproccount stored procedures in $db"
+                }
+            } finally {
+                Restore-DatabaseContext -Server $server -Database $callerDatabase
             }
             Write-Message -Level Verbose -Message "Evaluated $totalcount total stored procedures in $dbcount databases"
         }

--- a/public/Find-DbaTrigger.ps1
+++ b/public/Find-DbaTrigger.ps1
@@ -194,167 +194,175 @@ function Find-DbaTrigger {
             $dbcount = $dbs.count
 
             if ($TriggerLevel -in @('All', 'Database', 'Object')) {
-                foreach ($db in $dbs) {
+                # Working through a Database object moves the connection into that database and never moves it
+                # back - the query below runs there, and so does every enumeration of a database level
+                # collection. The database of the caller is put back when the work is done. See #10555.
+                $callerDatabase = $server.ConnectionContext.CurrentDatabase
+                try {
+                    foreach ($db in $dbs) {
 
-                    Write-Message -Level Verbose -Message "Searching on database $db"
+                        Write-Message -Level Verbose -Message "Searching on database $db"
 
-                    # If system objects aren't needed, find trigger text using SQL
-                    # This prevents SMO from having to enumerate
+                        # If system objects aren't needed, find trigger text using SQL
+                        # This prevents SMO from having to enumerate
 
-                    if (!$IncludeSystemObjects) {
-                        if ($TriggerLevel -in @('All', 'Database')) {
-                            #Get Database Level triggers (DDL)
-                            Write-Message -Level Debug -Message $sqlDatabaseTriggers
-                            $rows = $db.ExecuteWithResults($sqlDatabaseTriggers).Tables.Rows
-                            $triggercount = 0
+                        if (!$IncludeSystemObjects) {
+                            if ($TriggerLevel -in @('All', 'Database')) {
+                                #Get Database Level triggers (DDL)
+                                Write-Message -Level Debug -Message $sqlDatabaseTriggers
+                                $rows = $db.Query($sqlDatabaseTriggers)
+                                $triggercount = 0
 
-                            foreach ($row in $rows) {
-                                $totalcount++; $triggercount++; $everyserverstcount++
+                                foreach ($row in $rows) {
+                                    $totalcount++; $triggercount++; $everyserverstcount++
 
-                                $trigger = $row.name
+                                    $trigger = $row.name
 
-                                Write-Message -Level Verbose -Message "Looking in trigger $trigger for textBody with pattern $pattern on database $db"
-                                if ($row.TextBody -match $Pattern) {
-                                    $tr = $db.Triggers | Where-Object name -eq $row.name
+                                    Write-Message -Level Verbose -Message "Looking in trigger $trigger for textBody with pattern $pattern on database $db"
+                                    if ($row.TextBody -match $Pattern) {
+                                        $tr = $db.Triggers | Where-Object name -eq $row.name
 
-                                    $triggerText = $tr.TextBody.split($eol)
-                                    $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
+                                        $triggerText = $tr.TextBody.split($eol)
+                                        $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
-                                    [PSCustomObject]@{
-                                        ComputerName     = $server.ComputerName
-                                        SqlInstance      = $server.ServiceName
-                                        TriggerLevel     = "Database"
-                                        Database         = $db.name
-                                        DatabaseId       = $db.ID
-                                        Object           = $tr.Parent
-                                        Name             = $tr.Name
-                                        IsSystemObject   = $tr.IsSystemObject
-                                        CreateDate       = $tr.CreateDate
-                                        LastModified     = $tr.DateLastModified
-                                        TriggerTextFound = $trTextFound -join "`n"
-                                        Trigger          = $tr
-                                        TriggerFullText  = $tr.TextBody
-                                    } | Select-DefaultView -ExcludeProperty Trigger, TriggerFullText
-                                }
-                            }
-                        }
-
-                        if ($TriggerLevel -in @('All', 'Object')) {
-                            #Get Object Level triggers (DML)
-                            Write-Message -Level Debug -Message $sqlTableTriggers
-                            $rows = $db.ExecuteWithResults($sqlTableTriggers).Tables.Rows
-                            $triggercount = 0
-
-                            foreach ($row in $rows) {
-                                $totalcount++; $triggercount++; $everyserverstcount++
-
-                                $trigger = $row.name
-                                $triggerParentSchema = $row.TableSchema
-                                $triggerParent = $row.TableName
-
-                                Write-Message -Level Verbose -Message "Looking in trigger $trigger for textBody with pattern $pattern in object $triggerParentSchema.$triggerParent at database $db"
-                                if ($row.TextBody -match $Pattern) {
-
-                                    $tr = ($db.Tables | Where-Object { $_.Name -eq $triggerParent -and $_.Schema -eq $triggerParentSchema }).Triggers | Where-Object name -eq $row.name
-                                    if ($null -eq $tr) {
-                                        Write-Message -Level Verbose -Message "Could not find table named $($row.Name). Will try to find on Views."
-                                        $tr = ($db.Views | Where-Object { $_.Name -eq $triggerParent -and $_.Schema -eq $triggerParentSchema }).Triggers | Where-Object name -eq $row.name
+                                        [PSCustomObject]@{
+                                            ComputerName     = $server.ComputerName
+                                            SqlInstance      = $server.ServiceName
+                                            TriggerLevel     = "Database"
+                                            Database         = $db.name
+                                            DatabaseId       = $db.ID
+                                            Object           = $tr.Parent
+                                            Name             = $tr.Name
+                                            IsSystemObject   = $tr.IsSystemObject
+                                            CreateDate       = $tr.CreateDate
+                                            LastModified     = $tr.DateLastModified
+                                            TriggerTextFound = $trTextFound -join "`n"
+                                            Trigger          = $tr
+                                            TriggerFullText  = $tr.TextBody
+                                        } | Select-DefaultView -ExcludeProperty Trigger, TriggerFullText
                                     }
+                                }
+                            }
 
-                                    $triggerText = $tr.TextBody.split($eol)
-                                    $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
+                            if ($TriggerLevel -in @('All', 'Object')) {
+                                #Get Object Level triggers (DML)
+                                Write-Message -Level Debug -Message $sqlTableTriggers
+                                $rows = $db.Query($sqlTableTriggers)
+                                $triggercount = 0
 
-                                    [PSCustomObject]@{
-                                        ComputerName     = $server.ComputerName
-                                        SqlInstance      = $server.ServiceName
-                                        TriggerLevel     = "Object"
-                                        Database         = $db.name
-                                        DatabaseId       = $db.ID
-                                        Object           = $tr.Parent
-                                        Name             = $tr.Name
-                                        IsSystemObject   = $tr.IsSystemObject
-                                        CreateDate       = $tr.CreateDate
-                                        LastModified     = $tr.DateLastModified
-                                        TriggerTextFound = $trTextFound -join "`n"
-                                        Trigger          = $tr
-                                        TriggerFullText  = $tr.TextBody
-                                    } | Select-DefaultView -ExcludeProperty Trigger, TriggerFullText
+                                foreach ($row in $rows) {
+                                    $totalcount++; $triggercount++; $everyserverstcount++
+
+                                    $trigger = $row.name
+                                    $triggerParentSchema = $row.TableSchema
+                                    $triggerParent = $row.TableName
+
+                                    Write-Message -Level Verbose -Message "Looking in trigger $trigger for textBody with pattern $pattern in object $triggerParentSchema.$triggerParent at database $db"
+                                    if ($row.TextBody -match $Pattern) {
+
+                                        $tr = ($db.Tables | Where-Object { $_.Name -eq $triggerParent -and $_.Schema -eq $triggerParentSchema }).Triggers | Where-Object name -eq $row.name
+                                        if ($null -eq $tr) {
+                                            Write-Message -Level Verbose -Message "Could not find table named $($row.Name). Will try to find on Views."
+                                            $tr = ($db.Views | Where-Object { $_.Name -eq $triggerParent -and $_.Schema -eq $triggerParentSchema }).Triggers | Where-Object name -eq $row.name
+                                        }
+
+                                        $triggerText = $tr.TextBody.split($eol)
+                                        $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
+
+                                        [PSCustomObject]@{
+                                            ComputerName     = $server.ComputerName
+                                            SqlInstance      = $server.ServiceName
+                                            TriggerLevel     = "Object"
+                                            Database         = $db.name
+                                            DatabaseId       = $db.ID
+                                            Object           = $tr.Parent
+                                            Name             = $tr.Name
+                                            IsSystemObject   = $tr.IsSystemObject
+                                            CreateDate       = $tr.CreateDate
+                                            LastModified     = $tr.DateLastModified
+                                            TriggerTextFound = $trTextFound -join "`n"
+                                            Trigger          = $tr
+                                            TriggerFullText  = $tr.TextBody
+                                        } | Select-DefaultView -ExcludeProperty Trigger, TriggerFullText
+                                    }
+                                }
+                            }
+                        } else {
+                            if ($TriggerLevel -in @('All', 'Database')) {
+                                #Get Database Level triggers (DDL)
+                                $triggers = $db.Triggers
+
+                                $triggercount = 0
+
+                                foreach ($tr in $triggers) {
+                                    $totalcount++; $triggercount++; $everyserverstcount++
+                                    $trigger = $tr.Name
+
+                                    Write-Message -Level Verbose -Message "Looking in trigger $trigger for textBody with pattern $pattern on database $db"
+                                    if ($tr.TextBody -match $Pattern) {
+
+                                        $triggerText = $tr.TextBody.split($eol)
+                                        $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
+
+                                        [PSCustomObject]@{
+                                            ComputerName     = $server.ComputerName
+                                            SqlInstance      = $server.ServiceName
+                                            TriggerLevel     = "Database"
+                                            Database         = $db.name
+                                            DatabaseId       = $db.ID
+                                            Object           = $tr.Parent
+                                            Name             = $tr.Name
+                                            IsSystemObject   = $tr.IsSystemObject
+                                            CreateDate       = $tr.CreateDate
+                                            LastModified     = $tr.DateLastModified
+                                            TriggerTextFound = $trTextFound -join "`n"
+                                            Trigger          = $tr
+                                            TriggerFullText  = $tr.TextBody
+                                        } | Select-DefaultView -ExcludeProperty Trigger, TriggerFullText
+                                    }
+                                }
+                            }
+
+                            if ($TriggerLevel -in @('All', 'Object')) {
+                                #Get Object Level triggers (DML)
+                                $triggers = $db.Tables | ForEach-Object { $_.Triggers }
+                                $triggers += $db.Views | ForEach-Object { $_.Triggers }
+
+                                $triggercount = 0
+
+                                foreach ($tr in $triggers) {
+                                    $totalcount++; $triggercount++; $everyserverstcount++
+                                    $trigger = $tr.Name
+
+                                    Write-Message -Level Verbose -Message "Looking in trigger $trigger for textBody with pattern $pattern in object $($tr.Parent) at database $db"
+                                    if ($tr.TextBody -match $Pattern) {
+
+                                        $triggerText = $tr.TextBody.split($eol)
+                                        $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
+
+                                        [PSCustomObject]@{
+                                            ComputerName     = $server.ComputerName
+                                            SqlInstance      = $server.ServiceName
+                                            TriggerLevel     = "Object"
+                                            Database         = $db.name
+                                            DatabaseId       = $db.ID
+                                            Object           = $tr.Parent
+                                            Name             = $tr.Name
+                                            IsSystemObject   = $tr.IsSystemObject
+                                            CreateDate       = $tr.CreateDate
+                                            LastModified     = $tr.DateLastModified
+                                            TriggerTextFound = $trTextFound -join "`n"
+                                            Trigger          = $tr
+                                            TriggerFullText  = $tr.TextBody
+                                        } | Select-DefaultView -ExcludeProperty Trigger, TriggerFullText
+                                    }
                                 }
                             }
                         }
-                    } else {
-                        if ($TriggerLevel -in @('All', 'Database')) {
-                            #Get Database Level triggers (DDL)
-                            $triggers = $db.Triggers
-
-                            $triggercount = 0
-
-                            foreach ($tr in $triggers) {
-                                $totalcount++; $triggercount++; $everyserverstcount++
-                                $trigger = $tr.Name
-
-                                Write-Message -Level Verbose -Message "Looking in trigger $trigger for textBody with pattern $pattern on database $db"
-                                if ($tr.TextBody -match $Pattern) {
-
-                                    $triggerText = $tr.TextBody.split($eol)
-                                    $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
-
-                                    [PSCustomObject]@{
-                                        ComputerName     = $server.ComputerName
-                                        SqlInstance      = $server.ServiceName
-                                        TriggerLevel     = "Database"
-                                        Database         = $db.name
-                                        DatabaseId       = $db.ID
-                                        Object           = $tr.Parent
-                                        Name             = $tr.Name
-                                        IsSystemObject   = $tr.IsSystemObject
-                                        CreateDate       = $tr.CreateDate
-                                        LastModified     = $tr.DateLastModified
-                                        TriggerTextFound = $trTextFound -join "`n"
-                                        Trigger          = $tr
-                                        TriggerFullText  = $tr.TextBody
-                                    } | Select-DefaultView -ExcludeProperty Trigger, TriggerFullText
-                                }
-                            }
-                        }
-
-                        if ($TriggerLevel -in @('All', 'Object')) {
-                            #Get Object Level triggers (DML)
-                            $triggers = $db.Tables | ForEach-Object { $_.Triggers }
-                            $triggers += $db.Views | ForEach-Object { $_.Triggers }
-
-                            $triggercount = 0
-
-                            foreach ($tr in $triggers) {
-                                $totalcount++; $triggercount++; $everyserverstcount++
-                                $trigger = $tr.Name
-
-                                Write-Message -Level Verbose -Message "Looking in trigger $trigger for textBody with pattern $pattern in object $($tr.Parent) at database $db"
-                                if ($tr.TextBody -match $Pattern) {
-
-                                    $triggerText = $tr.TextBody.split($eol)
-                                    $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
-
-                                    [PSCustomObject]@{
-                                        ComputerName     = $server.ComputerName
-                                        SqlInstance      = $server.ServiceName
-                                        TriggerLevel     = "Object"
-                                        Database         = $db.name
-                                        DatabaseId       = $db.ID
-                                        Object           = $tr.Parent
-                                        Name             = $tr.Name
-                                        IsSystemObject   = $tr.IsSystemObject
-                                        CreateDate       = $tr.CreateDate
-                                        LastModified     = $tr.DateLastModified
-                                        TriggerTextFound = $trTextFound -join "`n"
-                                        Trigger          = $tr
-                                        TriggerFullText  = $tr.TextBody
-                                    } | Select-DefaultView -ExcludeProperty Trigger, TriggerFullText
-                                }
-                            }
-                        }
+                        Write-Message -Level Verbose -Message "Evaluated $triggercount triggers in $db"
                     }
-                    Write-Message -Level Verbose -Message "Evaluated $triggercount triggers in $db"
+                } finally {
+                    Restore-DatabaseContext -Server $server -Database $callerDatabase
                 }
             }
             Write-Message -Level Verbose -Message "Evaluated $totalcount total triggers in $dbcount databases"

--- a/public/Find-DbaView.ps1
+++ b/public/Find-DbaView.ps1
@@ -150,81 +150,89 @@ function Find-DbaView {
 
             $totalcount = 0
             $dbcount = $dbs.count
-            foreach ($db in $dbs) {
-                Write-Message -Level Verbose -Message "Searching on database $db"
+            # Working through a Database object moves the connection into that database and never moves it
+            # back - the query below runs there, and so does every enumeration of a database level
+            # collection. The database of the caller is put back when the work is done. See #10555.
+            $callerDatabase = $server.ConnectionContext.CurrentDatabase
+            try {
+                foreach ($db in $dbs) {
+                    Write-Message -Level Verbose -Message "Searching on database $db"
 
-                # If system objects aren't needed, find view text using SQL
-                # This prevents SMO from having to enumerate
+                    # If system objects aren't needed, find view text using SQL
+                    # This prevents SMO from having to enumerate
 
-                if (!$IncludeSystemObjects) {
-                    Write-Message -Level Debug -Message $sql
-                    $rows = $db.ExecuteWithResults($sql).Tables.Rows
-                    $vwcount = 0
+                    if (!$IncludeSystemObjects) {
+                        Write-Message -Level Debug -Message $sql
+                        $rows = $db.Query($sql)
+                        $vwcount = 0
 
-                    foreach ($row in $rows) {
-                        $totalcount++; $vwcount++; $everyservervwcount++
+                        foreach ($row in $rows) {
+                            $totalcount++; $vwcount++; $everyservervwcount++
 
-                        $viewSchema = $row.ViewSchema
-                        $view = $row.name
+                            $viewSchema = $row.ViewSchema
+                            $view = $row.name
 
-                        Write-Message -Level Verbose -Message "Looking in View: $viewSchema.$view TextBody for $pattern"
-                        if ($row.TextBody -match $Pattern) {
-                            $vw = $db.Views | Where-Object { $_.Schema -eq $viewSchema -and $_.Name -eq $view }
+                            Write-Message -Level Verbose -Message "Looking in View: $viewSchema.$view TextBody for $pattern"
+                            if ($row.TextBody -match $Pattern) {
+                                $vw = $db.Views | Where-Object { $_.Schema -eq $viewSchema -and $_.Name -eq $view }
 
-                            $viewText = $vw.TextBody.split($eol)
-                            $vwTextFound = $viewText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
+                                $viewText = $vw.TextBody.split($eol)
+                                $vwTextFound = $viewText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
-                            [PSCustomObject]@{
-                                ComputerName   = $server.ComputerName
-                                SqlInstance    = $server.ServiceName
-                                Database       = $db.Name
-                                DatabaseId     = $db.ID
-                                Schema         = $vw.Schema
-                                Name           = $vw.Name
-                                Owner          = $vw.Owner
-                                IsSystemObject = $vw.IsSystemObject
-                                CreateDate     = $vw.CreateDate
-                                LastModified   = $vw.DateLastModified
-                                ViewTextFound  = $vwTextFound -join "`n"
-                                View           = $vw
-                                ViewFullText   = $vw.TextBody
-                            } | Select-DefaultView -ExcludeProperty View, ViewFullText
+                                [PSCustomObject]@{
+                                    ComputerName   = $server.ComputerName
+                                    SqlInstance    = $server.ServiceName
+                                    Database       = $db.Name
+                                    DatabaseId     = $db.ID
+                                    Schema         = $vw.Schema
+                                    Name           = $vw.Name
+                                    Owner          = $vw.Owner
+                                    IsSystemObject = $vw.IsSystemObject
+                                    CreateDate     = $vw.CreateDate
+                                    LastModified   = $vw.DateLastModified
+                                    ViewTextFound  = $vwTextFound -join "`n"
+                                    View           = $vw
+                                    ViewFullText   = $vw.TextBody
+                                } | Select-DefaultView -ExcludeProperty View, ViewFullText
+                            }
+                        }
+                    } else {
+                        $Views = $db.Views
+
+                        foreach ($vw in $Views) {
+                            $totalcount++; $vwcount++; $everyservervwcount++
+
+                            $viewSchema = $row.ViewSchema
+                            $view = $vw.Name
+
+                            Write-Message -Level Verbose -Message "Looking in View: $viewSchema.$view TextBody for $pattern"
+                            if ($vw.TextBody -match $Pattern) {
+
+                                $viewText = $vw.TextBody.split($eol)
+                                $vwTextFound = $viewText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
+
+                                [PSCustomObject]@{
+                                    ComputerName   = $server.ComputerName
+                                    SqlInstance    = $server.ServiceName
+                                    Database       = $db.Name
+                                    DatabaseId     = $db.ID
+                                    Schema         = $vw.Schema
+                                    Name           = $vw.Name
+                                    Owner          = $vw.Owner
+                                    IsSystemObject = $vw.IsSystemObject
+                                    CreateDate     = $vw.CreateDate
+                                    LastModified   = $vw.DateLastModified
+                                    ViewTextFound  = $vwTextFound -join "`n"
+                                    View           = $vw
+                                    ViewFullText   = $vw.TextBody
+                                } | Select-DefaultView -ExcludeProperty View, ViewFullText
+                            }
                         }
                     }
-                } else {
-                    $Views = $db.Views
-
-                    foreach ($vw in $Views) {
-                        $totalcount++; $vwcount++; $everyservervwcount++
-
-                        $viewSchema = $row.ViewSchema
-                        $view = $vw.Name
-
-                        Write-Message -Level Verbose -Message "Looking in View: $viewSchema.$view TextBody for $pattern"
-                        if ($vw.TextBody -match $Pattern) {
-
-                            $viewText = $vw.TextBody.split($eol)
-                            $vwTextFound = $viewText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
-
-                            [PSCustomObject]@{
-                                ComputerName   = $server.ComputerName
-                                SqlInstance    = $server.ServiceName
-                                Database       = $db.Name
-                                DatabaseId     = $db.ID
-                                Schema         = $vw.Schema
-                                Name           = $vw.Name
-                                Owner          = $vw.Owner
-                                IsSystemObject = $vw.IsSystemObject
-                                CreateDate     = $vw.CreateDate
-                                LastModified   = $vw.DateLastModified
-                                ViewTextFound  = $vwTextFound -join "`n"
-                                View           = $vw
-                                ViewFullText   = $vw.TextBody
-                            } | Select-DefaultView -ExcludeProperty View, ViewFullText
-                        }
-                    }
+                    Write-Message -Level Verbose -Message "Evaluated $vwcount views in $db"
                 }
-                Write-Message -Level Verbose -Message "Evaluated $vwcount views in $db"
+            } finally {
+                Restore-DatabaseContext -Server $server -Database $callerDatabase
             }
             Write-Message -Level Verbose -Message "Evaluated $totalcount total views in $dbcount databases"
         }

--- a/public/Get-DbaDbSpace.ps1
+++ b/public/Get-DbaDbSpace.ps1
@@ -182,6 +182,11 @@ function Get-DbaDbSpace {
                 Stop-Function -Message "SQL Server 2000 not supported. $server skipped." -Continue
             }
 
+            # Working through a Database object moves the connection into that database and never moves it
+            # back - the query below runs there, and so does every enumeration of a database level
+            # collection. The database of the caller is put back when the work is done. See #10555.
+            $callerDatabase = $server.ConnectionContext.CurrentDatabase
+
             try {
                 Write-Message -Level Verbose -Message "Querying $server - $db."
                 # Gated on IsAccessible alone. Status is a flags enum, so a database that merely has
@@ -194,7 +199,7 @@ function Get-DbaDbSpace {
                     continue
                 }
                 #Execute query against individual database and add to output
-                foreach ($row in ($db.ExecuteWithResults($sql)).Tables.Rows) {
+                foreach ($row in $db.Query($sql)) {
                     if ($row.UsedSpaceMB -is [System.DBNull]) {
                         $UsedMB = 0
                     } else {
@@ -254,6 +259,8 @@ function Get-DbaDbSpace {
                 }
             } catch {
                 Stop-Function -Message "Unable to query $server - $db." -Target $db -ErrorRecord $_ -Continue
+            } finally {
+                Restore-DatabaseContext -Server $server -Database $callerDatabase
             }
         }
     }

--- a/public/Get-DbaLastGoodCheckDb.ps1
+++ b/public/Get-DbaLastGoodCheckDb.ps1
@@ -158,89 +158,98 @@ function Get-DbaLastGoodCheckDb {
 
             foreach ($db in $databases) {
                 $server = $db.Parent
-                Write-Message -Level Verbose -Message "Processing $($db.Name) on $($server.Name)."
 
-                if ($db.IsAccessible -eq $false) {
-                    Stop-Function -Message "The database $($db.Name) is not accessible. Skipping database." -Continue -Target $db
-                }
+                # Working through a Database object moves the connection into that database and never moves it
+                # back - the query below runs there, and so does every enumeration of a database level
+                # collection. The database of the caller is put back when the work is done. See #10555.
+                $callerDatabase = $server.ConnectionContext.CurrentDatabase
+                try {
+                    Write-Message -Level Verbose -Message "Processing $($db.Name) on $($server.Name)."
 
-                $isAzure = $db.Parent.DatabaseEngineType -match "Azure"
-
-                if (-not $isAzure) {
-                    $isAdmin = $db.Parent.ConnectionContext.ExecuteScalar("SELECT IS_SRVROLEMEMBER('sysadmin')")
-                } else {
-                    $isAdmin = $false
-                }
-
-                if ($db.Parent.VersionMajor -lt 10 -or $isAdmin) {
-                    $dbNameQuoted = '[' + $db.Name.Replace(']', ']]') + ']'
-                    $sql = "DBCC DBINFO ($dbNameQuoted) WITH TABLERESULTS"
-                    Write-Message -Level Debug -Message "T-SQL: $sql"
-
-                    $resultTable = $db.ExecuteWithResults($sql).Tables[0]
-                    [datetime[]]$lastKnownGoodArray = $resultTable | Where-Object Field -eq 'dbi_dbccLastKnownGood' | Select-Object -ExpandProperty Value
-
-                    ## look for databases with two or more occurrences of the field dbi_dbccLastKnownGood
-                    if ($lastKnownGoodArray.count -ge 2) {
-                        Write-Message -Level Verbose -Message "The database $db has $($lastKnownGoodArray.count) dbi_dbccLastKnownGood fields. This script will only use the newest."
+                    if ($db.IsAccessible -eq $false) {
+                        Stop-Function -Message "The database $($db.Name) is not accessible. Skipping database." -Continue -Target $db
                     }
-                    [datetime]$lastKnownGood = $lastKnownGoodArray | Sort-Object -Descending | Select-Object -First 1
 
-                    [int]$createVersion = ($resultTable | Where-Object Field -eq 'dbi_createVersion').Value
-                    [int]$dbccFlags = ($resultTable | Where-Object Field -eq 'dbi_dbccFlags').Value
+                    $isAzure = $db.Parent.DatabaseEngineType -match "Azure"
 
-                    if (($createVersion -lt 611) -and ($dbccFlags -eq 0)) {
-                        $dataPurityEnabled = $false
+                    if (-not $isAzure) {
+                        $isAdmin = $db.Parent.ConnectionContext.ExecuteScalar("SELECT IS_SRVROLEMEMBER('sysadmin')")
                     } else {
-                        $dataPurityEnabled = $true
+                        $isAdmin = $false
                     }
-                } else {
-                    $lastKnownGood = $db.LastGoodCheckDbTime
-                    $dataPurityEnabled = $null
-                }
 
-                if ($lastKnownGood -isnot [datetime]) {
-                    $lastKnownGood = Get-Date '1/1/1900 12:00:00 AM'
-                }
+                    if ($db.Parent.VersionMajor -lt 10 -or $isAdmin) {
+                        $dbNameQuoted = '[' + $db.Name.Replace(']', ']]') + ']'
+                        $sql = "DBCC DBINFO ($dbNameQuoted) WITH TABLERESULTS"
+                        Write-Message -Level Debug -Message "T-SQL: $sql"
 
-                $datecreated = $db.createDate
-                if ($datecreated -isnot [datetime]) {
-                    $datecreated = Get-Date '1/1/1900 12:00:00 AM'
-                }
+                        $resultTable = $db.Query($sql)
+                        [datetime[]]$lastKnownGoodArray = $resultTable | Where-Object Field -eq 'dbi_dbccLastKnownGood' | Select-Object -ExpandProperty Value
 
-                $daysSinceCheckDb = (New-TimeSpan -Start $lastKnownGood -End (Get-Date)).Days
-                $daysSinceDbCreated = (New-TimeSpan -Start $datecreated -End (Get-Date)).TotalDays
+                        ## look for databases with two or more occurrences of the field dbi_dbccLastKnownGood
+                        if ($lastKnownGoodArray.count -ge 2) {
+                            Write-Message -Level Verbose -Message "The database $db has $($lastKnownGoodArray.count) dbi_dbccLastKnownGood fields. This script will only use the newest."
+                        }
+                        [datetime]$lastKnownGood = $lastKnownGoodArray | Sort-Object -Descending | Select-Object -First 1
 
-                if ($daysSinceCheckDb -lt 7) {
-                    $Status = 'Ok'
-                } elseif ($daysSinceDbCreated -lt 7) {
-                    $Status = 'New database, not checked yet'
-                } else {
-                    $Status = 'CheckDB should be performed'
-                }
+                        [int]$createVersion = ($resultTable | Where-Object Field -eq 'dbi_createVersion').Value
+                        [int]$dbccFlags = ($resultTable | Where-Object Field -eq 'dbi_dbccFlags').Value
 
-                if ($lastKnownGood -eq '1/1/1900 12:00:00 AM') {
-                    Remove-Variable -Name lastKnownGood, daysSinceCheckDb
-                }
+                        if (($createVersion -lt 611) -and ($dbccFlags -eq 0)) {
+                            $dataPurityEnabled = $false
+                        } else {
+                            $dataPurityEnabled = $true
+                        }
+                    } else {
+                        $lastKnownGood = $db.LastGoodCheckDbTime
+                        $dataPurityEnabled = $null
+                    }
 
-                if ($datecreated -eq '1/1/1900 12:00:00 AM') {
-                    Remove-Variable -Name datecreated
-                }
+                    if ($lastKnownGood -isnot [datetime]) {
+                        $lastKnownGood = Get-Date '1/1/1900 12:00:00 AM'
+                    }
+
+                    $datecreated = $db.createDate
+                    if ($datecreated -isnot [datetime]) {
+                        $datecreated = Get-Date '1/1/1900 12:00:00 AM'
+                    }
+
+                    $daysSinceCheckDb = (New-TimeSpan -Start $lastKnownGood -End (Get-Date)).Days
+                    $daysSinceDbCreated = (New-TimeSpan -Start $datecreated -End (Get-Date)).TotalDays
+
+                    if ($daysSinceCheckDb -lt 7) {
+                        $Status = 'Ok'
+                    } elseif ($daysSinceDbCreated -lt 7) {
+                        $Status = 'New database, not checked yet'
+                    } else {
+                        $Status = 'CheckDB should be performed'
+                    }
+
+                    if ($lastKnownGood -eq '1/1/1900 12:00:00 AM') {
+                        Remove-Variable -Name lastKnownGood, daysSinceCheckDb
+                    }
+
+                    if ($datecreated -eq '1/1/1900 12:00:00 AM') {
+                        Remove-Variable -Name datecreated
+                    }
 
 
-                [PSCustomObject]@{
-                    ComputerName             = $server.ComputerName
-                    InstanceName             = $server.ServiceName
-                    SqlInstance              = $server.DomainInstanceName
-                    Database                 = $db.name
-                    DatabaseCreated          = $db.createDate
-                    LastGoodCheckDb          = $lastKnownGood
-                    DaysSinceDbCreated       = $daysSinceDbCreated
-                    DaysSinceLastGoodCheckDb = $daysSinceCheckDb
-                    Status                   = $status
-                    DataPurityEnabled        = $dataPurityEnabled
-                    CreateVersion            = $createVersion
-                    DbccFlags                = $dbccFlags
+                    [PSCustomObject]@{
+                        ComputerName             = $server.ComputerName
+                        InstanceName             = $server.ServiceName
+                        SqlInstance              = $server.DomainInstanceName
+                        Database                 = $db.name
+                        DatabaseCreated          = $db.createDate
+                        LastGoodCheckDb          = $lastKnownGood
+                        DaysSinceDbCreated       = $daysSinceDbCreated
+                        DaysSinceLastGoodCheckDb = $daysSinceCheckDb
+                        Status                   = $status
+                        DataPurityEnabled        = $dataPurityEnabled
+                        CreateVersion            = $createVersion
+                        DbccFlags                = $dbccFlags
+                    }
+                } finally {
+                    Restore-DatabaseContext -Server $server -Database $callerDatabase
                 }
             }
         }

--- a/public/Get-DbaPermission.ps1
+++ b/public/Get-DbaPermission.ps1
@@ -356,20 +356,28 @@ function Get-DbaPermission {
                 $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
             }
 
-            foreach ($db in $dbs) {
-                Write-Message -Level Verbose -Message "Processing $db on $instance."
+            # Working through a Database object moves the connection into that database and never moves it
+            # back - the query below runs there, and so does every enumeration of a database level
+            # collection. The database of the caller is put back when the work is done. See #10555.
+            $callerDatabase = $server.ConnectionContext.CurrentDatabase
+            try {
+                foreach ($db in $dbs) {
+                    Write-Message -Level Verbose -Message "Processing $db on $instance."
 
-                if ($db.IsAccessible -eq $false) {
-                    Write-Message -Level Warning -Message "The database $db is not accessible. Skipping database."
-                    Continue
-                }
+                    if ($db.IsAccessible -eq $false) {
+                        Write-Message -Level Warning -Message "The database $db is not accessible. Skipping database."
+                        Continue
+                    }
 
-                Write-Message -Level Debug -Message "T-SQL: $currentDBPermsql"
-                try {
-                    $db.ExecuteWithResults($currentDBPermsql).Tables.Rows
-                } catch {
-                    Stop-Function -Message "Failure executing against $($db.Name) on $instance" -ErrorRecord $_ -Continue
+                    Write-Message -Level Debug -Message "T-SQL: $currentDBPermsql"
+                    try {
+                        $db.Query($currentDBPermsql)
+                    } catch {
+                        Stop-Function -Message "Failure executing against $($db.Name) on $instance" -ErrorRecord $_ -Continue
+                    }
                 }
+            } finally {
+                Restore-DatabaseContext -Server $server -Database $callerDatabase
             }
         }
     }

--- a/public/Get-DbaQueryExecutionTime.ps1
+++ b/public/Get-DbaQueryExecutionTime.ps1
@@ -238,38 +238,46 @@ function Get-DbaQueryExecutionTime {
                 $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
             }
 
-            foreach ($db in $dbs) {
-                Write-Message -Level Verbose -Message "Processing $db on $instance"
+            # Working through a Database object moves the connection into that database and never moves it
+            # back - the query below runs there, and so does every enumeration of a database level
+            # collection. The database of the caller is put back when the work is done. See #10555.
+            $callerDatabase = $server.ConnectionContext.CurrentDatabase
+            try {
+                foreach ($db in $dbs) {
+                    Write-Message -Level Verbose -Message "Processing $db on $instance"
 
-                if ($db.IsAccessible -eq $false) {
-                    Write-Message -Level Warning -Message "The database $db is not accessible. Skipping database."
-                    continue
-                }
-
-                try {
-                    foreach ($row in $db.ExecuteWithResults($sql).Tables.Rows) {
-                        [PSCustomObject]@{
-                            ComputerName       = $server.ComputerName
-                            InstanceName       = $server.ServiceName
-                            SqlInstance        = $server.DomainInstanceName
-                            Database           = $row.DatabaseName
-                            ProcName           = $row.ProcName
-                            ObjectID           = $row.object_id
-                            TypeDesc           = $row.type_desc
-                            Executions         = $row.Execution_Count
-                            AvgExecMs          = $row.AvgExec_ms
-                            MaxExecMs          = $row.MaxExec_ms
-                            CachedTime         = $row.cached_time
-                            LastExecTime       = $row.last_execution_time
-                            TotalWorkerTimeMs  = $row.total_worker_time_ms
-                            TotalElapsedTimeMs = $row.total_elapsed_time_ms
-                            SQLText            = $row.SQLText
-                            FullStatementText  = $row.full_statement_text
-                        } | Select-DefaultView -ExcludeProperty FullStatementText
+                    if ($db.IsAccessible -eq $false) {
+                        Write-Message -Level Warning -Message "The database $db is not accessible. Skipping database."
+                        continue
                     }
-                } catch {
-                    Stop-Function -Message "Could not process $db on $instance" -Target $db -ErrorRecord $_ -Continue
+
+                    try {
+                        foreach ($row in $db.Query($sql)) {
+                            [PSCustomObject]@{
+                                ComputerName       = $server.ComputerName
+                                InstanceName       = $server.ServiceName
+                                SqlInstance        = $server.DomainInstanceName
+                                Database           = $row.DatabaseName
+                                ProcName           = $row.ProcName
+                                ObjectID           = $row.object_id
+                                TypeDesc           = $row.type_desc
+                                Executions         = $row.Execution_Count
+                                AvgExecMs          = $row.AvgExec_ms
+                                MaxExecMs          = $row.MaxExec_ms
+                                CachedTime         = $row.cached_time
+                                LastExecTime       = $row.last_execution_time
+                                TotalWorkerTimeMs  = $row.total_worker_time_ms
+                                TotalElapsedTimeMs = $row.total_elapsed_time_ms
+                                SQLText            = $row.SQLText
+                                FullStatementText  = $row.full_statement_text
+                            } | Select-DefaultView -ExcludeProperty FullStatementText
+                        }
+                    } catch {
+                        Stop-Function -Message "Could not process $db on $instance" -Target $db -ErrorRecord $_ -Continue
+                    }
                 }
+            } finally {
+                Restore-DatabaseContext -Server $server -Database $callerDatabase
             }
         }
     }

--- a/public/Invoke-DbaDbDecryptObject.ps1
+++ b/public/Invoke-DbaDbDecryptObject.ps1
@@ -356,17 +356,22 @@ SELECT IS_SRVROLEMEMBER('sysadmin') AS IsSysadmin
                 $triggerSchema = @{label = "Schema"; expression = { $_.Parent.Schema } }
 
                 # Loop through each of databases
-                foreach ($db in $databaseCollection) {
+                # Working through a Database object moves the connection into that database and never moves it
+                # back - the queries below run there, and so does every enumeration of a database level
+                # collection. The database of the caller is put back when the work is done. See #10555.
+                $callerDatabase = $server.ConnectionContext.CurrentDatabase
+                try {
+                    foreach ($db in $databaseCollection) {
 
-                    # Create array list to hold the results. This starts empty for every database, because the
-                    # objects of one database must not be looked up again in the next one.
-                    $objectCollection = @()
+                        # Create array list to hold the results. This starts empty for every database, because the
+                        # objects of one database must not be looked up again in the next one.
+                        $objectCollection = @()
 
-                    # A trigger's collection hangs off its parent table, so asking every table for its triggers
-                    # costs one round trip per table: on a database of a thousand tables that is a thousand
-                    # queries, run even when the object asked for is a stored procedure. The tables that own an
-                    # encrypted trigger are identified in one query first, and only those are asked. A database
-                    # with no encrypted triggers touches no tables at all.
+                        # A trigger's collection hangs off its parent table, so asking every table for its triggers
+                        # costs one round trip per table: on a database of a thousand tables that is a thousand
+                        # queries, run even when the object asked for is a stored procedure. The tables that own an
+                        # encrypted trigger are identified in one query first, and only those are asked. A database
+                        # with no encrypted triggers touches no tables at all.
                     $queryTriggerParent = @"
 SELECT DISTINCT SCHEMA_NAME(p.schema_id) AS ParentSchema, p.name AS ParentName
 FROM sys.sql_modules AS m
@@ -377,241 +382,241 @@ AND t.type = 'TR'
 AND p.is_ms_shipped = 0
 "@
 
-                    $triggers = @(
-                        foreach ($triggerParent in @($db.Query($queryTriggerParent))) {
-                            # A trigger's parent is a table or a view, and an INSTEAD OF trigger on a view is
-                            # just as encryptable as one on a table. Looking only at tables silently skipped
-                            # those, so both collections are asked.
-                            $parentObject = $db.Tables[$triggerParent.ParentName, $triggerParent.ParentSchema]
-                            if ($null -eq $parentObject) {
-                                $parentObject = $db.Views[$triggerParent.ParentName, $triggerParent.ParentSchema]
-                            }
-                            if ($null -ne $parentObject) {
-                                $parentObject.Triggers
-                            }
-                        }
-                    )
-
-                    # Get the objects
-                    if ($ObjectName) {
-                        $storedProcedures = @($db.StoredProcedures | Where-Object { $_.Name -in $ObjectName -and $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "StoredProcedure" } }, @{N = "SubType"; E = { "" } })
-                        $functions = @($db.UserDefinedFunctions | Where-Object { $_.Name -in $ObjectName -and $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "UserDefinedFunction" } }, @{N = "SubType"; E = { $_.FunctionType.ToString().Trim() } })
-                        $views = @($db.Views | Where-Object { $_.Name -in $ObjectName -and $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "View" } }, @{N = "SubType"; E = { "" } })
-                        $triggers = @($triggers | Where-Object { $_.Name -in $ObjectName -and $_.IsEncrypted -eq $true } | Select-Object Name, $triggerSchema, ID, Parent, @{N = "ObjectType"; E = { "Trigger" } }, @{N = "SubType"; E = { "" } })
-                    } else {
-                        # Get all encrypted objects
-                        $storedProcedures = @($db.StoredProcedures | Where-Object { $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "StoredProcedure" } }, @{N = "SubType"; E = { "" } })
-                        $functions = @($db.UserDefinedFunctions | Where-Object { $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "UserDefinedFunction" } }, @{N = "SubType"; E = { $_.FunctionType.ToString().Trim() } })
-                        $views = @($db.Views | Where-Object { $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "View" } }, @{N = "SubType"; E = { "" } })
-                        $triggers = @($triggers | Where-Object { $_.IsEncrypted -eq $true } | Select-Object Name, $triggerSchema, ID, Parent, @{N = "ObjectType"; E = { "Trigger" } }, @{N = "SubType"; E = { "" } })
-                    }
-
-                    # Check if there are any objects
-                    if ($storedProcedures.Count -ge 1) {
-                        $objectCollection += $storedProcedures
-                    }
-                    if ($functions.Count -ge 1) {
-                        $objectCollection += $functions
-                    }
-                    if ($views.Count -ge 1) {
-                        $objectCollection += $views
-                    }
-                    if ($triggers.Count -ge 1) {
-                        $objectCollection += $triggers
-                    }
-
-                    # Both methods identify an object by its id rather than by its name. The method that
-                    # reads the data pages needs the id to pick the rows out of sys.sysobjvalues, and the
-                    # method that uses the dedicated admin connection needs it because an object name is
-                    # allowed to contain a single quote: splicing the name into an OBJECT_ID('...') literal
-                    # would let a crafted name end the literal early and run whatever followed it as a
-                    # further statement in the same batch, as sysadmin over the dedicated admin connection.
-                    # An id is a number, so nothing a name contains can reach the query text.
-                    #
-                    # The id is SMO's own ID property on each object, fetched as part of the enumeration
-                    # above rather than looked up afterwards by schema and name. A lookup keyed by
-                    # "$schema.$name" cannot be unambiguous, because either half may itself contain a dot:
-                    # schema [a], object [b.c] and schema [a.b], object [c] both key as "a.b.c", so whichever
-                    # of the two is read last silently overwrites the other's id in the map, and the object
-                    # that lost the race is then decrypted with the wrong ciphertext. Reading the id SMO
-                    # already carries on the object needs no key at all, so two objects sharing a dotted name
-                    # can no longer collide.
-
-                    # Without a dedicated admin connection the ciphertext of every requested object is read in
-                    # a single pass over the data pages of sys.sysobjvalues, because reading those pages is by
-                    # far the most expensive part. The family GUID of the database and the object ids are the
-                    # only other inputs that rebuilding the keystream needs.
-                    if ($DataPages) {
-                        $familyGuid = $null
-                        $imageValueMap = @{ }
-
-                        try {
-                            $familyGuidRow = @($db.Query("DBCC DBINFO WITH TABLERESULTS") | Where-Object Field -eq "dbi_familyGUID")
-                        } catch {
-                            Stop-Function -Message "Couldn't read dbi_familyGUID of database $($db.Name) on $instance" -ErrorRecord $_ -Target $instance -Continue
-                        }
-
-                        if ($familyGuidRow.Count -eq 0) {
-                            Stop-Function -Message "Couldn't read dbi_familyGUID of database $($db.Name) on $instance" -Target $instance -Continue
-                        }
-                        $familyGuid = [guid]$familyGuidRow[0].VALUE
-
-                        $wantedObjectId = @($objectCollection.ID)
-
-                        if ($wantedObjectId.Count -ge 1) {
-                            try {
-                                foreach ($imageValue in (Get-EncryptedObjectImageValue -Database $db -ObjectId $wantedObjectId)) {
-                                    if (-not $imageValueMap.ContainsKey($imageValue.ObjectId)) {
-                                        $imageValueMap[$imageValue.ObjectId] = @()
-                                    }
-                                    $imageValueMap[$imageValue.ObjectId] += $imageValue
+                        $triggers = @(
+                            foreach ($triggerParent in @($db.Query($queryTriggerParent))) {
+                                # A trigger's parent is a table or a view, and an INSTEAD OF trigger on a view is
+                                # just as encryptable as one on a table. Looking only at tables silently skipped
+                                # those, so both collections are asked.
+                                $parentObject = $db.Tables[$triggerParent.ParentName, $triggerParent.ParentSchema]
+                                if ($null -eq $parentObject) {
+                                    $parentObject = $db.Views[$triggerParent.ParentName, $triggerParent.ParentSchema]
                                 }
-                            } catch {
-                                Stop-Function -Message "Couldn't read the encrypted definitions from the data pages of database $($db.Name) on $instance" -ErrorRecord $_ -Target $instance -Continue
+                                if ($null -ne $parentObject) {
+                                    $parentObject.Triggers
+                                }
                             }
+                        )
+
+                        # Get the objects
+                        if ($ObjectName) {
+                            $storedProcedures = @($db.StoredProcedures | Where-Object { $_.Name -in $ObjectName -and $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "StoredProcedure" } }, @{N = "SubType"; E = { "" } })
+                            $functions = @($db.UserDefinedFunctions | Where-Object { $_.Name -in $ObjectName -and $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "UserDefinedFunction" } }, @{N = "SubType"; E = { $_.FunctionType.ToString().Trim() } })
+                            $views = @($db.Views | Where-Object { $_.Name -in $ObjectName -and $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "View" } }, @{N = "SubType"; E = { "" } })
+                            $triggers = @($triggers | Where-Object { $_.Name -in $ObjectName -and $_.IsEncrypted -eq $true } | Select-Object Name, $triggerSchema, ID, Parent, @{N = "ObjectType"; E = { "Trigger" } }, @{N = "SubType"; E = { "" } })
+                        } else {
+                            # Get all encrypted objects
+                            $storedProcedures = @($db.StoredProcedures | Where-Object { $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "StoredProcedure" } }, @{N = "SubType"; E = { "" } })
+                            $functions = @($db.UserDefinedFunctions | Where-Object { $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "UserDefinedFunction" } }, @{N = "SubType"; E = { $_.FunctionType.ToString().Trim() } })
+                            $views = @($db.Views | Where-Object { $_.IsEncrypted -eq $true } | Select-Object Name, Schema, ID, @{N = "ObjectType"; E = { "View" } }, @{N = "SubType"; E = { "" } })
+                            $triggers = @($triggers | Where-Object { $_.IsEncrypted -eq $true } | Select-Object Name, $triggerSchema, ID, Parent, @{N = "ObjectType"; E = { "Trigger" } }, @{N = "SubType"; E = { "" } })
                         }
-                    }
 
-                    # Loop through all the objects
-                    foreach ($object in $objectCollection) {
+                        # Check if there are any objects
+                        if ($storedProcedures.Count -ge 1) {
+                            $objectCollection += $storedProcedures
+                        }
+                        if ($functions.Count -ge 1) {
+                            $objectCollection += $functions
+                        }
+                        if ($views.Count -ge 1) {
+                            $objectCollection += $views
+                        }
+                        if ($triggers.Count -ge 1) {
+                            $objectCollection += $triggers
+                        }
 
-                        $result = $null
+                        # Both methods identify an object by its id rather than by its name. The method that
+                        # reads the data pages needs the id to pick the rows out of sys.sysobjvalues, and the
+                        # method that uses the dedicated admin connection needs it because an object name is
+                        # allowed to contain a single quote: splicing the name into an OBJECT_ID('...') literal
+                        # would let a crafted name end the literal early and run whatever followed it as a
+                        # further statement in the same batch, as sysadmin over the dedicated admin connection.
+                        # An id is a number, so nothing a name contains can reach the query text.
+                        #
+                        # The id is SMO's own ID property on each object, fetched as part of the enumeration
+                        # above rather than looked up afterwards by schema and name. A lookup keyed by
+                        # "$schema.$name" cannot be unambiguous, because either half may itself contain a dot:
+                        # schema [a], object [b.c] and schema [a.b], object [c] both key as "a.b.c", so whichever
+                        # of the two is read last silently overwrites the other's id in the map, and the object
+                        # that lost the race is then decrypted with the wrong ciphertext. Reading the id SMO
+                        # already carries on the object needs no key at all, so two objects sharing a dotted name
+                        # can no longer collide.
 
-                        # Both methods below select this object's rows by id, taken from SMO's own ID
-                        # property rather than looked up by schema and name.
-                        $decryptObjectId = [int]$object.ID
-
-                        # Without a dedicated admin connection the ciphertext that was collected for this object
-                        # is combined with the keystream that its own metadata produces.
+                        # Without a dedicated admin connection the ciphertext of every requested object is read in
+                        # a single pass over the data pages of sys.sysobjvalues, because reading those pages is by
+                        # far the most expensive part. The family GUID of the database and the object ids are the
+                        # only other inputs that rebuilding the keystream needs.
                         if ($DataPages) {
-                            # Asked for a key it does not hold, a hashtable answers with null, and wrapping
-                            # null in @() gives an array of one null rather than an empty one. That reads as
-                            # a chunk with no ciphertext, so an object the reader deliberately skipped - a
-                            # CLR module, say - would be reported as one whose body could not be recovered.
-                            $chunkCollection = @()
-                            if ($imageValueMap.ContainsKey($decryptObjectId)) {
-                                $chunkCollection = @($imageValueMap[$decryptObjectId])
+                            $familyGuid = $null
+                            $imageValueMap = @{ }
+
+                            try {
+                                $familyGuidRow = @($db.Query("DBCC DBINFO WITH TABLERESULTS") | Where-Object Field -eq "dbi_familyGUID")
+                            } catch {
+                                Stop-Function -Message "Couldn't read dbi_familyGUID of database $($db.Name) on $instance" -ErrorRecord $_ -Target $instance -Continue
                             }
 
-                            # A chunk without ciphertext means an off row body that could not be reassembled.
-                            # Decrypting the rest would return a definition built from a fragment, so this
-                            # object is reported and skipped while the others carry on.
-                            $unresolvedChunk = @($chunkCollection | Where-Object { $null -eq $PSItem.Cipher })
+                            if ($familyGuidRow.Count -eq 0) {
+                                Stop-Function -Message "Couldn't read dbi_familyGUID of database $($db.Name) on $instance" -Target $instance -Continue
+                            }
+                            $familyGuid = [guid]$familyGuidRow[0].VALUE
 
-                            if ($unresolvedChunk.Count -gt 0) {
-                                Write-Message -Level Warning -Message "Couldn't recover the off row body of $($object.Schema).$($object.Name) in database $($db.Name) on $instance, so it is not returned."
-                            } elseif ($chunkCollection.Count -ge 1) {
-                                $chunkParams = @{
-                                    FamilyGuid = $familyGuid
-                                    ObjectId   = $decryptObjectId
-                                    Chunk      = $chunkCollection
-                                }
+                            $wantedObjectId = @($objectCollection.ID)
 
-                                # Anything wrong with this object's ciphertext fails this object and lets the
-                                # rest of the run stand, rather than ending the command part way through.
+                            if ($wantedObjectId.Count -ge 1) {
                                 try {
-                                    $result = ConvertFrom-EncryptedObjectChunk @chunkParams
+                                    foreach ($imageValue in (Get-EncryptedObjectImageValue -Database $db -ObjectId $wantedObjectId)) {
+                                        if (-not $imageValueMap.ContainsKey($imageValue.ObjectId)) {
+                                            $imageValueMap[$imageValue.ObjectId] = @()
+                                        }
+                                        $imageValueMap[$imageValue.ObjectId] += $imageValue
+                                    }
                                 } catch {
-                                    Stop-Function -Message "Couldn't decrypt $($object.Schema).$($object.Name) in database $($db.Name) on $instance" -ErrorRecord $_ -Target $instance -Continue
+                                    Stop-Function -Message "Couldn't read the encrypted definitions from the data pages of database $($db.Name) on $instance" -ErrorRecord $_ -Target $instance -Continue
                                 }
                             }
                         }
 
-                        # Only the DAC can read imageval directly, so none of this runs for the method that reads
-                        # the data pages, and the block below is skipped with it.
-                        $secret = $null
-                        if (-not $DataPages) {
-                            # Setup the query to get the secret. Select by object id rather than by name. Exclude null values in sys.sysobjvalues for triggers.
+                        # Loop through all the objects
+                        foreach ($object in $objectCollection) {
+
+                            $result = $null
+
+                            # Both methods below select this object's rows by id, taken from SMO's own ID
+                            # property rather than looked up by schema and name.
+                            $decryptObjectId = [int]$object.ID
+
+                            # Without a dedicated admin connection the ciphertext that was collected for this object
+                            # is combined with the keystream that its own metadata produces.
+                            if ($DataPages) {
+                                # Asked for a key it does not hold, a hashtable answers with null, and wrapping
+                                # null in @() gives an array of one null rather than an empty one. That reads as
+                                # a chunk with no ciphertext, so an object the reader deliberately skipped - a
+                                # CLR module, say - would be reported as one whose body could not be recovered.
+                                $chunkCollection = @()
+                                if ($imageValueMap.ContainsKey($decryptObjectId)) {
+                                    $chunkCollection = @($imageValueMap[$decryptObjectId])
+                                }
+
+                                # A chunk without ciphertext means an off row body that could not be reassembled.
+                                # Decrypting the rest would return a definition built from a fragment, so this
+                                # object is reported and skipped while the others carry on.
+                                $unresolvedChunk = @($chunkCollection | Where-Object { $null -eq $PSItem.Cipher })
+
+                                if ($unresolvedChunk.Count -gt 0) {
+                                    Write-Message -Level Warning -Message "Couldn't recover the off row body of $($object.Schema).$($object.Name) in database $($db.Name) on $instance, so it is not returned."
+                                } elseif ($chunkCollection.Count -ge 1) {
+                                    $chunkParams = @{
+                                        FamilyGuid = $familyGuid
+                                        ObjectId   = $decryptObjectId
+                                        Chunk      = $chunkCollection
+                                    }
+
+                                    # Anything wrong with this object's ciphertext fails this object and lets the
+                                    # rest of the run stand, rather than ending the command part way through.
+                                    try {
+                                        $result = ConvertFrom-EncryptedObjectChunk @chunkParams
+                                    } catch {
+                                        Stop-Function -Message "Couldn't decrypt $($object.Schema).$($object.Name) in database $($db.Name) on $instance" -ErrorRecord $_ -Target $instance -Continue
+                                    }
+                                }
+                            }
+
+                            # Only the DAC can read imageval directly, so none of this runs for the method that reads
+                            # the data pages, and the block below is skipped with it.
+                            $secret = $null
+                            if (-not $DataPages) {
+                                # Setup the query to get the secret. Select by object id rather than by name. Exclude null values in sys.sysobjvalues for triggers.
                             $querySecret = @"
 SELECT imageval AS Value FROM sys.sysobjvalues WHERE objid = $decryptObjectId AND imageval IS NOT NULL
 "@
 
-                            # Get the result of the secret query
-                            try {
-                                $secret = $server.Databases[$db.Name].Query($querySecret)
-                            } catch {
-                                Stop-Function -Message "Couldn't retrieve secret from $instance" -ErrorRecord $_ -Target $instance -Continue
-                            }
-                        }
-
-                        # Check if at least a value came back
-                        if ($secret) {
-
-                            # A schema, object or parent name is allowed to contain a closing bracket, which
-                            # would end the identifier early and leave the rest of the name standing as
-                            # statement text. Doubling it keeps the whole name inside the brackets.
-                            $bracketedSchema = $object.Schema -replace "\]", "]]"
-                            $bracketedName = $object.Name -replace "\]", "]]"
-
-                            # Cleared per object, because it survives the loop otherwise and an object type
-                            # that matched no branch below would be altered with the previous object's
-                            # statement instead of reaching the check that says the known plain is missing.
-                            $queryKnownPlain = $null
-
-                            # Setup a known plain command and get the binary version of it
-                            switch ($object.ObjectType) {
-
-                                'StoredProcedure' {
-                                    $queryKnownPlain = (" " * $secret.Value.Length) + "ALTER PROCEDURE [$bracketedSchema].[$bracketedName] WITH ENCRYPTION AS RETURN 0;"
+                                # Get the result of the secret query
+                                try {
+                                    $secret = $server.Databases[$db.Name].Query($querySecret)
+                                } catch {
+                                    Stop-Function -Message "Couldn't retrieve secret from $instance" -ErrorRecord $_ -Target $instance -Continue
                                 }
-                                'UserDefinedFunction' {
+                            }
 
-                                    switch ($object.SubType) {
-                                        'Inline' {
-                                            $queryKnownPlain = (" " * $secret.value.length) + "ALTER FUNCTION [$bracketedSchema].[$bracketedName]() RETURNS TABLE WITH ENCRYPTION AS RETURN SELECT 0 i;"
-                                        }
-                                        'Scalar' {
-                                            $queryKnownPlain = (" " * $secret.value.length) + "ALTER FUNCTION [$bracketedSchema].[$bracketedName]() RETURNS INT WITH ENCRYPTION AS BEGIN RETURN 0 END;"
-                                        }
-                                        'Table' {
-                                            $queryKnownPlain = (" " * $secret.value.length) + "ALTER FUNCTION [$bracketedSchema].[$bracketedName]() RETURNS @r TABLE(i INT) WITH ENCRYPTION AS BEGIN RETURN END;"
+                            # Check if at least a value came back
+                            if ($secret) {
+
+                                # A schema, object or parent name is allowed to contain a closing bracket, which
+                                # would end the identifier early and leave the rest of the name standing as
+                                # statement text. Doubling it keeps the whole name inside the brackets.
+                                $bracketedSchema = $object.Schema -replace "\]", "]]"
+                                $bracketedName = $object.Name -replace "\]", "]]"
+
+                                # Cleared per object, because it survives the loop otherwise and an object type
+                                # that matched no branch below would be altered with the previous object's
+                                # statement instead of reaching the check that says the known plain is missing.
+                                $queryKnownPlain = $null
+
+                                # Setup a known plain command and get the binary version of it
+                                switch ($object.ObjectType) {
+
+                                    'StoredProcedure' {
+                                        $queryKnownPlain = (" " * $secret.Value.Length) + "ALTER PROCEDURE [$bracketedSchema].[$bracketedName] WITH ENCRYPTION AS RETURN 0;"
+                                    }
+                                    'UserDefinedFunction' {
+
+                                        switch ($object.SubType) {
+                                            'Inline' {
+                                                $queryKnownPlain = (" " * $secret.value.length) + "ALTER FUNCTION [$bracketedSchema].[$bracketedName]() RETURNS TABLE WITH ENCRYPTION AS RETURN SELECT 0 i;"
+                                            }
+                                            'Scalar' {
+                                                $queryKnownPlain = (" " * $secret.value.length) + "ALTER FUNCTION [$bracketedSchema].[$bracketedName]() RETURNS INT WITH ENCRYPTION AS BEGIN RETURN 0 END;"
+                                            }
+                                            'Table' {
+                                                $queryKnownPlain = (" " * $secret.value.length) + "ALTER FUNCTION [$bracketedSchema].[$bracketedName]() RETURNS @r TABLE(i INT) WITH ENCRYPTION AS BEGIN RETURN END;"
+                                            }
                                         }
                                     }
-                                }
-                                'View' {
-                                    $queryKnownPlain = (" " * $secret.Value.Length) + "ALTER VIEW [$bracketedSchema].[$bracketedName] WITH ENCRYPTION AS SELECT NULL AS [Value];"
-                                }
-                                'Trigger' {
-                                    # A trigger names its parent as well as itself, so the parent gets the same
-                                    # treatment: taken from the object rather than left to however the SMO
-                                    # object renders as a string, and bracketed like every other identifier.
-                                    $bracketedParentSchema = $object.Parent.Schema -replace "\]", "]]"
-                                    $bracketedParentName = $object.Parent.Name -replace "\]", "]]"
+                                    'View' {
+                                        $queryKnownPlain = (" " * $secret.Value.Length) + "ALTER VIEW [$bracketedSchema].[$bracketedName] WITH ENCRYPTION AS SELECT NULL AS [Value];"
+                                    }
+                                    'Trigger' {
+                                        # A trigger names its parent as well as itself, so the parent gets the same
+                                        # treatment: taken from the object rather than left to however the SMO
+                                        # object renders as a string, and bracketed like every other identifier.
+                                        $bracketedParentSchema = $object.Parent.Schema -replace "\]", "]]"
+                                        $bracketedParentName = $object.Parent.Name -replace "\]", "]]"
 
-                                    # The quotes around the message are single, not doubled. This statement is
-                                    # written as it should reach SQL Server, and the doubling that puts it
-                                    # inside the EXEC literal happens in one place below, so that a quote in
-                                    # an object name is escaped by the same pass rather than being missed.
+                                        # The quotes around the message are single, not doubled. This statement is
+                                        # written as it should reach SQL Server, and the doubling that puts it
+                                        # inside the EXEC literal happens in one place below, so that a quote in
+                                        # an object name is escaped by the same pass rather than being missed.
                                     $statementTrigger = @"
 ALTER TRIGGER [$bracketedSchema].[$bracketedName] ON [$bracketedParentSchema].[$bracketedParentName] WITH ENCRYPTION AFTER INSERT AS RAISERROR ('Invoke-DbaDbDecryptObject', 16, 10);
 "@
-                                    $queryKnownPlain = (" " * $secret.Value.Length) + $statementTrigger
+                                        $queryKnownPlain = (" " * $secret.Value.Length) + $statementTrigger
+                                    }
                                 }
-                            }
 
-                            # Convert the known plain into binary
-                            if ($queryKnownPlain) {
-                                try {
-                                    $knownPlain = $encoding.GetBytes(($queryKnownPlain))
-                                } catch {
-                                    Stop-Function -Message "Couldn't convert the known plain to binary" -ErrorRecord $_ -Target $instance -Continue
+                                # Convert the known plain into binary
+                                if ($queryKnownPlain) {
+                                    try {
+                                        $knownPlain = $encoding.GetBytes(($queryKnownPlain))
+                                    } catch {
+                                        Stop-Function -Message "Couldn't convert the known plain to binary" -ErrorRecord $_ -Target $instance -Continue
+                                    }
+                                } else {
+                                    Stop-Function -Message "Something went wrong setting up the known plain" -Target $instance -Continue
                                 }
-                            } else {
-                                Stop-Function -Message "Something went wrong setting up the known plain" -Target $instance -Continue
-                            }
 
-                            # Setup the query to change the object in SQL Server and roll it back getting the encrypted version
-                            # Exclude null values in sys.sysobjvalues for triggers and select the object by id.
-                            #
-                            # The whole statement goes inside the string literal that EXEC runs, so every
-                            # single quote in it has to be doubled or the literal ends early and whatever
-                            # follows runs as a further statement in the same batch - as sysadmin, over the
-                            # dedicated admin connection. An object name may contain a quote, so this is the
-                            # escape that has to be in place, not only the doubling of the quotes written
-                            # above. Character 39 is the quote itself, named so that this line does not
-                            # need one of its own.
-                            $quoteCharacter = [string][char]39
-                            $queryKnownPlainLiteral = $queryKnownPlain -replace $quoteCharacter, ($quoteCharacter * 2)
+                                # Setup the query to change the object in SQL Server and roll it back getting the encrypted version
+                                # Exclude null values in sys.sysobjvalues for triggers and select the object by id.
+                                #
+                                # The whole statement goes inside the string literal that EXEC runs, so every
+                                # single quote in it has to be doubled or the literal ends early and whatever
+                                # follows runs as a further statement in the same batch - as sysadmin, over the
+                                # dedicated admin connection. An object name may contain a quote, so this is the
+                                # escape that has to be in place, not only the doubling of the quotes written
+                                # above. Character 39 is the quote itself, named so that this line does not
+                                # need one of its own.
+                                $quoteCharacter = [string][char]39
+                                $queryKnownPlainLiteral = $queryKnownPlain -replace $quoteCharacter, ($quoteCharacter * 2)
 
                             $queryKnownSecret = @"
 BEGIN TRANSACTION;
@@ -623,74 +628,77 @@ BEGIN TRANSACTION;
 ROLLBACK;
 "@
 
-                            # Get the result for the known encrypted
-                            try {
-                                $knownSecret = $server.Databases[$db.Name].Query($queryKnownSecret)
-                            } catch {
-                                Stop-Function -Message "Couldn't retrieve known secret from $instance" -ErrorRecord $_ -Target $instance -Continue
-                            }
-
-                            # Get the result
-                            $result = Invoke-DecryptData -Secret $secret.value -KnownPlain $knownPlain -KnownSecret $knownSecret.value
-                        }
-
-                        # Both methods arrive at the decrypted script here, so exporting it and returning it is
-                        # shared between them.
-                        if ($null -ne $result) {
-                            # Check if the results need to be exported
-                            $filePath = $null
-                            if ($ExportDestination) {
-                                # make up the file name
-                                $filename = "$($object.Schema).$($object.Name).sql"
-
-                                # Check the export destination
-                                if ($ExportDestination.EndsWith("\")) {
-                                    $destinationFolder = "$ExportDestination$instance\$($db.Name)\$($object.ObjectType)\"
-                                } else {
-                                    $destinationFolder = "$ExportDestination\$instance\$($db.Name)\$($object.ObjectType)\"
-                                }
-
-                                # Check if the destination folder exists
-                                if (-not (Test-Path $destinationFolder)) {
-                                    try {
-                                        # Create the new destination
-                                        # Plain -Force, matching the call in begin. It must not be written as
-                                        # -Force:$Force: this command has no Force parameter, so that binds
-                                        # $null and silently turns the switch off, and under StrictMode it
-                                        # throws instead.
-                                        New-Item -Path $destinationFolder -ItemType Directory -Force | Out-Null
-                                    } catch {
-                                        Stop-Function -Message "Couldn't create destination folder $destinationFolder" -ErrorRecord $_ -Target $instance -Continue
-                                    }
-                                }
-
-                                # Combine the destination folder and the file name to get the path
-                                $filePath = $destinationFolder + $filename
-
-                                # Export the result
+                                # Get the result for the known encrypted
                                 try {
-                                    $result | Out-File -FilePath $filePath -Force
+                                    $knownSecret = $server.Databases[$db.Name].Query($queryKnownSecret)
                                 } catch {
-                                    Stop-Function -Message "Couldn't export the results of $($object.Name) to $filePath" -ErrorRecord $_ -Target $instance -Continue
+                                    Stop-Function -Message "Couldn't retrieve known secret from $instance" -ErrorRecord $_ -Target $instance -Continue
                                 }
 
+                                # Get the result
+                                $result = Invoke-DecryptData -Secret $secret.value -KnownPlain $knownPlain -KnownSecret $knownSecret.value
                             }
 
-                            # Add the results to the custom object
-                            [PSCustomObject]@{
-                                ComputerName = $instance.ComputerName
-                                InstanceName = $server.ServiceName
-                                SqlInstance  = $server.DomainInstanceName
-                                Database     = $db.Name
-                                Type         = $object.ObjectType
-                                Schema       = $object.Schema
-                                Name         = $object.Name
-                                FullName     = "$($object.Schema).$($object.Name)"
-                                Script       = $result
-                                OutputFile   = $filePath
+                            # Both methods arrive at the decrypted script here, so exporting it and returning it is
+                            # shared between them.
+                            if ($null -ne $result) {
+                                # Check if the results need to be exported
+                                $filePath = $null
+                                if ($ExportDestination) {
+                                    # make up the file name
+                                    $filename = "$($object.Schema).$($object.Name).sql"
+
+                                    # Check the export destination
+                                    if ($ExportDestination.EndsWith("\")) {
+                                        $destinationFolder = "$ExportDestination$instance\$($db.Name)\$($object.ObjectType)\"
+                                    } else {
+                                        $destinationFolder = "$ExportDestination\$instance\$($db.Name)\$($object.ObjectType)\"
+                                    }
+
+                                    # Check if the destination folder exists
+                                    if (-not (Test-Path $destinationFolder)) {
+                                        try {
+                                            # Create the new destination
+                                            # Plain -Force, matching the call in begin. It must not be written as
+                                            # -Force:$Force: this command has no Force parameter, so that binds
+                                            # $null and silently turns the switch off, and under StrictMode it
+                                            # throws instead.
+                                            New-Item -Path $destinationFolder -ItemType Directory -Force | Out-Null
+                                        } catch {
+                                            Stop-Function -Message "Couldn't create destination folder $destinationFolder" -ErrorRecord $_ -Target $instance -Continue
+                                        }
+                                    }
+
+                                    # Combine the destination folder and the file name to get the path
+                                    $filePath = $destinationFolder + $filename
+
+                                    # Export the result
+                                    try {
+                                        $result | Out-File -FilePath $filePath -Force
+                                    } catch {
+                                        Stop-Function -Message "Couldn't export the results of $($object.Name) to $filePath" -ErrorRecord $_ -Target $instance -Continue
+                                    }
+
+                                }
+
+                                # Add the results to the custom object
+                                [PSCustomObject]@{
+                                    ComputerName = $instance.ComputerName
+                                    InstanceName = $server.ServiceName
+                                    SqlInstance  = $server.DomainInstanceName
+                                    Database     = $db.Name
+                                    Type         = $object.ObjectType
+                                    Schema       = $object.Schema
+                                    Name         = $object.Name
+                                    FullName     = "$($object.Schema).$($object.Name)"
+                                    Script       = $result
+                                    OutputFile   = $filePath
+                                }
                             }
                         }
                     }
+                } finally {
+                    Restore-DatabaseContext -Server $server -Database $callerDatabase
                 }
             } finally {
                 # The init fields belong to the connection, not to this command, so they go back however

--- a/public/Invoke-DbaDbUpgrade.ps1
+++ b/public/Invoke-DbaDbUpgrade.ps1
@@ -180,6 +180,10 @@ function Invoke-DbaDbUpgrade {
         foreach ($db in $InputObject) {
             # create objects to use in updates
             $server = $db.Parent
+
+            # Read before anything else runs, so that this is the database the caller was in and not one
+            # that a statement of this command left behind.
+            $callerDatabase = $server.ConnectionContext.CurrentDatabase
             $serverVersion = $server.VersionMajor
             Write-Message -Level Verbose -Message "SQL Server is using Version: $serverVersion"
 
@@ -228,12 +232,17 @@ function Invoke-DbaDbUpgrade {
                 $targetRecoveryTimeResult = "No change"
             }
 
+            # The maintenance statements below run in the database, so they go through the Invoke script
+            # method of the Database object rather than through SMO's own ExecuteNonQuery. Both issue a
+            # USE on the execution manager of the database, which is the connection context of the parent
+            # server and belongs to the caller, but only ours puts the previous database back afterwards.
+            # See #10555 and #10556.
             if (!($NoCheckDb)) {
                 Write-Message -Level Verbose -Message "Updating $db with DBCC CHECKDB DATA_PURITY"
                 If ($Pscmdlet.ShouldProcess($server, "Updating $db with DBCC CHECKDB DATA_PURITY")) {
                     $tsqlCheckDB = "DBCC CHECKDB ('$($db.Name)') WITH DATA_PURITY, NO_INFOMSGS"
                     try {
-                        $db.ExecuteNonQuery($tsqlCheckDB)
+                        $db.Invoke($tsqlCheckDB)
                         $DataPurityResult = "Success"
                     } catch {
                         Write-Message -Level Warning -Message "Failed run DBCC CHECKDB with DATA_PURITY on $db" -ErrorRecord $_ -Target $instance
@@ -249,7 +258,7 @@ function Invoke-DbaDbUpgrade {
                 If ($Pscmdlet.ShouldProcess($server, "Updating $db with DBCC UPDATEUSAGE")) {
                     $tsqlUpdateUsage = "DBCC UPDATEUSAGE ($db) WITH NO_INFOMSGS;"
                     try {
-                        $db.ExecuteNonQuery($tsqlUpdateUsage)
+                        $db.Invoke($tsqlUpdateUsage)
                         $UpdateUsageResult = "Success"
                     } catch {
                         Write-Message -Level Warning -Message "Failed to run DBCC UPDATEUSAGE on $db" -ErrorRecord $_ -Target $instance
@@ -266,7 +275,7 @@ function Invoke-DbaDbUpgrade {
                 If ($Pscmdlet.ShouldProcess($server, "Updating $db statistics")) {
                     $tsqlStats = "EXEC sp_updatestats;"
                     try {
-                        $db.ExecuteNonQuery($tsqlStats)
+                        $db.Invoke($tsqlStats)
                         $UpdateStatsResult = "Success"
                     } catch {
                         Write-Message -Level Warning -Message "Failed to run sp_updatestats on $db" -ErrorRecord $_ -Target $instance
@@ -280,23 +289,31 @@ function Invoke-DbaDbUpgrade {
 
             if (!($NoRefreshView)) {
                 Write-Message -Level Verbose -Message "Refreshing $db Views"
-                $dbViews = $db.Views | Where-Object IsSystemObject -eq $false
-                $RefreshViewResult = "Success"
-                foreach ($dbview in $dbviews) {
-                    $viewName = $dbView.Name
-                    $viewSchema = $dbView.Schema
-                    $fullName = $viewSchema + "." + $viewName
+                # Enumerating a database level collection like Views runs in the database as well: SMO issues
+                # a USE on the execution manager of the database, which is the connection context of the
+                # parent server, and never switches back. The Invoke calls above put the database back
+                # themselves, so this is the only place in the command that has to do it. See #10555.
+                try {
+                    $dbViews = $db.Views | Where-Object IsSystemObject -eq $false
+                    $RefreshViewResult = "Success"
+                    foreach ($dbview in $dbviews) {
+                        $viewName = $dbView.Name
+                        $viewSchema = $dbView.Schema
+                        $fullName = $viewSchema + "." + $viewName
 
-                    $tsqlupdateView = "EXECUTE sp_refreshview N'$fullName';  "
+                        $tsqlupdateView = "EXECUTE sp_refreshview N'$fullName';  "
 
-                    If ($Pscmdlet.ShouldProcess($server, "Refreshing view $fullName on $db")) {
-                        try {
-                            $db.ExecuteNonQuery($tsqlupdateView)
-                        } catch {
-                            Write-Message -Level Warning -Message "Failed update view $fullName on $db" -ErrorRecord $_ -Target $instance
-                            $RefreshViewResult = "Fail"
+                        If ($Pscmdlet.ShouldProcess($server, "Refreshing view $fullName on $db")) {
+                            try {
+                                $db.Invoke($tsqlupdateView)
+                            } catch {
+                                Write-Message -Level Warning -Message "Failed update view $fullName on $db" -ErrorRecord $_ -Target $instance
+                                $RefreshViewResult = "Fail"
+                            }
                         }
                     }
+                } finally {
+                    Restore-DatabaseContext -Server $server -Database $callerDatabase
                 }
             } else {
                 Write-Message -Level Verbose -Message "Ignore View Refreshes"

--- a/public/Remove-DbaDbOrphanUser.ps1
+++ b/public/Remove-DbaDbOrphanUser.ps1
@@ -143,6 +143,10 @@ function Remove-DbaDbOrphanUser {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
+            # Working through a Database object moves the connection into that database and never moves it
+            # back - the statements below run there, and so does every enumeration of a database level
+            # collection. The database of the caller is put back after every database. See #10555.
+            $callerDatabase = $server.ConnectionContext.CurrentDatabase
             $DatabaseCollection = $server.Databases | Where-Object IsAccessible | Where-Object ReadOnly -eq $false
 
             if ($Database) {
@@ -311,7 +315,7 @@ function Remove-DbaDbOrphanUser {
                                     if (-not $SkipUser) {
                                         if ($Force) {
                                             if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user $dbuser using -Force")) {
-                                                $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
+                                                $server.Databases[$db.Name].Invoke($query) | Out-Null
                                                 Write-Message -Level Verbose -Message "User $dbuser was dropped from $($db.Name). -Force parameter was used."
                                             }
                                         } else {
@@ -322,7 +326,7 @@ function Remove-DbaDbOrphanUser {
                                 } else {
                                     if (-not $SkipUser) {
                                         if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user $dbuser")) {
-                                            $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
+                                            $server.Databases[$db.Name].Invoke($query) | Out-Null
                                             Write-Message -Level Verbose -Message "User $dbuser was dropped from $($db.Name)."
                                         }
                                     }
@@ -335,6 +339,8 @@ function Remove-DbaDbOrphanUser {
                         $users = $null
                     } catch {
                         Stop-Function -Message "Failure" -ErrorRecord $_ -Target $db -Continue
+                    } finally {
+                        Restore-DatabaseContext -Server $server -Database $callerDatabase
                     }
                 }
             } else {

--- a/public/Repair-DbaDbOrphanUser.ps1
+++ b/public/Repair-DbaDbOrphanUser.ps1
@@ -137,6 +137,10 @@ function Repair-DbaDbOrphanUser {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
+            # Working through a Database object moves the connection into that database and never moves it
+            # back - the statements below run there, and so does every enumeration of a database level
+            # collection. The database of the caller is put back after every database. See #10555.
+            $callerDatabase = $server.ConnectionContext.CurrentDatabase
             $DatabaseCollection = $server.Databases | Where-Object IsAccessible
 
             if ($Database) {
@@ -176,7 +180,7 @@ function Repair-DbaDbOrphanUser {
                                     }
 
                                     if ($Pscmdlet.ShouldProcess($db.Name, "Mapping user '$($User.Name)'")) {
-                                        $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
+                                        $server.Databases[$db.Name].Invoke($query) | Out-Null
                                         Write-Message -Level Verbose -Message "User '$($User.Name)' mapped with their login."
 
                                         [PSCustomObject]@{
@@ -227,6 +231,8 @@ function Repair-DbaDbOrphanUser {
                         $UsersToWork = $null
                     } catch {
                         Stop-Function -Message $_ -Continue
+                    } finally {
+                        Restore-DatabaseContext -Server $server -Database $callerDatabase
                     }
                 }
             } else {

--- a/public/Sync-DbaLoginPermission.ps1
+++ b/public/Sync-DbaLoginPermission.ps1
@@ -120,58 +120,75 @@ function Sync-DbaLoginPermission {
         # Get current login to not sync permissions for that login.
         $currentLogin = $sourceServer.ConnectionContext.TrueLogin
 
-        foreach ($dest in $Destination) {
-            try {
-                $destServer = Connect-DbaInstance -SqlInstance $dest -SqlCredential $DestinationSqlCredential -MinimumVersion 8
-            } catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $dest -Continue
-            }
+        # Syncing the permissions of a login walks the database level collections of both servers and runs
+        # statements through their Database objects, which moves the connection into the database being
+        # worked on and never moves it back. The database of each caller connection is put back afterwards.
+        # See #10555.
+        $sourceCallerDatabase = $sourceServer.ConnectionContext.CurrentDatabase
 
-            $stepCounter = 0
-            foreach ($sourceLogin in $allLogins) {
-                $loginName = $sourceLogin.Name
-                if ($currentLogin -eq $loginName) {
-                    Write-Message -Level Verbose -Message "Sync does not modify the permissions of the current login '$loginName'. Skipping."
-                    continue
-                }
-
-                # Here we don't need the FullComputerName, but only the machine name to compare to the host part of the login name. So ComputerName should be fine.
-                $serverName = $sourceServer.ComputerName
-                $userBase = ($loginName.Split("\")[0]).ToLowerInvariant()
-                if ($serverName -eq $userBase -or $loginName.StartsWith("NT ")) {
-                    Write-Message -Level Verbose -Message "Sync does not modify the permissions of host or system login '$loginName'. Skipping."
-                    continue
-                }
-
-                if ($null -eq ($destLogin = $destServer.Logins.Item($loginName))) {
-                    Write-Message -Level Verbose -Message "Login '$loginName' not found on destination. Skipping."
-                    continue
-                }
-
-
-                $copyLoginPermissionStatus = [PSCustomObject]@{
-                    SourceServer      = $sourceserver.Name
-                    DestinationServer = $destServer.Name
-                    Name              = $loginName
-                    Type              = "Login Permissions"
-                    Status            = $null
-                    Notes             = $null
-                    DateTime          = [DbaDateTime](Get-Date)
-                }
-                Write-ProgressHelper -Activity "Executing Sync-DbaLoginPermission to sync login permissions from $($sourceServer.Name)" -StepNumber ($stepCounter++) -Message "Updating permissions for $loginName on $($destServer.Name)" -TotalSteps $allLogins.Count
+        try {
+            foreach ($dest in $Destination) {
                 try {
-                    Update-SqlPermission -SourceServer $sourceServer -SourceLogin $sourceLogin -DestServer $destServer -DestLogin $destLogin -EnableException
-                    $copyLoginPermissionStatus.Status = "Successful"
-                    if ($PSCmdlet.ShouldProcess("Console", "Outputting results for login $loginName permission sync")) {
-                        $copyLoginPermissionStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
-                    }
+                    $destServer = Connect-DbaInstance -SqlInstance $dest -SqlCredential $DestinationSqlCredential -MinimumVersion 8
                 } catch {
-                    $copyLoginPermissionStatus.Status = "Failed"
-                    $copyLoginPermissionStatus.Notes = (Get-ErrorMessage -Record $_)
-                    $copyLoginPermissionStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
-                    Stop-Function -Message "Issue syncing permissions for login" -Target $loginName -ErrorRecord $_ -Continue
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $dest -Continue
+                }
+
+                # See the comment above - the same for the connection of the destination.
+                $destCallerDatabase = $destServer.ConnectionContext.CurrentDatabase
+
+                try {
+                    $stepCounter = 0
+                    foreach ($sourceLogin in $allLogins) {
+                        $loginName = $sourceLogin.Name
+                        if ($currentLogin -eq $loginName) {
+                            Write-Message -Level Verbose -Message "Sync does not modify the permissions of the current login '$loginName'. Skipping."
+                            continue
+                        }
+
+                        # Here we don't need the FullComputerName, but only the machine name to compare to the host part of the login name. So ComputerName should be fine.
+                        $serverName = $sourceServer.ComputerName
+                        $userBase = ($loginName.Split("\")[0]).ToLowerInvariant()
+                        if ($serverName -eq $userBase -or $loginName.StartsWith("NT ")) {
+                            Write-Message -Level Verbose -Message "Sync does not modify the permissions of host or system login '$loginName'. Skipping."
+                            continue
+                        }
+
+                        if ($null -eq ($destLogin = $destServer.Logins.Item($loginName))) {
+                            Write-Message -Level Verbose -Message "Login '$loginName' not found on destination. Skipping."
+                            continue
+                        }
+
+
+                        $copyLoginPermissionStatus = [PSCustomObject]@{
+                            SourceServer      = $sourceserver.Name
+                            DestinationServer = $destServer.Name
+                            Name              = $loginName
+                            Type              = "Login Permissions"
+                            Status            = $null
+                            Notes             = $null
+                            DateTime          = [DbaDateTime](Get-Date)
+                        }
+                        Write-ProgressHelper -Activity "Executing Sync-DbaLoginPermission to sync login permissions from $($sourceServer.Name)" -StepNumber ($stepCounter++) -Message "Updating permissions for $loginName on $($destServer.Name)" -TotalSteps $allLogins.Count
+                        try {
+                            Update-SqlPermission -SourceServer $sourceServer -SourceLogin $sourceLogin -DestServer $destServer -DestLogin $destLogin -EnableException
+                            $copyLoginPermissionStatus.Status = "Successful"
+                            if ($PSCmdlet.ShouldProcess("Console", "Outputting results for login $loginName permission sync")) {
+                                $copyLoginPermissionStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+                            }
+                        } catch {
+                            $copyLoginPermissionStatus.Status = "Failed"
+                            $copyLoginPermissionStatus.Notes = (Get-ErrorMessage -Record $_)
+                            $copyLoginPermissionStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+                            Stop-Function -Message "Issue syncing permissions for login" -Target $loginName -ErrorRecord $_ -Continue
+                        }
+                    }
+                } finally {
+                    Restore-DatabaseContext -Server $destServer -Database $destCallerDatabase
                 }
             }
+        } finally {
+            Restore-DatabaseContext -Server $sourceServer -Database $sourceCallerDatabase
         }
     }
 }

--- a/tests/ConvertTo-DbaXESession.Tests.ps1
+++ b/tests/ConvertTo-DbaXESession.Tests.ps1
@@ -162,3 +162,49 @@ select TraceID=@TraceID
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # The default trace exists on every instance, and -OutputScriptOnly runs the conversion in
+            # tempdb without leaving an extended events session behind.
+            $contextTrace = Get-DbaTrace -SqlInstance $callerServer -Id 1
+            $splatConvert = @{
+                InputObject      = $contextTrace
+                Name             = "dbatoolsci_ctx_xe_$(Get-Random)"
+                OutputScriptOnly = $true
+            }
+            $contextResult = ConvertTo-DbaXESession @splatConvert
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still returns the script" {
+            # Only a call that really runs can move the connection, so without this the assertion below
+            # would pass for the wrong reason.
+            $contextResult | Should -Not -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -299,6 +299,9 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     Context "UseLastBackup with -Continue" {
+        # The destination database is pre-staged here in Restoring state, so SMO caches it as not
+        # accessible. This is the context that showed the skipped owner update of #10555: without the
+        # object refresh after the restore, Set-DbaDbOwner saw the stale value, warned and skipped.
         BeforeAll {
             $splatStopProcess = @{
                 SqlInstance = $TestConfig.InstanceCopy1, $TestConfig.InstanceCopy2
@@ -359,7 +362,7 @@ Describe $CommandName -Tag IntegrationTests {
             $results.Status | Should -Be "Successful"
         }
 
-        It "retains its name, recovery model, and status." {
+        It "retains its name, recovery model, status, and owner." {
             $splatGetDbs = @{
                 SqlInstance = $TestConfig.InstanceCopy1, $TestConfig.InstanceCopy2
                 Database    = $backuprestoredb
@@ -370,6 +373,10 @@ Describe $CommandName -Tag IntegrationTests {
             $dbs[0].Name | Should -Be $dbs[1].Name
             $dbs[0].RecoveryModel | Should -Be $dbs[1].RecoveryModel
             $dbs[0].Status | Should -Be $dbs[1].Status
+            # The owner catches the skipped Set-DbaDbOwner: when the stale SMO object made it skip,
+            # the destination kept the login that ran the restore as the owner instead of the owner
+            # of the source database.
+            $dbs[0].Owner | Should -Be $dbs[1].Owner
         }
     }
 

--- a/tests/Copy-DbaLogin.Tests.ps1
+++ b/tests/Copy-DbaLogin.Tests.ps1
@@ -365,3 +365,82 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connections of the caller are left in the database they were in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_copylogin_$(Get-Random)"
+            $contextLoginName = "dbatoolsci_ctx_login_$(Get-Random)"
+
+            # The database exists on both servers and the login has a user in it on the source, so the
+            # permission sync walks the database level collections of both servers - which is the leak
+            # this context guards against.
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceCopy1 -Name $contextDbName
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceCopy2 -Name $contextDbName
+            $splatContextLogin = @{
+                SqlInstance = $TestConfig.InstanceCopy1
+                Login       = $contextLoginName
+                Password    = (ConvertTo-SecureString -String "dbatools.IO" -AsPlainText -Force)
+            }
+            $null = New-DbaLogin @splatContextLogin
+            $splatContextUser = @{
+                SqlInstance = $TestConfig.InstanceCopy1
+                Database    = $contextDbName
+                Login       = $contextLoginName
+                Username    = $contextLoginName
+            }
+            $null = New-DbaDbUser @splatContextUser
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $sourceCallerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceCopy1 -NonPooledConnection
+            $destCallerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceCopy2 -NonPooledConnection
+            $sourceContextBefore = $sourceCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+            $destContextBefore = $destCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $splatCopyLogin = @{
+                Source      = $sourceCallerServer
+                Destination = $destCallerServer
+                Login       = $contextLoginName
+            }
+            $contextResult = Copy-DbaLogin @splatCopyLogin
+
+            $sourceContextAfter = $sourceCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+            $destContextAfter = $destCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $sourceCallerServer | Disconnect-DbaInstance
+            $null = $destCallerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceCopy1, $TestConfig.InstanceCopy2 -Database $contextDbName -ErrorAction SilentlyContinue
+            $null = Remove-DbaLogin -SqlInstance $TestConfig.InstanceCopy1, $TestConfig.InstanceCopy2 -Login $contextLoginName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "copies the login and syncs its database user" {
+            # Only a command that really did something can move the connections, so without this the
+            # assertions below would pass for the wrong reason.
+            $contextResult.Status | Should -Be "Successful"
+            (Get-DbaLogin -SqlInstance $TestConfig.InstanceCopy2 -Login $contextLoginName).Name | Should -Be $contextLoginName
+            (Get-DbaDbUser -SqlInstance $TestConfig.InstanceCopy2 -Database $contextDbName).Name | Should -Contain $contextLoginName
+        }
+
+        It "leaves the source connection in the database it was in" {
+            $sourceContextAfter | Should -Be $sourceContextBefore
+        }
+
+        It "leaves the destination connection in the database it was in" {
+            $destContextAfter | Should -Be $destContextBefore
+        }
+    }
+}

--- a/tests/Find-DbaDbDisabledIndex.Tests.ps1
+++ b/tests/Find-DbaDbDisabledIndex.Tests.ps1
@@ -79,3 +79,48 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_index_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -Query "CREATE TABLE dbo.dbatoolsci_table (id INT NOT NULL PRIMARY KEY, txt NVARCHAR(50)); CREATE INDEX ix_dbatoolsci ON dbo.dbatoolsci_table (txt); ALTER INDEX ix_dbatoolsci ON dbo.dbatoolsci_table DISABLE;"
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $contextResult = Find-DbaDbDisabledIndex -SqlInstance $callerServer -Database $contextDbName
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still returns what it was asked for" {
+            # Only a call that really runs can move the connection, so a command that returned nothing
+            # would pass the assertion below for the wrong reason.
+            $contextResult | Should -Not -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Find-DbaObject.Tests.ps1
+++ b/tests/Find-DbaObject.Tests.ps1
@@ -286,3 +286,48 @@ GO
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_object_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -Query "CREATE TABLE dbo.dbatoolsci_table (id INT);"
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $contextResult = Find-DbaObject -SqlInstance $callerServer -Database $contextDbName -Pattern dbatoolsci
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still returns what it was asked for" {
+            # Only a call that really runs can move the connection, so a command that returned nothing
+            # would pass the assertion below for the wrong reason.
+            $contextResult | Should -Not -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -128,3 +128,40 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            # This command reads the directory tree through master, so a caller that is already in master
+            # cannot show the leak at all. The connection starts in tempdb for that reason, and it is not
+            # pooled, because a pooled connection reconnects at its default database.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -Database tempdb -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $contextResult = Find-DbaOrphanedFile -SqlInstance $callerServer
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "starts in tempdb, so a leak into master can be seen at all" {
+            $contextBefore | Should -Be "tempdb"
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Find-DbaStoredProcedure.Tests.ps1
+++ b/tests/Find-DbaStoredProcedure.Tests.ps1
@@ -152,3 +152,48 @@ AS
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_proc_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -Query "EXEC ('CREATE PROCEDURE dbo.dbatoolsci_proc AS SELECT 1');"
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $contextResult = Find-DbaStoredProcedure -SqlInstance $callerServer -Database $contextDbName -Pattern dbatoolsci
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still returns what it was asked for" {
+            # Only a call that really runs can move the connection, so a command that returned nothing
+            # would pass the assertion below for the wrong reason.
+            $contextResult | Should -Not -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Find-DbaTrigger.Tests.ps1
+++ b/tests/Find-DbaTrigger.Tests.ps1
@@ -135,3 +135,48 @@ GO
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_trigger_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -Query "CREATE TABLE dbo.dbatoolsci_table (id INT); EXEC ('CREATE TRIGGER dbatoolsci_trigger ON dbo.dbatoolsci_table AFTER INSERT AS SELECT 1');"
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $contextResult = Find-DbaTrigger -SqlInstance $callerServer -Database $contextDbName -Pattern dbatoolsci
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still returns what it was asked for" {
+            # Only a call that really runs can move the connection, so a command that returned nothing
+            # would pass the assertion below for the wrong reason.
+            $contextResult | Should -Not -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Find-DbaView.Tests.ps1
+++ b/tests/Find-DbaView.Tests.ps1
@@ -90,3 +90,48 @@ AS
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_view_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -Query "CREATE TABLE dbo.dbatoolsci_table (id INT); EXEC ('CREATE VIEW dbo.dbatoolsci_view AS SELECT id FROM dbo.dbatoolsci_table');"
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $contextResult = Find-DbaView -SqlInstance $callerServer -Database $contextDbName -Pattern dbatoolsci
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still returns what it was asked for" {
+            # Only a call that really runs can move the connection, so a command that returned nothing
+            # would pass the assertion below for the wrong reason.
+            $contextResult | Should -Not -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Get-DbaDbSpace.Tests.ps1
+++ b/tests/Get-DbaDbSpace.Tests.ps1
@@ -172,3 +172,48 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_space_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -Query "CREATE TABLE dbo.dbatoolsci_table (id INT);"
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $contextResult = Get-DbaDbSpace -SqlInstance $callerServer -Database $contextDbName
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still returns what it was asked for" {
+            # Only a call that really runs can move the connection, so a command that returned nothing
+            # would pass the assertion below for the wrong reason.
+            $contextResult | Should -Not -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Get-DbaLastGoodCheckDb.Tests.ps1
+++ b/tests/Get-DbaLastGoodCheckDb.Tests.ps1
@@ -107,3 +107,48 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_checkdb_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Name $contextDbName
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceMulti1 -Database $contextDbName -Query "CREATE TABLE dbo.dbatoolsci_table (id INT);"
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $contextResult = Get-DbaLastGoodCheckDb -SqlInstance $callerServer -Database $contextDbName
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Database $contextDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still returns what it was asked for" {
+            # Only a call that really runs can move the connection, so a command that returned nothing
+            # would pass the assertion below for the wrong reason.
+            $contextResult | Should -Not -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Get-DbaPermission.Tests.ps1
+++ b/tests/Get-DbaPermission.Tests.ps1
@@ -141,3 +141,48 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_permission_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -Query "CREATE TABLE dbo.dbatoolsci_table (id INT);"
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $contextResult = Get-DbaPermission -SqlInstance $callerServer -Database $contextDbName
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still returns what it was asked for" {
+            # Only a call that really runs can move the connection, so a command that returned nothing
+            # would pass the assertion below for the wrong reason.
+            $contextResult | Should -Not -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Get-DbaQueryExecutionTime.Tests.ps1
+++ b/tests/Get-DbaQueryExecutionTime.Tests.ps1
@@ -30,3 +30,49 @@ Describe $CommandName -Tag UnitTests {
     Read https://github.com/dataplat/dbatools/blob/development/contributing.md#tests
     for more guidence.
 #>
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_querytime_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -Query "CREATE TABLE dbo.dbatoolsci_table (id INT);"
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $contextResult = Get-DbaQueryExecutionTime -SqlInstance $callerServer -Database $contextDbName -MinExecs 0 -MinExecMs 0
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "does not warn" {
+            # What this command returns depends on what is in the plan cache, so there is nothing to
+            # assert about the rows. The query runs either way, and running it is what moves the
+            # connection, so the assertion below still has teeth.
+            $WarnVar | Should -BeNullOrEmpty
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Invoke-DbaDbDecryptObject.Tests.ps1
+++ b/tests/Invoke-DbaDbDecryptObject.Tests.ps1
@@ -1122,3 +1122,63 @@ END
         }
     }
 }
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_decrypt_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Name $contextDbName
+
+            $contextProcName = "dbatoolsci_ctx_secret"
+            $splatCreateProc = @{
+                SqlInstance = $TestConfig.InstanceMulti1
+                Database    = $contextDbName
+                Query       = "EXEC ('CREATE PROCEDURE dbo.$contextProcName WITH ENCRYPTION AS SELECT 1');"
+            }
+            $null = Invoke-DbaQuery @splatCreateProc
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # -DataPages, because that path reads the definitions from the data pages and needs no dedicated
+            # admin connection - the command would otherwise open a connection of its own and the connection
+            # of the caller would never be touched.
+            $splatDecrypt = @{
+                SqlInstance = $callerServer
+                Database    = $contextDbName
+                ObjectName  = $contextProcName
+                DataPages   = $true
+            }
+            $contextResult = Invoke-DbaDbDecryptObject @splatDecrypt
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Database $contextDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still decrypts the procedure" {
+            # Only a command that really did the work can move the connection, so without this the
+            # assertion below would pass for the wrong reason.
+            $contextResult.Script | Should -BeLike "*CREATE PROCEDURE*"
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Invoke-DbaDbUpgrade.Tests.ps1
+++ b/tests/Invoke-DbaDbUpgrade.Tests.ps1
@@ -28,8 +28,165 @@ Describe $CommandName -Tag UnitTests {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/dataplat/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $setupServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+
+        # The command skips a database that is already at the compatibility level of the instance, so the
+        # test database is created one level below it. The level is asked of the instance instead of being
+        # hardcoded: every supported version accepts the level of the major version before it.
+        $instanceCompatibility = [Microsoft.SqlServer.Management.Smo.CompatibilityLevel]"Version$($setupServer.VersionMajor)0"
+        $previousCompatibility = [Microsoft.SqlServer.Management.Smo.CompatibilityLevel]"Version$($setupServer.VersionMajor - 1)0"
+
+        $upgradeDbName = "dbatoolsci_upgrade_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $setupServer -Name $upgradeDbName
+        $null = Set-DbaDbCompatibility -SqlInstance $setupServer -Database $upgradeDbName -Compatibility $previousCompatibility
+
+        # sp_refreshview only runs for a user view, so without one the fourth statement of the command
+        # would never execute and could not show whether it moves the connection.
+        $splatCreateView = @{
+            SqlInstance = $setupServer
+            Database    = $upgradeDbName
+            Query       = "CREATE TABLE dbo.dbatoolsci_table (id INT); EXEC ('CREATE VIEW dbo.dbatoolsci_view AS SELECT id FROM dbo.dbatoolsci_table');"
+        }
+        $null = Invoke-DbaQuery @splatCreateView
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $null = Remove-DbaDatabase -SqlInstance $setupServer -Database $upgradeDbName -ErrorAction SilentlyContinue
+        $null = $setupServer | Disconnect-DbaInstance
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "Upgrading a database leaves the connection of the caller alone (#10556)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which wipes the leak before it can be read.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $upgradeResult = Invoke-DbaDbUpgrade -SqlInstance $callerServer -Database $upgradeDbName
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "upgrades the database to the compatibility level of the instance" {
+            $upgradeResult.OriginalCompatibility | Should -Be $previousCompatibility.ToString().Replace("Version", "")
+            $upgradeResult.CurrentCompatibility | Should -Be $instanceCompatibility.ToString().Replace("Version", "")
+            $upgradeResult.Compatibility | Should -Be $instanceCompatibility.ToString().Replace("Version", "")
+        }
+
+        It "runs every maintenance step" {
+            # Only a statement that ran can move the connection, so a command that did nothing would pass
+            # the assertion below for the wrong reason.
+            $upgradeResult.DataPurity | Should -Be "Success"
+            $upgradeResult.UpdateUsage | Should -Be "Success"
+            $upgradeResult.UpdateStats | Should -Be "Success"
+            $upgradeResult.RefreshViews | Should -Be "Success"
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+
+        It "does not warn" {
+            $WarnVar | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "The database the caller was in is restored, not master (#10555)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $tempdbCallerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -Database tempdb -NonPooledConnection
+
+            # The database is at the level of the instance by now, so only -Force makes the maintenance
+            # statements run again. A fix that put the connection back to master instead of back to what
+            # the caller had would pass every assertion of the context above and fail here.
+            $forcedResult = Invoke-DbaDbUpgrade -SqlInstance $tempdbCallerServer -Database $upgradeDbName -Force
+
+            $tempdbContextAfter = $tempdbCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $tempdbCallerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "runs the maintenance steps again" {
+            $forcedResult.DataPurity | Should -Be "Success"
+            $forcedResult.UpdateUsage | Should -Be "Success"
+            $forcedResult.UpdateStats | Should -Be "Success"
+            $forcedResult.RefreshViews | Should -Be "Success"
+        }
+
+        It "leaves the connection in tempdb" {
+            $tempdbContextAfter | Should -Be "tempdb"
+        }
+    }
+
+    Context "The maintenance statements put the database back themselves (#10556)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $statementCallerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $statementContextBefore = $statementCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # -NoRefreshView is the case the restore around the view enumeration cannot cover, because with
+            # it the command never enumerates the views. Whatever the DBCC and stored procedure statements
+            # do to the connection has to be undone by the statements themselves.
+            $statementResult = Invoke-DbaDbUpgrade -SqlInstance $statementCallerServer -Database $upgradeDbName -NoRefreshView -Force
+
+            $statementContextAfter = $statementCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $statementCallerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "runs the statements it was not told to skip" {
+            $statementResult.DataPurity | Should -Be "Success"
+            $statementResult.UpdateUsage | Should -Be "Success"
+            $statementResult.UpdateStats | Should -Be "Success"
+            $statementResult.RefreshViews | Should -Be "Skipped"
+        }
+
+        It "leaves the connection in the database it was in" {
+            $statementContextAfter | Should -Be $statementContextBefore
+        }
+    }
+}

--- a/tests/Remove-DbaDbOrphanUser.Tests.ps1
+++ b/tests/Remove-DbaDbOrphanUser.Tests.ps1
@@ -192,3 +192,57 @@ Describe $CommandName -Tag IntegrationTests {
         $results1.Name -contains $loginWindows | Should -Be $false
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            $contextDbName = "dbatoolsci_ctx_orphanremove_$(Get-Random)"
+            $contextLoginName = "dbatoolsci_ctx_login_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+
+            # A user whose login is gone is an orphan, which is what gives the command something to do.
+            $splatContextLogin = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Login       = $contextLoginName
+                Password    = (ConvertTo-SecureString -String "dbatools.IO" -AsPlainText -Force)
+            }
+            $null = New-DbaLogin @splatContextLogin
+            $null = New-DbaDbUser -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -Login $contextLoginName -Username $contextLoginName
+            $null = Remove-DbaLogin -SqlInstance $TestConfig.InstanceSingle -Login $contextLoginName
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $null = Remove-DbaDbOrphanUser -SqlInstance $callerServer -Database $contextDbName
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+            $contextUsers = Get-DbaDbUser -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still removes the orphaned user" {
+            # Only a command that really did something can move the connection, so without this the
+            # assertion below would pass for the wrong reason.
+            $contextUsers.Name | Should -Not -Contain $contextLoginName
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Repair-DbaDbOrphanUser.Tests.ps1
+++ b/tests/Repair-DbaDbOrphanUser.Tests.ps1
@@ -100,3 +100,59 @@ CREATE LOGIN [dbatoolsci_orphan2] WITH PASSWORD = N'password2', CHECK_EXPIRATION
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connection of the caller is left in the database it was in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            $contextDbName = "dbatoolsci_ctx_orphanrepair_$(Get-Random)"
+            $contextLoginName = "dbatoolsci_ctx_login_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+
+            # Dropping the login and creating it again gives it a new SID, so the user is orphaned while a
+            # login of that name exists - which is the case this command is for.
+            $splatContextLogin = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Login       = $contextLoginName
+                Password    = (ConvertTo-SecureString -String "dbatools.IO" -AsPlainText -Force)
+            }
+            $null = New-DbaLogin @splatContextLogin
+            $null = New-DbaDbUser -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -Login $contextLoginName -Username $contextLoginName
+            $null = Remove-DbaLogin -SqlInstance $TestConfig.InstanceSingle -Login $contextLoginName
+            $null = New-DbaLogin @splatContextLogin
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $contextBefore = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $contextResult = Repair-DbaDbOrphanUser -SqlInstance $callerServer -Database $contextDbName
+
+            $contextAfter = $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName -ErrorAction SilentlyContinue
+            $null = Remove-DbaLogin -SqlInstance $TestConfig.InstanceSingle -Login $contextLoginName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "still maps the orphaned user to its login" {
+            # Only a command that really did something can move the connection, so without this the
+            # assertion below would pass for the wrong reason.
+            $contextResult.Status | Should -Be "Success"
+        }
+
+        It "leaves the connection in the database it was in" {
+            $contextAfter | Should -Be $contextBefore
+        }
+    }
+}

--- a/tests/Restore-DatabaseContext.Tests.ps1
+++ b/tests/Restore-DatabaseContext.Tests.ps1
@@ -1,0 +1,158 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Restore-DatabaseContext",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "Server",
+                "Database"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe $CommandName -Tag IntegrationTests {
+    # Restore-DatabaseContext is the private function that puts the current database of a connection back
+    # where the caller had it, for the commands that cannot avoid moving it. See #10555.
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $contextDbName = "dbatoolsci_restorectx_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $contextDbName
+
+        # A name with a closing bracket in it, so that the escaping of the USE statement is tested against a
+        # database that really exists. New-DbaDatabase would build the CREATE DATABASE statement itself, so
+        # the name is created here with the escaping written out.
+        $bracketDbName = "dbatoolsci_br]acket_$(Get-Random)"
+        $escapedBracketDbName = $bracketDbName.Replace("]", "]]")
+        $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database master -Query "CREATE DATABASE [$escapedBracketDbName]"
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName, $bracketDbName -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "Putting the database of the caller back" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $callerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+
+            # Moving the connection the way SMO does, for the tests that are about the restore rather than
+            # about what moved it. Only the first test below moves it by enumerating a collection, because
+            # SMO caches a collection once it is populated and a second enumeration never reaches the
+            # server - so that is a fixture that works exactly once per connection.
+            $moveTheConnection = {
+                $null = $callerServer.ConnectionContext.ExecuteNonQuery("USE [$contextDbName]")
+            }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterEach {
+            # Every test starts from master, whatever the test before it did to the connection.
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("USE [master]")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $callerServer | Disconnect-DbaInstance
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "puts the database back after a database level collection moved the connection" {
+            # Enumerating a collection of a Database object is one of the ways the context moves, and the
+            # one that no script method can cover, so it is what the helper exists for.
+            $null = $callerServer.Databases[$contextDbName].Users.Count
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be $contextDbName
+
+            Restore-DatabaseContext -Server $callerServer -Database "master"
+
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "master"
+        }
+
+        It "escapes a closing bracket in the name of the database it goes back to" {
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("USE [$escapedBracketDbName]")
+            $callerDatabase = $callerServer.ConnectionContext.CurrentDatabase
+            $callerDatabase | Should -Be $bracketDbName
+
+            & $moveTheConnection
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be $contextDbName
+
+            Restore-DatabaseContext -Server $callerServer -Database $callerDatabase
+
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be $bracketDbName
+        }
+
+        It "does nothing when no database was remembered" {
+            # A command passes what it managed to read, and reading it can come back empty. That must not
+            # move a connection that nothing asked to be moved.
+            & $moveTheConnection
+
+            Restore-DatabaseContext -Server $callerServer -Database ""
+
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be $contextDbName
+        }
+
+        It "warns instead of throwing when the database cannot be reached" {
+            # The database of the caller can be gone by the time the command is done with it - dropped,
+            # renamed, taken offline, access revoked. Housekeeping must not replace the outcome of the
+            # command that called it, so this warns and returns.
+            & $moveTheConnection
+
+            $missingDatabase = "dbatoolsci_does_not_exist_$(Get-Random)"
+
+            $splatRestore = @{
+                Server          = $callerServer
+                Database        = $missingDatabase
+                WarningVariable = "restoreWarning"
+                WarningAction   = "SilentlyContinue"
+            }
+
+            # Called directly and not inside a { } | Should -Not -Throw, because -WarningVariable fills
+            # the variable in the scope the command runs in and a scriptblock would take it with it. A
+            # terminating error fails this test on its own, which is what the assertion would have been.
+            Restore-DatabaseContext @splatRestore
+
+            $restoreWarning -join " " | Should -BeLike "*could not be restored*"
+
+            # The connection stays where it was, because there was nowhere to put it back to.
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be $contextDbName
+        }
+
+        It "leaves the connection open and on the session of the caller" {
+            # A restore that reconnected instead of running on the connection would lose everything the
+            # session holds, which is the reason this is not done with a copied connection context.
+            $callerSpid = $callerServer.ConnectionContext.ExecuteScalar("SELECT @@SPID")
+            $null = $callerServer.ConnectionContext.ExecuteNonQuery("CREATE TABLE #dbatoolsci_marker (id INT)")
+
+            & $moveTheConnection
+
+            Restore-DatabaseContext -Server $callerServer -Database "master"
+
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT @@SPID") | Should -Be $callerSpid
+            { $callerServer.ConnectionContext.ExecuteScalar("SELECT COUNT(*) FROM #dbatoolsci_marker") } | Should -Not -Throw
+        }
+    }
+}

--- a/tests/Restore-DatabaseContext.Tests.ps1
+++ b/tests/Restore-DatabaseContext.Tests.ps1
@@ -41,7 +41,7 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     AfterAll {
-        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the cleanup fails visibly.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $contextDbName, $bracketDbName -ErrorAction SilentlyContinue
@@ -136,6 +136,25 @@ Describe $CommandName -Tag IntegrationTests {
             Restore-DatabaseContext @splatRestore
 
             $restoreWarning -join " " | Should -BeLike "*could not be restored*"
+
+            # The connection stays where it was, because there was nowhere to put it back to.
+            $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be $contextDbName
+        }
+
+        It "does not throw when warning action is Stop" {
+            & $moveTheConnection
+
+            $missingDatabase = "dbatoolsci_does_not_exist_$(Get-Random)"
+
+            $splatRestore = @{
+                Server        = $callerServer
+                Database      = $missingDatabase
+                WarningAction = "Stop"
+            }
+
+            {
+                Restore-DatabaseContext @splatRestore
+            } | Should -Not -Throw
 
             # The connection stays where it was, because there was nowhere to put it back to.
             $callerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be $contextDbName

--- a/tests/Restore-DatabaseContext.Tests.ps1
+++ b/tests/Restore-DatabaseContext.Tests.ps1
@@ -152,8 +152,10 @@ Describe $CommandName -Tag IntegrationTests {
                 WarningAction = "Stop"
             }
 
+            # The command neutralises Stop to Continue, so the warning is printed instead of terminating.
+            # The redirect keeps it off the console, because a test run has to stay warning-free.
             {
-                Restore-DatabaseContext @splatRestore
+                Restore-DatabaseContext @splatRestore 3>$null
             } | Should -Not -Throw
 
             # The connection stays where it was, because there was nowhere to put it back to.

--- a/tests/Sync-DbaLoginPermission.Tests.ps1
+++ b/tests/Sync-DbaLoginPermission.Tests.ps1
@@ -114,3 +114,83 @@ CREATE LOGIN [$stateTestLogin]
         }
     }
 }
+
+Describe $CommandName -Tag IntegrationTests {
+    Context "The connections of the caller are left in the database they were in (#10555)" {
+        BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $contextDbName = "dbatoolsci_ctx_syncperm_$(Get-Random)"
+            $contextLoginName = "dbatoolsci_ctx_login_$(Get-Random)"
+
+            # The login exists on both servers because the sync does not create logins. The database exists
+            # on both servers and the login has a user in it on the source, so the permission sync walks the
+            # database level collections of both servers - which is the leak this context guards against.
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Name $contextDbName
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceMulti2 -Name $contextDbName
+            foreach ($contextInstance in $TestConfig.InstanceMulti1, $TestConfig.InstanceMulti2) {
+                $splatContextLogin = @{
+                    SqlInstance = $contextInstance
+                    Login       = $contextLoginName
+                    Password    = (ConvertTo-SecureString -String "dbatools.IO" -AsPlainText -Force)
+                }
+                $null = New-DbaLogin @splatContextLogin
+            }
+            $splatContextUser = @{
+                SqlInstance = $TestConfig.InstanceMulti1
+                Database    = $contextDbName
+                Login       = $contextLoginName
+                Username    = $contextLoginName
+            }
+            $null = New-DbaDbUser @splatContextUser
+
+            # Only a non-pooled connection can show this. A pooled connection that is closed between two
+            # calls reconnects at its default database, which puts the database back by accident.
+            $sourceCallerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -NonPooledConnection
+            $destCallerServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti2 -NonPooledConnection
+            $sourceContextBefore = $sourceCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+            $destContextBefore = $destCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            $splatSyncPermission = @{
+                Source      = $sourceCallerServer
+                Destination = $destCallerServer
+                Login       = $contextLoginName
+            }
+            $contextResult = Sync-DbaLoginPermission @splatSyncPermission
+
+            $sourceContextAfter = $sourceCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+            $destContextAfter = $destCallerServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")
+
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = $sourceCallerServer | Disconnect-DbaInstance
+            $null = $destCallerServer | Disconnect-DbaInstance
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1, $TestConfig.InstanceMulti2 -Database $contextDbName -ErrorAction SilentlyContinue
+            $null = Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti1, $TestConfig.InstanceMulti2 -Login $contextLoginName -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "syncs the database user of the login" {
+            # Only a command that really did something can move the connections, so without this the
+            # assertions below would pass for the wrong reason.
+            $contextResult.Status | Should -Be "Successful"
+            (Get-DbaDbUser -SqlInstance $TestConfig.InstanceMulti2 -Database $contextDbName).Name | Should -Contain $contextLoginName
+        }
+
+        It "leaves the source connection in the database it was in" {
+            $sourceContextAfter | Should -Be $sourceContextBefore
+        }
+
+        It "leaves the destination connection in the database it was in" {
+            $destContextAfter | Should -Be $destContextBefore
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #10556, closes #10555)
 - [x] Pester test is included

This completes bucket B of #10555 and **closes that issue**: with it, everything the issue documents as fixable by the wrapper mechanism is merged or in here - bucket A in #10579, the server level statements in #10580, the consumer side check in #10564. The two remaining surfaces, SMO `Create()`/`Drop()` (bucket C) and collection enumeration (bucket D), continue in #10604, which starts with the scope decision to make before any batch is written.

It replaces #10602, which fixed `Invoke-DbaDbUpgrade` on its own. That fix is in here, using the helper below instead of its own copy of the same block, so the two cannot be merged separately in the wrong order.

### Purpose

Eighteen commands handed the connection back pointing at the last database they touched. `Invoke-DbaDbUpgrade` is the command from the provisioning script that started this whole workstream (#10556); most of the others only read, which makes the leak worse rather than better - reading is supposed to be harmless.

Measured on SQL Server 2019 with `-NonPooledConnection`, before the fix. The row counts are there to show the commands were doing real work while they leaked:

```
Find-DbaTrigger           LEAKED   rows=1     Get-DbaPermission        LEAKED   rows=235
Find-DbaView              LEAKED   rows=1     Get-DbaLastGoodCheckDb   LEAKED   rows=1
Find-DbaStoredProcedure   LEAKED   rows=1     Get-DbaDbSpace           LEAKED   rows=2
Find-DbaObject            LEAKED   rows=4     Invoke-DbaDbUpgrade      LEAKED
Find-DbaDbDisabledIndex   LEAKED   rows=1
Get-DbaQueryExecutionTime LEAKED   rows=28
```

The second batch: `Remove-DbaDbOrphanUser`, `Repair-DbaDbOrphanUser`, `ConvertTo-DbaXESession`, `Find-DbaOrphanedFile`, `Invoke-DbaDbDecryptObject` and `Copy-DbaDatabase`.

The third batch closes bucket B: `Copy-DbaLogin` and `Sync-DbaLoginPermission`, together with the private `Update-SqlPermission` that does the permission work for both. These three are one unit on purpose - measured earlier on this issue, routing the two `ExecuteNonQuery` calls of `Update-SqlPermission` through the fixed wrapper alone does **not** stop the callers from leaking, because the leak is also the enumeration of database level collections (`$destDb.Users[...]`, `$destDb.Roles`, `$sourceDb.Roles`) and, in `Copy-DbaLogin`, SMO's own `Login.Create()` and `Login.Drop()`, which move the connection to `master`. Both commands leak on **two** connections, the source and every destination, and both are put back.

With this, every direct SMO `ExecuteNonQuery`/`ExecuteWithResults` on a `Database` object in the module is either fixed or deliberately left alone: `Get-EncryptedObjectImageValue` keeps its call because rerouting it broke the off-row decryption path, and its only caller `Invoke-DbaDbDecryptObject` restores the context instead.

### Approach

Every one of these commands has **two** causes, and fixing either alone leaves the leak in place.

**1. The call.** `Database.ExecuteWithResults` and `Database.ExecuteNonQuery` are SMO's own methods and issue a `USE` on the execution manager of the database - which is the connection context of the parent server and belongs to the caller. They go through our `Query` and `Invoke` script methods now, which restore the previous database in a `finally` since #10579. Statements that never needed a database context run on the server connection instead (the `sys.master_files` reads in `Copy-DbaDatabase`).

**2. Enumerating a database level collection does exactly the same**, and no script method can cover it, because it is a property getter and not a call we make:

```
db.Views                      leaked        db.Size (a plain property)   ok
db.Tables                     leaked        db.Refresh()                 ok
db.StoredProcedures           leaked
db.Users                      leaked
db.Schemas                    leaked
db.Roles                      leaked
db.FileGroups                 leaked
db.Tables[0].Columns          leaked
```

So each command reads `ConnectionContext.CurrentDatabase` **before it starts any work** - reading it later records a database an earlier statement already leaked into, and the restore then does nothing - and puts it back in a `finally`.

### The new private function

That block existed by hand in `Set-DbaTempDbConfig` (#10580) and in the four script methods (#10579), and this change would have added many more copies. `private/functions/Restore-DatabaseContext.ps1` is that block once: the case sensitive comparison, the escaping of a closing bracket in the name, and the rule that a failing restore **warns rather than throwing** - the database of the caller can be dropped, renamed, taken offline or made unreachable by the very statement that succeeded, and housekeeping must never replace the outcome of the command. Interrupting warning preferences (`Stop`, `Inquire`) are neutralised for that one warning, so cleanup can never terminate a command that succeeded - found in review, with its own regression test.

The script methods in `xml/dbatools.Types.ps1xml` keep their own copy on purpose; they are not commands and do not resolve module private functions. `Set-DbaTempDbConfig` was left alone, so this pull request stays about the commands it fixes.

### One behaviour trap worth flagging for review

Where `ExecuteWithResults` was replaced, the `.Tables.Rows` and `.Tables[0]` readers had to go with it. `Database.Query` ends in `.Tables[0]`, and PowerShell unrolls a `DataTable` on output, so the wrapper already hands back the rows:

```
ExecuteWithResults().Tables.Rows : count=3 firstName=master
Query()                          : count=3 firstName=master
Query().Rows                     : count=3 firstName=          <- one empty object per row
```

Keeping the `.Rows` compiles, runs, returns the right number of objects and empties every column. The existing tests of `Get-DbaDbSpace` and `Get-DbaPermission` caught it. The reverse trap exists too: `ConvertTo-DbaXESession` needs `Query($sql, $true)`, because the conversion procedure spreads its script over several result sets and the one-argument form returns only the first.

`Copy-DbaDatabase` and `Find-DbaOrphanedFile` also carried `$fttable = $null = ...`, a double assignment that always left `$fttable` empty, so no full text catalog was ever copied or reported. Both sit on the SQL Server 2005 path, which no instance in the lab or in CI can reach, so they get the fix and this description but no test.

### Tests

Every command got the same regression `Context`: its own database and objects, a non-pooled caller connection (a pooled one reconnects at its default database and hides the leak), the command run against it, then `DB_NAME()` compared with what it was before. Each also asserts the command still returned what it was asked for, because a command that does nothing cannot leak and would pass for the wrong reason. `Get-DbaQueryExecutionTime` had no integration tests at all and has some now.

`Invoke-DbaDbUpgrade` additionally has a `-NoRefreshView -Force` case, which is the one the restore around the view enumeration cannot cover, so the statements have to put the database back themselves; and a case where the caller sits in `tempdb`, which fails for any fix that restores "to master" instead of restoring what the caller had.

`Copy-DbaLogin` and `Sync-DbaLoginPermission` assert **both** connections, source and destination, each probed on its own non-pooled connection passed in as `-Source` and `-Destination`.

`Restore-DatabaseContext` has its own test file: the collection leak, the bracket escaping against a database really named `dbatoolsci_br]acket_*`, doing nothing when nothing was remembered, warning instead of throwing when the database cannot be reached - including with `-WarningAction Stop` - and running on the session of the caller rather than a copy.

All green in the lab, and each verified to have teeth by reverting the fix:

| test file | result |
| --- | --- |
| `Restore-DatabaseContext` | 6 passed |
| `Invoke-DbaDbUpgrade` | 9 passed |
| `Find-DbaTrigger` | 12 passed |
| `Find-DbaView` | 8 passed |
| `Find-DbaStoredProcedure` | 7 passed |
| `Find-DbaObject` | 16 passed |
| `Find-DbaDbDisabledIndex` | 6 passed |
| `Get-DbaQueryExecutionTime` | 3 passed |
| `Get-DbaPermission` | 10 passed |
| `Get-DbaLastGoodCheckDb` | 9 passed |
| `Get-DbaDbSpace` | 16 passed |
| `Remove-DbaDbOrphanUser` | 11 passed |
| `Repair-DbaDbOrphanUser` | 7 passed |
| `ConvertTo-DbaXESession` | 4 passed |
| `Find-DbaOrphanedFile` | 8 passed |
| `Invoke-DbaDbDecryptObject` | 48 passed |
| `Copy-DbaDatabase` | 28 passed |
| `Copy-DbaLogin` | 20 passed (2 pre-existing skips) |
| `Sync-DbaLoginPermission` | 7 passed |

Removing the single `Restore-DatabaseContext` call from `Find-DbaView` fails its context test and nothing else. Reverting `Invoke` to `ExecuteNonQuery` in `Invoke-DbaDbUpgrade` fails only its `-NoRefreshView` case. Dropping the bracket escaping from the helper fails only the bracket test. Removing the restores from `Copy-DbaLogin` and `Sync-DbaLoginPermission` fails their context tests and nothing else.

### Commands to test

```powershell
$server = Connect-DbaInstance -SqlInstance $instance -NonPooledConnection
$null = Get-DbaDbSpace -SqlInstance $server -Database <any user database>
$server.ConnectionContext.ExecuteScalar("SELECT DB_NAME()")   # master, was that database before
```

---

*This text was created by Claude and reviewed by Andreas Jordan.*
