### PR TITLE
Get-DbaXESession - Close the cloned connection behind the XEStore

### DIFF
--- a/public/Get-DbaXESession.ps1
+++ b/public/Get-DbaXESession.ps1
@@ -107,46 +107,52 @@ function Get-DbaXESession {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            Write-Message -Level Verbose -Message "Getting XEvents Sessions on $instance."
-            $xesessions = $XEStore.sessions
+            # The finally makes sure the cloned store connection is also closed when a downstream
+            # command ends the pipeline early (... | Select-Object -First 1 stops this command in
+            # the middle of the emission loop) and when a terminating error unwinds.
+            try {
+                Write-Message -Level Verbose -Message "Getting XEvents Sessions on $instance."
+                $xesessions = $XEStore.sessions
 
-            if ($Session) {
-                $xesessions = $xesessions | Where-Object { $_.Name -in $Session }
-            }
-
-            foreach ($x in $xesessions) {
-                $status = switch ($x.IsRunning) { $true { "Running" } $false { "Stopped" } }
-                $files = $x.Targets.TargetFields | Where-Object Name -eq Filename | Select-Object -ExpandProperty Value
-
-                $filecollection = $remotefile = @()
-
-                if ($files) {
-                    foreach ($file in $files) {
-                        if ($file -notmatch ':\\' -and $file -notmatch '\\\\' -and $file -notmatch '\/') {
-                            $directory = $server.ErrorLogPath.TrimEnd("\/")
-                            $file = (Join-DbaPath -SqlInstance $server $directory $file)
-                        }
-                        $filecollection += $file
-                        $remotefile += Join-AdminUnc -servername $server.ComputerName -filepath $file
-                    }
+                if ($Session) {
+                    $xesessions = $xesessions | Where-Object { $_.Name -in $Session }
                 }
 
-                Add-Member -Force -InputObject $x -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
-                Add-Member -Force -InputObject $x -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
-                Add-Member -Force -InputObject $x -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
-                Add-Member -Force -InputObject $x -MemberType NoteProperty -Name Status -Value $status
-                Add-Member -Force -InputObject $x -MemberType NoteProperty -Name Session -Value $x.Name
-                Add-Member -Force -InputObject $x -MemberType NoteProperty -Name TargetFile -Value $filecollection
-                Add-Member -Force -InputObject $x -MemberType NoteProperty -Name RemoteTargetFile -Value $remotefile
-                Add-Member -Force -InputObject $x -MemberType NoteProperty -Name Parent -Value $server
-                Add-Member -Force -InputObject $x -MemberType NoteProperty -Name Store -Value $XEStore
-                Select-DefaultView -InputObject $x -Property ComputerName, InstanceName, SqlInstance, Name, Status, StartTime, AutoStart, State, Targets, TargetFile, Events, MaxMemory, MaxEventSize
-            }
+                foreach ($x in $xesessions) {
+                    $status = switch ($x.IsRunning) { $true { "Running" } $false { "Stopped" } }
+                    $files = $x.Targets.TargetFields | Where-Object Name -eq Filename | Select-Object -ExpandProperty Value
 
-            # The store rides a cloned connection that nothing ever closed, so every call parked one
-            # more session on the instance until the process ended. Close it here; when a consumer of
-            # the emitted objects uses the store again, SFC transparently reconnects from the pool.
-            $XEStore.SfcConnection.Disconnect()
+                    $filecollection = $remotefile = @()
+
+                    if ($files) {
+                        foreach ($file in $files) {
+                            if ($file -notmatch ':\\' -and $file -notmatch '\\\\' -and $file -notmatch '\/') {
+                                $directory = $server.ErrorLogPath.TrimEnd("\/")
+                                $file = (Join-DbaPath -SqlInstance $server $directory $file)
+                            }
+                            $filecollection += $file
+                            $remotefile += Join-AdminUnc -servername $server.ComputerName -filepath $file
+                        }
+                    }
+
+                    Add-Member -Force -InputObject $x -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
+                    Add-Member -Force -InputObject $x -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
+                    Add-Member -Force -InputObject $x -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
+                    Add-Member -Force -InputObject $x -MemberType NoteProperty -Name Status -Value $status
+                    Add-Member -Force -InputObject $x -MemberType NoteProperty -Name Session -Value $x.Name
+                    Add-Member -Force -InputObject $x -MemberType NoteProperty -Name TargetFile -Value $filecollection
+                    Add-Member -Force -InputObject $x -MemberType NoteProperty -Name RemoteTargetFile -Value $remotefile
+                    Add-Member -Force -InputObject $x -MemberType NoteProperty -Name Parent -Value $server
+                    Add-Member -Force -InputObject $x -MemberType NoteProperty -Name Store -Value $XEStore
+                    Select-DefaultView -InputObject $x -Property ComputerName, InstanceName, SqlInstance, Name, Status, StartTime, AutoStart, State, Targets, TargetFile, Events, MaxMemory, MaxEventSize
+                }
+            } finally {
+                # The store rides a cloned connection that nothing ever closed, so every call parked
+                # one more session on the instance until the process ended. Close it here; when a
+                # consumer of the emitted objects uses the store again, SFC transparently reconnects
+                # from the pool.
+                $XEStore.SfcConnection.Disconnect()
+            }
         }
     }
 }

--- a/public/Get-DbaXESession.ps1
+++ b/public/Get-DbaXESession.ps1
@@ -142,6 +142,11 @@ function Get-DbaXESession {
                 Add-Member -Force -InputObject $x -MemberType NoteProperty -Name Store -Value $XEStore
                 Select-DefaultView -InputObject $x -Property ComputerName, InstanceName, SqlInstance, Name, Status, StartTime, AutoStart, State, Targets, TargetFile, Events, MaxMemory, MaxEventSize
             }
