### PR TITLE
Test-DbaDiskAlignment - Reach a failover cluster instance through its virtual name

### DIFF
--- a/public/Test-DbaDiskAlignment.ps1
+++ b/public/Test-DbaDiskAlignment.ps1
@@ -182,10 +182,45 @@ function Test-DbaDiskAlignment {
 
                     $instanceName = $instance.Replace("MSSQLSERVER", "Default")
                     Write-Message -Level Verbose -Message "Found instance $instanceName" -FunctionName $FunctionName
+
+                    # A failover cluster instance is reached through its virtual server name, not through
+                    # the name of the node it currently runs on. The virtual name is in the ClusterName
+                    # value of the Cluster key of the instance hive, which only exists for clustered instances.
+                    $connectionName = $ComputerName
+                    $splatRegistryHive = @{
+                        CimSession = $cimSession
+                        Namespace  = "root/default"
+                        ClassName  = "StdRegProv"
+                        MethodName = "GetStringValue"
+                        Arguments  = @{
+                            hDefKey     = [uint32]2147483650  # HKEY_LOCAL_MACHINE
+                            sSubKeyName = "SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL"
+                            sValueName  = $instance
+                        }
+                    }
+                    $instanceHive = (Invoke-CimMethod @splatRegistryHive).sValue
+                    if ($instanceHive) {
+                        $splatClusterName = @{
+                            CimSession = $cimSession
+                            Namespace  = "root/default"
+                            ClassName  = "StdRegProv"
+                            MethodName = "GetStringValue"
+                            Arguments  = @{
+                                hDefKey     = [uint32]2147483650  # HKEY_LOCAL_MACHINE
+                                sSubKeyName = "SOFTWARE\Microsoft\Microsoft SQL Server\$instanceHive\Cluster"
+                                sValueName  = "ClusterName"
+                            }
+                        }
+                        $clusterName = (Invoke-CimMethod @splatClusterName).sValue
+                        if ($clusterName) {
+                            Write-Message -Level Verbose -Message "Instance $instanceName is clustered, using virtual server name $clusterName" -FunctionName $FunctionName
+                            $connectionName = $clusterName
+                        }
+                    }
                     if ($instance -eq 'MSSQLSERVER') {
-                        $SqlInstances += $ComputerName
+                        $SqlInstances += $connectionName
                     } else {
-                        $SqlInstances += "$ComputerName\$instance"
+                        $SqlInstances += "$connectionName\$instance"
                     }
                 }
                 $sqlcount = $SqlInstances.Count


### PR DESCRIPTION
## Problem

Against a cluster node, `Test-DbaDiskAlignment` took 366 seconds and returned nothing.

The command discovers instances from the node''s `Win32_Service` list and builds connection names as `<node>` / `<node>\<instance>`. A failover cluster instance only listens on its virtual server name, so on a node hosting FCIs every `Connect-DbaInstance` attempt burned the full connection timeout ("The system cannot find the file specified"), per instance and per disk — that is the six minutes. And because no connection ever succeeded, no disk qualified as a SQL disk, so the output was empty.

## What changed

For each discovered SQL service the command now reads the `ClusterName` value from the instance hive''s `Cluster` registry key (`SOFTWARE\Microsoft\Microsoft SQL Server\<hive>\Cluster`) via `StdRegProv` over the CIM session it already holds — the key only exists for clustered instances. When present, the virtual server name is used as the connection name; otherwise the node name is used exactly as before. `StdRegProv` works over both WSMan and the DCOM fallback, so the command''s transport requirements are unchanged.

On the lab cluster node (hosting FCI01 as clustered default instance and FCI02\SQL2022): before, 366s and no output; after, **6 seconds** and both cluster volumes correctly reported as SQL disks.

## What deliberately did not change

- Stand-alone instance discovery and connection naming.
- The disk enumeration itself: cluster volumes owned by the node were always enumerated; the fix only makes the SQL-usage check able to see them.

## Tests

The existing test file passes on both lab shapes: 3/3 against the default configuration (stand-alone SQL 2019) and 3/3 against the setC configuration (FCI01 as InstanceSingle, previously failing with an empty result). An FCI cannot be provisioned on any CI runner, so like the `Get-DbaWsfc*` family this path gets its real-boundary coverage from lab runs; the stand-alone path stays covered by CI.

Part of the setC findings (first full run with a clustered default instance), alongside #10605, #10606 and #10613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)