### PR TITLE
Rename-DbaDatabase - Build expected file paths without validating drives of the test client

### DIFF
--- a/tests/Rename-DbaDatabase.Tests.ps1
+++ b/tests/Rename-DbaDatabase.Tests.ps1
@@ -240,10 +240,14 @@ Describe $CommandName -Tag IntegrationTests {
             $dataExtension = [System.IO.Path]::GetExtension($previewDataFile.FileName)
             $logExtension = [System.IO.Path]::GetExtension($previewLogFile.FileName)
 
-            $fileOverrideResults.FNN[$previewDataFile.FileName] | Should -Be (Join-Path -Path $dataDirectory -ChildPath "dbatoolsci_filemove_data_override$dataExtension")
-            $fileOverrideResults.FNN[$previewLogFile.FileName] | Should -Be (Join-Path -Path $logDirectory -ChildPath "dbatoolsci_filemove_log_override$logExtension")
-            $fileDefaultResults.FNN[$previewDataFile.FileName] | Should -Be (Join-Path -Path $dataDirectory -ChildPath "dbatoolsci_filemove_ROWS$dataExtension")
-            $fileDefaultResults.FNN[$previewLogFile.FileName] | Should -Be (Join-Path -Path $logDirectory -ChildPath "dbatoolsci_filemove_journal$logExtension")
+            # Combine instead of Join-Path: these are paths of the instance, and Windows PowerShell
+            # validates the drive of Join-Path against the drives of the machine running the test,
+            # which does not have to own a drive the remote instance keeps its files on. Combine is
+            # also what the command itself builds the new path with.
+            $fileOverrideResults.FNN[$previewDataFile.FileName] | Should -Be ([System.IO.Path]::Combine($dataDirectory, "dbatoolsci_filemove_data_override$dataExtension"))
+            $fileOverrideResults.FNN[$previewLogFile.FileName] | Should -Be ([System.IO.Path]::Combine($logDirectory, "dbatoolsci_filemove_log_override$logExtension"))
+            $fileDefaultResults.FNN[$previewDataFile.FileName] | Should -Be ([System.IO.Path]::Combine($dataDirectory, "dbatoolsci_filemove_ROWS$dataExtension"))
+            $fileDefaultResults.FNN[$previewLogFile.FileName] | Should -Be ([System.IO.Path]::Combine($logDirectory, "dbatoolsci_filemove_journal$logExtension"))
         }
     }
 


### PR DESCRIPTION
## Summary

The physical-name template test builds its expected paths with `Join-Path` from the file paths of the instance. Windows PowerShell validates the drive qualifier of `Join-Path` against the drives of the machine running the test, so against a remote instance whose files live on a drive the test client does not have - such as a failover cluster instance keeping its databases on a clustered disk - the test fails with "Cannot find drive. A drive with the name 'S' does not exist" although the command works.

## Changes (tests only)

The four expected paths are now built with `[System.IO.Path]::Combine`, which composes strings without touching the provider - and is also what Rename-DbaDatabase itself builds the new path with, so the expectation mirrors the command exactly.

Verified against a clustered instance with databases on a clustered drive (the previously failing shape) and against a regular instance, both warning-free with all tests passing.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)