### PR TITLE
New-DbaReplSubscription - Remove the latent continue escape and guard the process block

### DIFF
--- a/public/New-DbaReplSubscription.ps1
+++ b/public/New-DbaReplSubscription.ps1
@@ -129,17 +129,23 @@ function New-DbaReplSubscription {
         try {
             $pubReplServer = Get-DbaReplServer -SqlInstance $SqlInstance -SqlCredential $SqlCredential -EnableException:$EnableException
         } catch {
-            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance -Continue
+            # No -Continue on these guards: the begin block has no enclosing loop, so the continue
+            # would escape the command and eat an iteration of whatever loop the caller runs in.
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
+            return
         }
 
         try {
             $pub = Get-DbaReplPublication -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Name $PublicationName -EnableException:$EnableException
         } catch {
-            Stop-Function -Message ("Publication {0} not found on {1}" -f $PublicationName, $SqlInstance) -ErrorRecord $_ -Target $SqlInstance -Continue
+            Stop-Function -Message ("Publication {0} not found on {1}" -f $PublicationName, $SqlInstance) -ErrorRecord $_ -Target $SqlInstance
+            return
         }
     }
 
     process {
+        # The begin block stops without a publisher or publication - do not run the subscriber loop then.
+        if (Test-FunctionInterrupt) { return }
 
         # for each subscription SqlInstance we need to create a subscription
         foreach ($instance in $SubscriberSqlInstance) {

--- a/tests/New-DbaReplSubscription.Tests.ps1
+++ b/tests/New-DbaReplSubscription.Tests.ps1
@@ -26,6 +26,43 @@ Describe $CommandName -Tag UnitTests {
         }
     }
 }
+Describe $CommandName -Tag IntegrationTests {
+    Context "When the publisher cannot be reached" {
+        BeforeAll {
+            # Lower the connection timeout so the three failing connection attempts do not stretch
+            # the test to a minute and a half.
+            $oldConnectionTimeout = Get-DbatoolsConfigValue -FullName sql.connection.timeout
+            $null = Set-DbatoolsConfig -FullName sql.connection.timeout -Value 2
+        }
+
+        AfterAll {
+            $null = Set-DbatoolsConfig -FullName sql.connection.timeout -Value $oldConnectionTimeout
+        }
+
+        It "Warns without eating an iteration of the caller's loop" {
+            # The connection guards in the begin block used to run Stop-Function -Continue without an
+            # enclosing loop - the continue escaped the command and consumed an iteration of this very
+            # loop, so the counter fell short (#10638). The publisher name does not resolve, so every
+            # iteration fails at the connection attempt without touching any instance.
+            $loopCount = 0
+            foreach ($i in 1..3) {
+                $splatUnreachable = @{
+                    SqlInstance           = "dbatoolsci-nohost"
+                    SubscriberSqlInstance = "dbatoolsci-nohost2"
+                    Database              = "dbatoolsci_nope"
+                    PublicationName       = "dbatoolsci_nope"
+                    Type                  = "Push"
+                    WarningAction         = "SilentlyContinue"
+                }
+                $null = New-DbaReplSubscription @splatUnreachable
+                $loopCount++
+            }
+            $loopCount | Should -Be 3
+            ($WarnVar -join " ") | Should -BeLike "*Error connecting*"
+        }
+    }
+}
+
 <#
     Integration tests for replication are in GitHub Actions and run from \tests\gh-actions-repl-*.ps1.ps1
 #>


### PR DESCRIPTION
## Summary

Sixteenth entry from the #10638 inventory, and the first **latent** one: the two connection catches in the begin block carried `Stop-Function -Continue` without an enclosing loop, but the sites turn out to be unreachable. Without `EnableException`, the inner `Get-DbaReplServer`/`Get-DbaReplPublication` warn-and-return instead of throwing, so the catches never fire; with it, `Stop-Function` throws before the `continue`. Converted to stop-and-`return` anyway, so the defect cannot activate if the inner calls ever change their error behavior.

## The real find

The process block had **no `Test-FunctionInterrupt` guard**: had any begin-block stop ever fired, the subscriber loop would have run against a null publisher and publication. The standard guard is now in place.

## Tests

First integration test of this file: the unreachable-publisher path warns and the caller's loop completes, with `sql.connection.timeout` lowered during the context so three failing connection attempts cost ~9 seconds instead of ~90. Stated plainly: this test also passes on the unfixed code, because the escape sites were latent - there is no red-on-old for a defect that cannot activate.

References #10638

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
