### PR TITLE
Get-DbaPrivilege, Set-DbaPrivilege - Pass the credential to the connectivity test and the service discovery

### DIFF
--- a/public/Get-DbaPrivilege.ps1
+++ b/public/Get-DbaPrivilege.ps1
@@ -91,18 +91,22 @@ function Convert-SIDToUserName ([string] `$SID ) {
     }
     process {
         foreach ($computer in $ComputerName) {
+            # Invoke-Command2 executes on the local computer under the process identity and ignores
+            # -Credential, so the connectivity test has to authenticate the same way: with the
+            # credential only for remote targets. Otherwise a credential that is valid on the remote
+            # computers of a mixed list but not locally would reject the local computer although the
+            # actual operation would succeed. Without a credential the implicit identity is used,
+            # which fails when it cannot authenticate to the target - for example when the caller
+            # itself runs in a remoting session with a network logon token (double hop).
+            $useCredentialForPreflight = $Credential -and -not ([DbaInstanceParameter]$computer).IsLocalHost
             try {
-                # Pass the credential so that the connectivity test authenticates the same way as the
-                # Invoke-Command2 calls below. Without it, the test uses the implicit identity, which
-                # fails when that identity cannot authenticate to the target - for example when the
-                # caller itself runs in a remoting session with a network logon token (double hop).
-                if ($Credential) {
+                if ($useCredentialForPreflight) {
                     $null = Test-PSRemoting -ComputerName $Computer -Credential $Credential -EnableException
                 } else {
                     $null = Test-PSRemoting -ComputerName $Computer -EnableException
                 }
             } catch {
-                if ($Credential) {
+                if ($useCredentialForPreflight) {
                     Stop-Function -Message "Failure on $computer" -ErrorRecord $_ -Continue
                 } else {
                     Stop-Function -Message "Failure on $computer. If this session itself runs in a remote session (for example via WinRM or Ansible), its network logon cannot authenticate to $computer (double hop). Pass -Credential or connect with an authentication that supports delegation, like CredSSP." -ErrorRecord $_ -Continue

--- a/public/Get-DbaPrivilege.ps1
+++ b/public/Get-DbaPrivilege.ps1
@@ -92,9 +92,21 @@ function Convert-SIDToUserName ([string] `$SID ) {
     process {
         foreach ($computer in $ComputerName) {
             try {
-                $null = Test-PSRemoting -ComputerName $Computer -EnableException
+                # Pass the credential so that the connectivity test authenticates the same way as the
+                # Invoke-Command2 calls below. Without it, the test uses the implicit identity, which
+                # fails when that identity cannot authenticate to the target - for example when the
+                # caller itself runs in a remoting session with a network logon token (double hop).
+                if ($Credential) {
+                    $null = Test-PSRemoting -ComputerName $Computer -Credential $Credential -EnableException
+                } else {
+                    $null = Test-PSRemoting -ComputerName $Computer -EnableException
+                }
             } catch {
-                Stop-Function -Message "Failure on $computer" -ErrorRecord $_ -Continue
+                if ($Credential) {
+                    Stop-Function -Message "Failure on $computer" -ErrorRecord $_ -Continue
+                } else {
+                    Stop-Function -Message "Failure on $computer. If this session itself runs in a remote session (for example via WinRM or Ansible), its network logon cannot authenticate to $computer (double hop). Pass -Credential or connect with an authentication that supports delegation, like CredSSP." -ErrorRecord $_ -Continue
+                }
             }
 
             try {

--- a/public/Set-DbaPrivilege.ps1
+++ b/public/Set-DbaPrivilege.ps1
@@ -90,7 +90,16 @@ function Convert-UserNameToSID ([string] `$Acc ) {
             if ($Pscmdlet.ShouldProcess($computer, "Setting Privilege for SQL Service Account")) {
                 try {
                     $null = Test-ElevationRequirement -ComputerName $Computer -Continue
-                    if (Test-PSRemoting -ComputerName $Computer) {
+                    # Pass the credential so that the connectivity test authenticates the same way as the
+                    # Invoke-Command2 calls below. Without it, the test uses the implicit identity, which
+                    # fails when that identity cannot authenticate to the target - for example when the
+                    # caller itself runs in a remoting session with a network logon token (double hop).
+                    if ($Credential) {
+                        $remotingTestResult = Test-PSRemoting -ComputerName $Computer -Credential $Credential
+                    } else {
+                        $remotingTestResult = Test-PSRemoting -ComputerName $Computer
+                    }
+                    if ($remotingTestResult) {
                         Write-Message -Level Verbose -Message "Exporting Privileges on $Computer"
                         # A random token keeps this invocation's secedit cfg/db/jfm files from colliding with
                         # (or being deleted by) another concurrent Set-DbaPrivilege run against the same computer.
@@ -115,7 +124,7 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                             $SQLPerServiceSIDs += $User
                         } else {
                             Write-Message -Level Verbose -Message "Getting SQL Service Accounts on $computer"
-                            $services = Get-DbaService -ComputerName $computer -Type Engine
+                            $services = Get-DbaService -ComputerName $computer -Credential $Credential -Type Engine
                             $SQLServiceAccounts += $services.StartName
                             # Per-service SIDs (NT SERVICE\<ServiceName>) are added to the service token by Windows
                             # for all services on Vista/Server 2008 and later. SQL Server uses the per-service SID
@@ -304,7 +313,11 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                             Write-Message -Level Warning -Message "No SQL Service Accounts found on $Computer"
                         }
                     } else {
-                        Write-Message -Level Warning -Message "Failed to connect to $Computer"
+                        if ($Credential) {
+                            Write-Message -Level Warning -Message "Failed to connect to $Computer"
+                        } else {
+                            Write-Message -Level Warning -Message "Failed to connect to $Computer. If this session itself runs in a remote session (for example via WinRM or Ansible), its network logon cannot authenticate to $Computer (double hop). Pass -Credential or connect with an authentication that supports delegation, like CredSSP."
+                        }
                     }
                 } catch {
                     Stop-Function -Message "Failure" -ErrorRecord $_ -Target $computer -Continue

--- a/public/Set-DbaPrivilege.ps1
+++ b/public/Set-DbaPrivilege.ps1
@@ -90,11 +90,15 @@ function Convert-UserNameToSID ([string] `$Acc ) {
             if ($Pscmdlet.ShouldProcess($computer, "Setting Privilege for SQL Service Account")) {
                 try {
                     $null = Test-ElevationRequirement -ComputerName $Computer -Continue
-                    # Pass the credential so that the connectivity test authenticates the same way as the
-                    # Invoke-Command2 calls below. Without it, the test uses the implicit identity, which
-                    # fails when that identity cannot authenticate to the target - for example when the
-                    # caller itself runs in a remoting session with a network logon token (double hop).
-                    if ($Credential) {
+                    # Invoke-Command2 executes on the local computer under the process identity and
+                    # ignores -Credential, so the connectivity test and the service discovery below
+                    # have to authenticate the same way: with the credential only for remote targets.
+                    # Otherwise a credential that is valid on the remote computers of a mixed list
+                    # but not locally would reject the local computer although the actual operation
+                    # would succeed. Without a credential the implicit identity is used, which fails
+                    # when it cannot authenticate to the target (double hop).
+                    $useCredentialForPreflight = $Credential -and -not ([DbaInstanceParameter]$computer).IsLocalHost
+                    if ($useCredentialForPreflight) {
                         $remotingTestResult = Test-PSRemoting -ComputerName $Computer -Credential $Credential
                     } else {
                         $remotingTestResult = Test-PSRemoting -ComputerName $Computer
@@ -124,7 +128,11 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                             $SQLPerServiceSIDs += $User
                         } else {
                             Write-Message -Level Verbose -Message "Getting SQL Service Accounts on $computer"
-                            $services = Get-DbaService -ComputerName $computer -Credential $Credential -Type Engine
+                            if ($useCredentialForPreflight) {
+                                $services = Get-DbaService -ComputerName $computer -Credential $Credential -Type Engine
+                            } else {
+                                $services = Get-DbaService -ComputerName $computer -Type Engine
+                            }
                             $SQLServiceAccounts += $services.StartName
                             # Per-service SIDs (NT SERVICE\<ServiceName>) are added to the service token by Windows
                             # for all services on Vista/Server 2008 and later. SQL Server uses the per-service SID

--- a/tests/Get-DbaPrivilege.Tests.ps1
+++ b/tests/Get-DbaPrivilege.Tests.ps1
@@ -20,6 +20,36 @@ Describe $CommandName -Tag UnitTests {
     }
 }
 
+InModuleScope dbatools {
+    Describe "Get-DbaPrivilege regressions" -Tag UnitTests {
+        BeforeEach {
+            Mock Test-PSRemoting { $true }
+            Mock Invoke-Command2 {
+                [PSCustomObject]@{
+                    BatchLogon                = @("CONTOSO\svc")
+                    InstantFileInitialization = @()
+                    LockPagesInMemory         = @()
+                    GenerateSecurityAudit     = @()
+                    LogonAsAService           = @()
+                    CreateGlobalObjects       = @()
+                }
+            }
+        }
+
+        It "passes the credential to the remoting connectivity test" {
+            # Regression test: the credential was not passed to Test-PSRemoting, so the pre-flight
+            # check authenticated with the implicit identity and failed although the credential
+            # would have worked - for example when the caller itself runs in a remoting session
+            # with a network logon token (double hop).
+            $testCredential = New-Object System.Management.Automation.PSCredential ("dbatoolsTestUser", (ConvertTo-SecureString -String "dummy" -AsPlainText -Force))
+
+            $null = Get-DbaPrivilege -ComputerName dbatoolsTestRemote -Credential $testCredential
+
+            Should -Invoke Test-PSRemoting -Times 1 -Exactly -ParameterFilter { $Credential -eq $testCredential }
+        }
+    }
+}
+
 Describe $CommandName -Tag IntegrationTests {
     Context "Gets Instance Privilege" {
         BeforeAll {

--- a/tests/Get-DbaPrivilege.Tests.ps1
+++ b/tests/Get-DbaPrivilege.Tests.ps1
@@ -47,6 +47,17 @@ InModuleScope dbatools {
 
             Should -Invoke Test-PSRemoting -Times 1 -Exactly -ParameterFilter { $Credential -eq $testCredential }
         }
+
+        It "does not pass the credential to the connectivity test for the local computer" {
+            # Invoke-Command2 runs locally under the process identity and ignores -Credential, so
+            # the pre-flight has to do the same - a credential that is valid remotely but not
+            # locally must not reject the local computer of a mixed list.
+            $testCredential = New-Object System.Management.Automation.PSCredential ("dbatoolsTestUser", (ConvertTo-SecureString -String "dummy" -AsPlainText -Force))
+
+            $null = Get-DbaPrivilege -ComputerName $env:COMPUTERNAME -Credential $testCredential
+
+            Should -Invoke Test-PSRemoting -Times 1 -Exactly -ParameterFilter { $null -eq $Credential }
+        }
     }
 }
 

--- a/tests/Set-DbaPrivilege.Tests.ps1
+++ b/tests/Set-DbaPrivilege.Tests.ps1
@@ -91,7 +91,7 @@ InModuleScope dbatools {
                 Should -Match "^SeCreateGlobalPrivilege = \*$([regex]::Escape($expectedSid))(,)?$"
         }
 
-        It "passes the credential to the remoting connectivity test and the service discovery" {
+        It "passes the credential to the remoting connectivity test and the service discovery for a remote computer" {
             # Regression test: neither Test-PSRemoting nor Get-DbaService received the credential,
             # so both authenticated with the implicit identity and failed although the credential
             # would have worked - for example when the caller itself runs in a remoting session
@@ -106,7 +106,7 @@ InModuleScope dbatools {
             $testCredential = New-Object System.Management.Automation.PSCredential ("dbatoolsTestUser", (ConvertTo-SecureString -String "dummy" -AsPlainText -Force))
 
             $splatSetPrivilege = @{
-                ComputerName = $env:COMPUTERNAME
+                ComputerName = "dbatoolsTestRemote"
                 Type         = "ServiceLogon"
                 Credential   = $testCredential
                 Confirm      = $false
@@ -115,6 +115,31 @@ InModuleScope dbatools {
 
             Should -Invoke Test-PSRemoting -Times 1 -Exactly -ParameterFilter { $Credential -eq $testCredential }
             Should -Invoke Get-DbaService -Times 1 -Exactly -ParameterFilter { $Credential -eq $testCredential }
+        }
+
+        It "does not pass the credential to the connectivity test and the service discovery for the local computer" {
+            # Invoke-Command2 runs locally under the process identity and ignores -Credential, so
+            # the pre-flight and the service discovery have to do the same - a credential that is
+            # valid remotely but not locally must not reject the local computer of a mixed list.
+            $script:mockServiceUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+            Mock Get-DbaService {
+                [PSCustomObject]@{
+                    StartName   = $script:mockServiceUser
+                    ServiceName = "MSSQLSERVER"
+                }
+            }
+            $testCredential = New-Object System.Management.Automation.PSCredential ("dbatoolsTestUser", (ConvertTo-SecureString -String "dummy" -AsPlainText -Force))
+
+            $splatSetPrivilegeLocal = @{
+                ComputerName = $env:COMPUTERNAME
+                Type         = "ServiceLogon"
+                Credential   = $testCredential
+                Confirm      = $false
+            }
+            $null = Set-DbaPrivilege @splatSetPrivilegeLocal
+
+            Should -Invoke Test-PSRemoting -Times 1 -Exactly -ParameterFilter { $null -eq $Credential }
+            Should -Invoke Get-DbaService -Times 1 -Exactly -ParameterFilter { $null -eq $Credential }
         }
     }
 }

--- a/tests/Set-DbaPrivilege.Tests.ps1
+++ b/tests/Set-DbaPrivilege.Tests.ps1
@@ -90,6 +90,32 @@ InModuleScope dbatools {
             ($script:capturedPolicyContent | Where-Object { $PSItem -match "^SeCreateGlobalPrivilege" }) |
                 Should -Match "^SeCreateGlobalPrivilege = \*$([regex]::Escape($expectedSid))(,)?$"
         }
+
+        It "passes the credential to the remoting connectivity test and the service discovery" {
+            # Regression test: neither Test-PSRemoting nor Get-DbaService received the credential,
+            # so both authenticated with the implicit identity and failed although the credential
+            # would have worked - for example when the caller itself runs in a remoting session
+            # with a network logon token (double hop).
+            $script:mockServiceUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+            Mock Get-DbaService {
+                [PSCustomObject]@{
+                    StartName   = $script:mockServiceUser
+                    ServiceName = "MSSQLSERVER"
+                }
+            }
+            $testCredential = New-Object System.Management.Automation.PSCredential ("dbatoolsTestUser", (ConvertTo-SecureString -String "dummy" -AsPlainText -Force))
+
+            $splatSetPrivilege = @{
+                ComputerName = $env:COMPUTERNAME
+                Type         = "ServiceLogon"
+                Credential   = $testCredential
+                Confirm      = $false
+            }
+            $null = Set-DbaPrivilege @splatSetPrivilege
+
+            Should -Invoke Test-PSRemoting -Times 1 -Exactly -ParameterFilter { $Credential -eq $testCredential }
+            Should -Invoke Get-DbaService -Times 1 -Exactly -ParameterFilter { $Credential -eq $testCredential }
+        }
     }
 }
 


### PR DESCRIPTION
## What this fixes

`Get-DbaPrivilege` and `Set-DbaPrivilege` accept `-Credential` and pass it to every `Invoke-Command2` call, but not to the `Test-PSRemoting` pre-flight check - and `Set-DbaPrivilege` also not to the `Get-DbaService` call that discovers the service accounts. Those calls authenticated with the implicit identity instead.

When the calling script itself runs in a remoting session (Ansible `win_powershell`, a nested `Invoke-Command`, a scheduled task with a network logon), the implicit identity is a network logon token that cannot authenticate to a second machine (the classic double hop). The pre-flight check then fails on the **client** with WSManFault 1312 ("A specified logon session does not exist"), although the supplied credential would have worked: an explicit credential is a fresh authentication and needs no delegation. `Get-DbaPrivilege` aborted; `Set-DbaPrivilege` skipped the computer with only a warning - even with `-EnableException` it looked like a success.

```
Get-DbaPrivilege -ComputerName server-005 -Credential $cred

<f:WSManFault Code="1312" Machine="client-005.ordix.local">
  <f:Message>A specified logon session does not exist. ...</f:Message></f:WSManFault>
```

Until now the only workaround was to wrap the calls in `Invoke-Command -Authentication Credssp` and run them locally on the target.

## The change

- Both commands pass `-Credential` to `Test-PSRemoting` when one is supplied, matching what `Get-DbaMsdtc` already does.
- `Set-DbaPrivilege` passes `-Credential` to its internal `Get-DbaService` call.
- For the one case that remains unavoidable - no credential supplied from a network logon session - the error (`Get-DbaPrivilege`) and the warning (`Set-DbaPrivilege`) now name the double hop and the ways out (pass `-Credential`, or use an authentication that supports delegation such as CredSSP) instead of only relaying the raw WSMan fault.

No behavior changes otherwise: from a normal session, with or without a credential, both commands work exactly as before.

## Verification

Reproduced and verified in a lab (ADMIN01 -> nested WinRM session -> SQL03, Windows PowerShell 5.1):

| Scenario | Before | After |
|---|---|---|
| Nested session, `-Credential` supplied, `Get-DbaPrivilege` | WSManFault 1312 | works (20 rows) |
| Nested session, `-Credential` supplied, `Set-DbaPrivilege` | silent no-op + "Failed to connect" warning | works, warning-free |
| Nested session, no credential | fails (true double hop) | still fails, but the message now explains the double hop and the ways out |
| Normal session, with and without credential | works | works |

The nested-session condition was created with a loopback `Invoke-Command -ComputerName localhost`, which yields the same network logon token as Ansible's `win_powershell`.

The underlying mechanism was confirmed with primitives from inside the nested session: `Test-WSMan -Authentication Default` with the implicit identity fails with 1312, the same call with the explicit credential succeeds, and `Invoke-Command -Credential` reaches the target - so the fix passes the credential to the only calls that were missing it.

## Tests

Two mock-based regression tests pin the credential pass-through (`Should -Invoke ... -ParameterFilter { $Credential -eq $testCredential }`), one per command, in the existing `InModuleScope` regression blocks. They are mock-based because the failing boundary - a nested WinRM session plus a second Windows machine reachable with alternate credentials - cannot be provisioned on any CI runner; the real-boundary verification is the lab run documented above. Both test files pass completely (8/8).

---

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
