### PR TITLE
Progress bars - Complete the bars that 22 commands left behind

### DIFF
--- a/public/Disable-DbaDbEncryption.ps1
+++ b/public/Disable-DbaDbEncryption.ps1
@@ -126,6 +126,7 @@ function Disable-DbaDbEncryption {
                         Write-Message -Level Verbose -Message "Database state for $($db.Name) on $($server.Name): $($db.DatabaseEncryptionKey.EncryptionState)"
                     }
                     while ($db.DatabaseEncryptionKey.EncryptionState -notin "Unencrypted", "None")
+                    Write-ProgressHelper -Completed
 
                     if (-not $NoEncryptionKeyDrop) {
                         # https://www.sqlservercentral.com/steps/stairway-to-tde-removing-tde-from-a-database

--- a/public/Export-DbaUser.ps1
+++ b/public/Export-DbaUser.ps1
@@ -645,6 +645,7 @@ function Export-DbaUser {
                     $sql
                 }
             }
+            Write-ProgressHelper -Completed
         }
         # Just a single file, output path once here
         if (-Not $GenerateFilePerUser -and $FilePath) {

--- a/public/Find-DbaInstance.ps1
+++ b/public/Find-DbaInstance.ps1
@@ -597,6 +597,7 @@ function Find-DbaInstance {
                         }
                     }
 
+                    Write-ProgressHelper -Activity "Processing: $($computer)" -Completed
                     $masterList | Where-Object { $_.Confidence -ge $MinimumConfidence }
                 }
             }

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -1500,6 +1500,7 @@ WHERE c.object_id = OBJECT_ID(@tableName)
                         } else {
                             Write-Progress -Id 1 -Activity "Inserting $($script:totalRowsCopied) rows" -Status "Failed" -Completed
                         }
+                        Write-Progress -Activity "Importing from $file" -Completed
                     }
                 }
                 if ($PSCmdlet.ShouldProcess($instance, "Finalizing import")) {

--- a/public/Import-DbaParquet.ps1
+++ b/public/Import-DbaParquet.ps1
@@ -1038,6 +1038,7 @@ WHERE c.object_id = OBJECT_ID(@tableName)
                         } else {
                             Write-Progress -Id 1 -Activity "Inserting $($script:totalRowsCopied) rows" -Status "Failed" -Completed
                         }
+                        Write-Progress -Activity "Importing from $file" -Completed
                     }
                 }
                 # Clean up Parquet reader if ShouldProcess was skipped (WhatIf mode)

--- a/public/Install-DbaSqlWatch.ps1
+++ b/public/Install-DbaSqlWatch.ps1
@@ -196,5 +196,6 @@ function Install-DbaSqlWatch {
                 Write-Message -Level Verbose -Message "Finished installing/updating SqlWatch in $database on $instance."
             }
         }
+        Write-ProgressHelper -Completed
     }
 }

--- a/public/Invoke-DbaDbDataGenerator.ps1
+++ b/public/Invoke-DbaDbDataGenerator.ps1
@@ -555,6 +555,7 @@ function Invoke-DbaDbDataGenerator {
                     }
                 }
             }
+            Write-ProgressHelper -Completed
 
             try {
                 $sqlconn.Close()

--- a/public/Invoke-DbaDbDataMasking.ps1
+++ b/public/Invoke-DbaDbDataMasking.ps1
@@ -1374,6 +1374,7 @@ function Invoke-DbaDbDataMasking {
                     }
                 }
             } # End foreach database
+            Write-ProgressHelper -Completed
 
             # Do some cleanup
             $null = $server.Databases['tempdb'].Tables.Refresh()

--- a/public/Invoke-DbaDbMirroring.ps1
+++ b/public/Invoke-DbaDbMirroring.ps1
@@ -426,5 +426,6 @@ function Invoke-DbaDbMirroring {
                 }
             }
         }
+        Write-ProgressHelper -Completed
     }
 }

--- a/public/New-DbaComputerCertificate.ps1
+++ b/public/New-DbaComputerCertificate.ps1
@@ -526,6 +526,7 @@ function New-DbaComputerCertificate {
                     Stop-Function "Isue removing files from $certDir" -Target $certDir -ErrorRecord $_
                 }
             }
+            Write-ProgressHelper -Completed
         }
     }
 }

