### PR TITLE
Restore-DbaDatabase - Stop escaping the caller and resurrect the StopAt tests

### DIFF
--- a/public/Restore-DbaDatabase.ps1
+++ b/public/Restore-DbaDatabase.ps1
@@ -883,7 +883,10 @@ function Restore-DbaDatabase {
 
                 $null = $FilteredBackupHistory | Test-DbaBackupInformation @parms
             } catch {
-                Stop-Function -ErrorRecord $_ -Message "Failure" -Continue
+                # No -Continue here: this catch is in the end block outside of any loop, so the continue
+                # would escape the command and eat an iteration of whatever loop the caller runs in.
+                Stop-Function -ErrorRecord $_ -Message "Failure"
+                return
             }
             if (Test-Bound -ParameterName TestBackupInformation) {
                 Set-Variable -Name $TestBackupInformation -Value $FilteredBackupHistory -Scope Global
@@ -940,7 +943,12 @@ function Restore-DbaDatabase {
                 }
                 $FilteredBackupHistory | Where-Object { $_.IsVerified -eq $true } | Invoke-DbaAdvancedRestore @parms
             } catch {
-                Stop-Function -Message "Failure" -ErrorRecord $_ -Continue -Target $RestoreInstance
+                # No -Continue here: this catch is in the end block outside of any loop, so the continue
+                # would escape the command and eat an iteration of whatever loop the caller runs in. Under
+                # Pester that corrupted the test runner - the failure surfaced as "Cannot bind argument to
+                # parameter 'ErrorRecord' because it is null" and kept the StopAt tests broken for years.
+                Stop-Function -Message "Failure" -ErrorRecord $_ -Target $RestoreInstance
+                return
             }
             if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
                 if ($RestoreInstance.Edition -like '*Enterprise*') {

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -873,54 +873,115 @@ use master
     }
 
 
-    <#
-    TODO:
-    The next tests are skipped because they don't work as expected.
-    In "$($TestConfig.appveyorlabrepo)\sql2008-backups\StopAt" the backup chain is maybe broken (is file StopAt_22.trn missing?)
-    Restore-DbaDatabase writes a warning: Microsoft.Data.SqlClient.SqlError: The log in this backup set begins at LSN 19000000021500001, which is too recent to apply to the database. An earlier log backup that includes LSN 19000000020400004 can be restored.
-    Pester does not like this warning, reason currently unknown. But the context and the complete test fail with "System.Management.Automation.ParameterBindingValidationException: Cannot bind argument to parameter 'ErrorRecord' because it is null".
-    Maybe it's because the warning is written to $error but has no ErrorRecord.
-    #>
-
-    Context -Skip "Test restoring with StopAt" {
+    Context "Test restoring with StopMark, StopBefore, StopAfterDate and StopAtLsn" {
         BeforeAll {
-            $null = Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -ExcludeSystem -EnableException | Remove-DbaDatabase -EnableException
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # The old static fixture in sql2008-backups\StopAt was broken from its first commit
+            # (StopAt_22.trn never made it into the repo), so these tests were skipped for years.
+            # The chain is generated here instead: two transactions carry the same mark name, with
+            # a timestamp captured between them so StopAfterDate can select the second one. The
+            # steps table records how far a restore came: 1 before the first mark, 2 inside it,
+            # 3 after it, 4 inside the second mark, 5 after that.
+            $stopMarkDbName = "dbatoolsci_stopmark_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name $stopMarkDbName
+            $splatStopMarkQuery = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $stopMarkDbName
+            }
+            Invoke-DbaQuery @splatStopMarkQuery -Query "CREATE TABLE steps (step int NOT NULL)"
+            $splatStopMarkBackup = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $stopMarkDbName
+                Path        = $backupPath
+            }
+            # STOPATMARK references the transaction NAME - the string after WITH MARK is only a
+            # description - so the transactions themselves have to be named dbatoolstest.
+            $firstMarkQuery = @"
+BEGIN TRAN dbatoolstest WITH MARK 'first dbatools test mark';
+INSERT INTO steps VALUES (2);
+COMMIT TRAN dbatoolstest
+"@
+            $secondMarkQuery = @"
+BEGIN TRAN dbatoolstest WITH MARK 'second dbatools test mark';
+INSERT INTO steps VALUES (4);
+COMMIT TRAN dbatoolstest
+"@
+            $stopMarkFull = Backup-DbaDatabase @splatStopMarkBackup -Type Full -FilePath "stopmark_full.bak"
+            Invoke-DbaQuery @splatStopMarkQuery -Query "INSERT INTO steps VALUES (1)"
+            Invoke-DbaQuery @splatStopMarkQuery -Query $firstMarkQuery
+            Invoke-DbaQuery @splatStopMarkQuery -Query "INSERT INTO steps VALUES (3)"
+            $stopMarkLog1 = Backup-DbaDatabase @splatStopMarkBackup -Type Log -FilePath "stopmark_log1.trn"
+            # STOPATMARK ... AFTER selects the first mark after the given time, so the time has to
+            # sit strictly between the commits of the two marked transactions.
+            Start-Sleep -Seconds 2
+            $betweenMarksTime = Get-Date
+            Start-Sleep -Seconds 2
+            Invoke-DbaQuery @splatStopMarkQuery -Query $secondMarkQuery
+            Invoke-DbaQuery @splatStopMarkQuery -Query "INSERT INTO steps VALUES (5)"
+            $stopMarkLog2 = Backup-DbaDatabase @splatStopMarkBackup -Type Log -FilePath "stopmark_log2.trn"
+            $stopMarkBackupFiles = $stopMarkFull.BackupPath, $stopMarkLog1.BackupPath, $stopMarkLog2.BackupPath
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
-        It "Should have stoped at mark" {
-            $restoreOutput = Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name StopAt2 -Path "$($TestConfig.appveyorlabrepo)\sql2008-backups\StopAt" -StopMark dbatoolstest -WarningAction SilentlyContinue -ErrorAction SilentlyContinue -ErrorVariable x
-            $null = Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name StopAt2 -Recover
-            $sqlOut = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database StopAt2 -Query "select max(step) as ms from steps"
-            $sqlOut.ms | Should -Be 9876
-        }
-    }
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
+            $null = Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database $stopMarkDbName | Remove-DbaDatabase
 
