### PR TITLE
Policy Based Management - Run on PowerShell 7 on Windows

### DIFF
--- a/public/Export-DbaInstance.ps1
+++ b/public/Export-DbaInstance.ps1
@@ -446,10 +446,10 @@ function Export-DbaInstance {
                         Get-ChildItem -ErrorAction Ignore -Path "$exportPath\endpoints.sql"
                     }
 
-                    if ($Exclude -notcontains 'PolicyManagement' -and ($IsLinux -or $IsMacOS)) {
+                    if ($Exclude -notcontains "PolicyManagement" -and ($IsLinux -or $IsMacOS)) {
                         Write-Message -Level Verbose -Message "Skipping Policy Management -- not supported on Linux or macOS"
                     }
-                    if ($Exclude -notcontains 'PolicyManagement' -and -not ($IsLinux -or $IsMacOS)) {
+                    if ($Exclude -notcontains "PolicyManagement" -and -not ($IsLinux -or $IsMacOS)) {
                         Write-Message -Level Verbose -Message "Exporting Policy Management"
                         Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Exporting Policy Management"
 

--- a/public/Export-DbaInstance.ps1
+++ b/public/Export-DbaInstance.ps1
@@ -446,10 +446,10 @@ function Export-DbaInstance {
                         Get-ChildItem -ErrorAction Ignore -Path "$exportPath\endpoints.sql"
                     }
 
-                    if ($Exclude -notcontains 'PolicyManagement' -and $PSVersionTable.PSEdition -eq "Core") {
-                        Write-Message -Level Verbose -Message "Skipping Policy Management -- not supported by PowerShell Core"
+                    if ($Exclude -notcontains 'PolicyManagement' -and ($IsLinux -or $IsMacOS)) {
+                        Write-Message -Level Verbose -Message "Skipping Policy Management -- not supported on Linux or macOS"
                     }
-                    if ($Exclude -notcontains 'PolicyManagement' -and $PSVersionTable.PSEdition -ne "Core") {
+                    if ($Exclude -notcontains 'PolicyManagement' -and -not ($IsLinux -or $IsMacOS)) {
                         Write-Message -Level Verbose -Message "Exporting Policy Management"
                         Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Exporting Policy Management"
 

--- a/public/Get-DbaPbmCondition.ps1
+++ b/public/Get-DbaPbmCondition.ps1
@@ -101,8 +101,8 @@ function Get-DbaPbmCondition {
     }
     process {
         if (Test-FunctionInterrupt) { return }
-        if ($PSVersionTable.PSEdition -eq "Core") {
-            Stop-Function -Message "This command is not yet supported in PowerShell Core"
+        if ($IsLinux -or $IsMacOS) {
+            Stop-Function -Message "This command is not supported on Linux or macOS"
             return
         }
         foreach ($instance in $SqlInstance) {

--- a/public/Get-DbaPbmStore.ps1
+++ b/public/Get-DbaPbmStore.ps1
@@ -76,7 +76,7 @@ function Get-DbaPbmStore {
     }
     process {
         if (Test-FunctionInterrupt) { return }
-        if ($PSVersionTable.PSEdition -eq "Core") {
+        if ($IsLinux -or $IsMacOS) {
             Stop-Function -Message "This command is not supported on Linux or macOS"
             return
         }

--- a/tests/Export-DbaInstance.Tests.ps1
+++ b/tests/Export-DbaInstance.Tests.ps1
@@ -714,9 +714,7 @@ EXEC sp_dropmessage $leftoverCustomErrorId, 'all'
         $results.Length | Should -BeGreaterThan 0
     }
 
-    It "Export policies" -Skip:($PSVersionTable.PSVersion.Major -gt 5) {
-        # Skip It on pwsh because working with policies is not supported.
-
+    It "Export policies" {
         $results = Export-DbaInstance -SqlInstance $testServer -Path $exportDir -Exclude 'AgentServer', 'Audits', 'AvailabilityGroups', 'BackupDevices', 'CentralManagementServer', 'Credentials', 'CustomErrors', 'DatabaseMail', 'Databases', 'Endpoints', 'ExtendedEvents', 'LinkedServers', 'Logins', 'ReplicationSettings', 'ResourceGovernor', 'ServerAuditSpecifications', 'ServerRoles', 'SpConfigure', 'SysDbUserObjects', 'SystemTriggers', 'OleDbProvider'
 
         $results.FullName | Should -Exist

--- a/tests/Get-DbaPbmCategory.Tests.ps1
+++ b/tests/Get-DbaPbmCategory.Tests.ps1
@@ -23,9 +23,7 @@ Describe $CommandName -Tag UnitTests {
     }
 }
 
-Describe $CommandName -Tag IntegrationTests -Skip:($PSVersionTable.PSVersion.Major -gt 5) {
-    # Skip IntegrationTests on pwsh because working with policies is not supported.
-
+Describe $CommandName -Tag IntegrationTests {
     Context "Command actually works" {
         It "Gets Results" {
             $results = Get-DbaPbmCategory -SqlInstance $TestConfig.InstanceSingle

--- a/tests/Get-DbaPbmCondition.Tests.ps1
+++ b/tests/Get-DbaPbmCondition.Tests.ps1
@@ -23,9 +23,7 @@ Describe $CommandName -Tag UnitTests {
     }
 }
 
-Describe $CommandName -Tag IntegrationTests -Skip:($PSVersionTable.PSVersion.Major -gt 5) {
-    # Skip IntegrationTests on pwsh because working with policies is not supported.
-
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true

--- a/tests/Get-DbaPbmPolicy.Tests.ps1
+++ b/tests/Get-DbaPbmPolicy.Tests.ps1
@@ -24,9 +24,7 @@ Describe $CommandName -Tag UnitTests {
     }
 }
 
-Describe $CommandName -Tag IntegrationTests -Skip:($PSVersionTable.PSVersion.Major -gt 5) {
-    # Skip IntegrationTests on pwsh because working with policies is not supported.
-
+Describe $CommandName -Tag IntegrationTests {
     BeforeAll {
         # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true

--- a/tests/Get-DbaPbmStore.Tests.ps1
+++ b/tests/Get-DbaPbmStore.Tests.ps1
@@ -19,8 +19,25 @@ Describe $CommandName -Tag UnitTests {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/dataplat/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe $CommandName -Tag IntegrationTests {
+    # This Describe deliberately carries no pwsh skip: until #10662 the command refused to run on
+    # PowerShell 7 even on Windows, so running it here on both editions is the regression test.
+
+    Context "Getting the policy store" {
+        BeforeAll {
+            $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
+            $results = Get-DbaPbmStore -SqlInstance $TestConfig.InstanceSingle
+        }
+
+        It "Returns the store of the instance without warnings" {
+            $WarnVar | Should -BeNullOrEmpty
+            $results | Should -Not -BeNullOrEmpty
+            $results.SqlInstance | Should -Be $server.DomainInstanceName
+        }
+
+        It "Reaches the policies through the store" {
+            $results.Policies.Count | Should -BeGreaterThan 0
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10662

## Problem

`Get-DbaPbmStore`, `Get-DbaPbmCondition` - and with them every `Get-DbaPbm*` command - refuse to run on PowerShell 7 with "This command is not supported on Linux or macOS", even on Windows. `Export-DbaInstance` silently skips the policy export there. Combined with `-ErrorAction SilentlyContinue` in calling code this becomes a silent failure: an empty result that cannot be told apart from "no policy exists", which is how the reporter's "On Change: Prevent" policy went undetected before a `CREATE LOGIN`.

## Mechanism

The three gates tested the *edition*, `$PSVersionTable.PSEdition -eq "Core"`, while the message and the real constraint are about the *platform*. dbatools.library ships `Microsoft.SqlServer.Dmf.dll` and `Microsoft.SqlServer.Dmf.Common.dll` under `core/lib` as well as `desktop/lib`, and `Add-PbmLibrary` loads them from whichever edition folder is active. A `PolicyStore` built from the core assembly under pwsh 7.6 on Windows enumerates policies, conditions, categories and object sets exactly as on 5.1 (16 policies on the lab instance).

## What changed

- `Get-DbaPbmStore`, `Get-DbaPbmCondition`: the gate is now `$IsLinux -or $IsMacOS`, which is what `Export-DbaCredential` and `Export-DbaLinkedServer` already use. `Get-DbaPbmCondition` also gets the same message as the others instead of "not yet supported in PowerShell Core".
- `Export-DbaInstance`: the policy export runs unless on Linux or macOS; the verbose skip message says so.
- Tests: `Get-DbaPbmCategory`, `Get-DbaPbmCondition`, `Get-DbaPbmPolicy` and the "Export policies" test of `Export-DbaInstance` drop their `-Skip:($PSVersionTable.PSVersion.Major -gt 5)`. `Get-DbaPbmStore` gets its first integration test, deliberately without a pwsh skip - that is the regression test for this issue.

  A correction to the commit message, which says the pwsh lane in CI now covers this: CI runs the Pester suite under Windows PowerShell 5.1 only (`tests/appveyor.pester.ps1` starts `powershell.exe`, the cross-platform `windows-tests` job is `if: false`, and the only pwsh-on-Windows test is `Connect-DbaInstance.WindowsSspi.Tests.ps1`). So in CI these tests keep running on 5.1 as before; the pwsh coverage below comes from the lab. Removing the skips takes away the artificial exclusion so that the tests are ready the day a pwsh lane exists - the portable-pwsh step that runs the SSPI test would be the natural place, but that is a workflow decision, not part of this PR.

## What deliberately did not change

- Linux and macOS keep refusing exactly as before. Whether the Dmf assembly works there is untested and out of scope.
- The SSIS commands the issue also lists (`Copy-DbaSsisCatalog`, `New-DbaSsisCatalog`, `Get-DbaSsisEnvironmentVariable`) are a genuine limitation - the Integration Services object model is only shipped under `desktop/lib` - so their gate stays; only their message is wrong, and that gets its own small PR.
- `Export-DbaCredential` and `Export-DbaLinkedServer`, also listed in the issue, already gated on the platform in v2.8.2 and are untouched.

## Tests

Lab run through the testing-dbatools harness against SQL Server 2019 (`InstanceSingle`):

- `Get-DbaPbmStore`, `Get-DbaPbmCategory`, `Get-DbaPbmCondition`, `Get-DbaPbmPolicy` integration tests: green under pwsh 7.6.3 **and** Windows PowerShell 5.1.
- `Export-DbaInstance` integration tests under pwsh: 26 passed, 0 skipped - the policy export now runs there.
- Red on old: with the command change stashed, the new `Get-DbaPbmStore` test fails under pwsh with `Expected $null or empty, but got [Get-DbaPbmStore] This command is not supported on Linux or macOS` - the reporter's exact symptom.

Thanks to @JankeUwe for the report and the correct diagnosis of edition-versus-platform.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