--- a/public/New-DbaComputerCertificateSigningRequest.ps1
+++ b/public/New-DbaComputerCertificateSigningRequest.ps1
@@ -258,6 +258,7 @@ function New-DbaComputerCertificateSigningRequest {
                 }
                 Get-ChildItem $certCfg, $certCsr
             }
+            Write-ProgressHelper -Completed
         }
     }
 }

--- a/public/New-DbatoolsSupportPackage.ps1
+++ b/public/New-DbatoolsSupportPackage.ps1
@@ -201,6 +201,8 @@ Ideally start a new console, perform the minimal steps required to reproduce the
                 $hash["Variables"] = $Variables | Get-Variable -ErrorAction Ignore
             }
 
+            Write-ProgressHelper -Completed
+
             $data = [PSCustomObject]$hash
 
             try {

--- a/public/Read-DbaBackupHeader.ps1
+++ b/public/Read-DbaBackupHeader.ps1
@@ -374,6 +374,7 @@ function Read-DbaBackupHeader {
             }
             Start-Sleep -Milliseconds 500
         }
+        Write-Progress -Id 1 -Activity Updating -Completed
         #Close the runspace pool
         $runspacePool.Close()
         [System.Management.Automation.Runspaces.Runspace]::DefaultRunspace = $defaultrunspace

--- a/public/Remove-DbaNetworkCertificate.ps1
+++ b/public/Remove-DbaNetworkCertificate.ps1
@@ -116,10 +116,10 @@ function Remove-DbaNetworkCertificate {
 
             if ([System.String]::IsNullOrEmpty($vsname)) { $vsname = $instance }
 
-            Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Regroot: $regRoot" -Target $instance
-            Write-ProgressHelper -StepNumber ($stepCounter++) -Message "ServiceAcct: $serviceAccount" -Target $instance
-            Write-ProgressHelper -StepNumber ($stepCounter++) -Message "InstanceName: $instanceName" -Target $instance
-            Write-ProgressHelper -StepNumber ($stepCounter++) -Message "VSNAME: $vsname" -Target $instance
+            Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Regroot: $regRoot"
+            Write-ProgressHelper -StepNumber ($stepCounter++) -Message "ServiceAcct: $serviceAccount"
+            Write-ProgressHelper -StepNumber ($stepCounter++) -Message "InstanceName: $instanceName"
+            Write-ProgressHelper -StepNumber ($stepCounter++) -Message "VSNAME: $vsname"
 
             $scriptblock = {
                 $regRoot = $args[0]
@@ -147,6 +147,7 @@ function Remove-DbaNetworkCertificate {
                     Stop-Function -Message "Failed to connect to $($resolved.fqdn) using PowerShell remoting." -ErrorRecord $_ -Target $instance -Continue
                 }
             }
+            Write-ProgressHelper -Completed
         }
     }
 }

--- a/public/Reset-DbaAdmin.ps1
+++ b/public/Reset-DbaAdmin.ps1
@@ -448,6 +448,7 @@ function Reset-DbaAdmin {
                     }
                 }
             }
+            Write-ProgressHelper -Completed
 
         }
     }

--- a/public/Save-DbaDiagnosticQueryScript.ps1
+++ b/public/Save-DbaDiagnosticQueryScript.ps1
@@ -217,8 +217,10 @@ function Save-DbaDiagnosticQueryScript {
             Invoke-TlsWebRequest -Uri $link -OutFile $filename -ErrorAction Stop
             Get-ChildItem -Path $filename
         } catch {
+            Write-ProgressHelper -Completed
             Stop-Function -Message "Requesting and writing file failed: $_" -Target $filename -ErrorRecord $_
             return
         }
     }
+    Write-ProgressHelper -Completed
 }

--- a/public/Set-DbaNetworkCertificate.ps1
+++ b/public/Set-DbaNetworkCertificate.ps1
@@ -404,6 +404,7 @@ function Set-DbaNetworkCertificate {
                     Notes                 = $notes
                 }
             }
+            Write-ProgressHelper -Completed
         }
     }
 }

--- a/public/Start-DbaDbEncryption.ps1
+++ b/public/Start-DbaDbEncryption.ps1
@@ -383,6 +383,7 @@ function Start-DbaDbEncryption {
                     Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
                 }
             }
+            Write-ProgressHelper -Completed
         } else {
             # Parallel processing - group databases by instance and pre-create shared resources
             $instanceGroups = $InputObject | Group-Object -Property { $_.Parent.Name }
@@ -615,6 +616,7 @@ function Start-DbaDbEncryption {
                     }
                     Start-Sleep -Milliseconds 500
                 }
