### PR TITLE
Fix case sensitivity defects in 15 test files

### DIFF
--- a/tests/Find-DbaDbGrowthEvent.Tests.ps1
+++ b/tests/Find-DbaDbGrowthEvent.Tests.ps1
@@ -49,7 +49,7 @@ CROSS JOIN
 
 TRUNCATE TABLE Tab1;
 DBCC SHRINKFILE ($databaseName1, TRUNCATEONLY);
-DBCC SHRINKFILE ($($databaseName1)_Log, TRUNCATEONLY);
+DBCC SHRINKFILE ($($databaseName1)_log, TRUNCATEONLY);
 "@
 
             $null = $db1.Query($sqlGrowthAndShrink)

--- a/tests/Find-DbaStoredProcedure.Tests.ps1
+++ b/tests/Find-DbaStoredProcedure.Tests.ps1
@@ -40,7 +40,7 @@ FROM [master].[sys].[syslogins];
 "@
             $splatCreateProc = @{
                 SqlInstance = $TestConfig.InstanceSingle
-                Database    = "Master"
+                Database    = "master"
                 Query       = $ServerProcedure
             }
             $null = Invoke-DbaQuery @splatCreateProc
@@ -56,7 +56,7 @@ FROM [master].[sys].[syslogins];
             $DropProcedure = "DROP PROCEDURE dbo.cp_dbatoolsci_sysadmin;"
             $splatDropProc = @{
                 SqlInstance = $TestConfig.InstanceSingle
-                Database    = "Master"
+                Database    = "master"
                 Query       = $DropProcedure
             }
             $null = Invoke-DbaQuery @splatDropProc

--- a/tests/Find-DbaTrigger.Tests.ps1
+++ b/tests/Find-DbaTrigger.Tests.ps1
@@ -48,7 +48,7 @@ AS
 DROP TRIGGER dbatoolsci_ddl_trig_database
 ON ALL SERVER;
 "@
-            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database "Master" -Query $DropTrigger
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database "master" -Query $DropTrigger
         }
 
         It "Should find a specific Trigger at the Server Level" {
@@ -113,18 +113,18 @@ GO
         }
 
         It "Should find a specific Trigger at the Object Level" {
-            $results = Find-DbaTrigger -SqlInstance $TestConfig.InstanceSingle -Pattern dbatoolsci* -Database "dbatoolsci_triggerdb" -ExcludeDatabase Master -TriggerLevel Object
+            $results = Find-DbaTrigger -SqlInstance $TestConfig.InstanceSingle -Pattern dbatoolsci* -Database "dbatoolsci_triggerdb" -ExcludeDatabase master -TriggerLevel Object
             $results.TriggerLevel | Should -Be "Object"
             $results.DatabaseId | Should -Be $dbatoolsci_triggerdb.ID
         }
 
         It "Should find a specific Trigger named dbatoolsci_reminder1" {
-            $results = Find-DbaTrigger -SqlInstance $TestConfig.InstanceSingle -Pattern dbatoolsci* -Database "dbatoolsci_triggerdb" -ExcludeDatabase Master -TriggerLevel Object
+            $results = Find-DbaTrigger -SqlInstance $TestConfig.InstanceSingle -Pattern dbatoolsci* -Database "dbatoolsci_triggerdb" -ExcludeDatabase master -TriggerLevel Object
             $results.Name | Should -Be "dbatoolsci_reminder1"
         }
 
         It "Should find a specific Trigger on the Table [dbo].[Customer]" {
-            $results = Find-DbaTrigger -SqlInstance $TestConfig.InstanceSingle -Pattern dbatoolsci* -Database "dbatoolsci_triggerdb" -ExcludeDatabase Master -TriggerLevel Object
+            $results = Find-DbaTrigger -SqlInstance $TestConfig.InstanceSingle -Pattern dbatoolsci* -Database "dbatoolsci_triggerdb" -ExcludeDatabase master -TriggerLevel Object
             $results.Object | Should -Be "[dbo].[Customer]"
         }
 

--- a/tests/Find-DbaView.Tests.ps1
+++ b/tests/Find-DbaView.Tests.ps1
@@ -35,12 +35,12 @@ AS
     SELECT [sid],[loginname],[sysadmin]
     FROM [master].[sys].[syslogins];
 "@
