### PR TITLE
Import-DbaBinaryFile - Stop eating the caller loop on FilePath validation

### DIFF
--- a/public/Import-DbaBinaryFile.ps1
+++ b/public/Import-DbaBinaryFile.ps1
@@ -161,11 +161,16 @@ function Import-DbaBinaryFile {
 
         if ($FilePath) {
             if (-not (Test-Path $FilePath)) {
-                Stop-Function -Message "File $FilePath does not exist" -Continue
+                # No -Continue on these guards: no loop encloses them, so the continue would escape
+                # the command and eat an iteration of whatever loop the caller runs in. The guards
+                # above already stop and return, these two now do the same.
+                Stop-Function -Message "File $FilePath does not exist"
+                return
             }
 
             if ((Get-Item -Path $FilePath).PSIsContainer) {
-                Stop-Function -Message "FilePath must be one or more files, not a directory. For directories, use Path" -Continue
+                Stop-Function -Message "FilePath must be one or more files, not a directory. For directories, use Path"
+                return
             }
         }
 

--- a/tests/Import-DbaBinaryFile.Tests.ps1
+++ b/tests/Import-DbaBinaryFile.Tests.ps1
@@ -65,6 +65,28 @@ Describe $CommandName -Tag IntegrationTests {
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
+    Context "When the file does not exist" {
+        It "Warns without eating an iteration of the caller's loop" {
+            # The FilePath guards used to run Stop-Function -Continue without an enclosing loop -
+            # the continue escaped the command and consumed an iteration of this very loop, so the
+            # counter fell short (#10638).
+            $loopCount = 0
+            foreach ($i in 1..3) {
+                $splatMissingFile = @{
+                    SqlInstance   = $TestConfig.InstanceSingle
+                    Database      = $dbName
+                    Table         = "BinaryFiles"
+                    FilePath      = "$importPath\does-not-exist.bin"
+                    WarningAction = "SilentlyContinue"
+                }
+                $null = Import-DbaBinaryFile @splatMissingFile
+                $loopCount++
+            }
+            $loopCount | Should -Be 3
+            $WarnVar | Should -BeLike "*does not exist*"
+        }
+    }
+
     Context "Importing through a connection of the caller (#10554)" {
         BeforeAll {
             $PSDefaultParameterValues["*-Dba*:EnableException"] = $true


### PR DESCRIPTION
## Summary

Tenth fix from the #10638 inventory. The two `-FilePath` guards (file missing, path is a directory) called `Stop-Function -Continue` with no enclosing loop - the escape ate an iteration of the caller's loop. The guards directly above them already use the correct stop-and-`return` form; these two now match.

## Tests

Loop-counter regression test over a nonexistent `-FilePath`: red on the unfixed command ("Expected 3, but got 0"), green on the fix via the lab harness on SQL03\SQL2019, lab left clean.

References #10638

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
