### PR TITLE
Export-DbaCsv - Close the database-scoped connection it opens per call

### DIFF
--- a/public/Export-DbaCsv.ps1
+++ b/public/Export-DbaCsv.ps1
@@ -356,7 +356,10 @@ function Export-DbaCsv {
                 }
             } finally {
                 if ($isNewConnection) {
-                    $null = $server | Disconnect-DbaInstance -Verbose:$false
+                    # -WhatIf:$false because this is ownership bookkeeping, not the user's operation:
+                    # Disconnect-DbaInstance supports ShouldProcess, so a propagated $WhatIfPreference
+                    # would skip the actual disconnect and leak the connection this command opened.
+                    $null = $server | Disconnect-DbaInstance -Verbose:$false -WhatIf:$false -Confirm:$false
                 }
             }
         }

--- a/public/Export-DbaCsv.ps1
+++ b/public/Export-DbaCsv.ps1
@@ -283,63 +283,80 @@ function Export-DbaCsv {
 
         # Process SQL queries
         foreach ($instance in $SqlInstance) {
+            # Connect-DbaInstance tells us whether it opened a connection for us. We must only close what we
+            # opened ourselves, because closing a connection of the caller takes their session with it (#10554).
+            $isNewConnection = $false
             try {
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database
+                $splatConnect = @{
+                    SqlInstance              = $instance
+                    SqlCredential            = $SqlCredential
+                    Database                 = $Database
+                    IsNewConnectionReference = [ref]$isNewConnection
+                }
+                $server = Connect-DbaInstance @splatConnect
             } catch {
                 Stop-Function -Message "Failed to connect to $instance" -ErrorRecord $_ -Target $instance -Continue
             }
 
-            $sqlToExecute = $null
+            # The finally makes sure the connection is also closed when the export fails and the catch
+            # continues with the next instance, and when -WhatIf skips the export altogether.
+            try {
+                $sqlToExecute = $null
 
-            if ($PSBoundParameters.Query) {
-                $sqlToExecute = $Query
-            } elseif ($PSBoundParameters.Table) {
-                # Parse table name using Get-ObjectNameParts so that bracketed names
-                # (e.g. [My.Table]) and two-part names (e.g. schema.[My.Table]) are
-                # handled correctly instead of relying on a naive dot-split regex.
-                $parsedTable = Get-ObjectNameParts -ObjectName $Table
-                if ($parsedTable.Parsed -and $parsedTable.Schema) {
-                    $schemaName = $parsedTable.Schema
-                    $tableName  = $parsedTable.Name
-                } elseif ($parsedTable.Parsed) {
-                    $schemaName = "dbo"
-                    $tableName  = $parsedTable.Name
-                } else {
-                    $schemaName = "dbo"
-                    $tableName  = $Table
+                if ($PSBoundParameters.Query) {
+                    $sqlToExecute = $Query
+                } elseif ($PSBoundParameters.Table) {
+                    # Parse table name using Get-ObjectNameParts so that bracketed names
+                    # (e.g. [My.Table]) and two-part names (e.g. schema.[My.Table]) are
+                    # handled correctly instead of relying on a naive dot-split regex.
+                    $parsedTable = Get-ObjectNameParts -ObjectName $Table
+                    if ($parsedTable.Parsed -and $parsedTable.Schema) {
+                        $schemaName = $parsedTable.Schema
+                        $tableName  = $parsedTable.Name
+                    } elseif ($parsedTable.Parsed) {
+                        $schemaName = "dbo"
+                        $tableName  = $parsedTable.Name
+                    } else {
+                        $schemaName = "dbo"
+                        $tableName  = $Table
+                    }
+                    $sqlToExecute = "SELECT * FROM [$schemaName].[$tableName]"
                 }
-                $sqlToExecute = "SELECT * FROM [$schemaName].[$tableName]"
-            }
 
 
-            if ($PSCmdlet.ShouldProcess($instance, "Exporting data to $Path")) {
-                try {
-                    Write-Message -Level Verbose -Message "Executing query on $instance"
+                if ($PSCmdlet.ShouldProcess($instance, "Exporting data to $Path")) {
+                    try {
+                        Write-Message -Level Verbose -Message "Executing query on $instance"
 
-                    # Execute query and get data reader
-                    $cmd = $server.ConnectionContext.SqlConnectionObject.CreateCommand()
-                    $cmd.CommandText = $sqlToExecute
-                    $cmd.CommandTimeout = 0
+                        # Execute query and get data reader
+                        $cmd = $server.ConnectionContext.SqlConnectionObject.CreateCommand()
+                        $cmd.CommandText = $sqlToExecute
+                        $cmd.CommandTimeout = 0
 
-                    if ($server.ConnectionContext.SqlConnectionObject.State -ne "Open") {
-                        $server.ConnectionContext.SqlConnectionObject.Open()
+                        if ($server.ConnectionContext.SqlConnectionObject.State -ne "Open") {
+                            $server.ConnectionContext.SqlConnectionObject.Open()
+                        }
+
+                        $reader = $cmd.ExecuteReader()
+
+                        # Create writer if not already created
+                        if ($null -eq $writer) {
+                            $writer = New-Object Dataplat.Dbatools.Csv.Writer.CsvWriter($Path, $writerOptions)
+                        }
+
+                        # Write data from reader
+                        $rowsWritten += $writer.WriteFromReader($reader)
+
+                        $reader.Close()
+                        $reader.Dispose()
+
+                    } catch {
+                        Stop-Function -Message "Failed to export data from $instance" -ErrorRecord $_ -Target $instance -Continue
                     }
-
-                    $reader = $cmd.ExecuteReader()
-
-                    # Create writer if not already created
-                    if ($null -eq $writer) {
-                        $writer = New-Object Dataplat.Dbatools.Csv.Writer.CsvWriter($Path, $writerOptions)
-                    }
-
-                    # Write data from reader
-                    $rowsWritten += $writer.WriteFromReader($reader)
-
-                    $reader.Close()
-                    $reader.Dispose()
-
-                } catch {
-                    Stop-Function -Message "Failed to export data from $instance" -ErrorRecord $_ -Target $instance -Continue
+                }
+            } finally {
+                if ($isNewConnection) {
+                    $null = $server | Disconnect-DbaInstance -Verbose:$false
                 }
             }
         }

--- a/tests/Export-DbaCsv.Tests.ps1
+++ b/tests/Export-DbaCsv.Tests.ps1
@@ -332,6 +332,48 @@ INSERT INTO $tableName VALUES (3, 'Charlie', 300.25, '2024-03-25 09:15:00');
         }
     }
 
+    Context "When exporting repeatedly" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # The command used to open a database-scoped connection per call and never close it,
+            # one new sleeping session per call. Count sessions through a server object opened once,
+            # because a per-call counting command would open connections of its own.
+            $countServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $countQuery = @"
+select count(*)
+from sys.dm_exec_sessions
+where program_name like 'dbatools%'
+  and status = 'sleeping'
+  and session_id <> @@spid
+"@
+
+            # One warm-up call so the shared pooled connection exists before the baseline is taken.
+            $splatLeakExport = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = "tempdb"
+                Table       = $tableName
+            }
+            $null = Export-DbaCsv @splatLeakExport -Path "$testExportPath\leak-0.csv"
+            $sleepingBefore = $countServer.ConnectionContext.ExecuteScalar($countQuery)
+
+            foreach ($i in 1..3) {
+                $null = Export-DbaCsv @splatLeakExport -Path "$testExportPath\leak-$i.csv"
+            }
+            $sleepingAfter = $countServer.ConnectionContext.ExecuteScalar($countQuery)
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $countServer.ConnectionContext.Disconnect()
+        }
+
+        It "Leaves no sleeping session behind" {
+            $sleepingAfter | Should -Be $sleepingBefore
+        }
+    }
+
     Context "Compression options (issue #8646)" {
         It "exports with each compression type" {
             $compressionTypes = @("None", "GZip", "Deflate")

--- a/tests/Export-DbaCsv.Tests.ps1
+++ b/tests/Export-DbaCsv.Tests.ps1
@@ -362,6 +362,14 @@ where program_name like 'dbatools%'
             }
             $sleepingAfter = $countServer.ConnectionContext.ExecuteScalar($countQuery)
 
+            # -WhatIf still opens the connection before ShouldProcess skips the export, and
+            # Disconnect-DbaInstance supports ShouldProcess itself - the ownership disconnect has
+            # to ignore the propagated WhatIf preference or every -WhatIf call leaks its session.
+            foreach ($i in 1..3) {
+                $null = Export-DbaCsv @splatLeakExport -Path "$testExportPath\leak-whatif-$i.csv" -WhatIf
+            }
+            $sleepingAfterWhatIf = $countServer.ConnectionContext.ExecuteScalar($countQuery)
+
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
@@ -371,6 +379,10 @@ where program_name like 'dbatools%'
 
         It "Leaves no sleeping session behind" {
             $sleepingAfter | Should -Be $sleepingBefore
+        }
+
+        It "Leaves no sleeping session behind with -WhatIf" {
+            $sleepingAfterWhatIf | Should -Be $sleepingBefore
         }
     }
 


