### PR TITLE
Set-DbaAgentOperator - Stop eating the caller loop on connection failure

### DIFF
--- a/public/Set-DbaAgentOperator.ps1
+++ b/public/Set-DbaAgentOperator.ps1
@@ -296,7 +296,10 @@ function Set-DbaAgentOperator {
             try {
                 $InputObject += Get-DbaAgentOperator -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Operator $Operator -EnableException
             } catch {
-                Stop-Function -Message "Failed" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                # No -Continue here: this catch sits before the operator loop, so the continue would
+                # escape the command and eat an iteration of whatever loop the caller runs in.
+                Stop-Function -Message "Failed" -Category ConnectionError -ErrorRecord $_ -Target $instance
+                return
             }
         }
 

--- a/tests/Set-DbaAgentOperator.Tests.ps1
+++ b/tests/Set-DbaAgentOperator.Tests.ps1
@@ -61,4 +61,35 @@ Describe $CommandName -Tag IntegrationTests {
             $results.EmailAddress | Should -Be "new@new.com"
         }
     }
+
+    Context "When the instance cannot be reached" {
+        BeforeAll {
+            # Lower the connection timeout so the three failing connection attempts stay fast.
+            $oldConnectionTimeout = Get-DbatoolsConfigValue -FullName sql.connection.timeout
+            $null = Set-DbatoolsConfig -FullName sql.connection.timeout -Value 2
+        }
+
+        AfterAll {
+            $null = Set-DbatoolsConfig -FullName sql.connection.timeout -Value $oldConnectionTimeout
+        }
+
+        It "Warns without eating an iteration of the caller's loop" {
+            # The connection catch used to run Stop-Function -Continue before the operator loop -
+            # the continue escaped the command and consumed an iteration of this very loop, so the
+            # counter fell short (#10638).
+            $loopCount = 0
+            foreach ($i in 1..3) {
+                $splatUnreachable = @{
+                    SqlInstance   = "dbatoolsci-nohost"
+                    Operator      = "dbatoolsci_nope"
+                    EmailAddress  = "nope@nope.com"
+                    WarningAction = "SilentlyContinue"
+                }
+                $null = Set-DbaAgentOperator @splatUnreachable
+                $loopCount++
+            }
+            $loopCount | Should -Be 3
+            ($WarnVar -join " ") | Should -BeLike "*Failed*"
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Seventeenth fix from the #10638 inventory. The connection catch called `Stop-Function -Continue`, but it sits **before** the operator loop - the escape ate an iteration of the caller's loop. Stop-and-`return` now. The catch is reachable (the inner `Get-DbaAgentOperator` runs with `-EnableException` and throws on connection failure), unlike the latent sites documented in #10652.

## Tests

Loop-counter regression test over an unreachable instance, with `sql.connection.timeout` lowered during the context to keep the three failing attempts fast: red on the unfixed command ("Expected 3, but got 0"), green on the fix via the lab harness, lab left clean.

References #10638

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
