### PR TITLE
Testing Get-DbaNetworkConfiguration - Certify the virtual name of a cluster instance

### DIFF
--- a/tests/Get-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Get-DbaNetworkConfiguration.Tests.ps1
@@ -64,7 +64,24 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Command returns correct certificate information" {
         BeforeAll {
             $computerName = ([DbaInstanceParameter]$TestConfig.InstanceSingle).ComputerName
-            $certificate = New-DbaComputerCertificate -ComputerName $computerName -SelfSigned -KeyLength 2048 -HashAlgorithm Sha256 -EnableException
+
+            # On a failover cluster instance the certificate must carry the virtual network name of the
+            # instance, but New-DbaComputerCertificate resolves that name to the node it currently runs
+            # on and would issue the certificate for the node. So read the virtual server name first and
+            # pass it as ClusterInstanceName, which is the documented way to certify a cluster instance.
+            # On a stand-alone instance VSName is empty and the certificate is issued for the node.
+            $vsName = (Get-DbaNetworkConfiguration -SqlInstance $TestConfig.InstanceSingle -OutputType Certificate -EnableException).VSName
+            $splatCertificate = @{
+                ComputerName    = $computerName
+                SelfSigned      = $true
+                KeyLength       = 2048
+                HashAlgorithm   = "Sha256"
+                EnableException = $true
+            }
+            if ($vsName) {
+                $splatCertificate.ClusterInstanceName = $vsName
+            }
+            $certificate = New-DbaComputerCertificate @splatCertificate
             $results = Get-DbaNetworkConfiguration -SqlInstance $TestConfig.InstanceSingle -EnableException
         }
 


### PR DESCRIPTION
## Problem

On a lab configuration whose `InstanceSingle` is a failover cluster instance (FCI01, a clustered default instance), the test "Should return a suitable certificate thumbprint" fails: `SuitableCertificate` comes back empty.

The command is right and the test fixture is wrong. `Get-DbaNetworkConfiguration` checks candidate certificates against the instance''s virtual server name (`VSNAME`), per Microsoft''s certificate requirements for failover clusters. But the test created its certificate with `New-DbaComputerCertificate -ComputerName FCI01`, and that command resolves the virtual name to the node the instance currently runs on — the certificate was issued as `CN=SQL02.ordix.local` with only the node in its SAN. Diagnosed by evaluating each of the eight suitability conditions individually on the node: all pass except the DNS name match.

## What changed

Test only. The fixture now reads `VSName` from `Get-DbaNetworkConfiguration -OutputType Certificate` first and, when it is set, passes it as `-ClusterInstanceName` — the documented way to certify a cluster instance (nodes in `-ComputerName`, virtual name in `-ClusterInstanceName`). On a stand-alone instance `VSName` is empty and the call is exactly what it was before.

## What deliberately did not change

`New-DbaComputerCertificate` itself. That a plain `-ComputerName <cluster network name>` silently issues a certificate for the node could be considered surprising, but `-ClusterInstanceName` exists and is documented for this, so the command was left alone.

## Tests

Verified in the lab on both shapes: 4/4 against the setC configuration (FCI01 as InstanceSingle, previously failing) and 4/4 against the default configuration (stand-alone SQL 2019 instance).

This is the third test defect exposed by running the suite with a clustered default instance, after #10605 and #10606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)