### PR TITLE
Keep version groups out of the leftover-lane exclusion

### DIFF
--- a/tests/Install-DbaCommunitySoftware.Tests.ps1
+++ b/tests/Install-DbaCommunitySoftware.Tests.ps1
@@ -134,10 +134,10 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $multiToolDb = "dbatoolsci_community_$(Get-Random)"
-            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $multiToolDb
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Name $multiToolDb
 
             $splatMultiTool = @{
-                SqlInstance = $TestConfig.InstanceSingle
+                SqlInstance = $TestConfig.InstanceMulti1
                 Software    = "FirstResponderKit", "DarlingData"
                 Database    = $multiToolDb
                 Force       = $true
@@ -154,7 +154,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $splatCleanupMultiTool = @{
-                SqlInstance = $TestConfig.InstanceSingle
+                SqlInstance = $TestConfig.InstanceMulti1
                 Database    = $multiToolDb
                 ErrorAction = "SilentlyContinue"
             }
@@ -231,10 +231,10 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $singleToolDb = "dbatoolsci_community_$(Get-Random)"
-            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $singleToolDb
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Name $singleToolDb
 
             $splatSingleTool = @{
-                SqlInstance = $TestConfig.InstanceSingle
+                SqlInstance = $TestConfig.InstanceMulti1
                 Software    = "WhoIsActive"
                 Database    = $singleToolDb
                 Force       = $true
@@ -243,7 +243,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $singleToolResults = Install-DbaCommunitySoftware @splatSingleTool
 
             $splatMixedCase = @{
-                SqlInstance = $TestConfig.InstanceSingle
+                SqlInstance = $TestConfig.InstanceMulti1
                 Software    = "WhoIsActive", "whoisactive"
                 Database    = $singleToolDb
                 Force       = $true
@@ -258,7 +258,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $splatCleanupSingleTool = @{
-                SqlInstance = $TestConfig.InstanceSingle
+                SqlInstance = $TestConfig.InstanceMulti1
                 Database    = $singleToolDb
                 ErrorAction = "SilentlyContinue"
             }
@@ -284,7 +284,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
         BeforeAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-            $defaultServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+            $defaultServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
             $masterDatabase = $defaultServer.Databases["master"]
 
             # The install replaces dbo.sp_WhoisActive in place, and a copy already sitting in master
@@ -297,7 +297,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $defaultDatabaseResults = $null
             if (-not $whoIsActivePreExisted) {
                 $splatDefaultDatabase = @{
-                    SqlInstance = $TestConfig.InstanceSingle
+                    SqlInstance = $TestConfig.InstanceMulti1
                     Software    = "WhoIsActive"
                     Force       = $true
                     Verbose     = $false
@@ -339,7 +339,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $coreSkipDb = "dbatoolsci_community_$(Get-Random)"
-            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $coreSkipDb
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Name $coreSkipDb
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
 
@@ -357,7 +357,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $sqlWatchCacheAfter = $null
             if ($PSEdition -eq "Core") {
                 $splatCoreSkip = @{
-                    SqlInstance     = $TestConfig.InstanceSingle
+                    SqlInstance     = $TestConfig.InstanceMulti1
                     Software        = "SQLWATCH", "WhoIsActive"
                     Database        = $coreSkipDb
                     Force           = $true
@@ -373,7 +373,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $splatCleanupCoreSkip = @{
-                SqlInstance = $TestConfig.InstanceSingle
+                SqlInstance = $TestConfig.InstanceMulti1
                 Database    = $coreSkipDb
                 ErrorAction = "SilentlyContinue"
             }
@@ -412,14 +412,14 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $continueDb = "dbatoolsci_community_$(Get-Random)"
-            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $continueDb
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Name $continueDb
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
 
             # The unreachable host goes first on purpose: it must fail before the real
             # instance is reached, so a row back from the real one proves the batch continued.
             $splatContinue = @{
-                SqlInstance   = "dbatoolsci_no_such_host", $TestConfig.InstanceSingle
+                SqlInstance   = "dbatoolsci_no_such_host", $TestConfig.InstanceMulti1
                 Software      = "WhoIsActive"
                 Database      = $continueDb
                 WarningAction = "SilentlyContinue"
@@ -431,7 +431,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $splatCleanupContinue = @{
-                SqlInstance = $TestConfig.InstanceSingle
+                SqlInstance = $TestConfig.InstanceMulti1
                 Database    = $continueDb
                 ErrorAction = "SilentlyContinue"
             }
@@ -451,7 +451,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
 
         It "Throws on the first failure when EnableException is used" {
             $splatContinueException = @{
-                SqlInstance     = "dbatoolsci_no_such_host", $TestConfig.InstanceSingle
+                SqlInstance     = "dbatoolsci_no_such_host", $TestConfig.InstanceMulti1
                 Software        = "WhoIsActive"
                 Database        = $continueDb
                 EnableException = $true
@@ -467,13 +467,13 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $whatIfDb = "dbatoolsci_community_$(Get-Random)"
-            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $whatIfDb
-            $whatIfServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Name $whatIfDb
+            $whatIfServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
 
             $splatNoBranch = @{
-                SqlInstance     = $TestConfig.InstanceSingle
+                SqlInstance     = $TestConfig.InstanceMulti1
                 Software        = "WhoIsActive"
                 Branch          = "main"
                 WhatIf          = $true
@@ -483,7 +483,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $null = Install-DbaCommunitySoftware @splatNoBranch
 
             $splatWhatIf = @{
-                SqlInstance = $TestConfig.InstanceSingle
+                SqlInstance = $TestConfig.InstanceMulti1
                 Software    = "WhoIsActive"
                 Database    = $whatIfDb
                 WhatIf      = $true
@@ -499,7 +499,7 @@ Describe $CommandName -Tag IntegrationTests -Skip:([bool]$env:appveyor) {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $splatCleanupWhatIf = @{
-                SqlInstance = $TestConfig.InstanceSingle
+                SqlInstance = $TestConfig.InstanceMulti1
                 Database    = $whatIfDb
                 ErrorAction = "SilentlyContinue"
             }

--- a/tests/New-DbaDatabase.Tests.ps1
+++ b/tests/New-DbaDatabase.Tests.ps1
@@ -187,13 +187,13 @@ Describe $CommandName -Tag IntegrationTests {
             # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-            $containmentEnabled = (Get-DbaSpConfigure -SqlInstance $TestConfig.InstanceSingle -ConfigName ContainmentEnabled).ConfiguredValue
+            $containmentEnabled = (Get-DbaSpConfigure -SqlInstance $TestConfig.InstanceMulti1 -ConfigName ContainmentEnabled).ConfiguredValue
             if ($containmentEnabled -ne 1) {
-                $null = Set-DbaSpConfigure -SqlInstance $TestConfig.InstanceSingle -ConfigName ContainmentEnabled -Value 1
+                $null = Set-DbaSpConfigure -SqlInstance $TestConfig.InstanceMulti1 -ConfigName ContainmentEnabled -Value 1
             }
 
             $containmentDbName = "dbatoolsci_containment_$(Get-Random)"
-            $containedDatabase = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $containmentDbName -ContainmentType Partial
+            $containedDatabase = New-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Name $containmentDbName -ContainmentType Partial
 
             # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
@@ -203,9 +203,9 @@ Describe $CommandName -Tag IntegrationTests {
             # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-            Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $containmentDbName | Remove-DbaDatabase
+            Get-DbaDatabase -SqlInstance $TestConfig.InstanceMulti1 -Database $containmentDbName | Remove-DbaDatabase
             if ($containmentEnabled -ne 1) {
-                $null = Set-DbaSpConfigure -SqlInstance $TestConfig.InstanceSingle -ConfigName ContainmentEnabled -Value $containmentEnabled
+                $null = Set-DbaSpConfigure -SqlInstance $TestConfig.InstanceMulti1 -ConfigName ContainmentEnabled -Value $containmentEnabled
             }
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
@@ -226,10 +226,10 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             $random = Get-Random
-            $InstanceSingle = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
-            $instance3 = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti2
+            $serverMulti1 = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti1
+            $serverMulti2 = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti2
 
-            $randomDb = New-DbaDatabase -SqlInstance $InstanceSingle
+            $randomDb = New-DbaDatabase -SqlInstance $serverMulti1
 
             $newDbName = "dbatoolsci_newdb_$random"
             $newDb1Name = "dbatoolsci_newdb1_$random"
@@ -253,7 +253,7 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
             # Cleanup all created databases.
-            Get-DbaDatabase -SqlInstance $InstanceSingle, $instance3 -ExcludeSystem | Remove-DbaDatabase
+            Get-DbaDatabase -SqlInstance $serverMulti1, $serverMulti2 -ExcludeSystem | Remove-DbaDatabase
 
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
@@ -263,104 +263,104 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "creates one new database on two servers" {
-            $newDbOnTwoServers = New-DbaDatabase -SqlInstance $InstanceSingle, $instance3 -Name $newDbName -LogSize 32 -LogMaxSize 512 -PrimaryFilesize 64 -PrimaryFileMaxSize 512 -SecondaryFilesize 64 -SecondaryFileMaxSize 512 -LogGrowth 32 -PrimaryFileGrowth 64 -SecondaryFileGrowth 64 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
+            $newDbOnTwoServers = New-DbaDatabase -SqlInstance $serverMulti1, $serverMulti2 -Name $newDbName -LogSize 32 -LogMaxSize 512 -PrimaryFilesize 64 -PrimaryFileMaxSize 512 -SecondaryFilesize 64 -SecondaryFileMaxSize 512 -LogGrowth 32 -PrimaryFileGrowth 64 -SecondaryFileGrowth 64 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
             $newDbOnTwoServers.Count | Should -Be 2
             $newDbOnTwoServers[0].Name | Should -Be $newDbName
             $newDbOnTwoServers[1].Name | Should -Be $newDbName
 
-            $InstanceSingle.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Size | Should -Be 65536
-            $InstanceSingle.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].MaxSize | Should -Be 524288
-            $InstanceSingle.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Growth | Should -Be 65536
-            $InstanceSingle.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].GrowthType | Should -Be "KB"
+            $serverMulti1.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Size | Should -Be 65536
+            $serverMulti1.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].MaxSize | Should -Be 524288
+            $serverMulti1.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Growth | Should -Be 65536
+            $serverMulti1.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].GrowthType | Should -Be "KB"
 
-            $InstanceSingle.Databases[$newDbName].LogFiles["$($newDbName)_log"].Size | Should -Be 32768
-            $InstanceSingle.Databases[$newDbName].LogFiles["$($newDbName)_log"].MaxSize | Should -Be 524288
-            $InstanceSingle.Databases[$newDbName].LogFiles["$($newDbName)_log"].Growth | Should -Be 32768
-            $InstanceSingle.Databases[$newDbName].LogFiles["$($newDbName)_log"].GrowthType | Should -Be "KB"
+            $serverMulti1.Databases[$newDbName].LogFiles["$($newDbName)_log"].Size | Should -Be 32768
+            $serverMulti1.Databases[$newDbName].LogFiles["$($newDbName)_log"].MaxSize | Should -Be 524288
+            $serverMulti1.Databases[$newDbName].LogFiles["$($newDbName)_log"].Growth | Should -Be 32768
+            $serverMulti1.Databases[$newDbName].LogFiles["$($newDbName)_log"].GrowthType | Should -Be "KB"
 
-            $InstanceSingle.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Size | Should -Be 65536
-            $InstanceSingle.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].MaxSize | Should -Be 524288
-            $InstanceSingle.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Growth | Should -Be 65536
-            $InstanceSingle.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].GrowthType | Should -Be "KB"
+            $serverMulti1.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Size | Should -Be 65536
+            $serverMulti1.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].MaxSize | Should -Be 524288
+            $serverMulti1.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Growth | Should -Be 65536
+            $serverMulti1.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].GrowthType | Should -Be "KB"
 
-            $instance3.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Size | Should -Be 65536
-            $instance3.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].MaxSize | Should -Be 524288
-            $instance3.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Growth | Should -Be 65536
-            $instance3.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].GrowthType | Should -Be "KB"
+            $serverMulti2.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Size | Should -Be 65536
+            $serverMulti2.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].MaxSize | Should -Be 524288
+            $serverMulti2.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Growth | Should -Be 65536
+            $serverMulti2.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].GrowthType | Should -Be "KB"
 
-            $instance3.Databases[$newDbName].LogFiles["$($newDbName)_log"].Size | Should -Be 32768
-            $instance3.Databases[$newDbName].LogFiles["$($newDbName)_log"].MaxSize | Should -Be 524288
-            $instance3.Databases[$newDbName].LogFiles["$($newDbName)_log"].Growth | Should -Be 32768
-            $instance3.Databases[$newDbName].LogFiles["$($newDbName)_log"].GrowthType | Should -Be "KB"
+            $serverMulti2.Databases[$newDbName].LogFiles["$($newDbName)_log"].Size | Should -Be 32768
+            $serverMulti2.Databases[$newDbName].LogFiles["$($newDbName)_log"].MaxSize | Should -Be 524288
+            $serverMulti2.Databases[$newDbName].LogFiles["$($newDbName)_log"].Growth | Should -Be 32768
+            $serverMulti2.Databases[$newDbName].LogFiles["$($newDbName)_log"].GrowthType | Should -Be "KB"
 
-            $instance3.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Size | Should -Be 65536
-            $instance3.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].MaxSize | Should -Be 524288
-            $instance3.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Growth | Should -Be 65536
-            $instance3.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].GrowthType | Should -Be "KB"
+            $serverMulti2.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Size | Should -Be 65536
+            $serverMulti2.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].MaxSize | Should -Be 524288
+            $serverMulti2.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Growth | Should -Be 65536
+            $serverMulti2.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].GrowthType | Should -Be "KB"
         }
 
         It "creates two new databases on two servers" {
-            $multipleDbOnTwoServers = New-DbaDatabase -SqlInstance $InstanceSingle, $instance3 -Name $newDb1Name, $newDb2Name
+            $multipleDbOnTwoServers = New-DbaDatabase -SqlInstance $serverMulti1, $serverMulti2 -Name $newDb1Name, $newDb2Name
             $multipleDbOnTwoServers.Count | Should -Be 4
             $multipleDbOnTwoServers[0].Name | Should -Be $newDb1Name
             $multipleDbOnTwoServers[1].Name | Should -Be $newDb2Name
         }
 
         It "bug 6780 autogrowth params" {
-            $db6780 = New-DbaDatabase -SqlInstance $InstanceSingle -Name $bug6780DbName -Recoverymodel Simple -DataFilePath $randomDb.PrimaryFilePath -LogFilePath $randomDb.PrimaryFilePath -SecondaryFileCount 1 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
+            $db6780 = New-DbaDatabase -SqlInstance $serverMulti1 -Name $bug6780DbName -Recoverymodel Simple -DataFilePath $randomDb.PrimaryFilePath -LogFilePath $randomDb.PrimaryFilePath -SecondaryFileCount 1 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
             $db6780.Count | Should -Be 1
 
-            $InstanceSingle.Databases[$bug6780DbName].FileGroups["PRIMARY"].Files["$($bug6780DbName)_PRIMARY"].Growth | Should -Be $InstanceSingle.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Growth
-            $InstanceSingle.Databases[$bug6780DbName].FileGroups["PRIMARY"].Files["$($bug6780DbName)_PRIMARY"].GrowthType | Should -Be $InstanceSingle.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].GrowthType
+            $serverMulti1.Databases[$bug6780DbName].FileGroups["PRIMARY"].Files["$($bug6780DbName)_PRIMARY"].Growth | Should -Be $serverMulti1.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Growth
+            $serverMulti1.Databases[$bug6780DbName].FileGroups["PRIMARY"].Files["$($bug6780DbName)_PRIMARY"].GrowthType | Should -Be $serverMulti1.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].GrowthType
 
