### PR TITLE
Add-DbaRegServer - Close the store connection its verification call reopens

### DIFF
--- a/public/Add-DbaRegServer.ps1
+++ b/public/Add-DbaRegServer.ps1
@@ -245,14 +245,21 @@ function Add-DbaRegServer {
                             $newserver.CredentialPersistenceType = "PersistLoginNameAndPassword"
                             $newserver.Create()
 
-                            Get-DbaRegServer -SqlInstance $reggroup.ParentServer -Name $Name -ServerName $ServerName | Where-Object Source -ne 'Azure Data Studio'
-                            # The verification call above reconnects the store connection that Get-DbaRegServerGroup
-                            # already closed, and nothing closes it again - one session per call stayed open. Close it
-                            # like Add-DbaRegServerGroup does; only a connection this module opened is ever closed.
-                            Disconnect-RegServer -Server $newserver
+                            # Buffered rather than streamed: a downstream early stop (| Select-Object -First 1)
+                            # would end this command at a streamed emission, before the disconnect below.
+                            $verifiedServer = Get-DbaRegServer -SqlInstance $reggroup.ParentServer -Name $Name -ServerName $ServerName | Where-Object Source -ne 'Azure Data Studio'
                         } catch {
                             Stop-Function -Message "Failed to add $ServerName on $target" -ErrorRecord $_ -Continue
+                        } finally {
+                            # The verification call reconnects the store connection that Get-DbaRegServerGroup
+                            # already closed, and nothing closes it again - one session per call stayed open.
+                            # Closed in the finally, so a verification error or an early-stopped pipeline cannot
+                            # skip it; only a connection this module opened is ever closed.
+                            if ($newserver) {
+                                Disconnect-RegServer -Server $newserver
+                            }
                         }
+                        $verifiedServer
                     }
                 } else {
                     try {
@@ -265,14 +272,21 @@ function Add-DbaRegServer {
                         $newserver.OtherParams = $OtherParams
                         $newserver.Create()
 
-                        Get-DbaRegServer -SqlInstance $reggroup.ParentServer -Name $Name -ServerName $ServerName | Where-Object Source -ne 'Azure Data Studio'
-                        # The verification call above reconnects the store connection that Get-DbaRegServerGroup
-                        # already closed, and nothing closes it again - one session per call stayed open. Close it
-                        # like Add-DbaRegServerGroup does; only a connection this module opened is ever closed.
-                        Disconnect-RegServer -Server $newserver
+                        # Buffered rather than streamed: a downstream early stop (| Select-Object -First 1)
+                        # would end this command at a streamed emission, before the disconnect below.
+                        $verifiedServer = Get-DbaRegServer -SqlInstance $reggroup.ParentServer -Name $Name -ServerName $ServerName | Where-Object Source -ne 'Azure Data Studio'
                     } catch {
                         Stop-Function -Message "Failed to add $ServerName on $target" -ErrorRecord $_ -Continue
+                    } finally {
+                        # The verification call reconnects the store connection that Get-DbaRegServerGroup
+                        # already closed, and nothing closes it again - one session per call stayed open.
+                        # Closed in the finally, so a verification error or an early-stopped pipeline cannot
+                        # skip it; only a connection this module opened is ever closed.
+                        if ($newserver) {
+                            Disconnect-RegServer -Server $newserver
+                        }
                     }
+                    $verifiedServer
                 }
             }
         }

--- a/public/Add-DbaRegServer.ps1
+++ b/public/Add-DbaRegServer.ps1
@@ -246,6 +246,10 @@ function Add-DbaRegServer {
                             $newserver.Create()
 
                             Get-DbaRegServer -SqlInstance $reggroup.ParentServer -Name $Name -ServerName $ServerName | Where-Object Source -ne 'Azure Data Studio'
+                            # The verification call above reconnects the store connection that Get-DbaRegServerGroup
+                            # already closed, and nothing closes it again - one session per call stayed open. Close it
+                            # like Add-DbaRegServerGroup does; only a connection this module opened is ever closed.
+                            Disconnect-RegServer -Server $newserver
                         } catch {
                             Stop-Function -Message "Failed to add $ServerName on $target" -ErrorRecord $_ -Continue
                         }
@@ -262,6 +266,10 @@ function Add-DbaRegServer {
                         $newserver.Create()
 
                         Get-DbaRegServer -SqlInstance $reggroup.ParentServer -Name $Name -ServerName $ServerName | Where-Object Source -ne 'Azure Data Studio'
+                        # The verification call above reconnects the store connection that Get-DbaRegServerGroup
+                        # already closed, and nothing closes it again - one session per call stayed open. Close it
+                        # like Add-DbaRegServerGroup does; only a connection this module opened is ever closed.
+                        Disconnect-RegServer -Server $newserver
                     } catch {
                         Stop-Function -Message "Failed to add $ServerName on $target" -ErrorRecord $_ -Continue
                     }

