### PR TITLE
Test-DbaLastBackup - Stop eating the caller loop on inaccessible directories

### DIFF
--- a/public/Test-DbaLastBackup.ps1
+++ b/public/Test-DbaLastBackup.ps1
@@ -369,7 +369,11 @@ function Test-DbaLastBackup {
             if ($DataDirectory) {
                 if (-not (Test-DbaPath -SqlInstance $destserver -Path $DataDirectory)) {
                     $serviceAccount = $destserver.ServiceAccount
-                    Stop-Function -Message "Can't access $DataDirectory Please check if $serviceAccount has permissions." -Continue
+                    # No -Continue here: unlike the twin check in the per-instance loop below, no loop
+                    # encloses this call, so the continue would escape the command and eat an iteration
+                    # of whatever loop the caller runs in.
+                    Stop-Function -Message "Can't access $DataDirectory Please check if $serviceAccount has permissions."
+                    return
                 }
                 $effectiveDataDirectory = $DataDirectory
             } else {
@@ -379,7 +383,9 @@ function Test-DbaLastBackup {
             if ($LogDirectory) {
                 if (-not (Test-DbaPath -SqlInstance $destserver -Path $LogDirectory)) {
                     $serviceAccount = $destserver.ServiceAccount
-                    Stop-Function -Message "$Destination can't access its local directory $LogDirectory. Please check if $serviceAccount has permissions." -Continue
+                    # No -Continue here either, see above.
+                    Stop-Function -Message "$Destination can't access its local directory $LogDirectory. Please check if $serviceAccount has permissions."
+                    return
                 }
                 $effectiveLogDirectory = $LogDirectory
             } else {

--- a/tests/Test-DbaLastBackup.Tests.ps1
+++ b/tests/Test-DbaLastBackup.Tests.ps1
@@ -383,6 +383,27 @@ Describe $CommandName -Tag IntegrationTests {
         }
     }
 
+    Context "Test -Path with an inaccessible DataDirectory" {
+        It "Warns without eating an iteration of the caller's loop" {
+            # The inaccessible-directory checks used to run Stop-Function -Continue without an
+            # enclosing loop - the continue escaped the command and consumed an iteration of this
+            # very loop, so the counter fell short (#10638).
+            $splatInaccessible = @{
+                Path          = $backupPath
+                Destination   = $TestConfig.InstanceSingle
+                DataDirectory = "Q:\dbatoolsci\does\not\exist"
+                WarningAction = "SilentlyContinue"
+            }
+            $loopCount = 0
+            foreach ($i in 1..3) {
+                $null = Test-DbaLastBackup @splatInaccessible
+                $loopCount++
+            }
+            $loopCount | Should -Be 3
+            $WarnVar | Should -BeLike "*Can't access*"
+        }
+    }
+
     Context "Test a single database" {
         BeforeAll {
             $singleDbResults = Test-DbaLastBackup -SqlInstance $TestConfig.InstanceSingle -Database $testlastbackup


### PR DESCRIPTION
## Summary

Second command fix from the #10638 inventory. The `-Path` branch of `Test-DbaLastBackup` validates `-DataDirectory` and `-LogDirectory` with `Stop-Function -Continue`, but unlike its twin checks inside the per-instance loop further down the file, **no loop encloses these two calls**. Without `-EnableException`, the `continue` escaped the command and consumed an iteration of whatever loop the caller was running in - the regression test loops three times over an inaccessible `DataDirectory` and completed **zero** iterations on the unfixed command ("Expected 3, but got 0").

## Fix

Stop and `return`, mirroring #10636/#10637 - and mirroring the two correct patterns that already sit three lines above these calls in the same branch (the missing `-Destination` check and the connection catch). The twin checks in the per-instance loop keep their `-Continue`, which is correct there: it moves to the next instance.

## Tests

Lab harness on SQL03\SQL2019: 17 tests, 0 failed. The new test uses the loop-counter pattern from #10637, asserting all three iterations complete and the warning text appears.

References #10638

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
