### PR TITLE
Add-DbaAgListener - Stop demanding databases the command does not know

### DIFF
--- a/public/Add-DbaAgListener.ps1
+++ b/public/Add-DbaAgListener.ps1
@@ -139,7 +139,7 @@ function Add-DbaAgListener {
         }
 
         if ((Test-Bound -ParameterName SqlInstance) -and (Test-Bound -Not -ParameterName AvailabilityGroup)) {
-            Stop-Function -Message "You must specify one or more databases and one or more Availability Groups when using the SqlInstance parameter."
+            Stop-Function -Message "You must specify one or more Availability Groups when using the SqlInstance parameter."
             return
         }
 


### PR DESCRIPTION
## Problem

When `Add-DbaAgListener` is called with `-SqlInstance` but without `-AvailabilityGroup`, it stops with:

> You must specify one or more databases and one or more Availability Groups when using the SqlInstance parameter.

The command has no `-Database` parameter at all — the wording was copy-pasted from the availability group database commands. A user who follows the message literally is told to supply a parameter that does not exist.

## What changed

The message now matches what the check at that line actually requires:

> You must specify one or more Availability Groups when using the SqlInstance parameter.

One line; no behavior change. No test asserts the old wording, so no test changes are needed. The existing test file passes against the lab HADR instance (3/3).

Sibling wording fixes for `Remove-DbaAgDatabase` and `Remove-DbaAgListener` ride along in #10608 and #10609; `Set-DbaAgListener` has the same message shape but its text matches its check, so it is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)