+
+            # The store rides a cloned connection that nothing ever closed, so every call parked one
+            # more session on the instance until the process ended. Close it here; when a consumer of
+            # the emitted objects uses the store again, SFC transparently reconnects from the pool.
+            $XEStore.SfcConnection.Disconnect()
         }
     }
 }

--- a/tests/Get-DbaXESession.Tests.ps1
+++ b/tests/Get-DbaXESession.Tests.ps1
@@ -59,6 +59,13 @@ where program_name like 'dbatools%'
             }
             $sleepingAfter = $countServer.ConnectionContext.ExecuteScalar($countQuery)
 
+            # Early pipeline termination stops the command in the middle of its emission loop, so
+            # a disconnect placed after the loop never runs on this path - only a finally covers it.
+            foreach ($i in 1..3) {
+                $null = Get-DbaXESession -SqlInstance $TestConfig.InstanceSingle | Select-Object -First 1
+            }
+            $sleepingAfterEarlyEnd = $countServer.ConnectionContext.ExecuteScalar($countQuery)
+
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
@@ -70,10 +77,17 @@ where program_name like 'dbatools%'
             $sleepingAfter | Should -Be $sleepingBefore
         }
 
+        It "Leaves no sleeping session behind when the pipeline ends early" {
+            $sleepingAfterEarlyEnd | Should -Be $sleepingBefore
+        }
+
         It "Emits objects whose store still works after the connection is returned" {
             $result = Get-DbaXESession -SqlInstance $TestConfig.InstanceSingle -Session system_health
             # The store must transparently reconnect for downstream commands like Start or Stop.
             $result.Store.Sessions.Name | Should -Contain "system_health"
+            # The assertion above deliberately reopened the store connection - return it, so this
+            # test does not leave shared connection state behind for later tests to trip over.
+            $result.Store.SfcConnection.Disconnect()
         }
     }
 }

--- a/tests/Get-DbaXESession.Tests.ps1
+++ b/tests/Get-DbaXESession.Tests.ps1
@@ -33,4 +33,47 @@ Describe $CommandName -Tag IntegrationTests {
             $results.Name -eq "system_health" | Should -Be $true
         }
     }
+
+    Context "When querying sessions repeatedly" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # The command used to leave the cloned connection of its XEStore open, one new sleeping
+            # session per call. Count sessions through a server object opened once, because a per-call
+            # counting command would open connections of its own.
+            $countServer = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle -NonPooledConnection
+            $countQuery = @"
+select count(*)
+from sys.dm_exec_sessions
+where program_name like 'dbatools%'
+  and status = 'sleeping'
+  and session_id <> @@spid
+"@
+
+            # One warm-up call so the shared pooled connection exists before the baseline is taken.
+            $null = Get-DbaXESession -SqlInstance $TestConfig.InstanceSingle -Session system_health
+            $sleepingBefore = $countServer.ConnectionContext.ExecuteScalar($countQuery)
+
+            foreach ($i in 1..3) {
+                $null = Get-DbaXESession -SqlInstance $TestConfig.InstanceSingle -Session system_health
+            }
+            $sleepingAfter = $countServer.ConnectionContext.ExecuteScalar($countQuery)
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $countServer.ConnectionContext.Disconnect()
+        }
+
+        It "Leaves no sleeping session behind" {
+            $sleepingAfter | Should -Be $sleepingBefore
+        }
+
+        It "Emits objects whose store still works after the connection is returned" {
+            $result = Get-DbaXESession -SqlInstance $TestConfig.InstanceSingle -Session system_health
+            # The store must transparently reconnect for downstream commands like Start or Stop.
+            $result.Store.Sessions.Name | Should -Contain "system_health"
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Third fix from the sleeping-connection inventory (after #10633 and #10634). Every `Get-DbaXESession` call leaked one connection: it clones the SqlConnection for its `XEStore` and nothing ever closed the clone. Because the whole Extended Events family funnels through this command - `Start-DbaXESession` even re-queries through it after every start - the leak multiplied across Start, Stop, Remove, ConvertTo, Watch and the Export commands. The first `-CheckSleepingConnections` full lab run flagged Start-DbaXESession at +15, ConvertTo at +7 and Remove at +6.

## Fix

Disconnect the store connection after the sessions are enumerated and emitted. The emitted objects keep their `Store` note property fully functional: SFC transparently reconnects from the pool when a downstream command uses the store again - confirmed in the lab for piped `Start-DbaXESession` and `Stop-DbaXESession`, and pinned by a test that uses the store of an emitted object after the connection was returned.

## Measurements (SQL03\SQL2019)

- Three Get calls used to add three sleeping sessions; with the fix they add none. The regression test is red on the unfixed command ("Expected 4, but got 7").
- Runner measurements of the family test files: Start-DbaXESession **15 -> 7**, Remove-DbaXESession **6 -> 2**, ConvertTo-DbaXESession **7 -> 3**.

## Deliberately left for a follow-up

The residue in Start-DbaXESession comes from a different, smaller mechanism: when a piped object's store reconnects for an operation, that reopened connection stays checked out once per pipeline. Fixing that means consumer-side disconnects across several commands and deserves its own change with its own measurements.

## Tests

Same counting pattern as #10633/#10634: sleeping dbatools sessions counted through a server object opened once, warm-up call before the baseline, three further calls must add nothing - plus the store-reconnect assertion described above. All green via the lab harness (5 tests, 0 failed).

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