### PR DESCRIPTION
## Summary

Second fix from the sleeping-connection inventory (first: #10633). Every `Export-DbaCsv -SqlInstance` call leaked one connection to the instance, held open until the process exits. The command's own test file left **18** sleeping sessions behind in an isolated runner measurement; the first `-CheckSleepingConnections` full lab run flagged it at +17.

## Mechanism

The command calls `Connect-DbaInstance -Database $Database`, which returns a server object whose connection was opened for this call (the database-scoped clone path), streams the data reader off its raw `SqlConnectionObject` - and never closes the connection. The throwaway server object keeps the session checked out of the pool.

## Fix

The established #10554 ownership pattern: pass `IsNewConnectionReference [ref]$isNewConnection` to `Connect-DbaInstance` and close via `Disconnect-DbaInstance` only when it reports the connection as newly opened. The disconnect sits in a `finally` so it also runs when the export fails (`Stop-Function -Continue` leaves the try block) and when `-WhatIf` skips the export - two paths where the sibling pattern in `Invoke-DbaQuery` places the disconnect after the catch and would miss it.

## Tests

New context counts sleeping dbatools sessions through a server object opened once (a per-call counting command would open connections of its own), with a warm-up call before the baseline, asserting three further calls add nothing. Verified red on the unfixed command ("Expected 14, but got 17") and green on the fix (16 passed, 0 failed via the lab harness on SQL03\SQL2019). Runner measurement of the whole file: 18 sleeping sessions before, **2** after.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
