### PR TITLE
Testing Get-DbaDbRestoreHistory - Give every backup its own file so the diff always finds its full

### DIFF
--- a/tests/Get-DbaDbRestoreHistory.Tests.ps1
+++ b/tests/Get-DbaDbRestoreHistory.Tests.ps1
@@ -108,13 +108,41 @@ Describe $CommandName -Tag IntegrationTests {
         }
         $null = Restore-DbaDatabase @splatRestore3
 
-        $fullBackup = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbname1 -Type Full -Path $backupPath
-        $diffBackup = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbname1 -Type Diff -Path $backupPath
-        $logBackup = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $dbname1 -Type Log -Path $backupPath
+        # Every backup gets its own file name. The default name carries a timestamp with minute
+        # resolution, so the full and the diff usually land in the same file and the restore below
+        # found the full inside the diff file by accident - and when the minute changed between the
+        # two backups, the diff had no full to anchor to, Restore-DbaDatabase warned and restored
+        # nothing, and six tests failed on a restore history that was never written.
+        $splatBackupFull = @{
+            SqlInstance = $TestConfig.InstanceSingle
+            Database    = $dbname1
+            Type        = "Full"
+            Path        = $backupPath
+            FilePath    = "restorehistory_full_$random.bak"
+        }
+        $fullBackup = Backup-DbaDatabase @splatBackupFull
+
+        $splatBackupDiff = @{
+            SqlInstance = $TestConfig.InstanceSingle
+            Database    = $dbname1
+            Type        = "Diff"
+            Path        = $backupPath
+            FilePath    = "restorehistory_diff_$random.bak"
+        }
+        $diffBackup = Backup-DbaDatabase @splatBackupDiff
+
+        $splatBackupLog = @{
+            SqlInstance = $TestConfig.InstanceSingle
+            Database    = $dbname1
+            Type        = "Log"
+            Path        = $backupPath
+            FilePath    = "restorehistory_log_$random.trn"
+        }
+        $logBackup = Backup-DbaDatabase @splatBackupLog
 
         $splatRestoreFinal = @{
             SqlInstance  = $TestConfig.InstanceSingle
-            Path         = $diffBackup.BackupPath, $logBackup.BackupPath
+            Path         = $fullBackup.BackupPath, $diffBackup.BackupPath, $logBackup.BackupPath
             DatabaseName = $dbname1
             WithReplace  = $true
         }


### PR DESCRIPTION
`Get-DbaDbRestoreHistory.Tests.ps1` failed 6 of 12 tests in three full lab runs (2026-08-08, 2026-08-16, 2026-08-24) and passed everywhere else. The failing runs all share one signature: the first database ends with only its initial restore row - the final diff+log restore never happened.

## Mechanism, measured in the lab

The fixture backs up full, diff and log without file names and then restores only `$diffBackup.BackupPath, $logBackup.BackupPath`. The default backup file name carries a timestamp with **minute resolution**, so the full and the diff usually land in **the same .bak file** - the restore plan visibly reads `FILE = 1` (the full) and `FILE = 2` (the diff) from one file, which is the only reason the diff ever had a base and the expected counts (four rows: initial full, full, diff, log) ever came out.

When the minute changes between the two backups, they land in separate files, and the restore silently does nothing: `Select-DbaBackupInformation` stops with "Fullname property not found", but `Restore-DbaDatabase` does not pass `EnableException` into that call, so the stop degrades to a warning, the setup (which runs with EnableException) does not fail, and six tests then count rows that were never written.

## Fix

Every backup gets its own explicit file name, and the full backup is passed to the restore alongside the diff and the log. That produces the same three history rows the expected counts were always built on - deterministically instead of by file-name collision. Verified green in the lab (12/12); both the accidental-success and the silent-no-op paths were reproduced with probe databases before changing the test.

The swallowed stop in `Restore-DbaDatabase` (warning instead of exception with `-EnableException` when no full anchors the chain) is a command defect independent of this test and is not changed here.

Created by Claude and reviewed by Andreas Jordan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)