### PR TITLE
Get-DbaRandomizedType - Stop eating the caller loop when the type list is missing

### DIFF
--- a/public/Get-DbaRandomizedType.ps1
+++ b/public/Get-DbaRandomizedType.ps1
@@ -93,7 +93,10 @@ function Get-DbaRandomizedType {
         try {
             $randomizerTypes = Import-Csv (Resolve-Path -Path "$script:PSModuleRoot\bin\randomizer\en.randomizertypes.csv")
         } catch {
-            Stop-Function -Message "Could not import randomized types" -Continue
+            # No -Continue here: the begin block has no enclosing loop, so the continue would escape
+            # the command and eat an iteration of whatever loop the caller runs in.
+            Stop-Function -Message "Could not import randomized types"
+            return
         }
 
     }


### PR DESCRIPTION
## Summary

Twelfth fix from the #10638 inventory, the smallest possible shape: the csv import guard in the begin block called `Stop-Function -Continue` with no enclosing loop, escaping into the caller's loop on failure. Stop-and-`return` now; the process block already guards with `Test-FunctionInterrupt`.

## Tests

No new regression test: the guard fires only when the module's own shipped `bin\randomizer\en.randomizertypes.csv` is missing, which cannot be triggered without corrupting the installation. The existing tests (which exercise the healthy import on every run) stay green via the lab harness.

References #10638

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
