### PR TITLE
Get-DbaDbTable - Make IncludeSystemDBs actually exclude system databases by default

### DIFF
--- a/public/Get-DbaDbTable.ps1
+++ b/public/Get-DbaDbTable.ps1
@@ -27,6 +27,7 @@ function Get-DbaDbTable {
     .PARAMETER IncludeSystemDBs
         Includes system databases (master, model, msdb, tempdb) in the table scan.
         By default system databases are excluded since they rarely contain user tables of interest.
+        Databases requested explicitly with -Database are always processed, whether they are system databases or not.
 
     .PARAMETER Table
         Specifies specific tables to retrieve using one, two, or three-part naming (table, schema.table, or database.schema.table).
@@ -170,7 +171,18 @@ function Get-DbaDbTable {
         if (Test-FunctionInterrupt) { return }
 
         foreach ($instance in $SqlInstance) {
-            $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase | Where-Object IsAccessible
+            $splatGetDatabase = @{
+                SqlInstance     = $instance
+                SqlCredential   = $SqlCredential
+                Database        = $Database
+                ExcludeDatabase = $ExcludeDatabase
+            }
+            # An explicitly requested database is always honored, even a system database.
+            # The switch only decides whether a scan of the whole instance includes the system databases.
+            if (-not $Database -and -not $IncludeSystemDBs) {
+                $splatGetDatabase.ExcludeSystem = $true
+            }
+            $InputObject += Get-DbaDatabase @splatGetDatabase | Where-Object IsAccessible
         }
 
         foreach ($db in $InputObject) {

--- a/tests/Get-DbaDbTable.Tests.ps1
+++ b/tests/Get-DbaDbTable.Tests.ps1
@@ -141,4 +141,21 @@ Describe $CommandName -Tag IntegrationTests {
             (Get-DbaDbTable -SqlInstance $TestConfig.InstanceSingle -ExcludeDatabase $dbname).Name | Should -Not -Contain $tablename
         }
     }
+
+    Context "System database handling" {
+        It "Does not return tables from system databases by default" {
+            $results = Get-DbaDbTable -SqlInstance $TestConfig.InstanceSingle
+            $results.Database | Should -Not -Contain "msdb"
+        }
+
+        It "Returns tables from system databases with -IncludeSystemDBs" {
+            $results = Get-DbaDbTable -SqlInstance $TestConfig.InstanceSingle -IncludeSystemDBs
+            $results.Database | Should -Contain "msdb"
+        }
+
+        It "Returns tables from a system database that is requested explicitly" {
+            $results = Get-DbaDbTable -SqlInstance $TestConfig.InstanceSingle -Database msdb
+            $results.Database | Should -Contain "msdb"
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`Get-DbaDbTable` declares `-IncludeSystemDBs` and its help promises "By default system databases are excluded since they rarely contain user tables of interest" — but the switch was never referenced in the body. A default scan always returned the tables of master, model, msdb and tempdb (151 system tables on a bare lab instance), and the switch changed nothing.

## What changed

When scanning the instance (no `-Database` given), the internal `Get-DbaDatabase` call now passes `-ExcludeSystem` unless `-IncludeSystemDBs` is set. The call was converted to a splat per the style guide.

The semantics follow `Get-DbaDbEncryption`: a database requested explicitly with `-Database` is always honored, whether it is a system database or not. This keeps `Get-DbaDbTable -Database msdb -Table backupset` working without the switch, and keeps the in-repo caller in `Install-DbaMaintenanceSolution` (which passes `-Database` together with `-IncludeSystemDBs`) working unchanged. The help now states this explicitly.

## What deliberately did not change

- The pipeline path (`-InputObject`) is untouched: piped database objects are the caller's explicit selection.
- This is a behavior change for callers who relied on the buggy default returning system tables in a full scan — but it is the behavior the parameter and its documentation have promised since the parameter was introduced.

## Tests

Added a "System database handling" context: default scan contains no msdb tables, `-IncludeSystemDBs` brings them back, and an explicit `-Database msdb` works without the switch. Verified in the lab against SQL Server 2019: the default-scan test fails on the old code (msdb found) and the full file passes with the fix (9/9).

Found by @greenmtnsun via static analysis, reported in #10607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)