### PR TITLE
Remove-DbaAgDatabase - Honor the AvailabilityGroup filter

### DIFF
--- a/public/Remove-DbaAgDatabase.ps1
+++ b/public/Remove-DbaAgDatabase.ps1
@@ -98,7 +98,7 @@ function Remove-DbaAgDatabase {
 
         if ((Test-Bound -ParameterName SqlInstance)) {
             if ((Test-Bound -Not -ParameterName Database)) {
-                Stop-Function -Message "You must specify one or more databases and one or more Availability Groups when using the SqlInstance parameter."
+                Stop-Function -Message "You must specify one or more databases when using the SqlInstance parameter."
                 return
             }
         }

--- a/public/Remove-DbaAgDatabase.ps1
+++ b/public/Remove-DbaAgDatabase.ps1
@@ -110,7 +110,13 @@ function Remove-DbaAgDatabase {
         }
 
         if ($SqlInstance) {
-            $InputObject += Get-DbaAgDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database
+            $splatGetAgDatabase = @{
+                SqlInstance       = $SqlInstance
+                SqlCredential     = $SqlCredential
+                Database          = $Database
+                AvailabilityGroup = $AvailabilityGroup
+            }
+            $InputObject += Get-DbaAgDatabase @splatGetAgDatabase
         }
 
         foreach ($db in $InputObject) {

--- a/tests/Remove-DbaAgDatabase.Tests.ps1
+++ b/tests/Remove-DbaAgDatabase.Tests.ps1
@@ -47,6 +47,18 @@ Describe $CommandName -Tag IntegrationTests {
         }
         $ag = New-DbaAvailabilityGroup @splatAvailabilityGroup
 
+        # A second availability group without any databases, to prove that a removal scoped
+        # to this group does not touch databases in other availability groups.
+        $agname2 = "dbatoolsci_removeagdb_agroup2"
+        $splatAvailabilityGroup2 = @{
+            Primary      = $TestConfig.InstanceHadr
+            Name         = $agname2
+            ClusterType  = "None"
+            FailoverMode = "Manual"
+            Certificate  = "dbatoolsci_AGCert"
+        }
+        $null = New-DbaAvailabilityGroup @splatAvailabilityGroup2
+
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
@@ -55,12 +67,23 @@ Describe $CommandName -Tag IntegrationTests {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-        $null = Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname
+        $null = Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname, $agname2
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.InstanceHadr -Type DatabaseMirroring | Remove-DbaEndpoint
         $null = Remove-DbaDatabase -SqlInstance $server -Database $dbname
         Remove-Item -Path "$($TestConfig.Temp)\$dbname.bak", "$($TestConfig.Temp)\$dbname.trn" -ErrorAction SilentlyContinue
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "honors the AvailabilityGroup filter" {
+        It "does not remove the database when the removal is scoped to another availability group" {
+            $results = Remove-DbaAgDatabase -SqlInstance $TestConfig.InstanceHadr -Database $dbname -AvailabilityGroup $agname2
+            $results | Should -BeNullOrEmpty
+            $WarnVar | Should -BeNullOrEmpty
+
+            $agDatabase = Get-DbaAgDatabase -SqlInstance $TestConfig.InstanceHadr -Database $dbname
+            $agDatabase.AvailabilityGroup | Should -Be $agname
+        }
     }
 
     Context "removes ag db" {


### PR DESCRIPTION
## Problem

`Remove-DbaAgDatabase` declares and documents `-AvailabilityGroup` ("Limits the operation to databases within specific availability groups") but never uses it. The internal `Get-DbaAgDatabase` call only received `-Database`, so a removal scoped to one availability group removed the database from whatever availability group actually contained it.

## What changed

The `-AvailabilityGroup` parameter is now passed through to `Get-DbaAgDatabase`, which already supported it. The call was converted to a splat per the style guide.

## What deliberately did not change

- The pipeline path (`-InputObject`) is untouched: piped objects are already the caller's explicit selection.
- The error text for the `-SqlInstance` path used to demand "one or more Availability Groups" although the check only requires `-Database`; a follow-up commit on this branch corrects the wording to match what is actually required.

## Tests

Added a regression test that creates a second availability group, scopes a removal to it, and asserts the database in the first availability group survives and nothing is returned. Verified against the lab HADR instance (SQL Server 2025): the new test fails on the old code with exactly the reported behavior (`Status=Removed` for the out-of-scope database) and the full file passes with the fix (4/4).

Found by @greenmtnsun via static analysis, reported in #10607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
