### PR TITLE
Set-DbaTempDbConfig - Make forced file removal survive work tables and stop resetting the log growth

### DIFF
--- a/public/Set-DbaTempDbConfig.ps1
+++ b/public/Set-DbaTempDbConfig.ps1
@@ -198,17 +198,20 @@ function Set-DbaTempDbConfig {
             }
 
             #Set DataFileCount if not specified. If specified, check against best practices.
+            # Per-iteration local: assigning the fallback to the parameter variable would carry the
+            # first instance's core count into every later instance of the same call.
             if (-not $DataFileCount) {
-                $DataFileCount = $cores
-                Write-Message -Message "Data file count set to number of cores: $DataFileCount" -Level Verbose
+                $effectiveDataFileCount = $cores
+                Write-Message -Message "Data file count set to number of cores: $effectiveDataFileCount" -Level Verbose
             } else {
-                if ($DataFileCount -gt $cores) {
-                    Write-Message -Message "Data File Count of $DataFileCount exceeds the Logical Core Count of $cores. This is outside of best practices." -Level Warning
+                $effectiveDataFileCount = $DataFileCount
+                if ($effectiveDataFileCount -gt $cores) {
+                    Write-Message -Message "Data File Count of $effectiveDataFileCount exceeds the Logical Core Count of $cores. This is outside of best practices." -Level Warning
                 }
-                Write-Message -Message "Data file count set explicitly: $DataFileCount" -Level Verbose
+                Write-Message -Message "Data file count set explicitly: $effectiveDataFileCount" -Level Verbose
             }
 
-            $DataFilesizeSingle = $([Math]::Floor($DataFileSize / $DataFileCount))
+            $DataFilesizeSingle = $([Math]::Floor($DataFileSize / $effectiveDataFileCount))
             Write-Message -Message "Single data file size (MB): $DataFilesizeSingle." -Level Verbose
 
             if (Test-Bound -ParameterName DataPath) {
@@ -278,12 +281,12 @@ ORDER BY file_id;
             $filesToRemove = @()
             $filesToKeep = @($tempdbFiles)
 
-            if ($CurrentFileCount -gt $DataFileCount) {
+            if ($CurrentFileCount -gt $effectiveDataFileCount) {
                 if (-not $Force) {
-                    Stop-Function -Message "Current tempdb in $instance is not suitable to be reconfigured. The current tempdb has a greater number of files ($CurrentFileCount) than the calculated configuration ($DataFileCount)." -Continue
+                    Stop-Function -Message "Current tempdb in $instance is not suitable to be reconfigured. The current tempdb has a greater number of files ($CurrentFileCount) than the calculated configuration ($effectiveDataFileCount)." -Continue
                 }
 
-                $removeCount = $CurrentFileCount - $DataFileCount
+                $removeCount = $CurrentFileCount - $effectiveDataFileCount
                 $filesToRemove = @(
                     $tempdbFiles |
                         Where-Object { $PSItem.FileId -ne 1 } |
@@ -292,7 +295,7 @@ ORDER BY file_id;
                 )
 
                 if ($filesToRemove.Count -ne $removeCount) {
-                    Stop-Function -Message "Current tempdb in $instance cannot be reduced to $DataFileCount data files without removing the primary data file." -Continue
+                    Stop-Function -Message "Current tempdb in $instance cannot be reduced to $effectiveDataFileCount data files without removing the primary data file." -Continue
                 }
 
                 $usedMb = ($tempdbFiles | Measure-Object -Property UsedMb -Sum).Sum
@@ -358,7 +361,7 @@ END;
             $dataPathIndexToUse = 0
 
             #Checks passed, process reconfiguration
-            for ($i = 0; $i -lt $DataFileCount; $i++) {
+            for ($i = 0; $i -lt $effectiveDataFileCount; $i++) {
                 $File = $DataFiles[$i]
 
                 if ($DataPath.Count -gt 1) {
@@ -400,8 +403,12 @@ END;
 
             $logfile = Get-DbaDbFile -SqlInstance $server -Database tempdb | Where-Object Type -eq 1 | Select-Object LogicalName, PhysicalName, @{L = "SizeMb"; E = { $_.Size.Megabyte } }
 
+            # Per-iteration local: assigning the fallback to the parameter variable would carry the
+            # first instance's log size into the statement for every later instance of the same call.
             if (-not $LogFileSize) {
-                $LogFileSize = $logfile.SizeMb
+                $effectiveLogFileSize = $logfile.SizeMb
+            } else {
+                $effectiveLogFileSize = $LogFileSize
             }
 
             # The log path is always known at this point, because it is derived from the running
@@ -419,7 +426,7 @@ END;
                     $NewPath = $logfile.PhysicalName
                 }
 
-                $sql += "ALTER DATABASE tempdb MODIFY FILE(name=$LogicalName,filename='$NewPath',size=$LogFileSize MB,filegrowth=$LogFileGrowth);"
+                $sql += "ALTER DATABASE tempdb MODIFY FILE(name=$LogicalName,filename='$NewPath',size=$effectiveLogFileSize MB,filegrowth=$LogFileGrowth);"
             }
 
             Write-Message -Message "SQL Statement to resize tempdb." -Level Verbose
@@ -440,7 +447,10 @@ END;
                         # only. So the database of the caller is put back once the batches have run,
                         # in a finally, because a reconfiguration that fails half way moves it just as much.
                         try {
-                            $server.ConnectionContext.ExecuteNonQuery($sql)
+                            # ExecuteNonQuery returns the rows-affected count per statement; without
+                            # the assignment every executed batch leaked a raw -1 into the pipeline
+                            # alongside the result object.
+                            $null = $server.ConnectionContext.ExecuteNonQuery($sql)
                         } finally {
                             & $restoreCallerDatabase
                         }
@@ -450,10 +460,10 @@ END;
                             ComputerName       = $server.ComputerName
                             InstanceName       = $server.ServiceName
                             SqlInstance        = $server.DomainInstanceName
-                            DataFileCount      = $DataFileCount
+                            DataFileCount      = $effectiveDataFileCount
                             DataFileSize       = [dbasize]($DataFileSize * 1024 * 1024)
                             SingleDataFileSize = [dbasize]($DataFilesizeSingle * 1024 * 1024)
-                            LogSize            = [dbasize]($LogFileSize * 1024 * 1024)
+                            LogSize            = [dbasize]($effectiveLogFileSize * 1024 * 1024)
                             DataPath           = $DataPath
                             LogPath            = $LogPath
                             DataFileGrowth     = [dbasize]($DataFileGrowth * 1024 * 1024)

--- a/public/Set-DbaTempDbConfig.ps1
+++ b/public/Set-DbaTempDbConfig.ps1
@@ -39,6 +39,7 @@ function Set-DbaTempDbConfig {
     .PARAMETER LogFileGrowth
         Controls the growth increment for the tempdb log file in MB when it needs to expand. Defaults to 512 MB.
         Size this according to your transaction log activity in tempdb to minimize auto-growth events during peak workloads.
+        The log file is only modified when at least one of LogPath, LogFileSize, LogFileGrowth or DisableGrowth is specified; otherwise it stays untouched.
 
     .PARAMETER DataPath
         Sets the folder path(s) where tempdb data files will be created. When omitted, uses the current tempdb data file location.
@@ -63,6 +64,7 @@ function Set-DbaTempDbConfig {
     .PARAMETER Force
         Allows the command to reduce the number of tempdb data files. The highest-numbered secondary data files are emptied and removed first, and the primary data file is never selected for removal.
         The command refuses the reduction when current used space exceeds the requested total data file size. Use OutputScriptOnly to review the generated DBCC SHRINKFILE and ALTER DATABASE statements before execution.
+        The generated script releases the unused server cache entries (DBCC FREESYSTEMCACHE) before emptying the files, because cached work tables otherwise block DBCC SHRINKFILE with EMPTYFILE. Active cache entries and the buffer pool are not touched.
 
     .PARAMETER WhatIf
         If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
@@ -102,7 +104,7 @@ function Set-DbaTempDbConfig {
 
         System.String[] (when -OutputScriptOnly is specified)
 
-        Returns an array of T-SQL statements that would configure tempdb without executing them. Forced file-count reductions also include DBCC SHRINKFILE and ALTER DATABASE REMOVE FILE statements.
+        Returns an array of T-SQL statements that would configure tempdb without executing them. Forced file-count reductions also include DBCC FREESYSTEMCACHE, DBCC SHRINKFILE and ALTER DATABASE REMOVE FILE statements.
 
         System.Void (when -OutFile is specified)
 
@@ -314,8 +316,38 @@ ORDER BY file_id;
             foreach ($fileToRemove in $filesToRemove) {
                 $escapedLogicalName = $fileToRemove.LogicalName.Replace("'", "''")
                 $escapedIdentifier = $fileToRemove.LogicalName.Replace("]", "]]")
-                $removalSql += "USE [tempdb]; DBCC SHRINKFILE (N'$escapedLogicalName', EMPTYFILE);"
-                $removalSql += "USE [tempdb]; ALTER DATABASE tempdb REMOVE FILE [$escapedIdentifier];"
+                # EMPTYFILE cannot move work table pages, and cached work tables survive the queries
+                # that created them, so on an instance that has seen any workload the removal fails
+                # with "could not be moved because it is a work table page". Releasing the unused
+                # cache entries drops those cached work tables; active cache entries and the buffer
+                # pool stay untouched, and a restart is due after this command anyway. Because a
+                # fresh work table can appear in the file at any moment, the release, the emptying
+                # and the removal travel as one batch per file and the batch retries.
+                $removalSql += @"
+USE [tempdb];
+DECLARE @removalAttempt int;
+SET @removalAttempt = 0;
+WHILE 1 = 1
+BEGIN
+    BEGIN TRY
+        DBCC FREESYSTEMCACHE ('ALL');
+        DBCC SHRINKFILE (N'$escapedLogicalName', EMPTYFILE);
+        ALTER DATABASE tempdb REMOVE FILE [$escapedIdentifier];
+        BREAK;
+    END TRY
+    BEGIN CATCH
+        SET @removalAttempt = @removalAttempt + 1;
+        IF @removalAttempt >= 5
+        BEGIN
+            DECLARE @removalError nvarchar(2048);
+            SET @removalError = ERROR_MESSAGE();
+            RAISERROR(@removalError, 16, 1);
+            BREAK;
+        END;
+        WAITFOR DELAY '00:00:02';
+    END CATCH
+END;
+"@
             }
 
             $DataFiles = @($filesToKeep | Sort-Object FileId | Select-Object LogicalName, PhysicalName)
@@ -368,18 +400,23 @@ ORDER BY file_id;
 
             $logfile = Get-DbaDbFile -SqlInstance $server -Database tempdb | Where-Object Type -eq 1 | Select-Object LogicalName, PhysicalName, @{L = "SizeMb"; E = { $_.Size.Megabyte } }
 
-            if ($LogPath -or $LogFileSize) {
+            if (-not $LogFileSize) {
+                $LogFileSize = $logfile.SizeMb
+            }
+
+            # The log path is always known at this point, because it is derived from the running
+            # instance when the parameter is not bound. So whether the log file is touched at all
+            # has to be decided from the bound parameters: on the variables, every call would emit
+            # the log statement and silently reset the growth of the log file to the LogFileGrowth
+            # default of 512 MB.
+            if ((Test-Bound -ParameterName LogPath, LogFileSize, LogFileGrowth) -or $DisableGrowth) {
                 $Filename = Split-Path $logfile.PhysicalName -Leaf
                 $LogicalName = $logfile.LogicalName
 
-                if ($LogPath) {
+                if (Test-Bound -ParameterName LogPath) {
                     $NewPath = "$LogPath\$Filename"
                 } else {
                     $NewPath = $logfile.PhysicalName
-                }
-
-                if (-not($LogFileSize)) {
-                    $LogFileSize = $logfile.SizeMb
                 }
 
                 $sql += "ALTER DATABASE tempdb MODIFY FILE(name=$LogicalName,filename='$NewPath',size=$LogFileSize MB,filegrowth=$LogFileGrowth);"

--- a/tests/Set-DbaTempDbConfig.Tests.ps1
+++ b/tests/Set-DbaTempDbConfig.Tests.ps1
@@ -39,18 +39,18 @@ Describe $CommandName -Tag IntegrationTests {
 
         $random = Get-Random
 
-        $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+        $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
 
         $tempdbDataFilePhysicalName = $server.Databases["tempdb"].Query("SELECT physical_name as PhysicalName FROM sys.database_files WHERE file_id = 1").PhysicalName
         $tempdbDataFilePath = Split-Path $tempdbDataFilePhysicalName
 
-        if (([DbaInstanceParameter]($TestConfig.InstanceSingle)).IsLocalHost) {
+        if (([DbaInstanceParameter]($TestConfig.InstanceMulti1)).IsLocalHost) {
             $null = New-Item -Path "$tempdbDataFilePath\DataDir0_$random" -Type Directory
             $null = New-Item -Path "$tempdbDataFilePath\DataDir1_$random" -Type Directory
             $null = New-Item -Path "$tempdbDataFilePath\DataDir2_$random" -Type Directory
             $null = New-Item -Path "$tempdbDataFilePath\Log_$random" -Type Directory
         } else {
-            Invoke-Command2 -ComputerName $TestConfig.InstanceSingle -ScriptBlock {
+            Invoke-Command2 -ComputerName $TestConfig.InstanceMulti1 -ScriptBlock {
                 $null = New-Item -Path "$($args[0])\DataDir0_$($args[1])" -Type Directory
                 $null = New-Item -Path "$($args[0])\DataDir1_$($args[1])" -Type Directory
                 $null = New-Item -Path "$($args[0])\DataDir2_$($args[1])" -Type Directory
@@ -67,13 +67,13 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
         # Cleanup all created directories.
-        if (([DbaInstanceParameter]($TestConfig.InstanceSingle)).IsLocalHost) {
+        if (([DbaInstanceParameter]($TestConfig.InstanceMulti1)).IsLocalHost) {
             Remove-Item -Path "$tempdbDataFilePath\DataDir0_$random" -Force -ErrorAction SilentlyContinue
             Remove-Item -Path "$tempdbDataFilePath\DataDir1_$random" -Force -ErrorAction SilentlyContinue
             Remove-Item -Path "$tempdbDataFilePath\DataDir2_$random" -Force -ErrorAction SilentlyContinue
             Remove-Item -Path "$tempdbDataFilePath\Log_$random" -Force -ErrorAction SilentlyContinue
         } else {
-            Invoke-Command2 -ComputerName $TestConfig.InstanceSingle -ScriptBlock {
+            Invoke-Command2 -ComputerName $TestConfig.InstanceMulti1 -ScriptBlock {
                 Remove-Item -Path "$($args[0])\DataDir0_$($args[1])" -Force -ErrorAction SilentlyContinue
                 Remove-Item -Path "$($args[0])\DataDir1_$($args[1])" -Force -ErrorAction SilentlyContinue
                 Remove-Item -Path "$($args[0])\DataDir2_$($args[1])" -Force -ErrorAction SilentlyContinue
@@ -86,13 +86,13 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Command actually works" {
 
         It "test with an invalid data dir" {
-            $result = Set-DbaTempDbConfig -SqlInstance $TestConfig.InstanceSingle -DataFileSize 1024 -DataPath "$tempdbDataFilePath\invalidDir_$random" -OutputScriptOnly -WarningAction SilentlyContinue -WarningVariable WarnVar
+            $result = Set-DbaTempDbConfig -SqlInstance $TestConfig.InstanceMulti1 -DataFileSize 1024 -DataPath "$tempdbDataFilePath\invalidDir_$random" -OutputScriptOnly -WarningAction SilentlyContinue -WarningVariable WarnVar
             $WarnVar | Should -Match "does not exist"
             $result | Should -BeNullOrEmpty
         }
 
         It "valid sql is produced with nearly all options set and a single data directory" {
-            $result = Set-DbaTempDbConfig -SqlInstance $TestConfig.InstanceSingle -DataFileCount 8 -DataFileSize 2048 -LogFileSize 512 -DataFileGrowth 1024 -LogFileGrowth 512 -DataPath "$tempdbDataFilePath\DataDir0_$random" -LogPath "$tempdbDataFilePath\Log_$random" -OutputScriptOnly -WarningAction SilentlyContinue
+            $result = Set-DbaTempDbConfig -SqlInstance $TestConfig.InstanceMulti1 -DataFileCount 8 -DataFileSize 2048 -LogFileSize 512 -DataFileGrowth 1024 -LogFileGrowth 512 -DataPath "$tempdbDataFilePath\DataDir0_$random" -LogPath "$tempdbDataFilePath\Log_$random" -OutputScriptOnly -WarningAction SilentlyContinue
             $sqlStatements = $result -Split ";" | Where-Object { $PSItem -ne "" }
 
             $sqlStatements.Count | Should -Be 9
@@ -101,7 +101,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "valid sql is produced with -DisableGrowth" {
-            $result = Set-DbaTempDbConfig -SqlInstance $TestConfig.InstanceSingle -DataFileCount 8 -DataFileSize 1024 -LogFileSize 512 -DisableGrowth -DataPath $tempdbDataFilePath -LogPath $tempdbDataFilePath -OutputScriptOnly -WarningAction SilentlyContinue
+            $result = Set-DbaTempDbConfig -SqlInstance $TestConfig.InstanceMulti1 -DataFileCount 8 -DataFileSize 1024 -LogFileSize 512 -DisableGrowth -DataPath $tempdbDataFilePath -LogPath $tempdbDataFilePath -OutputScriptOnly -WarningAction SilentlyContinue
             $sqlStatements = $result -Split ";" | Where-Object { $PSItem -ne "" }
 
             $sqlStatements.Count | Should -Be 9
@@ -111,7 +111,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "multiple data directories are supported" {
             $dataDirLocations = "$tempdbDataFilePath\DataDir0_$random", "$tempdbDataFilePath\DataDir1_$random", "$tempdbDataFilePath\DataDir2_$random"
-            $result = Set-DbaTempDbConfig -SqlInstance $TestConfig.InstanceSingle -DataFileCount 8 -DataFileSize 1024 -DataPath $dataDirLocations -OutputScriptOnly -WarningAction SilentlyContinue
+            $result = Set-DbaTempDbConfig -SqlInstance $TestConfig.InstanceMulti1 -DataFileCount 8 -DataFileSize 1024 -DataPath $dataDirLocations -OutputScriptOnly -WarningAction SilentlyContinue
             $sqlStatements = $result -Split ";" | Where-Object { $PSItem -ne "" }
 
             # check the round robin assignment of files to data dir locations
@@ -131,7 +131,7 @@ Describe $CommandName -Tag IntegrationTests {
         BeforeAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-            $tempdbReductionServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+            $tempdbReductionServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
             $tempdbReductionPhysicalName = $tempdbReductionServer.Databases["tempdb"].Query("SELECT physical_name AS PhysicalName FROM sys.database_files WHERE file_id = 1").PhysicalName
             $tempdbReductionDataPath = Split-Path $tempdbReductionPhysicalName
             $originalDataFileState = @($tempdbReductionServer.Databases["tempdb"].Query("SELECT file_id AS ID, name AS LogicalName, size AS SizePages, growth AS GrowthValue, is_percent_growth AS IsPercentGrowth FROM sys.database_files WHERE type = 0 ORDER BY file_id"))
@@ -149,7 +149,7 @@ Describe $CommandName -Tag IntegrationTests {
             # database of the caller back. It has to be non-pooled: SMO reopens a pooled connection at its
             # default database, which hides the leak. msdb rather than master, because restoring to master
             # would pass an assertion and still be wrong. See #10555.
-            $tempdbContextServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -Database msdb -NonPooledConnection
+            $tempdbContextServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1 -Database msdb -NonPooledConnection
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
@@ -383,6 +383,105 @@ END
             $preservedRowCount = $tempdbReductionServer.Databases["tempdb"].Query("SELECT COUNT(1) AS PreservedRows FROM dbo.[$allocationTableName]").PreservedRows
             $preservedRowCount | Should -Be $allocationRowCount
             $tempdbReductionServer.Databases["tempdb"].ExecuteNonQuery("DROP TABLE dbo.[$allocationTableName];")
+        }
+    }
+
+    Context "Two instances keep their own log sizes in one call" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # The per-instance fallback for an unbound -LogFileSize used to be assigned to the
+            # parameter variable, so the first instance's log size leaked into the log statement
+            # of every later instance of the same call.
+            $serverMulti1 = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
+            $serverMulti2 = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti2
+
+            # Two captures per instance: the configured values (master) are what AfterAll restores;
+            # the running values (tempdb itself) are what the command reads for its fallback, and
+            # the two can drift apart on a lab instance that has not restarted since a resize.
+            $configuredQuery = @"
+SELECT name, type, size / 128 AS SizeMb, growth / 128 AS GrowthMb, is_percent_growth
+FROM sys.master_files WHERE database_id = 2
+"@
+            $runningQuery = @"
+SELECT name, type, size / 128 AS SizeMb FROM tempdb.sys.database_files
+"@
+            $configuredBefore1 = Invoke-DbaQuery -SqlInstance $serverMulti1 -Query $configuredQuery
+            $configuredBefore2 = Invoke-DbaQuery -SqlInstance $serverMulti2 -Query $configuredQuery
+            $runningBefore1 = Invoke-DbaQuery -SqlInstance $serverMulti1 -Query $runningQuery
+            $runningBefore2 = Invoke-DbaQuery -SqlInstance $serverMulti2 -Query $runningQuery
+
+            $dataFileCount1 = @($configuredBefore1 | Where-Object type -eq 0).Count
+            $dataFileCount2 = @($configuredBefore2 | Where-Object type -eq 0).Count
+            if ($dataFileCount1 -ne $dataFileCount2) {
+                throw "The two instances have different tempdb data file counts ($dataFileCount1 vs $dataFileCount2), the regression needs equal counts"
+            }
+            $dataFileSizeTotal1 = ($configuredBefore1 | Where-Object type -eq 0 | Measure-Object SizeMb -Sum).Sum
+
+            # Make the two running log sizes provably different: growing is immediate, so the
+            # command's fallback reads the new value right away.
+            $logRunningSize1 = ($runningBefore1 | Where-Object type -eq 1).SizeMb
+            $logNameMulti2 = ($runningBefore2 | Where-Object type -eq 1).name
+            $logSizeTarget2 = ($runningBefore2 | Where-Object type -eq 1).SizeMb + 64
+            Invoke-DbaQuery -SqlInstance $serverMulti2 -Query "ALTER DATABASE tempdb MODIFY FILE (NAME = $logNameMulti2, SIZE = $($logSizeTarget2)MB)"
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+
+            # LogFileSize stays unbound on purpose: the per-instance fallback is what regressed.
+            $splatTwoInstances = @{
+                SqlInstance   = $serverMulti1, $serverMulti2
+                DataFileCount = $dataFileCount1
+                DataFileSize  = $dataFileSizeTotal1
+                LogFileGrowth = 64
+                WarningAction = "SilentlyContinue"
+            }
+            $resultsTwoInstances = Set-DbaTempDbConfig @splatTwoInstances
+
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            $logConfiguredQuery = "SELECT size / 128 AS SizeMb FROM sys.master_files WHERE database_id = 2 AND type = 1"
+            $logConfiguredAfter1 = (Invoke-DbaQuery -SqlInstance $serverMulti1 -Query $logConfiguredQuery).SizeMb
+            $logConfiguredAfter2 = (Invoke-DbaQuery -SqlInstance $serverMulti2 -Query $logConfiguredQuery).SizeMb
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # The grown running log of the second instance shrinks back first; best effort, because
+            # active log use can refuse the shrink, and the configured restore below stands either way.
+            $logRunningTarget2 = ($runningBefore2 | Where-Object type -eq 1).SizeMb
+            try {
+                Invoke-DbaQuery -SqlInstance $serverMulti2 -Database tempdb -Query "DBCC SHRINKFILE ($logNameMulti2, $logRunningTarget2)"
+            } catch {
+                Write-Message -Level Warning -Message "Could not shrink the tempdb log of the second instance back: $PSItem"
+            }
+
+            $restoreServers = @($serverMulti1, $serverMulti2)
+            $restoreCaptures = @($configuredBefore1, $configuredBefore2)
+            for ($i = 0; $i -lt 2; $i++) {
+                foreach ($file in $restoreCaptures[$i]) {
+                    $growthUnit = if ($file.is_percent_growth) { "%" } else { "MB" }
+                    $restoreQuery = "ALTER DATABASE tempdb MODIFY FILE (NAME = $($file.name), SIZE = $($file.SizeMb)MB, FILEGROWTH = $($file.GrowthMb)$growthUnit)"
+                    Invoke-DbaQuery -SqlInstance $restoreServers[$i] -Query $restoreQuery
+                }
+            }
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Returns exactly one clean object per instance" {
+            # The command used to leak a raw -1 per executed batch into the pipeline.
+            @($resultsTwoInstances).Count | Should -Be 2
+        }
+
+        It "Returns the size of each instance's own log file" {
+            ($resultsTwoInstances | Select-Object -First 1).LogSize.Megabyte | Should -Be $logRunningSize1
+            ($resultsTwoInstances | Select-Object -Last 1).LogSize.Megabyte | Should -Be $logSizeTarget2
+        }
+
+        It "Configures each instance's log to its own size" {
+            $logConfiguredAfter1 | Should -Be $logRunningSize1
+            $logConfiguredAfter2 | Should -Be $logSizeTarget2
         }
     }
 }

--- a/tests/Set-DbaTempDbConfig.Tests.ps1
+++ b/tests/Set-DbaTempDbConfig.Tests.ps1
@@ -135,6 +135,7 @@ Describe $CommandName -Tag IntegrationTests {
             $tempdbReductionPhysicalName = $tempdbReductionServer.Databases["tempdb"].Query("SELECT physical_name AS PhysicalName FROM sys.database_files WHERE file_id = 1").PhysicalName
             $tempdbReductionDataPath = Split-Path $tempdbReductionPhysicalName
             $originalDataFileState = @($tempdbReductionServer.Databases["tempdb"].Query("SELECT file_id AS ID, name AS LogicalName, size AS SizePages, growth AS GrowthValue, is_percent_growth AS IsPercentGrowth FROM sys.database_files WHERE type = 0 ORDER BY file_id"))
+            $originalLogFileState = $tempdbReductionServer.Databases["tempdb"].Query("SELECT name AS LogicalName, size AS SizePages FROM sys.database_files WHERE type = 1")
             $originalDataFiles = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0)
             $originalDataFileCount = $originalDataFiles.Count
             $expandedDataFileCount = $originalDataFileCount + 2
@@ -194,7 +195,22 @@ Describe $CommandName -Tag IntegrationTests {
                     foreach ($extraDataFile in $extraDataFiles) {
                         $escapedExtraLogicalName = $extraDataFile.LogicalName.Replace("'", "''")
                         $escapedExtraIdentifier = $extraDataFile.LogicalName.Replace("]", "]]")
-                        $tempdbReductionServer.Databases["master"].ExecuteNonQuery("USE [tempdb]; DBCC SHRINKFILE (N'$escapedExtraLogicalName', EMPTYFILE); ALTER DATABASE tempdb REMOVE FILE [$escapedExtraIdentifier];")
+                        # The cache release makes the removal possible, but a fresh work table can appear in
+                        # the file between two removals, so every file gets up to three attempts.
+                        $extraRemovalAttempt = 0
+                        do {
+                            $extraRemovalAttempt += 1
+                            try {
+                                $tempdbReductionServer.Databases["master"].ExecuteNonQuery("DBCC FREESYSTEMCACHE ('ALL'); USE [tempdb]; DBCC SHRINKFILE (N'$escapedExtraLogicalName', EMPTYFILE); ALTER DATABASE tempdb REMOVE FILE [$escapedExtraIdentifier];")
+                                $extraRemovalError = $null
+                            } catch {
+                                $extraRemovalError = $PSItem
+                                Start-Sleep -Seconds 2
+                            }
+                        } while ($extraRemovalError -and $extraRemovalAttempt -lt 3)
+                        if ($extraRemovalError) {
+                            throw $extraRemovalError
+                        }
                     }
                     $currentDataFileCount = @(Get-DbaDbFile -SqlInstance $tempdbReductionServer -Database tempdb | Where-Object Type -eq 0).Count
                 }
@@ -218,7 +234,7 @@ Describe $CommandName -Tag IntegrationTests {
                     $sizeRestoreAttempt = 0
                     do {
                         $sizeRestoreAttempt += 1
-                        $tempdbReductionServer.Databases["tempdb"].ExecuteNonQuery("DBCC SHRINKFILE (N'$escapedOriginalLogicalName', $originalSizeMb);")
+                        $tempdbReductionServer.Databases["tempdb"].ExecuteNonQuery("DBCC FREESYSTEMCACHE ('ALL'); DBCC SHRINKFILE (N'$escapedOriginalLogicalName', $originalSizeMb);")
                         $restoredSizePages = $tempdbReductionServer.Databases["tempdb"].Query("SELECT size AS SizePages FROM sys.database_files WHERE file_id = $($originalDataFile.ID)").SizePages
                     } while ($restoredSizePages -gt $originalDataFile.SizePages -and $sizeRestoreAttempt -lt 3)
 
@@ -238,6 +254,26 @@ Describe $CommandName -Tag IntegrationTests {
                     if ($restoredDataFile.SizePages -ne $originalDataFile.SizePages -or $restoredDataFile.GrowthValue -ne $originalDataFile.GrowthValue -or $restoredDataFile.IsPercentGrowth -ne $originalDataFile.IsPercentGrowth) {
                         throw "Failed to restore tempdb file $($originalDataFile.LogicalName) to its original size and growth settings."
                     }
+                }
+            }
+
+            # The allocation table grows the tempdb log through normal autogrowth and no command
+            # call puts it back, so the original size is restored explicitly.
+            if ($null -ne $originalLogFileState) {
+                $escapedLogLogicalName = $originalLogFileState.LogicalName.Replace("'", "''")
+                $originalLogSizeMb = [Math]::Max(1, [Math]::Floor($originalLogFileState.SizePages / 128.0))
+                $logRestoreAttempt = 0
+                do {
+                    $logRestoreAttempt += 1
+                    $tempdbReductionServer.Databases["tempdb"].ExecuteNonQuery("DBCC FREESYSTEMCACHE ('ALL'); DBCC SHRINKFILE (N'$escapedLogLogicalName', $originalLogSizeMb);")
+                    $restoredLogSizePages = $tempdbReductionServer.Databases["tempdb"].Query("SELECT size AS SizePages FROM sys.database_files WHERE name = N'$escapedLogLogicalName'").SizePages
+                } while ($restoredLogSizePages -gt $originalLogFileState.SizePages -and $logRestoreAttempt -lt 3)
+
+                if ($restoredLogSizePages -lt $originalLogFileState.SizePages) {
+                    $tempdbReductionServer.Databases["master"].ExecuteNonQuery("ALTER DATABASE tempdb MODIFY FILE (NAME = N'$escapedLogLogicalName', SIZE = $($originalLogFileState.SizePages * 8)KB);")
+                }
+                if ($restoredLogSizePages -gt $originalLogFileState.SizePages) {
+                    throw "Failed to shrink the tempdb log file back to its original size after $logRestoreAttempt attempts."
                 }
             }
 
@@ -294,6 +330,26 @@ CROSS JOIN sys.all_objects AS second_source;
             $capacityResult | Should -BeNullOrEmpty
             ($capacityWarning -join " ") | Should -Match "exceeds the requested target capacity"
 
+            # Seed cached work tables. They survive the queries that created them, are allocated into the
+            # emptiest files - exactly the files the reduction is about to remove - and EMPTYFILE cannot
+            # move their pages. On an instance with a warm cache this is what made the reduction fail, so
+            # it is made deterministic here: without the cache release in the command, the reduction fails.
+            $seedWorkTablesQuery = @"
+DECLARE @i int = 0, @sql nvarchar(max);
+WHILE @i < 40
+BEGIN
+    SET @sql = N'DECLARE cur CURSOR STATIC FOR SELECT TOP (' + CAST(1000 + @i AS nvarchar(10)) + N') name FROM sys.all_objects ORDER BY NEWID(); OPEN cur; CLOSE cur; DEALLOCATE cur;';
+    EXEC sp_executesql @sql;
+    SET @i += 1;
+END
+"@
+            $tempdbReductionServer.Databases["tempdb"].ExecuteNonQuery($seedWorkTablesQuery)
+
+            # The reduction below passes no log related parameter, so the log file has to stay
+            # untouched. This guards against the log statement that every call used to emit, which
+            # silently reset the growth of the log file to the LogFileGrowth default of 512 MB.
+            $logGrowthBeforeReduce = $tempdbReductionServer.Databases["tempdb"].Query("SELECT growth AS GrowthValue FROM sys.database_files WHERE type = 1").GrowthValue
+
             # Run the reduction through the connection that starts in msdb, so that the assertion below can
             # show that the command leaves the database of the caller where it found it. This is the path
             # that moves it twice: reading tempdb through FILEPROPERTY, which only reports on the current
@@ -311,6 +367,9 @@ CROSS JOIN sys.all_objects AS second_source;
             }
             $reduceResult = Set-DbaTempDbConfig @splatReduce
             $reduceResult.DataFileCount | Should -Be $originalDataFileCount
+
+            $logGrowthAfterReduce = $tempdbReductionServer.Databases["tempdb"].Query("SELECT growth AS GrowthValue FROM sys.database_files WHERE type = 1").GrowthValue
+            $logGrowthAfterReduce | Should -Be $logGrowthBeforeReduce
 
             $tempdbContextServer.ConnectionContext.ExecuteScalar("SELECT DB_NAME()") | Should -Be "msdb"
 


### PR DESCRIPTION
## Problem 1: forced reductions die on work table pages

`Set-DbaTempDbConfig -Force` empties and removes the highest-numbered files with `DBCC SHRINKFILE (..., EMPTYFILE)`. EMPTYFILE cannot move work table pages, and cached work tables survive the queries that created them — so on any instance whose cache is warm the reduction fails with:

> Cannot move all contents of file "tempdev4" ... Page 6:2521 could not be moved because it is a work table page.

This looked environment-sensitive for weeks (it failed deterministically on instances with small tempdb files and passed elsewhere) because it depends on where proportional fill placed the cached work tables — the freshly added, emptiest files are exactly where new work tables land, and exactly the files the reduction removes.

**Fix:** the removal travels as one T-SQL batch per file that releases the unused cache entries first (`DBCC FREESYSTEMCACHE (''ALL'')` — measured as the minimal sufficient statement; the plan cache''s active entries and the buffer pool are untouched), then empties and removes, and retries up to five times inside the batch, because a fresh work table can appear in the file at any moment. Measured on the lab: a single up-front release is not enough (a round trip later, the file was blocked again), and even release+empty in one batch failed intermittently — hence the retry. The retry lives in the emitted script, so `-OutputScriptOnly` users get the same robustness, and it avoids `THROW` so the script stays runnable on older versions.

## Problem 2: every call silently reset the log file growth

When `-LogPath` is not bound the command derives it from the running instance, and the decision whether to emit the log file statement read the variable (`if ($LogPath -or $LogFileSize)`) — which after the derivation is always true. So **every** call, even one asking for nothing log-related, rewrote the log file with `filegrowth=512` (the `-LogFileGrowth` default). Verified with a sentinel: set log growth to 64 MB, run a reduction without log parameters, growth is 512 MB afterwards. This contradicts the documented contract ("When omitted, the existing log file size remains unchanged") and is how lab instances ended up with oversized tempdb logs — one growth step is half a gigabyte.

**Fix:** the decision is made from the bound parameters: the log statement is emitted only when at least one of `-LogPath`, `-LogFileSize`, `-LogFileGrowth` or `-DisableGrowth` is specified. `$LogFileSize` is still defaulted from the current size so the output object keeps reporting the real log size.

## Tests

- The reduction test now seeds 40 cached work tables (distinct static cursors) before reducing, making defect 1 deterministic: with the seeding and the old command, the test fails with exactly the production error; with the fix it passes.
- A new assertion runs the reduction without log parameters and asserts the log growth is unchanged (red on the old code, where it flips to 512 MB).
- The `AfterAll` now restores the tempdb log size (the allocation table grows it through normal autogrowth and nothing put it back — the other half of the drift), and its size-restore and file-removal fallbacks release caches the same way the command does.

Verified in the lab: three consecutive clean passes (6/6, no leftovers, no warnings) against SQL05\SQL2025 (the 8 MB-file shape that failed deterministically) and one against the stand-alone SQL 2019 default instance. Lab tempdb left pristine after every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)