### PR TITLE
New-DbaDbDataGeneratorConfig - Stop eating the caller loop on failures

### DIFF
--- a/public/New-DbaDbDataGeneratorConfig.ps1
+++ b/public/New-DbaDbDataGeneratorConfig.ps1
@@ -122,7 +122,10 @@ function New-DbaDbDataGeneratorConfig {
         try {
             $columnTypes = Get-Content -Path "$script:PSModuleRoot\bin\datamasking\columntypes.json" | ConvertFrom-Json
         } catch {
-            Stop-Function -Message "Something went wrong importing the column types" -Continue
+            # No -Continue here: no loop encloses this call, so the continue would escape the
+            # command and eat an iteration of whatever loop the caller runs in.
+            Stop-Function -Message "Something went wrong importing the column types"
+            return
         }
 
         # Check if the Path is accessible
@@ -365,7 +368,9 @@ function New-DbaDbDataGeneratorConfig {
                     Get-ChildItem -Path $temppath
                 }
             } catch {
-                Stop-Function -Message "Something went wrong writing the results to the Path" -Target $Path -Continue -ErrorRecord $_
+                # No -Continue here either, see the begin block.
+                Stop-Function -Message "Something went wrong writing the results to the Path" -Target $Path -ErrorRecord $_
+                return
             }
         } else {
             Write-Message -Message "No tables to save for database $($db.Name) on $($server.Name)" -Level Verbose

--- a/tests/New-DbaDbDataGeneratorConfig.Tests.ps1
+++ b/tests/New-DbaDbDataGeneratorConfig.Tests.ps1
@@ -74,4 +74,41 @@ Describe $CommandName -Tag IntegrationTests {
             $configResults | Remove-Item -ErrorAction SilentlyContinue
         }
     }
+
+    Context "When the target file cannot be written" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Generate the config once so the target file exists, then make it read-only so that
+            # every following write fails inside the command.
+            $splatLockedConfig = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $dbNameGenerator
+                Path        = $tempConfigPath
+            }
+            $lockedConfigFile = New-DbaDbDataGeneratorConfig @splatLockedConfig
+            $lockedConfigFile.IsReadOnly = $true
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+
+            # The write-failure guard used to run Stop-Function -Continue without an enclosing loop -
+            # the continue escaped the command and consumed an iteration of this very loop, so the
+            # counter fell short (#10638).
+            $loopCount = 0
+            foreach ($i in 1..3) {
+                $null = New-DbaDbDataGeneratorConfig @splatLockedConfig -WarningAction SilentlyContinue
+                $loopCount++
+            }
+        }
+
+        AfterAll {
+            $lockedConfigFile.IsReadOnly = $false
+            $lockedConfigFile | Remove-Item -ErrorAction SilentlyContinue
+        }
+
+        It "Warns without eating an iteration of the caller's loop" {
+            $loopCount | Should -Be 3
+            $WarnVar | Should -BeLike "*Something went wrong writing the results*"
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Eleventh fix from the #10638 inventory. Both guards called `Stop-Function -Continue` without an enclosing loop: the columntypes.json import guard in the begin block, and the write-failure guard at the tail of the process block. The escape ate an iteration of the caller's loop; both now stop and `return`.

## Tests

The write-failure path is pinned by a regression test that generates the config once, sets the target file read-only, and loops three times over the then-failing write: red on the unfixed command ("Expected 3, but got 0"), green on the fix (lab harness, environment clean). The import guard carries no test because it fires only when the module's own shipped `bin\datamasking\columntypes.json` is missing - untriggerable without corrupting the installation, and the fix is the same two-line shape verified nine times in this series.

References #10638

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