+                Write-Progress -Id 1 -Activity "Enabling encryption on $servername" -Completed
 
                 $runspacePool.Close()
                 $runspacePool.Dispose()

--- a/public/Start-DbaMigration.ps1
+++ b/public/Start-DbaMigration.ps1
@@ -625,6 +625,7 @@ function Start-DbaMigration {
                 Write-Message -Level Verbose -Message "Skipping SSIS catalog migration because the source instance does not have an SSISDB catalog."
             }
         }
+        Write-ProgressHelper -Completed
     }
     end {
         if ($dacOpened) {

--- a/public/Stop-DbaDbEncryption.ps1
+++ b/public/Stop-DbaDbEncryption.ps1
@@ -110,6 +110,7 @@ function Stop-DbaDbEncryption {
                     Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
                 }
             }
+            Write-ProgressHelper -Completed
         } else {
             # Parallel processing using runspaces
             $disableScript = {
@@ -249,6 +250,7 @@ function Stop-DbaDbEncryption {
                 }
                 Start-Sleep -Milliseconds 500
             }
+            Write-Progress -Id 1 -Activity "Disabling encryption" -Completed
 
             $runspacePool.Close()
             $runspacePool.Dispose()

--- a/public/Sync-DbaAvailabilityGroup.ps1
+++ b/public/Sync-DbaAvailabilityGroup.ps1
@@ -425,6 +425,7 @@ function Sync-DbaAvailabilityGroup {
                 Write-ProgressHelper -Activity $activity -StepNumber ($stepCounter++) -Message "Syncing login permissions"
                 Sync-DbaLoginPermission -Source $server -Destination $secondaries -Login $Login -ExcludeLogin $ExcludeLogin
             }
+            Write-ProgressHelper -Activity $activity -Completed
         }
     }
 }

--- a/public/Sync-DbaLoginPermission.ps1
+++ b/public/Sync-DbaLoginPermission.ps1
@@ -172,6 +172,7 @@ function Sync-DbaLoginPermission {
                     Stop-Function -Message "Issue syncing permissions for login" -Target $loginName -ErrorRecord $_ -Continue
                 }
             }
+            Write-ProgressHelper -Completed
         }
     }
 }


### PR DESCRIPTION
Opened as a draft on 2026-08-30 as the tactical half of the progress-bar topic, parked while the structural RFC (#10548) waited for maintainer opinions. That discussion has not started, so this first step is put up for review on its own: it is self-contained and does not prejudge the RFC.

## What this fixes

An AST scan over the module found 22 commands that start a `Write-Progress` bar and **never complete it at all** - on any path, success included. Their stale bars stay on screen until some later command happens to reuse the same progress Id, or the pipeline ends.

This PR adds the missing `Write-Progress -Completed` calls: 25 completion calls across 22 commands, 30 insertions, no logic changes.

## What this deliberately does not fix

The second class found by the same scan: commands that complete their bar on the success path but leak it when they throw under `-EnableException` (confirmed example: `Add-DbaAgDatabase`, whose completion sits after the `foreach` and whose 28 `Stop-Function` calls all throw past it). That class needs a structural answer - completing bars from inside `Stop-Function`, as proposed in #10548 - rather than 28 hand-placed completions, and is left out here on purpose.

Scan notes for reviewers: a bar is identified by `-Id` (default 0), not by its Activity text, so Activity mismatches are not leaks; and `Invoke-Parallel.ps1` is a permanent false positive for grep-based scans (the splat carries the Id, completed later).

## Testing

All 22 affected test files were run individually against the lab at the time the branch was built (2026-08-10): 171 passed, 0 failed, 7 pre-existing skips. `Write-Progress` writes zero bytes to stdout/stderr when redirected, so these calls cannot affect captured test output; CI additionally suppresses progress rendering via `$ProgressPreference` in its runner scripts.

The branch was based on development as of 2026-08-10. Development was merged in on 2026-09-12: the only conflict was `Sync-DbaLoginPermission.ps1`, where #10603 wrapped the login loop in `try`/`finally` for the database-context restore. The completion call sits where it did, after the inner loop, now inside that `try` before the `finally`. The merged branch differs from development by exactly the 30 insertions and 4 deletions of the original commit; `Sync-DbaLoginPermission` re-run through the lab harness on both editions after the merge, green.

References #10548.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