-            $InstanceSingle.Databases[$bug6780DbName].LogFiles["$($bug6780DbName)_log"].Growth | Should -Be $InstanceSingle.Databases["model"].LogFiles["modellog"].Growth
-            $InstanceSingle.Databases[$bug6780DbName].LogFiles["$($bug6780DbName)_log"].GrowthType | Should -Be $InstanceSingle.Databases["model"].LogFiles["modellog"].GrowthType
+            $serverMulti1.Databases[$bug6780DbName].LogFiles["$($bug6780DbName)_log"].Growth | Should -Be $serverMulti1.Databases["model"].LogFiles["modellog"].Growth
+            $serverMulti1.Databases[$bug6780DbName].LogFiles["$($bug6780DbName)_log"].GrowthType | Should -Be $serverMulti1.Databases["model"].LogFiles["modellog"].GrowthType
 
             # also check the randomDb since it was created without any additional params
-            $InstanceSingle.Databases[$($randomDb.Name)].FileGroups["PRIMARY"].Files["$($randomDb.Name)"].Growth | Should -Be $InstanceSingle.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Growth
-            $InstanceSingle.Databases[$($randomDb.Name)].FileGroups["PRIMARY"].Files["$($randomDb.Name)"].GrowthType | Should -Be $InstanceSingle.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].GrowthType
+            $serverMulti1.Databases[$($randomDb.Name)].FileGroups["PRIMARY"].Files["$($randomDb.Name)"].Growth | Should -Be $serverMulti1.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Growth
+            $serverMulti1.Databases[$($randomDb.Name)].FileGroups["PRIMARY"].Files["$($randomDb.Name)"].GrowthType | Should -Be $serverMulti1.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].GrowthType
 
