### PR TITLE
Convert-DbaMaskingValue - Stop eating the caller loop on missing input

### DIFF
--- a/private/functions/Convert-DbaMaskingValue.ps1
+++ b/private/functions/Convert-DbaMaskingValue.ps1
@@ -70,11 +70,16 @@ function Convert-DbaMaskingValue {
 
     begin {
         if (-not $Nullable -and -not $Value) {
-            Stop-Function -Message "Please enter a value" -Target $Value -Continue
+            # No -Continue on these guards: the begin block has no enclosing loop, so the continue
+            # would escape the function and eat an iteration of whatever loop the caller runs in.
+            # Invoke-DbaDbDataMasking calls this with EnableException, so there it throws instead.
+            Stop-Function -Message "Please enter a value" -Target $Value
+            return
         }
 
         if (-not $Nullable -and -not $DataType) {
-            Stop-Function -Message "Please enter a data type" -Target $DataType -Continue
+            Stop-Function -Message "Please enter a data type" -Target $DataType
+            return
         }
 
         if ($Value.Count -eq 0 -and $Nullable) {

--- a/tests/Convert-DbaMaskingValue.Tests.ps1
+++ b/tests/Convert-DbaMaskingValue.Tests.ps1
@@ -112,5 +112,18 @@ Describe $CommandName -Tag IntegrationTests {
         It "Should throw an error when data type is missing" {
             { Convert-DbaMaskingValue -Value "whatever" -EnableException } | Should -Throw "Please enter a data type"
         }
+
+        It "Warns without eating an iteration of the caller's loop" {
+            # The validation guards used to run Stop-Function -Continue without an enclosing loop -
+            # without EnableException the continue escaped the function and consumed an iteration of
+            # this very loop, so the counter fell short (#10638).
+            $loopCount = 0
+            foreach ($i in 1..3) {
+                $null = Convert-DbaMaskingValue -Value $null -DataType datetime -WarningAction SilentlyContinue
+                $loopCount++
+            }
+            $loopCount | Should -Be 3
+            $WarnVar | Should -BeLike "*Please enter a value*"
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fourteenth fix from the #10638 inventory. Both validation guards in this private function's begin block called `Stop-Function -Continue` with no enclosing loop. `Invoke-DbaDbDataMasking` - the only production caller - passes `EnableException` at all five call sites, so there the guards throw before the `continue`; the escape only bit non-EnableException callers. Stop-and-`return` now.

## Tests

Loop-counter regression test on the warning path: red on the unfixed function ("Expected 3, but got 0"), green on the fix via the lab harness.

References #10638

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
