### PR TITLE
Set-DbaDbFileGroup - Resolve filegroups reliably on case sensitive databases

### DIFF
--- a/public/Set-DbaDbFileGroup.ps1
+++ b/public/Set-DbaDbFileGroup.ps1
@@ -150,11 +150,22 @@ function Set-DbaDbFileGroup {
 
                 foreach ($fg in $FileGroup) {
 
-                    if ($obj.FileGroups.Name -notcontains $fg) {
-                        Stop-Function -Message "Filegroup $fg does not exist in the database $($obj.Name) on $($obj.Parent.Name)" -Continue
+                    # On a case sensitive database the SMO collection indexer compares case sensitively, so checking
+                    # with -notcontains (case insensitive) and then retrieving with the indexer returns null for a
+                    # name in the wrong case. Resolve with one lookup: exact match first, case insensitive fallback.
+                    $fileGroupObject = $obj.FileGroups | Where-Object Name -ceq $fg
+                    if (-not $fileGroupObject) {
+                        $fileGroupObject = $obj.FileGroups | Where-Object Name -eq $fg
                     }
 
-                    $fileGroupsToModify += $obj.FileGroups[$fg]
+                    if (-not $fileGroupObject) {
+                        Stop-Function -Message "Filegroup $fg does not exist in the database $($obj.Name) on $($obj.Parent.Name)" -Continue
+                    }
+                    if (@($fileGroupObject).Count -gt 1) {
+                        Stop-Function -Message "Multiple filegroups match $fg case insensitively in the database $($obj.Name) on $($obj.Parent.Name). Specify the exact name." -Continue
+                    }
+
+                    $fileGroupsToModify += $fileGroupObject
                 }
             } elseif ($obj -is [Microsoft.SqlServer.Management.Smo.FileGroup]) {
                 $fileGroupsToModify += $obj
@@ -164,7 +175,7 @@ function Set-DbaDbFileGroup {
         foreach ($fgToModify in $fileGroupsToModify) {
 
             if ($fgToModify.Files.Count -eq 0) {
-                Stop-Function -Message "Filegroup $FileGroup is empty on $($obj.Name) on $($obj.Parent.Name). Before the options can be set there must be at least one file in the filegroup." -Continue
+                Stop-Function -Message "Filegroup $($fgToModify.Name) is empty on $($fgToModify.Parent.Name) on $($fgToModify.Parent.Parent.Name). Before the options can be set there must be at least one file in the filegroup." -Continue
             }
 
             if ($Pscmdlet.ShouldProcess($fgToModify.Parent.Parent.Name, "Updating the filegroup options for $($fgToModify.Name) on the database $($fgToModify.Parent.Name) on $($fgToModify.Parent.Parent.Name)")) {


### PR DESCRIPTION
## Summary

Found by the first suite run against a case sensitive instance. The command checked filegroup existence with `-notcontains` (case insensitive, PowerShell) and then retrieved the object with the SMO collection indexer (`$obj.FileGroups[$fg]`), which compares with the database collation. On a case sensitive database, `-FileGroup Primary` against the `PRIMARY` filegroup passed the existence check, the indexer returned `$null`, `$null.Files.Count -eq 0` evaluated true, and the command warned "Filegroup Primary is empty" about a filegroup that has files.

Existence check and retrieval are now a single lookup: exact-case match first, case insensitive fallback (so the forgiving behavior every case insensitive instance always had is preserved), and an explicit warning when several filegroups match only case insensitively - which a case sensitive database allows.

Also fixed in the same command: the empty-filegroup warning interpolated the whole `-FileGroup` array plus `$obj`, the enumeration variable of the *previous* loop - with filegroup objects piped in, it named the wrong filegroup and database. It now names the filegroup actually being modified.

## Verification

5/5 tests green on SQL05\SQL2025 (case sensitive) and SQL03\SQL2019 (case insensitive), via the lab test harness. The existing pipeline test that passes `-FileGroup Primary` is the regression test for the fallback path - red on the old code on the case sensitive instance, green on the fix.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)