### PR TITLE
Remove-DbaAgListener - Honor the AvailabilityGroup filter

### DIFF
--- a/public/Remove-DbaAgListener.ps1
+++ b/public/Remove-DbaAgListener.ps1
@@ -97,7 +97,13 @@ function Remove-DbaAgListener {
         }
 
         if ($SqlInstance) {
-            $InputObject += Get-DbaAgListener -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Listener $Listener
+            $splatGetAgListener = @{
+                SqlInstance       = $SqlInstance
+                SqlCredential     = $SqlCredential
+                Listener          = $Listener
+                AvailabilityGroup = $AvailabilityGroup
+            }
+            $InputObject += Get-DbaAgListener @splatGetAgListener
         }
 
         foreach ($aglistener in $InputObject) {

--- a/public/Remove-DbaAgListener.ps1
+++ b/public/Remove-DbaAgListener.ps1
@@ -91,7 +91,7 @@ function Remove-DbaAgListener {
 
         if ((Test-Bound -ParameterName SqlInstance)) {
             if ((Test-Bound -Not -ParameterName Listener)) {
-                Stop-Function -Message "You must specify one or more listeners and one or more Availability Groups when using the SqlInstance parameter."
+                Stop-Function -Message "You must specify one or more listeners when using the SqlInstance parameter."
                 return
             }
         }

--- a/tests/Remove-DbaAgListener.Tests.ps1
+++ b/tests/Remove-DbaAgListener.Tests.ps1
@@ -44,6 +44,18 @@ Describe $CommandName -Tag IntegrationTests {
         }
         $agListener = $ag | Add-DbaAgListener @splatListener
 
+        # A second availability group without a listener, to prove that a removal scoped
+        # to this group does not touch listeners of other availability groups.
+        $agName2 = "dbatoolsci_ag_removelistener2"
+        $splatAg2 = @{
+            Primary      = $TestConfig.InstanceHadr
+            Name         = $agName2
+            ClusterType  = "None"
+            FailoverMode = "Manual"
+            Certificate  = "dbatoolsci_AGCert"
+        }
+        $null = New-DbaAvailabilityGroup @splatAg2
+
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
@@ -52,10 +64,21 @@ Describe $CommandName -Tag IntegrationTests {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-        $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.InstanceHadr -AvailabilityGroup $agName
+        $null = Remove-DbaAvailabilityGroup -SqlInstance $TestConfig.InstanceHadr -AvailabilityGroup $agName, $agName2
         $null = Get-DbaEndpoint -SqlInstance $TestConfig.InstanceHadr -Type DatabaseMirroring | Remove-DbaEndpoint
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "honors the AvailabilityGroup filter" {
+        It "does not remove the listener when the removal is scoped to another availability group" {
+            $results = Remove-DbaAgListener -SqlInstance $TestConfig.InstanceHadr -Listener $agListener.Name -AvailabilityGroup $agName2
+            $results | Should -BeNullOrEmpty
+            $WarnVar | Should -BeNullOrEmpty
+
+            $listener = Get-DbaAgListener -SqlInstance $TestConfig.InstanceHadr -Listener $agListener.Name
+            $listener.AvailabilityGroup | Should -Be $agName
+        }
     }
 
     Context "When removing a listener" {


### PR DESCRIPTION
## Problem

`Remove-DbaAgListener` declares and documents `-AvailabilityGroup` ("Filters listener removal to only those within the specified availability groups") but never uses it. The internal `Get-DbaAgListener` call only received `-Listener`, so a removal scoped to one availability group removed the named listener regardless of which availability group it belonged to.

## What changed

The `-AvailabilityGroup` parameter is now passed through to `Get-DbaAgListener`, which already supported it. The call was converted to a splat per the style guide.

A follow-up commit also corrects the `-SqlInstance` validation message, which demanded "one or more Availability Groups" although the check only requires `-Listener`.

## What deliberately did not change

The pipeline path (`-InputObject`) is untouched: piped listener objects are already the caller's explicit selection.

## Tests

Added a regression test that creates a second availability group, scopes the removal of the first group's listener to that second group, and asserts nothing is returned and the listener survives. Verified against the lab HADR instance (SQL Server 2025): the new test fails on the old code with exactly the reported behavior (`Status=Removed` for the out-of-scope listener) and the full file passes with the fix (3/3).

Same defect shape as #10608. Found by @greenmtnsun via static analysis, reported in #10607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
