### PR TITLE
Add-DbaReplArticle - Stop eating the caller loop on parameter validation

### DIFF
--- a/public/Add-DbaReplArticle.ps1
+++ b/public/Add-DbaReplArticle.ps1
@@ -149,11 +149,15 @@ function Add-DbaReplArticle {
 
         # Check that $CreationScriptOptions is a valid object
         if ($CreationScriptOptions -and ($CreationScriptOptions -isnot [Microsoft.SqlServer.Replication.CreationScriptOptions])) {
-            Stop-Function -Message "CreationScriptOptions should be the right type. Use New-DbaReplCreationScriptOptions to create the object" -Target $instance -Continue
+            # No -Continue on these guards: they sit before the instance loop, so the continue would
+            # escape the command and eat an iteration of whatever loop the caller runs in.
+            Stop-Function -Message "CreationScriptOptions should be the right type. Use New-DbaReplCreationScriptOptions to create the object" -Target $instance
+            return
         }
 
-        if ($Filter -like 'WHERE*') {
-            Stop-Function -Message "Filter should not include the word 'WHERE'" -Target $instance -Continue
+        if ($Filter -like "WHERE*") {
+            Stop-Function -Message "Filter should not include the word WHERE" -Target $instance
+            return
         }
 
         foreach ($instance in $SqlInstance) {

--- a/tests/Add-DbaReplArticle.Tests.ps1
+++ b/tests/Add-DbaReplArticle.Tests.ps1
@@ -26,6 +26,32 @@ Describe $CommandName -Tag UnitTests {
     }
 }
 
+Describe $CommandName -Tag IntegrationTests {
+    Context "When the filter includes WHERE" {
+        It "Warns without eating an iteration of the caller's loop" {
+            # The validation guards used to run Stop-Function -Continue before the instance loop -
+            # the continue escaped the command and consumed an iteration of this very loop, so the
+            # counter fell short (#10638). The guard fires before any connection is made, so the
+            # instance name is never contacted.
+            $loopCount = 0
+            foreach ($i in 1..3) {
+                $splatWhereFilter = @{
+                    SqlInstance   = "dbatoolsci-nohost"
+                    Database      = "dbatoolsci_nope"
+                    Publication   = "dbatoolsci_nope"
+                    Name          = "dbatoolsci_nope"
+                    Filter        = "WHERE 1 = 1"
+                    WarningAction = "SilentlyContinue"
+                }
+                $null = Add-DbaReplArticle @splatWhereFilter
+                $loopCount++
+            }
+            $loopCount | Should -Be 3
+            $WarnVar | Should -BeLike "*Filter should not include the word WHERE*"
+        }
+    }
+}
+
 <#
     Integration tests for replication are in GitHub Actions and run from \tests\gh-actions-repl-*.ps1.ps1
 #>


### PR DESCRIPTION
## Summary

Fifteenth fix from the #10638 inventory. The two guards at the top of the process block (CreationScriptOptions type check, WHERE-in-filter check) called `Stop-Function -Continue` - but they sit **before** the instance loop, so the escape ate an iteration of the caller's loop. Stop-and-`return` now. The filter guard's legacy single quotes became double quotes per repo style, and its message drops the quoted WHERE.

## Tests

The guards fire before any connection is made, so the new loop-counter regression test contacts no instance at all and runs in about a second: red on the unfixed command ("Expected 3, but got 0"), green on the fix.

References #10638

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