-            $InstanceSingle.Databases[$($randomDb.Name)].LogFiles["$($randomDb.Name)_log"].Growth | Should -Be $InstanceSingle.Databases["model"].LogFiles["modellog"].Growth
-            $InstanceSingle.Databases[$($randomDb.Name)].LogFiles["$($randomDb.Name)_log"].GrowthType | Should -Be $InstanceSingle.Databases["model"].LogFiles["modellog"].GrowthType
+            $serverMulti1.Databases[$($randomDb.Name)].LogFiles["$($randomDb.Name)_log"].Growth | Should -Be $serverMulti1.Databases["model"].LogFiles["modellog"].Growth
+            $serverMulti1.Databases[$($randomDb.Name)].LogFiles["$($randomDb.Name)_log"].GrowthType | Should -Be $serverMulti1.Databases["model"].LogFiles["modellog"].GrowthType
         }
 
         It "collation is validated" {
-            $collationDb = New-DbaDatabase -SqlInstance $InstanceSingle -Name $collationDbName -Collation "invalid_collation" -WarningAction SilentlyContinue
+            $collationDb = New-DbaDatabase -SqlInstance $serverMulti1 -Name $collationDbName -Collation "invalid_collation" -WarningAction SilentlyContinue
             $collationDb | Should -BeNull
 
-            $collationDb = New-DbaDatabase -SqlInstance $InstanceSingle -Name $collationDbName -Collation $InstanceSingle.Databases["model"].Collation
-            $InstanceSingle.Databases[$collationDbName].Collation | Should -Be $InstanceSingle.Databases["model"].Collation
+            $collationDb = New-DbaDatabase -SqlInstance $serverMulti1 -Name $collationDbName -Collation $serverMulti1.Databases["model"].Collation
+            $serverMulti1.Databases[$collationDbName].Collation | Should -Be $serverMulti1.Databases["model"].Collation
         }
 
         It "SecondaryFilesize is specified but not the SecondaryFileCount" {
-            $secondaryFileTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileTestDbName -SecondaryFilesize 10 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
-            $instance3.Databases[$secondaryFileTestDbName].FileGroups["$($secondaryFileTestDbName)_MainData"].Files.Count | Should -Be 1
-            $instance3.Databases[$secondaryFileTestDbName].FileGroups["$($secondaryFileTestDbName)_MainData"].Files[0].Size | Should -Be 10240
+            $secondaryFileTestDb = New-DbaDatabase -SqlInstance $serverMulti2 -Name $secondaryFileTestDbName -SecondaryFilesize 10 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
+            $serverMulti2.Databases[$secondaryFileTestDbName].FileGroups["$($secondaryFileTestDbName)_MainData"].Files.Count | Should -Be 1
+            $serverMulti2.Databases[$secondaryFileTestDbName].FileGroups["$($secondaryFileTestDbName)_MainData"].Files[0].Size | Should -Be 10240
         }
 
         It "SecondaryFileCount is specified but not the other secondary file params" {
-            $secondaryFileCountTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileCountTestDbName -SecondaryFileCount 2 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
-            $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files.Count | Should -Be 2
-            $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files[0].Size | Should -Be $instance3.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
-            $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files[1].Size | Should -Be $instance3.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
+            $secondaryFileCountTestDb = New-DbaDatabase -SqlInstance $serverMulti2 -Name $secondaryFileCountTestDbName -SecondaryFileCount 2 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
+            $serverMulti2.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files.Count | Should -Be 2
+            $serverMulti2.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files[0].Size | Should -Be $serverMulti2.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
+            $serverMulti2.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files[1].Size | Should -Be $serverMulti2.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
         }
 
         It "RecoveryModel" {
-            $simpleRecoveryModelDb = New-DbaDatabase -SqlInstance $InstanceSingle -Name $simpleRecoveryModelDbName -RecoveryModel Simple
+            $simpleRecoveryModelDb = New-DbaDatabase -SqlInstance $serverMulti1 -Name $simpleRecoveryModelDbName -RecoveryModel Simple
             $simpleRecoveryModelDb.RecoveryModel | Should -Be "Simple"
 
-            $fullRecoveryModelDb = New-DbaDatabase -SqlInstance $InstanceSingle -Name $fullRecoveryModelDbName -RecoveryModel Full
+            $fullRecoveryModelDb = New-DbaDatabase -SqlInstance $serverMulti1 -Name $fullRecoveryModelDbName -RecoveryModel Full
             $fullRecoveryModelDb.RecoveryModel | Should -Be "Full"
 
-            $bulkLoggedRecoveryModelDb = New-DbaDatabase -SqlInstance $InstanceSingle -Name $bulkLoggedRecoveryModelDbName -RecoveryModel BulkLogged
+            $bulkLoggedRecoveryModelDb = New-DbaDatabase -SqlInstance $serverMulti1 -Name $bulkLoggedRecoveryModelDbName -RecoveryModel BulkLogged
             $bulkLoggedRecoveryModelDb.RecoveryModel | Should -Be "BulkLogged"
         }
 
         It "DefaultFileGroup" {
-            $primaryFileGroupDb = New-DbaDatabase -SqlInstance $instance3 -Name $primaryFileGroupDbName -DefaultFileGroup "Primary"
+            $primaryFileGroupDb = New-DbaDatabase -SqlInstance $serverMulti2 -Name $primaryFileGroupDbName -DefaultFileGroup "Primary"
             $primaryFileGroupDb.DefaultFileGroup | Should -Be "PRIMARY"
 
-            $secondaryFileGroupDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileGroupDbName -DefaultFileGroup "Secondary" -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
+            $secondaryFileGroupDb = New-DbaDatabase -SqlInstance $serverMulti2 -Name $secondaryFileGroupDbName -DefaultFileGroup "Secondary" -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
             $secondaryFileGroupDb.DefaultFileGroup | Should -Be "$($secondaryFileGroupDbName)_MainData"
         }
     }