-            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database "Master" -Query $ServerView
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database "master" -Query $ServerView
         }
 
         AfterAll {
             $DropView = "DROP VIEW dbo.v_dbatoolsci_sysadmin;"
-            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database "Master" -Query $DropView
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database "master" -Query $DropView
         }
 
         BeforeEach {
@@ -51,9 +51,9 @@ AS
             $results.Name | Should -Be "v_dbatoolsci_sysadmin"
         }
 
-        It "Should find v_dbatoolsci_sysadmin in Master" {
-            $results.Database | Should -Be "Master"
-            $results.DatabaseId | Should -Be (Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database Master).ID
+        It "Should find v_dbatoolsci_sysadmin in master" {
+            $results.Database | Should -Be "master"
+            $results.DatabaseId | Should -Be (Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database master).ID
         }
     }
 

--- a/tests/Get-DbaDbUser.Tests.ps1
+++ b/tests/Get-DbaDbUser.Tests.ps1
@@ -35,12 +35,12 @@ Describe $CommandName -Tag IntegrationTests {
         $CreateTestUser = @"
 CREATE LOGIN [$DBUserName]
     WITH PASSWORD = '$($tempguid.guid)';
-USE Master;
+USE master;
 CREATE USER [$dbUserName] FOR LOGIN [$dbUserName]
     WITH DEFAULT_SCHEMA = dbo;
 CREATE LOGIN [$dbUserName2]
     WITH PASSWORD = '$($tempguid.guid)';
-USE Master;
+USE master;
 CREATE USER [$dbUserName2] FOR LOGIN [$dbUserName2]
     WITH DEFAULT_SCHEMA = dbo;
 "@

--- a/tests/Get-DbaExecutionPlan.Tests.ps1
+++ b/tests/Get-DbaExecutionPlan.Tests.ps1
@@ -41,7 +41,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
 
     Context "Gets Execution Plan when using -Database" {
         BeforeAll {
-            $databaseResults = @(Get-DbaExecutionPlan -SqlInstance $TestConfig.InstanceSingle -Database Master | Select-Object -First 1)
+            $databaseResults = @(Get-DbaExecutionPlan -SqlInstance $TestConfig.InstanceSingle -Database master | Select-Object -First 1)
         }
 
         It "Gets results" {
@@ -49,13 +49,13 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
         }
 
         It "Should be execution plan on Master" {
-            $databaseResults.DatabaseName | Should -Be "Master"
+            $databaseResults.DatabaseName | Should -Be "master"
         }
     }
 
     Context "Gets no Execution Plan when using -ExcludeDatabase" {
         BeforeAll {
-            $excludeResults = @(Get-DbaExecutionPlan -SqlInstance $TestConfig.InstanceSingle -ExcludeDatabase Master | Select-Object -First 1)
+            $excludeResults = @(Get-DbaExecutionPlan -SqlInstance $TestConfig.InstanceSingle -ExcludeDatabase master | Select-Object -First 1)
         }
 
         It "Gets results" {
@@ -63,13 +63,13 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
         }
 
         It "Should be execution plan on Master" {
-            $excludeResults.DatabaseName | Should -Not -Be "Master"
+            $excludeResults.DatabaseName | Should -Not -Be "master"
         }
     }
 
     Context "Gets Execution Plan when using -SinceCreation" {
         BeforeAll {
-            $creationResults = @(Get-DbaExecutionPlan -SqlInstance $TestConfig.InstanceSingle -Database Master -SinceCreation "01-01-2000" | Select-Object -First 1)
+            $creationResults = @(Get-DbaExecutionPlan -SqlInstance $TestConfig.InstanceSingle -Database master -SinceCreation "01-01-2000" | Select-Object -First 1)
         }
 
         It "Gets results" {
@@ -77,7 +77,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
         }
 
         It "Should be execution plan on Master" {
-            $creationResults.DatabaseName | Should -Be "Master"
+            $creationResults.DatabaseName | Should -Be "master"
         }
 
         It "Should have a creation date Greater than 01-01-2000" {
@@ -87,7 +87,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
 
     Context "Gets Execution Plan when using -SinceLastExecution" {
         BeforeAll {
-            $executionResults = @(Get-DbaExecutionPlan -SqlInstance $TestConfig.InstanceSingle -Database Master -SinceLastExecution "01-01-2000" | Select-Object -First 1)
+            $executionResults = @(Get-DbaExecutionPlan -SqlInstance $TestConfig.InstanceSingle -Database master -SinceLastExecution "01-01-2000" | Select-Object -First 1)
         }
 
         It "Gets results" {
@@ -95,7 +95,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
         }
 
         It "Should be execution plan on Master" {
-            $executionResults.DatabaseName | Should -Be "Master"
+            $executionResults.DatabaseName | Should -Be "master"
         }
 
         It "Should have a execution time Greater than 01-01-2000" {

--- a/tests/Get-DbaHelpIndex.Tests.ps1
+++ b/tests/Get-DbaHelpIndex.Tests.ps1
@@ -36,7 +36,7 @@ Describe $CommandName -Tag IntegrationTests {
         $random = Get-Random
         $dbname = "dbatoolsci_$random"
         $server.Query("CREATE DATABASE $dbname")
-        $server.Query("Create Table Test (col1 varchar(50) PRIMARY KEY, col2 int)", $dbname)
+        $server.Query("Create Table test (col1 varchar(50) PRIMARY KEY, col2 int)", $dbname)
         $server.Query("Insert into test values ('value1',1),('value2',2)", $dbname)
         $server.Query("create statistics dbatools_stats on test (col2)", $dbname)
         $server.Query("select * from test", $dbname)
@@ -58,7 +58,7 @@ Describe $CommandName -Tag IntegrationTests {
     }
     Context "Command works for indexes" {
         BeforeAll {
-            $results = Get-DbaHelpIndex -SqlInstance $TestConfig.InstanceSingle -Database $dbname -ObjectName Test
+            $results = Get-DbaHelpIndex -SqlInstance $TestConfig.InstanceSingle -Database $dbname -ObjectName test
         }
 
         It "Results should be returned" {
@@ -79,7 +79,7 @@ Describe $CommandName -Tag IntegrationTests {
     }
     Context "Command works when including statistics" {
         BeforeAll {
-            $results = Get-DbaHelpIndex -SqlInstance $TestConfig.InstanceSingle -Database $dbname -ObjectName Test -IncludeStats | Where-Object { $PSItem.Statistics }
+            $results = Get-DbaHelpIndex -SqlInstance $TestConfig.InstanceSingle -Database $dbname -ObjectName test -IncludeStats | Where-Object { $PSItem.Statistics }
         }
 
         It "Results should be returned" {
@@ -92,7 +92,7 @@ Describe $CommandName -Tag IntegrationTests {
     }
     Context "Command output includes data types" {
         BeforeAll {
-            $results = Get-DbaHelpIndex -SqlInstance $TestConfig.InstanceSingle -Database $dbname -ObjectName Test -IncludeDataTypes
+            $results = Get-DbaHelpIndex -SqlInstance $TestConfig.InstanceSingle -Database $dbname -ObjectName test -IncludeDataTypes
         }
 
         It "Results should be returned" {
@@ -105,7 +105,7 @@ Describe $CommandName -Tag IntegrationTests {
     }
     Context "Formatting is correct" {
         It "Formatted as strings" {
-            $results = Get-DbaHelpIndex -SqlInstance $TestConfig.InstanceSingle -Database $dbname -ObjectName Test -IncludeFragmentation
+            $results = Get-DbaHelpIndex -SqlInstance $TestConfig.InstanceSingle -Database $dbname -ObjectName test -IncludeFragmentation
             $results.IndexReads | Should -BeOfType "String"
             $results.IndexUpdates | Should -BeOfType "String"
             $results.Size | Should -BeOfType "String"
@@ -117,7 +117,7 @@ Describe $CommandName -Tag IntegrationTests {
     }
     Context "Formatting is correct for raw" {
         BeforeAll {
-            $results = Get-DbaHelpIndex -SqlInstance $TestConfig.InstanceSingle -Database $dbname -ObjectName Test -raw -IncludeFragmentation
+            $results = Get-DbaHelpIndex -SqlInstance $TestConfig.InstanceSingle -Database $dbname -ObjectName test -raw -IncludeFragmentation
         }
 
         It "Formatted as Long" {

--- a/tests/Install-DbaSqlWatch.Tests.ps1
+++ b/tests/Install-DbaSqlWatch.Tests.ps1
@@ -27,7 +27,19 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests -Skip:($PSVersionTable.PSVersion.Major -gt 5 -or $env:appveyor) {
     # Skip IntegrationTests on AppVeyor because they take too long and skip on pwsh because the command is not supported.
 
-    Context "Testing SqlWatch installer" {
+    # The SqlWatch dacpac contains a case insensitive model and DacFx refuses to deploy that to a case sensitive
+    # target (error SQL72030), so the installer cannot work there and the Context below skips. We ask the instance
+    # for the behaviour instead of matching the collation name, because _BIN and _BIN2 collations are case sensitive
+    # too and carry no _CS_. A failed probe leaves the skip off so a real connection problem still fails the tests loudly.
+    $sqlWatchInstanceIsCaseSensitive = $false
+    try {
+        $sqlWatchCaseQuery = "SELECT CASE WHEN EXISTS (SELECT 1 FROM sys.databases WHERE name = UPPER(DB_NAME(1))) THEN 0 ELSE 1 END AS IsCaseSensitive"
+        $sqlWatchInstanceIsCaseSensitive = (Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $sqlWatchCaseQuery -EnableException).IsCaseSensitive -eq 1
+    } catch {
+        $sqlWatchInstanceIsCaseSensitive = $false
+    }
+
+    Context "Testing SqlWatch installer" -Skip:$sqlWatchInstanceIsCaseSensitive {
         BeforeAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 

--- a/tests/Invoke-DbaDbDbccCleanTable.Tests.ps1
+++ b/tests/Invoke-DbaDbDbccCleanTable.Tests.ps1
@@ -31,7 +31,7 @@ Describe $CommandName -Tag IntegrationTests {
         $db = Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database tempdb
         $null = $db.Query("CREATE TABLE dbo.dbatoolct_example (object_id int, [definition] nvarchar(max),Document varchar(2000));
         INSERT INTO dbo.dbatoolct_example([object_id], [definition], Document) Select [object_id], [definition], REPLICATE('ab', 800) from master.sys.sql_modules;
-        ALTER TABLE dbo.dbatoolct_example DROP COLUMN Definition, Document;")
+        ALTER TABLE dbo.dbatoolct_example DROP COLUMN [definition], Document;")
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")

--- a/tests/Invoke-DbaWhoIsActive.Tests.ps1
+++ b/tests/Invoke-DbaWhoIsActive.Tests.ps1
@@ -120,7 +120,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:$env:appveyor {
         }
 
         It "Should execute with averagetime" {
-            $resultsAverageTime = Invoke-DbaWhoIsActive -SqlInstance $TestConfig.InstanceSingle -Database Tempdb -GetAverageTime
+            $resultsAverageTime = Invoke-DbaWhoIsActive -SqlInstance $TestConfig.InstanceSingle -Database tempdb -GetAverageTime
             $WarnVar | Should -BeNullOrEmpty
             # No test for results as we don't expect any running queries
         }

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -771,17 +771,17 @@ insert #TmpIndex exec ('dbcc ind(PageRestore,testpage,-1)')
 dbcc ind(PageRestore,testpage,-1)
 
 declare @pageid int
-select top 1 @pageid=PagePid from #TmpIndex where IAMFID is not null and IAmPID is not null
+select top 1 @pageid=PagePid from #TmpIndex where IAMFID is not null and IAMPid is not null
 
 --select * from #TmpIndex
 --pageid = 256
-alter database pagerestore set single_user with rollback immediate
+alter database PageRestore set single_user with rollback immediate
 
-dbcc writepage(pagerestore,1,@pageid,0,1,0x41,1)
-dbcc writepage(pagerestore,1,@pageid,1,1,0x41,1)
-dbcc writepage(pagerestore,1,@pageid,2,1,0x41,1)
+dbcc writepage(PageRestore,1,@pageid,0,1,0x41,1)
+dbcc writepage(PageRestore,1,@pageid,1,1,0x41,1)
+dbcc writepage(PageRestore,1,@pageid,2,1,0x41,1)
 
-alter database pagerestore set multi_user
+alter database PageRestore set multi_user
 
 insert into testpage values (REPLICATE('e','8000'))
 
@@ -790,18 +790,18 @@ Backup log PageRestore to disk='$backupPath\PageRestore.trn'
 insert into testpage values (REPLICATE('f','8000'))
 use master
 "@
-            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $sql -Database Pagerestore
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $sql -Database PageRestore
         }
 
         It "Should have warned about corruption" {
-            $sqlResults2 = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database Master -Query "select * from pagerestore.dbo.testpage where filler like 'a%'" -WarningAction SilentlyContinue
+            $sqlResults2 = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database master -Query "select * from PageRestore.dbo.testpage where filler like 'a%'" -WarningAction SilentlyContinue
             $WarnVar | Should -Match ([regex]::Escape("SQL Server detected a logical consistency-based I/O error: incorrect checksum (expected"))
             $sqlResults2 | Should -BeNullOrEmpty
         }
 
         It "Should work after page restore" {
-            $null = Get-DbaDbBackupHistory -SqlInstance $TestConfig.InstanceSingle -Database pagerestore -last | Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -PageRestore (Get-DbaSuspectPage -SqlInstance $TestConfig.InstanceSingle -Database PageRestore) -TrustDbBackupHistory -DatabaseName PageRestore -PageRestoreTailFolder $backupPath
-            $sqlResults3 = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query "select * from pagerestore.dbo.testpage where filler like 'f%'"
+            $null = Get-DbaDbBackupHistory -SqlInstance $TestConfig.InstanceSingle -Database PageRestore -last | Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -PageRestore (Get-DbaSuspectPage -SqlInstance $TestConfig.InstanceSingle -Database PageRestore) -TrustDbBackupHistory -DatabaseName PageRestore -PageRestoreTailFolder $backupPath
+            $sqlResults3 = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query "select * from PageRestore.dbo.testpage where filler like 'f%'"
             ($null -eq $sqlResults3) | Should -Be $false
         }
     }
@@ -811,7 +811,7 @@ use master
         It "Should backup and restore cleanly" {
             Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -ExcludeSystem | Remove-DbaDatabase
             $null = Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Path "$($TestConfig.appveyorlabrepo)\singlerestore\singlerestore.bak" -DatabaseName PipeTest -DestinationFilePrefix PipeTest
-            $results = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database Pipetest -BackupDirectory $backupPath -CopyOnly | Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -DatabaseName restored -ReplaceDbNameInFile
+            $results = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database PipeTest -BackupDirectory $backupPath -CopyOnly | Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -DatabaseName restored -ReplaceDbNameInFile
             $results.RestoreComplete | Should -Be $true
         }
     }

--- a/tests/Test-DbaDbQueryStore.Tests.ps1
+++ b/tests/Test-DbaDbQueryStore.Tests.ps1
@@ -97,13 +97,13 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "When a system database is named explicitly" {
         It "Warns about master instead of failing with a null array" {
-            $resultsSystemDb = Test-DbaDbQueryStore -SqlInstance $TestConfig.InstanceSingle -Database master -WarningVariable warnSystemDb
+            $resultsSystemDb = Test-DbaDbQueryStore -SqlInstance $TestConfig.InstanceSingle -Database master -WarningVariable warnSystemDb -WarningAction SilentlyContinue
             $warnSystemDb -join "`n" | Should -Match "Query Store cannot be enabled on system database master"
             ($resultsSystemDb | Where-Object Database) | Should -BeNullOrEmpty
         }
 
         It "Does not fall back to evaluating every database once the filters leave nothing" {
-            $resultsSystemDb = Test-DbaDbQueryStore -SqlInstance $TestConfig.InstanceSingle -Database master
+            $resultsSystemDb = Test-DbaDbQueryStore -SqlInstance $TestConfig.InstanceSingle -Database master -WarningAction SilentlyContinue
             ($resultsSystemDb | Where-Object Database -eq $dbname) | Should -BeNullOrEmpty
         }
     }

--- a/tests/Test-DbaIdentityUsage.Tests.ps1
+++ b/tests/Test-DbaIdentityUsage.Tests.ps1
@@ -29,23 +29,23 @@ Describe $CommandName -Tag IntegrationTests {
         BeforeAll {
             $table1 = "TestTable_$(Get-Random)"
             $tableDDL = "CREATE TABLE $table1 (testId TINYINT IDENTITY(1,1),testData DATETIME2 DEFAULT getdate() )"
-            Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $tableDDL -Database TempDb
+            Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $tableDDL -Database tempdb
 
             $insertSql = "INSERT INTO $table1 (testData) DEFAULT VALUES"
             for ($i = 1; $i -le 128; $i++) {
-                Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $insertSql -Database TempDb
+                Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $insertSql -Database tempdb
             }
-            $results128 = Test-DbaIdentityUsage -SqlInstance $TestConfig.InstanceSingle -Database TempDb | Where-Object Table -eq $table1
+            $results128 = Test-DbaIdentityUsage -SqlInstance $TestConfig.InstanceSingle -Database tempdb | Where-Object Table -eq $table1
 
             for ($i = 1; $i -le 127; $i++) {
-                Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $insertSql -Database TempDb
+                Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $insertSql -Database tempdb
             }
-            $results255 = Test-DbaIdentityUsage -SqlInstance $TestConfig.InstanceSingle -Database TempDb | Where-Object Table -eq $table1
+            $results255 = Test-DbaIdentityUsage -SqlInstance $TestConfig.InstanceSingle -Database tempdb | Where-Object Table -eq $table1
         }
 
         AfterAll {
             $cleanup = "Drop table $table1"
-            Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $cleanup -Database TempDb
+            Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $cleanup -Database tempdb
         }
 
         It "Identity column should have 128 uses" {
@@ -69,18 +69,18 @@ Describe $CommandName -Tag IntegrationTests {
         BeforeAll {
             $table2 = "TestTable_$(Get-Random)"
             $tableDDL = "CREATE TABLE $table2 (testId tinyint IDENTITY(0,5),testData DATETIME2 DEFAULT getdate() )"
-            Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $tableDDL -Database TempDb
+            Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $tableDDL -Database tempdb
 
             $insertSql = "INSERT INTO $table2 (testData) DEFAULT VALUES"
             for ($i = 1; $i -le 25; $i++) {
-                Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $insertSql -Database TempDb
+                Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $insertSql -Database tempdb
             }
-            $results25 = Test-DbaIdentityUsage -SqlInstance $TestConfig.InstanceSingle -Database TempDb | Where-Object Table -eq $table2
+            $results25 = Test-DbaIdentityUsage -SqlInstance $TestConfig.InstanceSingle -Database tempdb | Where-Object Table -eq $table2
         }
 
         AfterAll {
             $cleanup = "Drop table $table2"
-            Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $cleanup -Database TempDb
+            Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $cleanup -Database tempdb
         }
 
         It "Identity column should have 24 uses" {

--- a/tests/Uninstall-DbaSqlWatch.Tests.ps1
+++ b/tests/Uninstall-DbaSqlWatch.Tests.ps1
@@ -24,6 +24,19 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests -Skip:($PSVersionTable.PSVersion.Major -gt 5 -or $env:appveyor) {
     # Skip IntegrationTests on AppVeyor because they take too long and skip on pwsh because the command is not supported.
 
+    # The SqlWatch dacpac contains a case insensitive model and DacFx refuses to deploy that to a case sensitive
+    # target (error SQL72030), so there is nothing to uninstall there and the Context below skips, which also keeps
+    # the BeforeAll from installing. We ask the instance for the behaviour instead of matching the collation name,
+    # because _BIN and _BIN2 collations are case sensitive too and carry no _CS_. A failed probe leaves the skip off
+    # so a real connection problem still fails the tests loudly.
+    $sqlWatchInstanceIsCaseSensitive = $false
+    try {
+        $sqlWatchCaseQuery = "SELECT CASE WHEN EXISTS (SELECT 1 FROM sys.databases WHERE name = UPPER(DB_NAME(1))) THEN 0 ELSE 1 END AS IsCaseSensitive"
+        $sqlWatchInstanceIsCaseSensitive = (Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Query $sqlWatchCaseQuery -EnableException).IsCaseSensitive -eq 1
+    } catch {
+        $sqlWatchInstanceIsCaseSensitive = $false
+    }
+
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
@@ -46,7 +59,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:($PSVersionTable.PSVersion.Maj
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
-    Context "Testing SqlWatch uninstaller" {
+    Context "Testing SqlWatch uninstaller" -Skip:$sqlWatchInstanceIsCaseSensitive {
         BeforeAll {
             $null = Uninstall-DbaSqlWatch -SqlInstance $TestConfig.InstanceSingle -Database $database
         }

--- a/tests/Update-DbaMaintenanceSolution.Tests.ps1
+++ b/tests/Update-DbaMaintenanceSolution.Tests.ps1
@@ -142,7 +142,7 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     It "downloads the current GitHub source before checking installed procedures" {
-        $results = Update-DbaMaintenanceSolution -SqlInstance $TestConfig.InstanceSingle -Database $databaseName -Solution CommandExecute -Force -EnableException
+        $results = Update-DbaMaintenanceSolution -SqlInstance $TestConfig.InstanceSingle -Database $databaseName -Solution CommandExecute -Force -EnableException -WarningAction SilentlyContinue
 
         $results | Should -HaveCount 1
         $results.Procedure | Should -Be "CommandExecute"


### PR DESCRIPTION
## Summary

The first full suite run against a case sensitive instance (SQL05\SQL2025, SQL_Latin1_General_CP1_CS_AS, matching SQL03\SQL2025 build-for-build so collation is the only variable) failed 18 test files. This PR fixes the 15 that are test-only defects - wrong-case identifiers that every case insensitive instance silently forgave. The remaining three failures are command defects (Get-DbaDbMailLog, Get-DbaDbMailHistory, Install-DbaWhoIsActive, Set-DbaDbFileGroup) and get their own PRs.

### Wrong-case database names in fixtures and assertions

`-Database "Master"`, `USE Master;`, `-Database Tempdb`/`TempDb`, `-Database Pagerestore` - on a case sensitive instance these fail to connect ("Cannot open database ... login failed"). Affected: Find-DbaStoredProcedure, Find-DbaTrigger, Find-DbaView, Get-DbaDbUser, Get-DbaExecutionPlan, Invoke-DbaWhoIsActive, Test-DbaIdentityUsage, Restore-DbaDatabase. A detail worth knowing: Test-DbaIdentityUsage inserts test rows one `Invoke-DbaQuery -Database TempDb` call at a time, so every call burned a 10-second connection timeout - about 280 failures and ~48 minutes of a 218-minute run.

### Wrong-case object identifiers inside fixture T-SQL

- Get-DbaHelpIndex: created `Table Test`, then inserted into `test` and passed `-ObjectName Test`.
- Invoke-DbaDbDbccCleanTable: created column `[definition]`, then dropped `Definition` (tempdb inherits the case sensitive collation via model).
- Find-DbaDbGrowthEvent: `DBCC SHRINKFILE (<db>_Log)` where New-DbaDatabase names the log file `<db>_log`.
- Restore-DbaDatabase: the page restore context mixed `PageRestore`/`Pagerestore`/`pagerestore`, and read `IAmPID` from a temp table declaring `IAMPid`.
- Find-DbaTrigger: dropped its `ON ALL SERVER` trigger via `-Database "Master"`; the failed cleanup leaked the trigger and inflated the later TriggerLevel All count to 3.

### SqlWatch cannot deploy to a case sensitive instance

DacFx refuses with SQL72030 ("deploying a case insensitive model to a case sensitive target") because the SqlWatch dacpac carries a CI model. Install-/Uninstall-DbaSqlWatch now compute a discovery-time probe and skip their integration contexts on a case sensitive instance. The probe asks `sys.databases` whether `master` equals `UPPER(master)` instead of matching the collation name, because `_BIN`/`_BIN2` collations are case sensitive too and carry no `_CS_`. A failed probe leaves the skip off so a real connection problem still fails loudly.

### Warning hygiene

Test-DbaDbQueryStore and Update-DbaMaintenanceSolution asserted their expected warnings without silencing the stream; both now pass `-WarningAction SilentlyContinue` so warning-checked runs stay clean.

## Verification

All 15 files run green against SQL05\SQL2025 via the lab harness (Find-DbaTrigger twice: the first run also cleaned the leaked server trigger through the fixed AfterAll, the second proved the steady state). The changes are inert on case insensitive instances - the corrected lowercase names match the actual objects there as well, and the SqlWatch skip evaluates to false.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)