### PR TITLE
Data generation - Stop on configuration errors and write the generated unique values

### DIFF
--- a/public/Invoke-DbaDbDataGenerator.ps1
+++ b/public/Invoke-DbaDbDataGenerator.ps1
@@ -299,8 +299,27 @@ function Invoke-DbaDbDataGenerator {
 
                         # Only the index columns that are part of the configuration get a value generated
                         # here. The insert statement further down only names configured columns, so an
-                        # index column outside the configuration is left to SQL Server.
-                        $uniqueValueColumns = @($uniqueIndexes.IndexedColumns.Name | Select-Object -Unique | Where-Object { $PSItem -in $tableobject.Columns.Name })
+                        # index column outside the configuration is left to SQL Server. Identity columns
+                        # are excluded even when they carry the unique index - the typical primary key:
+                        # their values come from the identity branch of the insert, and random values
+                        # here would jump the identity seed toward the type limit.
+                        $identityColumnNames = @($tableobject.Columns | Where-Object Identity | Select-Object -ExpandProperty Name)
+                        $uniqueValueColumns = @($uniqueIndexes.IndexedColumns.Name | Select-Object -Unique | Where-Object { $PSItem -in $tableobject.Columns.Name -and $PSItem -notin $identityColumnNames })
+
+                        # The collision check must also see what is already persisted: without
+                        # TruncateTable, a candidate matching an existing indexed value would pass
+                        # the generation and then fail at insert time.
+                        $existingUniqueValues = @()
+                        if ($uniqueValueColumns.Count -gt 0 -and -not $tableobject.TruncateTable) {
+                            $existingColumnList = "[" + ($uniqueValueColumns -join "], [") + "]"
+                            $existingValuesQuery = "SELECT DISTINCT $existingColumnList FROM [$($tableobject.Schema)].[$($tableobject.Name)]"
+                            try {
+                                $existingUniqueValues = @(Invoke-DbaQuery -SqlInstance $server -Database $db.Name -Query $existingValuesQuery -EnableException)
+                            } catch {
+                                Stop-Function -Message "Error reading the existing unique index values from $($tableobject.Schema).$($tableobject.Name)" -Target $tableobject -ErrorRecord $_
+                                return
+                            }
+                        }
 
                         for ($i = 0; $i -lt $tableobject.Rows; $i++) {
                             $attempt = 0
@@ -344,7 +363,7 @@ function Invoke-DbaDbDataGenerator {
                                         continue
                                     }
 
-                                    foreach ($existingRow in $uniqueValues) {
+                                    foreach ($existingRow in ($existingUniqueValues + $uniqueValues)) {
                                         $matchingColumnNames = @($indexColumnNames | Where-Object { $existingRow.$PSItem -eq $rowValue.$PSItem })
 
                                         if ($matchingColumnNames.Count -eq $indexColumnNames.Count) {

--- a/public/Invoke-DbaDbDataGenerator.ps1
+++ b/public/Invoke-DbaDbDataGenerator.ps1
@@ -141,7 +141,9 @@ function Invoke-DbaDbDataGenerator {
             Stop-Function -Message "Could not load randomizer class" -Continue
         }
 
-        $supportedDataTypes = 'bigint', 'bit', 'bool', 'char', 'date', 'datetime', 'datetime2', 'decimal', 'int', 'float', 'guid', 'money', 'numeric', 'nchar', 'ntext', 'nvarchar', 'real', 'smalldatetime', 'smallint', 'text', 'time', 'tinyint', 'uniqueidentifier', 'userdefineddatatype', 'varchar'
+        # This list has to match the one in Test-DbaDbDataGeneratorConfig, because a configuration is
+        # rejected up front on every finding reported there.
+        $supportedDataTypes = "bigint", "bit", "bool", "char", "date", "datetime", "datetime2", "decimal", "int", "float", "guid", "money", "numeric", "nchar", "ntext", "nvarchar", "real", "smalldatetime", "smallint", "text", "time", "tinyint", "uniqueidentifier", "userdefineddatatype", "varchar"
         # This list decides which configurations we accept, so it has to predict what Get-DbaRandomizedValue
         # will accept further down. That command validates its input against the randomizer types, so we use
         # the same list here. Reflecting over a Bogus.Faker object instead offered subtypes that
@@ -168,7 +170,17 @@ function Invoke-DbaDbDataGenerator {
 
             # Test the configuration
             try {
-                Test-DbaDbDataGeneratorConfig -FilePath $FilePath -EnableException
+                $configErrors = @()
+
+                # The findings are output objects, not exceptions, so they have to be collected and
+                # acted on. Left unassigned they went to the output stream and the generation ran on
+                # an invalid configuration.
+                $configErrors += Test-DbaDbDataGeneratorConfig -FilePath $FilePath -EnableException
+
+                if ($configErrors.Count -ge 1) {
+                    Stop-Function -Message "Errors found testing the configuration file." -Target $FilePath
+                    return $configErrors
+                }
             } catch {
                 Stop-Function -Message "Errors found testing the configuration file. `n$_" -ErrorRecord $_ -Target $FilePath
                 return
@@ -276,85 +288,86 @@ function Invoke-DbaDbDataGenerator {
                     }
 
                     $uniqueValues = @()
+                    $uniqueValueColumns = @()
 
                     # Check if the table contains unique indexes
                     if ($tableobject.HasUniqueIndex) {
                         # Loop through the rows and generate a unique value for each row
                         Write-Message -Level Verbose -Message "Generating unique values for $($tableobject.Name)"
 
+                        $uniqueIndexes = @($db.Tables[$($tableobject.Name)].Indexes | Where-Object IsUnique -eq $true)
+
+                        # Only the index columns that are part of the configuration get a value generated
+                        # here. The insert statement further down only names configured columns, so an
+                        # index column outside the configuration is left to SQL Server.
+                        $uniqueValueColumns = @($uniqueIndexes.IndexedColumns.Name | Select-Object -Unique | Where-Object { $PSItem -in $tableobject.Columns.Name })
+
                         for ($i = 0; $i -lt $tableobject.Rows; $i++) {
-                            $rowValue = New-Object PSCustomObject
+                            $attempt = 0
 
-                            # Loop through each of the unique indexes
-                            foreach ($index in ($db.Tables[$($tableobject.Name)].Indexes | Where-Object IsUnique -eq $true )) {
+                            # Generate a candidate row holding a value for every unique index column and
+                            # try again as long as a unique index of an earlier row holds the same
+                            # combination. The whole candidate is regenerated on a collision, so two
+                            # indexes sharing a column stay consistent within the row.
+                            do {
+                                $attempt++
+                                $rowValue = New-Object PSCustomObject
 
-                                # Loop through the index columns
-                                foreach ($indexColumn in $index.IndexedColumns) {
+                                foreach ($indexColumnName in $uniqueValueColumns) {
                                     # Get the column mask info
-                                    $columnMaskInfo = $tableobject.Columns | Where-Object Name -eq $indexColumn.Name
+                                    $columnMaskInfo = $tableobject.Columns | Where-Object Name -eq $indexColumnName
 
-                                    if ($columnMaskInfo) {
-                                        # Generate a new value
-                                        try {
-                                            if ($PSBoundParameters.MaxValue -and $columnMaskInfo.SubType -eq 'String' -and $columnMaskInfo.MaxValue -gt $MaxValue) {
-                                                $columnMaskInfo.MaxValue = $MaxValue
-                                            }
-                                            if ($columnMaskInfo.ColumnType -in $supportedDataTypes -and $columnMaskInfo.MaskingType -eq 'Random' -and $columnMaskInfo.SubType -in 'Bool', 'Number', 'Float', 'Byte', 'String') {
-                                                $newValue = Get-DbaRandomizedValue -DataType $columnMaskInfo.ColumnType -Locale $Locale -Min $columnMaskInfo.MinValue -Max $columnMaskInfo.MaxValue
-                                            } else {
-                                                $newValue = Get-DbaRandomizedValue -RandomizerType $columnMaskInfo.MaskingType -RandomizerSubtype $columnMaskInfo.SubType -Locale $Locale -Min $columnMaskInfo.MinValue -Max $columnMaskInfo.MaxValue
-                                            }
-                                        } catch {
-                                            Stop-Function -Message "Failure" -Target $columnMaskInfo -Continue -ErrorRecord $_
+                                    # Generate a new value
+                                    try {
+                                        if ($PSBoundParameters.MaxValue -and $columnMaskInfo.SubType -eq "String" -and $columnMaskInfo.MaxValue -gt $MaxValue) {
+                                            $columnMaskInfo.MaxValue = $MaxValue
                                         }
+                                        if ($columnMaskInfo.ColumnType -in $supportedDataTypes -and $columnMaskInfo.MaskingType -eq "Random" -and $columnMaskInfo.SubType -in "Bool", "Number", "Float", "Byte", "String") {
+                                            $newValue = Get-DbaRandomizedValue -DataType $columnMaskInfo.ColumnType -Locale $Locale -Min $columnMaskInfo.MinValue -Max $columnMaskInfo.MaxValue
+                                        } else {
+                                            $newValue = Get-DbaRandomizedValue -RandomizerType $columnMaskInfo.MaskingType -RandomizerSubtype $columnMaskInfo.SubType -Locale $Locale -Min $columnMaskInfo.MinValue -Max $columnMaskInfo.MaxValue
+                                        }
+                                    } catch {
+                                        Stop-Function -Message "Failure" -Target $columnMaskInfo -Continue -ErrorRecord $_
+                                    }
 
-                                        # Check if the value is already present as a property
-                                        if (($rowValue | Get-Member -MemberType NoteProperty).Name -notcontains $indexColumn.Name) {
-                                            $rowValue | Add-Member -Name $indexColumn.Name -Type NoteProperty -Value $newValue
+                                    $rowValue | Add-Member -Name $indexColumnName -Type NoteProperty -Value $newValue
+                                }
+
+                                # A collision is an earlier row that carries the same values in all the
+                                # configured columns of one of the unique indexes.
+                                $collision = $false
+                                foreach ($index in $uniqueIndexes) {
+                                    $indexColumnNames = @($index.IndexedColumns.Name | Where-Object { $PSItem -in $uniqueValueColumns })
+
+                                    if ($indexColumnNames.Count -eq 0) {
+                                        continue
+                                    }
+
+                                    foreach ($existingRow in $uniqueValues) {
+                                        $matchingColumnNames = @($indexColumnNames | Where-Object { $existingRow.$PSItem -eq $rowValue.$PSItem })
+
+                                        if ($matchingColumnNames.Count -eq $indexColumnNames.Count) {
+                                            $collision = $true
+                                            break
                                         }
                                     }
 
-                                }
-
-                                # To be sure the values are unique, loop as long as long as needed to generate a unique value
-                                while (($uniqueValues | Select-Object -Property ($rowValue | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name)) -match $rowValue) {
-
-                                    $rowValue = New-Object PSCustomObject
-
-                                    # Loop through the index columns
-                                    foreach ($indexColumn in $index.IndexedColumns) {
-                                        # Get the column mask info
-                                        $columnMaskInfo = $tableobject.Columns | Where-Object Name -eq $indexColumn.Name
-
-                                        # Generate a new value
-                                        try {
-                                            if ($PSBoundParameters.MaxValue -and $columnMaskInfo.SubType -eq 'String' -and $columnMaskInfo.MaxValue -gt $MaxValue) {
-                                                $columnMaskInfo.MaxValue = $MaxValue
-                                            }
-                                            if ($columnMaskInfo.ColumnType -in $supportedDataTypes -and $columnMaskInfo.MaskingType -eq 'Random' -and $columnMaskInfo.SubType -in 'Bool', 'Number', 'Float', 'Byte', 'String') {
-                                                $newValue = Get-DbaRandomizedValue -DataType $columnMaskInfo.ColumnType -Locale $Locale -Min $columnMaskInfo.MinValue -Max $columnMaskInfo.MaxValue
-                                            } else {
-                                                $newValue = Get-DbaRandomizedValue -RandomizerType $columnMaskInfo.MaskingType -RandomizerSubtype $columnMaskInfo.SubType -Locale $Locale -Min $columnMaskInfo.MinValue -Max $columnMaskInfo.MaxValue
-                                            }
-
-                                        } catch {
-                                            Stop-Function -Message "Failure" -Target $script:faker -Continue -ErrorRecord $_
-                                        }
-
-                                        # Check if the value is already present as a property
-                                        if (($rowValue | Get-Member -MemberType NoteProperty).Name -notcontains $indexColumn.Name) {
-                                            $rowValue | Add-Member -Name $indexColumn.Name -Type NoteProperty -Value $newValue
-                                            $uniqueValueColumns += $indexColumn.Name
-                                        }
+                                    if ($collision) {
+                                        break
                                     }
                                 }
+                            } while ($collision -and $attempt -lt 100)
+
+                            if ($collision) {
+                                Stop-Function -Message "Could not generate a unique value for the unique indexes of $($tableobject.Name) after $attempt tries" -Target $tableobject
+                                return
                             }
+
                             # Add the row value to the array
                             $uniqueValues += $rowValue
                         }
                     }
-
-                    $uniqueValueColumns = $uniqueValueColumns | Select-Object -Unique
 
                     if (-not $server.IsAzure) {
                         $sqlconn.ChangeDatabase($db.Name)
@@ -417,17 +430,19 @@ function Invoke-DbaDbDataGenerator {
                                 # before the insert statement was built.
 
                                 # make sure max is good
-                                if ($columnobject.Nullable -and (($nullmod++) % $ModulusFactor -eq 0)) {
-                                    $columnValue = $null
-                                } elseif ($tableobject.HasUniqueIndex -and $columnobject.Name -in $uniqueValueColumns) {
+                                # A column of a unique index always gets its pre-generated value, even when
+                                # it is nullable - the second NULL would already violate the index.
+                                if ($tableobject.HasUniqueIndex -and $columnobject.Name -in $uniqueValueColumns) {
 
                                     if ($uniqueValues.Count -lt 1) {
                                         Stop-Function -Message "Could not find any unique values in dictionary" -Target $tableobject
                                         return
                                     }
 
-                                    $columnValue = $uniqueValues[$rowNumber].$($columnobject.Name)
+                                    $columnValue = $uniqueValues[$i - 1].$($columnobject.Name)
 
+                                } elseif ($columnobject.Nullable -and (($nullmod++) % $ModulusFactor -eq 0)) {
+                                    $columnValue = $null
                                 } elseif ($columnobject.Identity) {
                                     if ($nextIdentity -or (-not $nextIdentity -and $tableobject.TruncateTable)) {
                                         $nextIdentity += $identityValues.IdentityIncrement

--- a/public/Test-DbaDbDataGeneratorConfig.ps1
+++ b/public/Test-DbaDbDataGeneratorConfig.ps1
@@ -94,7 +94,10 @@ function Test-DbaDbDataGeneratorConfig {
             return
         }
 
-        $supportedDataTypes = 'bigint', 'bit', 'bool', 'char', 'date', 'datetime', 'datetime2', 'decimal', 'int', 'money', 'nchar', 'ntext', 'nvarchar', 'smalldatetime', 'text', 'time', 'uniqueidentifier', 'userdefineddatatype', 'varchar'
+        # This list has to match the one in Invoke-DbaDbDataGenerator, because that command stops on
+        # every finding reported here. A type missing here but supported there rejects a valid
+        # configuration - float, guid, numeric, real, smallint and tinyint were missing that way.
+        $supportedDataTypes = "bigint", "bit", "bool", "char", "date", "datetime", "datetime2", "decimal", "int", "float", "guid", "money", "numeric", "nchar", "ntext", "nvarchar", "real", "smalldatetime", "smallint", "text", "time", "tinyint", "uniqueidentifier", "userdefineddatatype", "varchar"
 
         $randomizerTypes = Get-DbaRandomizedType
 

--- a/tests/Invoke-DbaDbDataGenerator.Tests.ps1
+++ b/tests/Invoke-DbaDbDataGenerator.Tests.ps1
@@ -428,4 +428,141 @@ Describe $CommandName -Tag IntegrationTests {
             ($uniqueNumbersRows.Nr | Select-Object -Unique).Count | Should -Be 10
         }
     }
+
+    Context "Config for a table with an identity primary key" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # The primary key is an identity column and also the table's unique index. Its values
+            # must come from the identity branch (IDENT_CURRENT + increment) - the unique value
+            # machinery used to claim the column and insert random values, jumping the seed.
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -Query "CREATE TABLE [dbo].[identitypeople]([Id] [int] IDENTITY(1,1) NOT NULL PRIMARY KEY, [Nr] [int] NOT NULL);"
+
+            $identityConfig = @"
+{
+  "Name": "$generatorDb",
+  "Type": "DataGenerationConfiguration",
+  "Tables": [
+    {
+      "Name": "identitypeople",
+      "Schema": "dbo",
+      "Columns": [
+        {
+          "Name": "Id",
+          "ColumnType": "int",
+          "CharacterString": null,
+          "MinValue": 1,
+          "MaxValue": 1000,
+          "MaskingType": "Random",
+          "SubType": "Number",
+          "Identity": true,
+          "ForeignKey": false,
+          "Composite": false,
+          "Nullable": false
+        },
+        {
+          "Name": "Nr",
+          "ColumnType": "int",
+          "CharacterString": null,
+          "MinValue": 1,
+          "MaxValue": 1000,
+          "MaskingType": "Random",
+          "SubType": "Number",
+          "Identity": false,
+          "ForeignKey": false,
+          "Composite": false,
+          "Nullable": false
+        }
+      ],
+      "ResetIdentity": false,
+      "TruncateTable": false,
+      "HasUniqueIndex": true,
+      "Rows": 5
+    }
+  ]
+}
+"@
+            $identityConfigPath = "$backupPath\identitypk.json"
+            Set-Content -Path $identityConfigPath -Value $identityConfig
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+
+            $identityResult = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $identityConfigPath
+            $identityWarning = $WarnVar
+            $identityRows = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -Query "select Id from dbo.identitypeople order by Id"
+        }
+
+        It "Does not warn" {
+            $identityWarning | Should -BeNullOrEmpty
+        }
+
+        It "Reports the rows" {
+            $identityResult.Rows | Should -Be 5
+        }
+
+        It "Fills the identity column from the identity sequence" {
+            ($identityRows.Id -join ",") | Should -Be "1,2,3,4,5"
+        }
+    }
+
+    Context "Config for a unique index whose values already exist in the table" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # With TruncateTable disabled the candidates have to avoid what is already persisted.
+            # MinValue = MaxValue = 1 against an existing value 1 makes success impossible - the
+            # command has to stop cleanly before the insert instead of failing on the duplicate key.
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -Query "CREATE TABLE [dbo].[uniquepersisted]([Nr] [int] NOT NULL);
+                CREATE UNIQUE INDEX [ix_uniquepersisted_nr] ON [dbo].[uniquepersisted]([Nr]);
+                INSERT INTO [dbo].[uniquepersisted] VALUES (1);"
+
+            $persistedConfig = @"
+{
+  "Name": "$generatorDb",
+  "Type": "DataGenerationConfiguration",
+  "Tables": [
+    {
+      "Name": "uniquepersisted",
+      "Schema": "dbo",
+      "Columns": [
+        {
+          "Name": "Nr",
+          "ColumnType": "int",
+          "CharacterString": null,
+          "MinValue": 1,
+          "MaxValue": 1,
+          "MaskingType": "Random",
+          "SubType": "Number",
+          "Identity": false,
+          "ForeignKey": false,
+          "Composite": false,
+          "Nullable": false
+        }
+      ],
+      "ResetIdentity": false,
+      "TruncateTable": false,
+      "HasUniqueIndex": true,
+      "Rows": 1
+    }
+  ]
+}
+"@
+            $persistedConfigPath = "$backupPath\uniquepersisted.json"
+            Set-Content -Path $persistedConfigPath -Value $persistedConfig
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+
+            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $persistedConfigPath -WarningAction SilentlyContinue
+            $persistedWarning = $WarnVar
+            $persistedCount = (Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -Query "select count(*) as c from dbo.uniquepersisted").c
+        }
+
+        It "Stops cleanly before the insert instead of failing on the duplicate key" {
+            $persistedWarning | Should -BeLike "*Could not generate a unique value*"
+        }
+
+        It "Inserts nothing" {
+            $persistedCount | Should -Be 1
+        }
+    }
 }

--- a/tests/Invoke-DbaDbDataGenerator.Tests.ps1
+++ b/tests/Invoke-DbaDbDataGenerator.Tests.ps1
@@ -146,21 +146,24 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
-        It "Warns about the masking type and names the column" {
-            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $junkTypeConfigPath -WarningAction SilentlyContinue
-            ($WarnVar -join " ") | Should -BeLike "*Unsupported masking type*Locale*for column City*"
+        It "Rejects the masking type and names the column" {
+            $results = @(Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $junkTypeConfigPath -WarningAction SilentlyContinue)
+            ($WarnVar -join " ") | Should -BeLike "*Errors found testing the configuration file*"
+            $results.Column | Should -Contain "City"
+            ($results | Where-Object Column -eq "City").Error | Should -BeLike "*MaskingType is not valid*"
         }
 
-        It "Warns about the masking sub type and names the column" {
-            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $junkSubTypeConfigPath -WarningAction SilentlyContinue
-            ($WarnVar -join " ") | Should -BeLike "*Unsupported masking sub type*ContainsKey*for column City*"
+        It "Rejects the masking sub type and names the column" {
+            $results = @(Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $junkSubTypeConfigPath -WarningAction SilentlyContinue)
+            ($WarnVar -join " ") | Should -BeLike "*Errors found testing the configuration file*"
+            $results.Column | Should -Contain "City"
+            ($results | Where-Object Column -eq "City").Error | Should -BeLike "*SubType is not valid*"
         }
 
-        It "Skips the table instead of running an insert it cannot fill" {
-            # The insert statement names every column of the table, so skipping a single column further down
-            # left it with fewer values than columns and SQL Server answered with a syntax error.
+        It "Stops before running an insert it cannot fill" {
+            # The insert statement names every column of the table, so running it with a rejected column
+            # would leave it with fewer values than columns and SQL Server answered with a syntax error.
             $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $junkTypeConfigPath -WarningAction SilentlyContinue
-            ($WarnVar -join " ") | Should -BeLike "*Skipping table dbo.people*"
             ($WarnVar -join " ") | Should -Not -BeLike "*Incorrect syntax*"
         }
     }
@@ -293,9 +296,9 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Names the parameter the configuration cannot supply" {
-            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $needsFormatConfigPath -WarningAction SilentlyContinue
-            ($WarnVar -join " ") | Should -BeLike "*needs a Format*for column City*"
-            ($WarnVar -join " ") | Should -BeLike "*Skipping table dbo.people*"
+            $results = @(Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $needsFormatConfigPath -WarningAction SilentlyContinue)
+            ($WarnVar -join " ") | Should -BeLike "*Errors found testing the configuration file*"
+            ($results | Where-Object Column -eq "City").Error | Should -BeLike "*needs a Format*"
         }
     }
 
@@ -347,13 +350,82 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Rejects the column before generating unique values for it" {
-            $null = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $uniqueConfigPath -WarningAction SilentlyContinue
-            ($WarnVar -join " ") | Should -BeLike "*Unsupported masking type*Locale*for column City*"
-            ($WarnVar -join " ") | Should -BeLike "*Skipping table dbo.uniquepeople*"
+            $results = @(Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $uniqueConfigPath -WarningAction SilentlyContinue)
+            ($WarnVar -join " ") | Should -BeLike "*Errors found testing the configuration file*"
+            ($results | Where-Object Column -eq "City").Error | Should -BeLike "*MaskingType is not valid*"
         }
 
         It "Leaves the table empty" {
             (Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -Query "select count(*) as c from dbo.uniquepeople").c | Should -Be 0
+        }
+    }
+
+    Context "Config for a table with a unique index and a valid column" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # The generated unique values were never written to the rows: the insert read them with a row
+            # index variable that was never assigned, and the list of unique index columns was only filled
+            # after a collision. So every row got a fresh random value instead of its pre-generated unique
+            # one, and nothing guarded the rows against violating the index.
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -Query "CREATE TABLE [dbo].[uniquenumbers]([Nr] [int] NOT NULL);
+                CREATE UNIQUE INDEX [ix_uniquenumbers_nr] ON [dbo].[uniquenumbers]([Nr]);"
+
+            $uniqueNumbersConfig = @"
+{
+  "Name": "$generatorDb",
+  "Type": "DataGenerationConfiguration",
+  "Tables": [
+    {
+      "Name": "uniquenumbers",
+      "Schema": "dbo",
+      "Columns": [
+        {
+          "Name": "Nr",
+          "ColumnType": "int",
+          "CharacterString": null,
+          "MinValue": 1,
+          "MaxValue": 10,
+          "MaskingType": "Random",
+          "SubType": "Number",
+          "Identity": false,
+          "ForeignKey": false,
+          "Composite": false,
+          "Nullable": false
+        }
+      ],
+      "ResetIdentity": false,
+      "TruncateTable": false,
+      "HasUniqueIndex": true,
+      "Rows": 10
+    }
+  ]
+}
+"@
+            $uniqueNumbersConfigPath = "$backupPath\uniquenumbers.json"
+            Set-Content -Path $uniqueNumbersConfigPath -Value $uniqueNumbersConfig
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+
+            $uniqueNumbersResult = Invoke-DbaDbDataGenerator -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -FilePath $uniqueNumbersConfigPath
+            $uniqueNumbersWarning = $WarnVar
+            $uniqueNumbersRows = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $generatorDb -Query "select Nr from dbo.uniquenumbers"
+        }
+
+        It "Accepts the config without a warning" {
+            $uniqueNumbersWarning | Should -BeNullOrEmpty
+        }
+
+        It "Reports the generated rows" {
+            $uniqueNumbersResult.Rows | Should -Be 10
+        }
+
+        It "Inserts every row with its own unique value" {
+            # Ten rows from a domain of only ten values: without the unique value machinery, ten
+            # independent random draws practically never form a permutation, so this fails when the
+            # generated unique values are not the ones that reach the insert.
+            $uniqueNumbersRows.Nr.Count | Should -Be 10
+            ($uniqueNumbersRows.Nr | Select-Object -Unique).Count | Should -Be 10
         }
     }
 }

--- a/tests/Test-DbaDbDataGeneratorConfig.Tests.ps1
+++ b/tests/Test-DbaDbDataGeneratorConfig.Tests.ps1
@@ -44,15 +44,42 @@ Describe $CommandName -Tag IntegrationTests {
 
         $file = New-DbaDbDataGeneratorConfig -SqlInstance $TestConfig.InstanceSingle -Database $dbname -Table Customer -Path "$($TestConfig.Temp)\datageneration"
 
+        $query = "
+        CREATE TABLE [dbo].[NumericTypes](
+            [FloatCol] [float] NULL,
+            [RealCol] [real] NULL,
+            [NumericCol] [numeric](10, 2) NULL,
+            [SmallintCol] [smallint] NULL,
+            [TinyintCol] [tinyint] NULL
+        ) ON [PRIMARY]
+        "
+
+        Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database $dbname -Query $query
+
+        # The config for this table lands in its own directory, because the file name only carries the
+        # instance and the database, so a second config for the same database overwrites the first.
+        $numericTypesFile = New-DbaDbDataGeneratorConfig -SqlInstance $TestConfig.InstanceSingle -Database $dbname -Table NumericTypes -Path "$($TestConfig.Temp)\datageneration-numeric"
+
     }
     AfterAll {
         Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbname
         Remove-Item -Path "$($TestConfig.Temp)\datageneration" -Recurse
+        Remove-Item -Path "$($TestConfig.Temp)\datageneration-numeric" -Recurse
     }
 
     It "gives no errors with a correct json file" {
         $findings = @()
         $findings += Test-DbaDbDataGeneratorConfig -FilePath $file.FullName
+
+        $findings.Count | Should -Be 0
+    }
+
+    It "gives no errors for the numeric data types the generator supports" {
+        # float, guid, numeric, real, smallint and tinyint were missing from the supported data types
+        # here while Invoke-DbaDbDataGenerator supported them, so a configuration fresh from
+        # New-DbaDbDataGeneratorConfig was rejected for using them.
+        $findings = @()
+        $findings += Test-DbaDbDataGeneratorConfig -FilePath $numericTypesFile.FullName
 
         $findings.Count | Should -Be 0
     }


### PR DESCRIPTION
Fixes three defects in the data generation family, found while working PR #10517 and verified against the lab.

## Configuration errors did not stop the generation

`Invoke-DbaDbDataGenerator` called `Test-DbaDbDataGeneratorConfig -EnableException` without assigning the result. The findings of that command are output objects, not exceptions, so the surrounding `try/catch` could never fire: an invalid configuration was reported *into the output stream of the generator itself*, mixed with the per-table results, and the generation ran anyway. The command now collects the findings and stops with "Errors found testing the configuration file.", returning the finding objects - the same pattern `Invoke-DbaDbDataMasking` already uses.

## The two supported data type lists had drifted

Stopping on findings surfaced a second defect: the `$supportedDataTypes` list in `Test-DbaDbDataGeneratorConfig` was missing `float`, `guid`, `numeric`, `real`, `smallint` and `tinyint`, all of which `Invoke-DbaDbDataGenerator` supports. Harmless while the findings were ignored - but with the stop in place, a configuration fresh from `New-DbaDbDataGeneratorConfig` for a table with such a column would have been rejected. The lists now match, and both carry a comment pointing at the other.

## The unique index branch never delivered its values

The branch that pre-generates values for tables with a unique index has been broken since the command was created in 2019, in four ways:

- the insert read the values with `$uniqueValues[$rowNumber]`, and `$rowNumber` is never assigned anywhere - so every row read `$null`,
- `$uniqueValueColumns` was only filled inside the collision-retry copy of the code, so in the common no-collision case the main loop did not even look at the pre-generated values and inserted fresh independent random draws,
- a collision retry started from an empty object, wiping the values already generated for earlier indexes of the same row,
- the collision check matched objects with `-match`, i.e. against a stringified regex.

The branch is rewritten: one candidate per row, generated for all configured unique index columns, checked per index against the earlier rows, retried up to 100 times, and the insert reads it by the row loop index. The unique value branch also moved ahead of the nullable branch, because a second NULL would already violate the index.

## Tests

- The existing invalid-configuration tests now assert the up-front rejection and that the finding objects name the column; the in-command column checks remain as the only validation for configurations fetched over http, which skip `Test-DbaDbDataGeneratorConfig`.
- New regression: ten rows into a unique-indexed int column with a ten-value domain must form a permutation. On the old code this fails with "Cannot insert duplicate key"; verified red-on-old (7 tests fail), green-on-new (17/17).
- New regression in `Test-DbaDbDataGeneratorConfig.Tests.ps1`: a configuration generated for a table with the six previously missing numeric types produces no findings (5 findings on the old code).

`Invoke-DbaDbDataMasking` was checked for the same defects: its unique index handling uses a different mechanism (temp table keyed by a properly incremented row number) and is not affected.

Created by Claude and reviewed by Andreas Jordan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)