### PR TITLE
SSIS commands - Say why they refuse to run on PowerShell 7

### DIFF
--- a/public/Copy-DbaSsisCatalog.ps1
+++ b/public/Copy-DbaSsisCatalog.ps1
@@ -127,7 +127,7 @@ function Copy-DbaSsisCatalog {
     <# Developer note: The throw calls must stay in this command #>
     begin {
         if ($PSVersionTable.PSEdition -eq "Core") {
-            Stop-Function -Message "This command is not supported on Linux or macOS"
+            Stop-Function -Message "PowerShell Core is not supported because the SQL Server Integration Services object model is only shipped for Windows PowerShell, please use Windows PowerShell."
             return
         }
         $ISNamespace = "Microsoft.SqlServer.Management.IntegrationServices"

--- a/public/Get-DbaSsisEnvironmentVariable.ps1
+++ b/public/Get-DbaSsisEnvironmentVariable.ps1
@@ -148,7 +148,7 @@ function Get-DbaSsisEnvironmentVariable {
     )
     process {
         if ($PSVersionTable.PSEdition -eq "Core") {
-            Stop-Function -Message "This command is not supported on Linux or macOS"
+            Stop-Function -Message "PowerShell Core is not supported because the SQL Server Integration Services object model is only shipped for Windows PowerShell, please use Windows PowerShell."
             return
         }
         foreach ($instance in $SqlInstance) {

--- a/public/New-DbaSsisCatalog.ps1
+++ b/public/New-DbaSsisCatalog.ps1
@@ -87,7 +87,7 @@ function New-DbaSsisCatalog {
     )
     begin {
         if ($PSVersionTable.PSEdition -eq "Core") {
-            Stop-Function -Message "This command is not supported on Linux or macOS"
+            Stop-Function -Message "PowerShell Core is not supported because the SQL Server Integration Services object model is only shipped for Windows PowerShell, please use Windows PowerShell."
             return
         }
         if (-not $SecurePassword -and -not $Credential) {

--- a/tests/Copy-DbaSsisCatalog.Tests.ps1
+++ b/tests/Copy-DbaSsisCatalog.Tests.ps1
@@ -26,4 +26,14 @@ Describe $CommandName -Tag UnitTests {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
+
+    Context "Running on PowerShell Core" {
+        # The SSIS object model is only shipped for Windows PowerShell, so the command has to refuse on pwsh -
+        # but it must say so, not claim the caller is on Linux or macOS (#10662).
+        It "Refuses with a message that names Windows PowerShell" -Skip:($PSVersionTable.PSEdition -ne "Core") {
+            $null = Copy-DbaSsisCatalog -Source dbatoolsci_notconnected -Destination dbatoolsci_notconnected2 -WarningAction SilentlyContinue
+            $WarnVar | Should -Match "Windows PowerShell"
+            $WarnVar | Should -Not -Match "Linux"
+        }
+    }
 }

--- a/tests/Get-DbaSsisEnvironmentVariable.Tests.ps1
+++ b/tests/Get-DbaSsisEnvironmentVariable.Tests.ps1
@@ -22,6 +22,16 @@ Describe $CommandName -Tag UnitTests {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
+
+    Context "Running on PowerShell Core" {
+        # The SSIS object model is only shipped for Windows PowerShell, so the command has to refuse on pwsh -
+        # but it must say so, not claim the caller is on Linux or macOS (#10662).
+        It "Refuses with a message that names Windows PowerShell" -Skip:($PSVersionTable.PSEdition -ne "Core") {
+            $null = Get-DbaSsisEnvironmentVariable -SqlInstance dbatoolsci_notconnected -WarningAction SilentlyContinue
+            $WarnVar | Should -Match "Windows PowerShell"
+            $WarnVar | Should -Not -Match "Linux"
+        }
+    }
 }
 
 <#

--- a/tests/New-DbaSsisCatalog.Tests.ps1
+++ b/tests/New-DbaSsisCatalog.Tests.ps1
@@ -21,6 +21,16 @@ Describe $CommandName -Tag UnitTests {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
+
+    Context "Running on PowerShell Core" {
+        # The SSIS object model is only shipped for Windows PowerShell, so the command has to refuse on pwsh -
+        # but it must say so, not claim the caller is on Linux or macOS (#10662).
+        It "Refuses with a message that names Windows PowerShell" -Skip:($PSVersionTable.PSEdition -ne "Core") {
+            $null = New-DbaSsisCatalog -SqlInstance dbatoolsci_notconnected -SecurePassword (ConvertTo-SecureString "dbatools.IO" -AsPlainText -Force) -WarningAction SilentlyContinue
+            $WarnVar | Should -Match "Windows PowerShell"
+            $WarnVar | Should -Not -Match "Linux"
+        }
+    }
 }
 
 Describe $CommandName -Tag IntegrationTests {


### PR DESCRIPTION
Refs #10662

## Problem

`Copy-DbaSsisCatalog`, `New-DbaSsisCatalog` and `Get-DbaSsisEnvironmentVariable` refuse to run on PowerShell 7 with "This command is not supported on Linux or macOS" - also on Windows, which sends the user looking for a platform problem that does not exist.

## Mechanism

Unlike the PBM commands (fixed separately), the refusal itself is correct: dbatools.library ships `Microsoft.SqlServer.Management.IntegrationServices.dll` only under `desktop/lib`, so the SSIS object model does not exist on pwsh at all. Only the message is wrong.

## What changed

The three messages now read "PowerShell Core is not supported because the SQL Server Integration Services object model is only shipped for Windows PowerShell, please use Windows PowerShell." - the wording `Install-DbaSqlWatch` and `Uninstall-DbaSqlWatch` already use for the same kind of limitation. The gate (`$PSVersionTable.PSEdition -eq "Core"`) is unchanged.

Each of the three test files gets a unit test that runs only on pwsh and asserts the warning names Windows PowerShell and does not mention Linux. It uses a placeholder instance name, because the gate fires before any connection is attempted.

## What deliberately did not change

Nothing is made to work on pwsh here; that would need the assembly in the core library first.

## Tests

- The three unit test files: green under pwsh 7.6.3 (new test runs) and Windows PowerShell 5.1 (new test skipped), through the testing-dbatools harness.
- Red on old: with the command change stashed, `New-DbaSsisCatalog.Tests.ps1` fails with `Expected regular expression 'Windows PowerShell' to match [New-DbaSsisCatalog] This command is not supported on Linux or macOS`.

Thanks to @JankeUwe for listing these commands in #10662.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
