### PR TITLE
Get-DbaWaitingTask - Harden flaky test setup and fix always-null InfoUrl

### DIFF
--- a/public/Get-DbaWaitingTask.ps1
+++ b/public/Get-DbaWaitingTask.ps1
@@ -110,7 +110,7 @@ function Get-DbaWaitingTask {
                 [er].[database_id] AS [DbId],
                 [est].[text] AS [SqlText],
                 [eqp].[query_plan] AS [QueryPlan],
-                CAST ('https://www.sqlskills.com/help/waits/' + [owt].[wait_type] AS XML) AS [URL]
+                CAST ('https://www.sqlskills.com/help/waits/' + [owt].[wait_type] AS XML) AS [InfoUrl]
             FROM sys.dm_os_waiting_tasks [owt]
             INNER JOIN sys.dm_os_tasks [ot] ON
                 [owt].[waiting_task_address] = [ot].[task_address]

--- a/public/Get-DbaWaitingTask.ps1
+++ b/public/Get-DbaWaitingTask.ps1
@@ -10,7 +10,7 @@ function Get-DbaWaitingTask {
         Reference: https://www.sqlskills.com/blogs/paul/updated-sys-dm_os_waiting_tasks-script-2/
 
     .PARAMETER SqlInstance
-        The target SQL Server instance or instances. Server version must be SQL Server version XXXX or higher.
+        The target SQL Server instance or instances. Server version must be SQL Server 2005 or higher.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).

--- a/tests/Get-DbaWaitingTask.Tests.ps1
+++ b/tests/Get-DbaWaitingTask.Tests.ps1
@@ -34,7 +34,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
         $waitingTaskSql = "SELECT '$waitingTaskFlag'; WAITFOR DELAY '$waitingTaskTime'"
         $waitingTaskInstance = $TestConfig.InstanceSingle
 
-        $waitingTaskModulePath = "C:\Github\dbatools\dbatools.psm1"
+        $waitingTaskModulePath = (Get-Module -Name dbatools).Path
         $waitingTaskJobName = "YouHaveBeenFoundWaiting"
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
@@ -63,25 +63,39 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
 
     Context "Command functionality with waiting task" {
         BeforeAll {
+            # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
             Start-Job -Name $waitingTaskJobName -ScriptBlock {
                 Import-Module $args[0];
                 (Connect-DbaInstance -SqlInstance $args[1] -ClientName dbatools-waiting).ConnectionContext.ExecuteNonQuery($args[2])
             } -ArgumentList $waitingTaskModulePath, $waitingTaskInstance, $waitingTaskSql
 
-            # The job needs some seconds to load the module and to open the connection
-            foreach ($second in 1..30) {
+            # The job needs some seconds to load the module and to open the connection.
+            # On a busy machine this can take more than 30 seconds, so we wait up to 60 seconds and fail loudly instead of continuing with a null spid.
+            foreach ($second in 1..60) {
                 $waitingTaskProcess = Get-DbaProcess -SqlInstance $waitingTaskInstance | Where-Object Program -eq "dbatools-waiting" | Select-Object -ExpandProperty Spid
                 if ($waitingTaskProcess) {
                     break
                 }
                 Start-Sleep -Seconds 1
             }
+            if (-not $waitingTaskProcess) {
+                $waitingTaskJobOutput = Get-Job -Name $waitingTaskJobName | Receive-Job -ErrorAction SilentlyContinue | Out-String
+                throw "The dbatools-waiting session did not appear on $waitingTaskInstance within 60 seconds. Job output: $waitingTaskJobOutput"
+            }
 
-            # Wait another second for the query to start
-            Start-Sleep -Seconds 1
+            # The query needs another moment to start, so we poll until the waiting task is reported.
+            foreach ($second in 1..30) {
+                $results = Get-DbaWaitingTask -SqlInstance $waitingTaskInstance -Spid $waitingTaskProcess
+                if ($results) {
+                    break
+                }
+                Start-Sleep -Seconds 1
+            }
 
-            # Get the results
-            $results = Get-DbaWaitingTask -SqlInstance $waitingTaskInstance -Spid $waitingTaskProcess
+            # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
         It "Should have correct properties" {
@@ -108,6 +122,10 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
 
         It "Should have command of WAITFOR" {
             $results.WaitType | Should -BeLike "*WAITFOR*"
+        }
+
+        It "Should have an InfoUrl for the wait type" {
+            $results.InfoUrl | Should -Be "https://www.sqlskills.com/help/waits/WAITFOR"
         }
     }
 }


### PR DESCRIPTION
## Summary

The full test suite run of 2026-08-28 (setC config, FCI01 as InstanceSingle) failed only one file: `Get-DbaWaitingTask.Tests.ps1`, with both assertions comparing against `$null`. Standalone the test passes, so this is a timing flake, and while fixing the test a small command defect turned up.

### Test hardening

The integration test starts a background job that imports dbatools and runs a `WAITFOR DELAY`, then gave it a hard 30 seconds to show up on the instance. On a machine under load (four hours into a full suite run) importing the module in a fresh job can exceed that, the spid stays `$null`, and the tests fail with unhelpful messages like `Expected like wildcard '*WAITFOR*' to match $null`.

- The setup now waits up to 60 seconds for the session and **throws with the job output** if it never appears, so a future failure says what actually went wrong.
- Instead of a single blind attempt one second after the session appears, it polls up to 30 seconds for the waiting task to be reported.
- The module path for the job is derived from the loaded module instead of the hard-coded `C:\Github\dbatools\dbatools.psm1`.
- Setup runs with `EnableException` per test policy.

### Command fix: InfoUrl was always null

The query aliases the SQLSkills documentation link as `[URL]`, but the output object reads `$row.InfoUrl` - so the `InfoUrl` property has been silently `$null` since the command was added in 2018 (the `.OUTPUTS` documentation describes it as a real property). The alias now matches, and a new test asserts the URL comes back for the WAITFOR wait type.

## Verification

All 4 tests (including the new InfoUrl regression test) pass against FCI01 (clustered default instance, SQL Server 2022) via the lab test harness.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)