### PR TITLE
Get-DbaComputerCertificate - Keep the friendly name of certificates on remote computers

### DIFF
--- a/public/Get-DbaComputerCertificate.ps1
+++ b/public/Get-DbaComputerCertificate.ps1
@@ -64,7 +64,7 @@ function Get-DbaComputerCertificate {
         - ComputerName: The name of the computer where the certificate is stored
         - Store: The certificate store location (CurrentUser or LocalMachine)
         - Folder: The certificate folder/container name (My, Root, AddressBook, etc.)
-        - Name: The friendly name of the certificate (added via Add-Member)
+        - Name: The friendly name of the certificate (added via Add-Member; FriendlyName carries the same value, also for remote computers)
         - DnsNameList: Collection of DNS names associated with the certificate
         - Thumbprint: The SHA-1 hash fingerprint uniquely identifying the certificate
         - NotBefore: DateTime when the certificate becomes valid
@@ -232,9 +232,22 @@ function Get-DbaComputerCertificate {
             foreach ($currentStore in $Store) {
                 foreach ($currentFolder in $Folder) {
                     try {
-                        Invoke-Command2 -ComputerName $computer -Credential $Credential -ScriptBlock $scriptBlock -ArgumentList $thumbprint, $currentStore, $currentFolder, $Path -ErrorAction Stop | Select-DefaultView -Property ComputerName, Store, Folder, Name, DnsNameList, Thumbprint, NotBefore, NotAfter, Subject, Issuer, Algorithm
+                        $certificates = Invoke-Command2 -ComputerName $computer -Credential $Credential -ScriptBlock $scriptBlock -ArgumentList $thumbprint, $currentStore, $currentFolder, $Path -ErrorAction Stop
                     } catch {
                         Stop-Function -Message "Issue connecting to computer" -ErrorRecord $_ -Target $computer -Continue
+                    }
+                    foreach ($certificate in $certificates) {
+                        # Remoting rebuilds the certificate on this side from its raw bytes, and the friendly name is a
+                        # property of the store entry, not of the certificate - so it arrives empty from a remote computer.
+                        # The scriptblock carries it over as Name; put it back where callers expect it.
+                        if (-not $certificate.FriendlyName -and $certificate.Name) {
+                            try {
+                                $certificate.FriendlyName = $certificate.Name
+                            } catch {
+                                Write-Message -Level Verbose -Message "Could not restore the friendly name $($certificate.Name) on the certificate object: $PSItem"
+                            }
+                        }
+                        $certificate | Select-DefaultView -Property ComputerName, Store, Folder, Name, DnsNameList, Thumbprint, NotBefore, NotAfter, Subject, Issuer, Algorithm
                     }
                 }
             }

--- a/tests/Get-DbaComputerCertificate.Tests.ps1
+++ b/tests/Get-DbaComputerCertificate.Tests.ps1
@@ -54,4 +54,32 @@ Describe $CommandName -Tag IntegrationTests -Skip:($PSVersionTable.PSVersion.Maj
             "$($allCertificates.EnhancedKeyUsageList)" -match "1\.3\.6\.1\.5\.5\.7\.3\.1" | Should -Be $true
         }
     }
+
+    Context "Friendly name" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $friendlyName = "dbatoolsci_friendly_$(Get-Random)"
+            $friendlyCertificate = New-DbaComputerCertificate -SelfSigned -FriendlyName $friendlyName
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $null = Remove-DbaComputerCertificate -Thumbprint $friendlyCertificate.Thumbprint -ErrorAction SilentlyContinue
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "returns the friendly name as Name and as FriendlyName" {
+            # For a remote computer the FriendlyName arrives empty from the remoting serializer and the command
+            # restores it from Name; on this local run both come straight from the store. The remote path has
+            # no boundary in CI, so it was verified in the lab against a second computer, on both PowerShell editions.
+            $result = Get-DbaComputerCertificate -Thumbprint $friendlyCertificate.Thumbprint
+            $result.Name | Should -Be $friendlyName
+            $result.FriendlyName | Should -Be $friendlyName
+        }
+    }
 }


### PR DESCRIPTION
## Problem

For a remote computer, `Get-DbaComputerCertificate` returns certificates whose `FriendlyName` is empty, although the certificate in the remote store has one and the command's own `Name` property carries it. `New-DbaComputerCertificate` returns this object for remote computers, so its documented `FriendlyName` was empty there too, while local results had it.

## Mechanism

PowerShell remoting rebuilds the `X509Certificate2` on the calling side from its raw bytes. The friendly name is a property of the store entry, not of the certificate, so it does not survive the trip - and a remote note property of the same name does not survive either (probed), which is why the scriptblock already exposes it as `Name`.

## What changed

The command copies `Name` back into `FriendlyName` on the calling side when it arrives empty. Local and remote results now carry the same properties; nothing changes for localhost. The `.OUTPUTS` note on `Name` says so.

## Tests

- New test: pins that both `Name` and `FriendlyName` carry the friendly name. It runs locally in CI, where no second computer exists.
- Lab: `Get-DbaComputerCertificate` and `New-DbaComputerCertificate` against a second computer on PowerShell 7.6 and 5.1 - both now return the friendly name for the remote host, unchanged for localhost. `Get-DbaComputerCertificate.Tests.ps1` green through the testing-dbatools harness.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