--- a/tests/Add-DbaRegServer.Tests.ps1
+++ b/tests/Add-DbaRegServer.Tests.ps1
@@ -102,4 +102,46 @@ Describe $CommandName -Tag IntegrationTests {
             $results2.SqlInstance | Should -Not -BeNullOrEmpty
         }
     }
+
+    Context "When adding registered servers repeatedly" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # The command used to reconnect the store connection for its verification call and never
+            # close it again, one new sleeping session per call. Count sessions through a server object
+            # opened once, because a per-call counting command would open connections of its own.
+            $countServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $countQuery = @"
+select count(*)
+from sys.dm_exec_sessions
+where program_name like 'dbatools%'
+  and status = 'sleeping'
+  and session_id <> @@spid
+"@
+
+            # One warm-up call so the shared pooled connection exists before the baseline is taken.
+            $null = Add-DbaRegServer -SqlInstance $TestConfig.InstanceSingle -ServerName "dbatoolsci-leak0" -Name "dbatoolsci-leak0"
+            $sleepingBefore = $countServer.ConnectionContext.ExecuteScalar($countQuery)
+
+            foreach ($i in 1..3) {
+                $null = Add-DbaRegServer -SqlInstance $TestConfig.InstanceSingle -ServerName "dbatoolsci-leak$i" -Name "dbatoolsci-leak$i"
+            }
+            $sleepingAfter = $countServer.ConnectionContext.ExecuteScalar($countQuery)
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            Get-DbaRegServer -SqlInstance $TestConfig.InstanceSingle | Where-Object Name -Like "dbatoolsci-leak*" | Remove-DbaRegServer
+            $countServer.ConnectionContext.Disconnect()
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Leaves no sleeping session behind" {
+            $sleepingAfter | Should -Be $sleepingBefore
+        }
+    }
 }

--- a/tests/Add-DbaRegServer.Tests.ps1
+++ b/tests/Add-DbaRegServer.Tests.ps1
@@ -128,6 +128,13 @@ where program_name like 'dbatools%'
             }
             $sleepingAfter = $countServer.ConnectionContext.ExecuteScalar($countQuery)
 
+            # Early pipeline termination stops the command right after the emitted verification
+            # object - only a buffered emission with the disconnect in a finally survives that.
+            foreach ($i in 4..6) {
+                $null = Add-DbaRegServer -SqlInstance $TestConfig.InstanceSingle -ServerName "dbatoolsci-leak$i" -Name "dbatoolsci-leak$i" | Select-Object -First 1
+            }
+            $sleepingAfterEarlyEnd = $countServer.ConnectionContext.ExecuteScalar($countQuery)
+
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
@@ -142,6 +149,10 @@ where program_name like 'dbatools%'
 
         It "Leaves no sleeping session behind" {
             $sleepingAfter | Should -Be $sleepingBefore
+        }
+
+        It "Leaves no sleeping session behind when the pipeline ends early" {
+            $sleepingAfterEarlyEnd | Should -Be $sleepingBefore
         }
     }
 }


### PR DESCRIPTION
## Summary

Every `Add-DbaRegServer` call leaked one connection to the CMS instance, held open until the process exits. This is the standout from the first `-CheckSleepingConnections` full lab run (2026-08-28), which flagged the `Export-DbaRegServer` test file at **+33 sleeping sessions** - that file runs `Add-DbaRegServer` three times per test across eleven tests.

## Mechanism

After `Create()`, the command verifies the registration with `Get-DbaRegServer -SqlInstance $reggroup.ParentServer`. That `ParentServer` rides the store connection `Get-DbaRegServerGroup` had already closed (correctly, per #10572), so SMO silently **reconnects** it for the verification - and because `Connect-DbaInstance` then rightly reports it did not open this connection, `Disconnect-RegServer` inside `Get-DbaRegServer` declines to close it. The reconnected session stays checked out of the pool, owned by a server object nothing references. `Import-DbaRegServer` inherits the leak because it registers through this command.

## Fix

Mirror what `Add-DbaRegServerGroup` already does after its own verification call: `Disconnect-RegServer -Server $newserver` after the `Get`, in both the plain and the `-ServerObject` branch. The helper walks up to the store and closes only a connection this module opened.

## Measurements (SQL03\SQL2019)

- Before: five `Add-DbaRegServer` calls grew the sleeping-session count from 1 to 6; the isolated `Export-DbaRegServer` test file left **25** sessions behind.
- After: five calls stay at **1** (the shared pooled connection); the `Export-DbaRegServer` file's runner measurement drops from 25 to **1**.

## Tests

New context counts sleeping dbatools sessions through a server object opened once (a per-call counting command would open connections of its own), takes a warm-up call so the shared pooled connection exists before the baseline, then asserts three further calls add nothing. Verified red on the unfixed command ("Expected 3, but got 6") and green on the fix (9 tests, 0 failed via the lab harness).

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
