### PR TITLE
Invoke-DbaDbDataGenerator - Stop eating the caller loop when Bogus fails to load

### DIFF
--- a/public/Invoke-DbaDbDataGenerator.ps1
+++ b/public/Invoke-DbaDbDataGenerator.ps1
@@ -138,7 +138,10 @@ function Invoke-DbaDbDataGenerator {
         try {
             $script:faker = New-Object Bogus.Faker($Locale)
         } catch {
-            Stop-Function -Message "Could not load randomizer class" -Continue
+            # No -Continue here: the begin block has no enclosing loop, so the continue would escape
+            # the command and eat an iteration of whatever loop the caller runs in.
+            Stop-Function -Message "Could not load randomizer class"
+            return
         }
 
         $supportedDataTypes = 'bigint', 'bit', 'bool', 'char', 'date', 'datetime', 'datetime2', 'decimal', 'int', 'float', 'guid', 'money', 'numeric', 'nchar', 'ntext', 'nvarchar', 'real', 'smalldatetime', 'smallint', 'text', 'time', 'tinyint', 'uniqueidentifier', 'userdefineddatatype', 'varchar'


### PR DESCRIPTION
## Summary

Thirteenth fix from the #10638 inventory, same minimal shape as #10648: the Bogus faker-creation guard in the begin block called `Stop-Function -Continue` with no enclosing loop, escaping into the caller's loop on failure. Stop-and-`return` now; the process block already guards with `Test-FunctionInterrupt`.

## Tests

No new regression test: the guard fires only when the Bogus library shipped by dbatools.library cannot load - untriggerable without corrupting the installation. The 13 existing integration tests stay green via the lab harness, lab left clean.

References #10638

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
