### PR TITLE
Get-DbaDbMailHistory - Make the Status filter work on case sensitive instances

### DIFF
--- a/public/Get-DbaDbMailHistory.ps1
+++ b/public/Get-DbaDbMailHistory.ps1
@@ -169,7 +169,9 @@ function Get-DbaDbMailHistory {
                 if ($Status) {
                     # The sysmail_allitems view emits sent_status in lowercase, so compare lowercased or the
                     # documented values (Sent, Unsent, Failed, Retrying) never match on a case sensitive instance.
-                    $Status = ($Status -join "', '").ToLower()
+                    # Invariantly: a culture-sensitive lowercase turns the I of FAILED or RETRYING into a
+                    # dotless i under Turkish rules, which never matches the ASCII tokens sysmail stores.
+                    $Status = ($Status -join "', '").ToLowerInvariant()
                     $wherearray += "LOWER(sent_status) IN ('$Status')"
                 }
 

--- a/public/Get-DbaDbMailHistory.ps1
+++ b/public/Get-DbaDbMailHistory.ps1
@@ -167,8 +167,10 @@ function Get-DbaDbMailHistory {
                 }
 
                 if ($Status) {
-                    $Status = $Status -join "', '"
-                    $wherearray += "sent_status IN ('$Status')"
+                    # The sysmail_allitems view emits sent_status in lowercase, so compare lowercased or the
+                    # documented values (Sent, Unsent, Failed, Retrying) never match on a case sensitive instance.
+                    $Status = ($Status -join "', '").ToLower()
+                    $wherearray += "LOWER(sent_status) IN ('$Status')"
                 }
 
                 $wherearray = $wherearray -join ' AND '

--- a/tests/Get-DbaDbMailHistory.Tests.ps1
+++ b/tests/Get-DbaDbMailHistory.Tests.ps1
@@ -71,6 +71,42 @@ Describe $CommandName -Tag IntegrationTests {
            ($profile_id,'dbatoolssci@dbatools.io',NULL,NULL,'Test Job',NULL,NULL,'A Test Job failed to run','TEXT','NORMAL','NORMAL',NULL,'MIME',NULL,NULL,
           0,1,256,'',0,0,'2018-12-9 11:44:32.600','dbatools\dbatoolssci',1,1,'2018-12-9 11:44:33.000','2018-12-9 11:44:33.273','sa')"
         )
+        # A second row with sent_status = 2 (failed): FAILED is a status whose uppercase form
+        # contains the letter I, which a culture-sensitive lowercase turns into a dotless i under
+        # the Turkish culture - the culture regression below needs exactly this row.
+        $server.Query("INSERT INTO msdb.[dbo].[sysmail_mailitems]
+           ([profile_id]
+           ,[recipients]
+           ,[copy_recipients]
+           ,[blind_copy_recipients]
+           ,[subject]
+           ,[from_address]
+           ,[reply_to]
+           ,[body]
+           ,[body_format]
+           ,[importance]
+           ,[sensitivity]
+           ,[file_attachments]
+           ,[attachment_encoding]
+           ,[query]
+           ,[execute_query_database]
+           ,[attach_query_result_as_file]
+           ,[query_result_header]
+           ,[query_result_width]
+           ,[query_result_separator]
+           ,[exclude_query_output]
+           ,[append_query_error]
+           ,[send_request_date]
+           ,[send_request_user]
+           ,[sent_account_id]
+           ,[sent_status]
+           ,[sent_date]
+           ,[last_mod_date]
+           ,[last_mod_user])
+        VALUES
+           ($profile_id,'dbatoolssci@dbatools.io',NULL,NULL,'Test Job Failed',NULL,NULL,'A Test Job failed to run','TEXT','NORMAL','NORMAL',NULL,'MIME',NULL,NULL,
+          0,1,256,'',0,0,'2018-12-9 11:44:32.600','dbatools\dbatoolssci',1,2,'2018-12-9 11:44:33.000','2018-12-9 11:44:33.273','sa')"
+        )
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
@@ -123,6 +159,26 @@ Describe $CommandName -Tag IntegrationTests {
 
         It "Should have SentStatus of Sent" {
             $results.SentStatus | Should -Be "Sent"
+        }
+    }
+
+    Context "Gets Db Mail History using -Status under a Turkish culture" {
+        BeforeAll {
+            # ValidateSet accepts case-insensitive input, so FAILED reaches the command as typed.
+            # Its uppercase I is the letter a culture-sensitive lowercase turns into a dotless i
+            # under Turkish rules, which can never match the ASCII tokens sysmail stores - the
+            # command has to normalize invariantly.
+            $cultureBefore = [System.Globalization.CultureInfo]::CurrentCulture
+            try {
+                [System.Globalization.CultureInfo]::CurrentCulture = "tr-TR"
+                $resultsTurkish = Get-DbaDbMailHistory -SqlInstance $TestConfig.InstanceSingle -Status FAILED
+            } finally {
+                [System.Globalization.CultureInfo]::CurrentCulture = $cultureBefore
+            }
+        }
+
+        It "Finds the failed mail although the culture lowercases differently" {
+            $resultsTurkish.SentStatus | Should -Be "Failed"
         }
     }
 

--- a/tests/Get-DbaDbMailHistory.Tests.ps1
+++ b/tests/Get-DbaDbMailHistory.Tests.ps1
@@ -68,7 +68,7 @@ Describe $CommandName -Tag IntegrationTests {
            ,[last_mod_date]
            ,[last_mod_user])
         VALUES
-           ($profile_id,'dbatoolssci@dbatools.io',NULL,NULL,'Test Job',NULL,NULL,'A Test Job failed to run','TEXT','Normal','Normal',NULL,'MIME',NULL,NULL,
+           ($profile_id,'dbatoolssci@dbatools.io',NULL,NULL,'Test Job',NULL,NULL,'A Test Job failed to run','TEXT','NORMAL','NORMAL',NULL,'MIME',NULL,NULL,
           0,1,256,'',0,0,'2018-12-9 11:44:32.600','dbatools\dbatoolssci',1,1,'2018-12-9 11:44:33.000','2018-12-9 11:44:33.273','sa')"
         )
 


### PR DESCRIPTION
## Summary

Found by the first suite run against a case sensitive instance (SQL05\SQL2025). The msdb view `sysmail_allitems` emits `sent_status` in lowercase (`unsent`, `sent`, `failed`, `retrying` - verified from the view definition), but the command''s documented `-Status` values are capitalized and were injected into the WHERE clause verbatim, so `-Status Sent` returned nothing on a case sensitive instance. The filter now lowercases both sides: `LOWER(sent_status) IN (''sent'')`.

The test fixture had a companion defect that masked this: it inserted `importance` and `sensitivity` as `''Normal''`, which violates msdb''s CHECK constraints on a case sensitive instance (`sysmail_OutMailImportanceMustBeValid` compares against uppercase `NORMAL`/`HIGH`/`LOW` - also verified against the live constraint definitions). The fixture now inserts the uppercase values, which is also what Database Mail itself writes.

## Verification

11/11 tests green on SQL05\SQL2025 (case sensitive) and on SQL03\SQL2019 (case insensitive), via the lab test harness. Sibling defect of the same shape in Get-DbaDbMailLog (`-Type`) gets its own PR.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)