### PR TITLE
Install-DbaFirstResponderKit - Use the declared variable name when cloning the certificate to master

### DIFF
--- a/public/Install-DbaFirstResponderKit.ps1
+++ b/public/Install-DbaFirstResponderKit.ps1
@@ -310,7 +310,7 @@ function Install-DbaFirstResponderKit {
                             CREATE CERTIFICATE FirstResponderKitCertificate
                                 FROM BINARY = ' + convert(varchar(MAX), @public_key, 1);
 
-                            EXEC(@SQL)
+                            EXEC(@sql)
                             "
                             Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $certClone -EnableException
                         }


### PR DESCRIPTION
## Problem

On a case-sensitive instance, `Install-DbaFirstResponderKit -PublicExecute` into a user database warns `Certificate signing failed ... Must declare the scalar variable "@SQL"`, and public never gets the promised EXECUTE permissions.

## Mechanism

The batch that clones the signing certificate into master declares `@sql` and then runs `EXEC(@SQL)`. Variable names follow the instance collation, so a case-sensitive server does not know `@SQL`. Case-insensitive instances - which is what CI has - never notice.

## What changed

`EXEC(@sql)`. One character. A scan over every `@variable` in `public/` and `private/` for names that appear in more than one casing within one file found no other site.

## Tests

- CI has no case-sensitive instance, so the regression proof is the existing context "Testing certificate signing in user database" on a case-sensitive lab instance (SQL Server 2025, `SQL_Latin1_General_CP1_CS_AS`): red on the old code exactly as reported above, green with the fix. Full `Install-DbaFirstResponderKit.Tests.ps1` green through the testing-dbatools harness.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