-    Context -Skip "Test restoring with StopAtBefore" {
-        BeforeAll {
-            $null = Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -ExcludeSystem -EnableException | Remove-DbaDatabase -EnableException
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
-        It "Should have stoped at mark" {
-            $restoreOutput = Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name StopAt2 -Path "$($TestConfig.appveyorlabrepo)\sql2008-backups\StopAt" -StopMark dbatoolstest -StopBefore -WarningAction SilentlyContinue
-            $null = Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name StopAt2 -Recover
-            $sqlOut = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database StopAt2 -Query "select max(step) as ms from steps"
-            $sqlOut.ms | Should -Be 8764
+        It "Should have stopped at the first mark" {
+            $splatRestore = @{
+                SqlInstance   = $TestConfig.InstanceSingle
+                Path          = $stopMarkBackupFiles
+                DatabaseName  = $stopMarkDbName
+                WithReplace   = $true
+                StopMark      = "dbatoolstest"
+                WarningAction = "SilentlyContinue"
+            }
+            $null = Restore-DbaDatabase @splatRestore
+            $null = Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -DatabaseName $stopMarkDbName -Recover
+            $maxStep = Invoke-DbaQuery @splatStopMarkQuery -Query "select max(step) as ms from steps" -As SingleValue
+            # The marked transaction itself is included, everything after it is not.
+            $maxStep | Should -Be 2
         }
-    }
 
-
-    Context -Skip "Test restoring with StopAt, StopAtLsn and StopAfterDate" {
-        BeforeAll {
-            $null = Get-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -ExcludeSystem -EnableException | Remove-DbaDatabase -EnableException
+        It "Should have stopped before the first mark" {
+            $splatRestore = @{
+                SqlInstance   = $TestConfig.InstanceSingle
+                Path          = $stopMarkBackupFiles
+                DatabaseName  = $stopMarkDbName
+                WithReplace   = $true
+                StopMark      = "dbatoolstest"
+                StopBefore    = $true
+                WarningAction = "SilentlyContinue"
+            }
+            $null = Restore-DbaDatabase @splatRestore
+            $null = Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -DatabaseName $stopMarkDbName -Recover
+            $maxStep = Invoke-DbaQuery @splatStopMarkQuery -Query "select max(step) as ms from steps" -As SingleValue
+            # The marked transaction itself is excluded this time.
+            $maxStep | Should -Be 1
         }
 
-        It "Should have stoped at mark" {
-            $restoreOutput = Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name StopAt2 -Path "$($TestConfig.appveyorlabrepo)\sql2008-backups\StopAt" -StopMark dbatoolstest -StopAfterDate (Get-Date "2020-05-12 13:33:35") -WarningAction SilentlyContinue
-            $null = Restore-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Name StopAt2 -Recover
-            $sqlOut = Invoke-DbaQuery -SqlInstance $TestConfig.InstanceSingle -Database StopAt2 -Query "select max(step) as ms from steps"
-            $sqlOut.ms | Should -Be 29876
-            $null = Remove-DbaDatabase -SqlInstance $TestConfig.InstanceSingle -Database StopAt2
+        It "Should have stopped at the second mark with StopAfterDate" {
+            $splatRestore = @{
+                SqlInstance   = $TestConfig.InstanceSingle
+                Path          = $stopMarkBackupFiles
+                DatabaseName  = $stopMarkDbName
+                WithReplace   = $true
+                StopMark      = "dbatoolstest"
+                StopAfterDate = $betweenMarksTime
+                WarningAction = "SilentlyContinue"
+            }
+            $null = Restore-DbaDatabase @splatRestore
+            # No -Recover here: the second mark sits in the last log file, so the restore stops at the
+            # mark and recovers the database in the same statement.
+            $maxStep = Invoke-DbaQuery @splatStopMarkQuery -Query "select max(step) as ms from steps" -As SingleValue
+            # The first mark before the timestamp is skipped, the second marked transaction is included.
+            $maxStep | Should -Be 4
         }
 
         It "Should have stoped at lsn" {


### PR DESCRIPTION
## Summary

Two fixes that belong together: a flow-control defect in `Restore-DbaDatabase` that has corrupted callers since at least 2020, and the resurrection of the StopAt tests whose failure it made undiagnosable.

## The command defect

Two `Stop-Function` calls in the `end` block carried `-Continue` although **no loop encloses them** (the catch around `Test-DbaBackupInformation` and the catch around `Invoke-DbaAdvancedRestore`). `Stop-Function -Continue` executes PowerShell's `continue`, and with no enclosing loop in the function, that flow-control unwinds **out of the command into the caller**:

- a user restoring in a `foreach` over instances silently skips their next iteration when one restore fails without `-EnableException`;
- under Pester, it corrupts the runner's internal loops and surfaces as `Cannot bind argument to parameter 'ErrorRecord' because it is null` - the exact crash the old TODO comment above the skipped StopAt tests documented as "reason currently unknown".

Both sites now `Stop-Function` + `return`, with comments stating why `-Continue` is forbidden there. Reproduced before the fix with a plain script: a marker line after the restore call was never reached while the `finally` still ran - the signature of escaped flow control, not of an exception.

## The StopAt tests

Skipped since the 2025 Pester rewrite because their static fixture (`appveyor-lab\sql2008-backups\StopAt`) was broken from its very first 2020 commit - `StopAt_22.trn` never existed in git, and regenerating 2008-era files would need a SQL Server 2008 instance. The tests now generate their own chain in `BeforeAll`: a `steps` table, two marked transactions **named** `dbatoolstest` (STOPATMARK references the transaction name; the `WITH MARK` string is only a description - the first rewrite attempt proved this the hard way), a timestamp captured between the marks for `StopAfterDate`, and assertions that follow the generated layout instead of the old magic values.

Semantics pinned: stop at mark includes the marked transaction (step 2), `-StopBefore` excludes it (step 1), `-StopAfterDate` with a between-marks timestamp selects the second mark (step 4). A mark in the **last** log file recovers the database in the same statement, so no separate `-Recover` may follow it - encoded as a comment.

## Deliberately not changed

After stopping at a mark mid-chain, the command still attempts the remaining log files, which SQL Server refuses ("log too recent to apply") - with `-EnableException` a successful stop-at-mark therefore still throws on the tail file. Whether the restore loop should end gracefully once the stop is reached is a design question worth its own issue.

Same file as #10631, different hunks (this end-block region vs. the backup-information splats); the branches merge cleanly in either order.

## Tests

Lab harness on SQL03\SQL2019: 81 tests, 77 passed, 0 failed, 3 skipped (Azure contexts), no warnings. Before the flow-control fix, the same file aborted the entire Pester run with the null-ErrorRecord crash - which doubles as the red-on-old proof.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