--- a/tests/appveyor.common.ps1
+++ b/tests/appveyor.common.ps1
@@ -228,7 +228,11 @@ function Get-TestsForBuildScenario {
             $AllScenarioTests = Get-TestsForScenario -scenario $env:SCENARIO -AllTests $AllTests -Silent:$Silent
         } else {
             $AllTestsToExclude = @()
-            $validScenarios = $TestsRunGroups.Keys | Where-Object { $_ -notin @('disabled', 'appveyor_disabled') }
+            # Version groups (named like the 20* they support, e.g. 2008R2SP2Express) are additive: they say what
+            # ALSO runs on an old-version lane. The autodetect path already skips them when computing tied functions
+            # (see the '20*' filter above); skip them here too, or their members are removed from the leftover lane
+            # and - when they match no autodetect scenario either - run in no lane at all.
+            $validScenarios = $TestsRunGroups.Keys | Where-Object { $_ -notin @('disabled', 'appveyor_disabled') -and $_ -notlike '20*' }
             foreach ($k in $validScenarios) {
                 $AllTestsToExclude += Get-TestsForScenario -scenario $k -AllTests $AllTests
             }


### PR DESCRIPTION
## Summary

The leftover lane - any `SCENARIO` value that is not a group key, which is how the CI matrix entry `default` works - is computed in `Get-TestsForBuildScenario` as all tests minus every valid group in `pester.groups.ps1`. That subtraction included the explicit `2008R2SP2Express` list, whose lane existed on AppVeyor but is not in the current CI matrix. Consequence: a file on that list that does not land in an autodetect scenario ran in **no lane at all**. Concretely: `Invoke-DbaDbLogShipping.Tests.ps1` (unit-only, no instance references - even its parameter validation never ran on CI), and `New-DbaDatabase.Tests.ps1` until #10628.

The autodetect path already anticipates exactly this class of problem: when computing tied functions it deliberately skips groups named `20*` so that version groups stay additive - "also run these on an old-version lane" - rather than subtractive. This PR applies the same one-line filter to the leftover-lane computation, with a comment explaining why. The `2008R2SP2Express` group itself stays untouched and ready for an old-version lane to return.

## Verification

Computed the `default` lane with the fix in a fresh process: 219 files, now including the orphaned `Invoke-DbaDbLogShipping.Tests.ps1`, while files belonging to autodetect scenarios (spot check: `Get-DbaDatabase.Tests.ps1`) remain excluded. Scenario-scoped lanes are unaffected - the change only touches the `else` branch for non-key scenario names.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
