### PR TITLE
Set-DbaNetworkCertificate - Say why a private key is unsuitable

### DIFF
--- a/public/Set-DbaNetworkCertificate.ps1
+++ b/public/Set-DbaNetworkCertificate.ps1
@@ -316,7 +316,20 @@ function Set-DbaNetworkCertificate {
                     if (-not $detailedCertTest.CertificateFound) { $failedChecks += "CertificateNotFound" }
                     if ($detailedCertTest.CertificateFound -and -not $detailedCertTest.KeyUsagesValid) { $failedChecks += "KeyUsagesInvalid" }
                     if ($detailedCertTest.CertificateFound -and -not $detailedCertTest.DnsNamesValid) { $failedChecks += "DnsNamesInvalid" }
-                    if ($detailedCertTest.CertificateFound -and -not $detailedCertTest.PrivateKeyValid) { $failedChecks += "PrivateKeyInvalid" }
+                    if ($detailedCertTest.CertificateFound -and -not $detailedCertTest.PrivateKeyValid) {
+                        # SQL Server can only use a private key from a legacy Cryptographic Service Provider with KeySpec
+                        # AT_KEYEXCHANGE; a Key Storage Provider (CNG) key - what New-SelfSignedCertificate creates by
+                        # default - is refused by SQL Server itself. Say so, because "invalid" alone sends people looking
+                        # at permissions.
+                        $privateKeyDescription = "not accessible or a CNG (Key Storage Provider) key"
+                        if ($detailedCertTest.PrivateKeyType) {
+                            $privateKeyDescription = $detailedCertTest.PrivateKeyType
+                            if ($null -ne $detailedCertTest.PrivateKeyNumber) {
+                                $privateKeyDescription += " with KeyNumber $($detailedCertTest.PrivateKeyNumber)"
+                            }
+                        }
+                        $failedChecks += "PrivateKeyInvalid (SQL Server needs a legacy CSP key with KeySpec AT_KEYEXCHANGE; this private key is $privateKeyDescription)"
+                    }
                     if ($detailedCertTest.CertificateFound -and -not $detailedCertTest.PublicKeyValid) { $failedChecks += "PublicKeyInvalid" }
                     if ($detailedCertTest.CertificateFound -and -not $detailedCertTest.SignatureAlgorithmValid) { $failedChecks += "SignatureAlgorithmInvalid" }
                     if ($detailedCertTest.CertificateFound -and -not $detailedCertTest.EnhancedKeyUsageValid) { $failedChecks += "EnhancedKeyUsageInvalid" }

--- a/public/Test-DbaNetworkCertificate.ps1
+++ b/public/Test-DbaNetworkCertificate.ps1
@@ -78,7 +78,7 @@ function Test-DbaNetworkCertificate {
         - CertificateFound: Boolean indicating if the certificate was found in LocalMachine\My
         - KeyUsagesValid: Boolean indicating if the certificate has the required key usages (DigitalSignature and KeyEncipherment)
         - DnsNamesValid: Boolean indicating if the certificate's DNS names include the server's network name
-        - PrivateKeyValid: Boolean indicating if the private key is RSACryptoServiceProvider with KeyNumber Exchange
+        - PrivateKeyValid: Boolean indicating if the private key is RSACryptoServiceProvider with KeyNumber Exchange (a legacy CSP key with KeySpec AT_KEYEXCHANGE, which SQL Server requires; CNG / Key Storage Provider keys are not supported by SQL Server)
         - PublicKeyValid: Boolean indicating if the public key is RSA with at least 2048 bits
         - SignatureAlgorithmValid: Boolean indicating if the signature algorithm is SHA-256, SHA-384, or SHA-512
         - EnhancedKeyUsageValid: Boolean indicating if the certificate has the Server Authentication enhanced key usage

--- a/tests/Set-DbaNetworkCertificate.Tests.ps1
+++ b/tests/Set-DbaNetworkCertificate.Tests.ps1
@@ -65,6 +65,32 @@ Describe $CommandName -Tag IntegrationTests {
         $WarnVar | Should -Match "No suitable certificate found"
     }
 
+    It "Says why a certificate with a CNG key is unsuitable" {
+        # New-SelfSignedCertificate creates a Key Storage Provider (CNG) key by default. SQL Server cannot use
+        # such a key, and the refusal has to name that reason instead of a bare PrivateKeyInvalid.
+        $newCngCertificate = {
+            param ($DnsName)
+            $splatCertificate = @{
+                DnsName           = $DnsName
+                CertStoreLocation = "Cert:\LocalMachine\My"
+                FriendlyName      = "dbatoolsci_cng_key"
+            }
+            (New-SelfSignedCertificate @splatCertificate).Thumbprint
+        }
+        $splatCreateCng = @{
+            ComputerName = $computerName
+            ScriptBlock  = $newCngCertificate
+            ArgumentList = $computerName
+        }
+        $cngThumbprint = Invoke-Command2 @splatCreateCng
+        $script:createdNetworkCertificateThumbprints += $cngThumbprint
+
+        $result = Set-DbaNetworkCertificate -SqlInstance $TestConfig.InstanceRestart -Thumbprint $cngThumbprint -WarningAction SilentlyContinue
+        $result | Should -BeNullOrEmpty
+        $WarnVar | Should -Match "PrivateKeyInvalid"
+        $WarnVar | Should -Match "legacy CSP key with KeySpec AT_KEYEXCHANGE"
+    }
+
     It "applies an unsuitable certificate when Force is used" {
         $splatNewUnsuitableCertificate = @{
             ComputerName           = $computerName

--- a/tests/Set-DbaNetworkCertificate.Tests.ps1
+++ b/tests/Set-DbaNetworkCertificate.Tests.ps1
@@ -81,6 +81,8 @@ Describe $CommandName -Tag IntegrationTests {
             ComputerName = $computerName
             ScriptBlock  = $newCngCertificate
             ArgumentList = $computerName
+            # Raw, because Invoke-Command2 otherwise wraps the string in an object that only has a Length.
+            Raw          = $true
         }
         $cngThumbprint = Invoke-Command2 @splatCreateCng
         $script:createdNetworkCertificateThumbprints += $cngThumbprint


### PR DESCRIPTION
## Problem

A certificate whose private key lives in a Key Storage Provider - what `New-SelfSignedCertificate` creates by default - is refused by `Set-DbaNetworkCertificate` with `Failed checks: PrivateKeyInvalid`. That sends people looking at key permissions, which are not the problem.

## Mechanism

SQL Server can only use a legacy CSP private key created with KeySpec `AT_KEYEXCHANGE`; CNG keys are not supported at all (Microsoft documentation). So the check was right - it just did not say why it failed. `Test-DbaNetworkCertificate` already knows the key type and key number, but the message did not use them.

## What changed

The failed check now names the requirement and describes the key it found: the type plus `KeyNumber` when the key is accessible, otherwise "not accessible or a CNG (Key Storage Provider) key". The check itself is unchanged. The `PrivateKeyValid` description of `Test-DbaNetworkCertificate` says the same.

## Tests

- New test on `InstanceRestart`: a default `New-SelfSignedCertificate` on the target host is refused with the new message and nothing is configured; the certificate is tracked and removed again in `AfterAll`.
- Lab: the command verified on PowerShell 7.6 and 5.1; `Set-DbaNetworkCertificate.Tests.ps1` green through the testing-dbatools harness against a case sensitive SQL Server 2022 as `InstanceRestart`. The first harness run caught the test itself handing the command an `Invoke-Command2` result without `-Raw` (an object with only a `Length`), fixed in the second commit.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
