### PR TITLE
Testing Find-DbaCommand - Restore the index file the Rebuild test overwrites

### DIFF
--- a/tests/Find-DbaCommand.Tests.ps1
+++ b/tests/Find-DbaCommand.Tests.ps1
@@ -25,6 +25,21 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        # The -Rebuild test regenerates bin\dbatools-index.json in place. When the module runs from
+        # a git working copy, that overwrites a tracked release asset and leaves the tree modified
+        # after every run. Back the file up and restore it, so the rebuild is still exercised for
+        # real but leaves no trace.
+        $indexFile = Join-Path (Get-Module $ModuleName).ModuleBase "bin\dbatools-index.json"
+        $indexBackup = "$($TestConfig.Temp)\$CommandName-$(Get-Random)-index.json"
+        Copy-Item -Path $indexFile -Destination $indexBackup
+    }
+
+    AfterAll {
+        Copy-Item -Path $indexBackup -Destination $indexFile -ErrorAction SilentlyContinue
+        Remove-Item -Path $indexBackup -ErrorAction SilentlyContinue
+    }
+
     Context "Command finds jobs using all parameters" {
         It "Should find more than 5 snapshot commands" {
             $results = @(Find-DbaCommand -Pattern "snapshot")


### PR DESCRIPTION
## Summary

`Find-DbaCommand.Tests.ps1` runs `Find-DbaCommand -Pattern snapshot -Rebuild`, and the rebuild path writes the regenerated index straight over `bin\dbatools-index.json` in the module root. When the module runs from a git working copy, that overwrites a tracked release asset - the file is committed only by the release process (v2.8.0 through v2.8.4 in the history) - so every suite run left the tree with a permanent 13 MB modification.

The fix stays in the test: `BeforeAll` copies the index file to the test temp directory, `AfterAll` copies it back and removes the backup. The `-Rebuild` coverage is unchanged - the rebuild still executes against the real file and the assertion still reads its output - only the leftover goes away. Ignoring the file instead would not work (`.gitignore` has no effect on tracked files), and untracking it would change what the release ships.

## Verification

Ran the file via the lab harness: 7/7 green (1 unit, 6 integration), and `git status` shows a clean `bin\dbatools-index.json` after the run - before the fix it showed as modified after every run that included this file.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
