### PR TITLE
Restore-DbaDatabase - Honor EnableException in the backup information pipeline

### DIFF
--- a/public/Restore-DbaDatabase.ps1
+++ b/public/Restore-DbaDatabase.ps1
@@ -676,7 +676,12 @@ function Restore-DbaDatabase {
 
         if ($RestoreInstance.VersionMajor -eq 8 -and $true -ne $TrustDbBackupHistory) {
             foreach ($file in $Path) {
-                $bh = Get-DbaBackupInformation -SqlInstance $RestoreInstance -Path $file
+                $splatBackupInformation = @{
+                    SqlInstance     = $RestoreInstance
+                    Path            = $file
+                    EnableException = $EnableException
+                }
+                $bh = Get-DbaBackupInformation @splatBackupInformation
                 $bound = $PSBoundParameters
                 $bound['TrustDbBackupHistory'] = $true
                 $bound['Path'] = $bh
@@ -752,6 +757,7 @@ function Restore-DbaDatabase {
                     IgnoreLogBackup     = $IgnoreLogBackup
                     StorageCredential   = $StorageCredential
                     NoXpDirRecurse      = $NoXpDirRecurse
+                    EnableException     = $EnableException
                 }
                 $BackupHistory += Get-DbaBackupInformation @parms
             }
@@ -815,7 +821,7 @@ function Restore-DbaDatabase {
         }
         if ($PSCmdlet.ParameterSetName -like "Restore*") {
             if ($BackupHistory.Count -eq 0 -and $RestoreInstance.VersionMajor -ne 8) {
-                Write-Message -Level Warning -Message "No backups passed through. `n This could mean the SQL instance cannot see the referenced files, the file's headers could not be read or some other issue"
+                Stop-Function -Message "No backups passed through. `n This could mean the SQL instance cannot see the referenced files, the file's headers could not be read or some other issue"
                 return
             }
             Write-Message -message "Processing DatabaseName - $DatabaseName" -Level Verbose
@@ -859,6 +865,7 @@ function Restore-DbaDatabase {
                     ContinuePoints  = $ContinuePoints
                     LastRestoreType = $LastRestoreType
                     DatabaseName    = $DatabaseName
+                    EnableException = $EnableException
                 }
                 $FilteredBackupHistory = $BackupHistory | Select-DbaBackupInformation @parms
             }

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -172,6 +172,76 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
 
+    Context "Honors EnableException when no full backup anchors the chain #10621" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Build a full/diff/log chain with one file per backup, so the diff and log never share a
+            # file with the full (the default backup file name has minute resolution and would hide
+            # the missing full by accident).
+            $chainDbName = "dbatoolsci_chaintest_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $chainDbName
+            $splatChainBackup = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $chainDbName
+                Path        = $backupPath
+            }
+            $null = Backup-DbaDatabase @splatChainBackup -Type Full -FilePath "chaintest_full.bak"
+            $chainDiff = Backup-DbaDatabase @splatChainBackup -Type Diff -FilePath "chaintest_diff.bak"
+            $chainLog = Backup-DbaDatabase @splatChainBackup -Type Log -FilePath "chaintest_log.trn"
+
+            # An existing directory without any backup files, to hit the "No backups passed through" path.
+            $emptyBackupDir = "$backupPath\emptydir"
+            $null = New-Item -Path $emptyBackupDir -ItemType Directory
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $chainDbName | Remove-DbaDatabase
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Throws when only diff and log are passed with EnableException" {
+            $splatRestore = @{
+                SqlInstance     = $TestConfig.InstanceSingle
+                Path            = $chainDiff.BackupPath, $chainLog.BackupPath
+                DatabaseName    = $chainDbName
+                WithReplace     = $true
+                EnableException = $true
+            }
+            { Restore-DbaDatabase @splatRestore } | Should -Throw "*Fullname property not found*"
+        }
+
+        It "Still warns and returns nothing without EnableException" {
+            $splatRestore = @{
+                SqlInstance   = $TestConfig.InstanceSingle
+                Path          = $chainDiff.BackupPath, $chainLog.BackupPath
+                DatabaseName  = $chainDbName
+                WithReplace   = $true
+                WarningAction = "SilentlyContinue"
+            }
+            $results = Restore-DbaDatabase @splatRestore
+            $WarnVar | Should -BeLike "*Fullname property not found*"
+            $results | Should -BeNullOrEmpty
+        }
+
+        It "Throws when the path holds no backups at all with EnableException" {
+            $splatRestore = @{
+                SqlInstance     = $TestConfig.InstanceSingle
+                Path            = $emptyBackupDir
+                DatabaseName    = $chainDbName
+                WithReplace     = $true
+                EnableException = $true
+            }
+            { Restore-DbaDatabase @splatRestore } | Should -Throw "*No backups passed through*"
+        }
+    }
+
+
     Context "Database is restored with correct renamings" {
         BeforeAll {
             $null = Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -ExcludeSystem -EnableException | Remove-DbaDatabase -EnableException


### PR DESCRIPTION
## Summary

Fixes #10621. When `Restore-DbaDatabase` is given backups without a full to anchor the chain, `Select-DbaBackupInformation` correctly calls `Stop-Function` - but the splat `Restore-DbaDatabase` builds for it never passed `EnableException` on, so under `-EnableException` the stop degraded to a warning, control returned, and the restore proceeded over an empty `$FilteredBackupHistory` to a successful-looking no-op. A caller relying on the promised exception (a test fixture, or any script that restores and then uses the database) continued as if the restore had happened - exactly how `Get-DbaDbRestoreHistory.Tests.ps1` was flaky for years (#10620).

## What changed

- `EnableException = $EnableException` added to the `Select-DbaBackupInformation` splat and the `Get-DbaBackupInformation` splat, and to the per-file `Get-DbaBackupInformation` call on the SQL Server 2000 path (now a splat, since it grew to three parameters).
- The "No backups passed through" bail-out is now a `Stop-Function` instead of a plain `Write-Message -Level Warning`, so it too honors `-EnableException`.

## What deliberately did not change

- **Without `-EnableException` nothing changes**: `Stop-Function` writes the identical warning and returns, so the default warn-and-return behavior is untouched. The open behavior question from #10621 - whether an empty selection should also stop the non-exception path - is left for a maintainer decision.
- The `Test-DbaBackupInformation` call already passed `EnableException = $true` inside try/catch and stays as it is.
- `Format-DbaBackupInformation` contains no `Stop-Function` at all, so there is nothing to propagate.
- `Get-DbaAgBackupHistory` has the same gap on its `Select-DbaBackupInformation` call and gets its own pull request, one command per PR.

## Tests

Three regression tests in a new context, each backup written to its own file so the minute-resolution default name cannot hide the missing full by merging it into the diff's file:

- diff+log without the full throws `*Fullname property not found*` with `-EnableException` (the exact repro from the issue),
- the same input still warns and returns nothing without it,
- an existing directory with no backups throws `*No backups passed through*` with `-EnableException`.

Full file verified via the lab harness on SQL03\SQL2019: 84 tests, 76 passed, 0 failed, 7 skipped (the documented StopAt and Azure skips), lab left clean.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
