### PR TITLE
Get-DbaWsfcResourceGroup - Name the PartialOnline and Pending states of a resource group

### DIFF
--- a/private/functions/Get-ResourceGroupState.ps1
+++ b/private/functions/Get-ResourceGroupState.ps1
@@ -4,6 +4,8 @@ function Get-ResourceGroupState ($state) {
         0 { "Online" }
         1 { "Offline" }
         2 { "Failed" }
+        3 { "PartialOnline" }
+        4 { "Pending" }
         default { $state }
     }
 }

--- a/public/Get-DbaWsfcResourceGroup.ps1
+++ b/public/Get-DbaWsfcResourceGroup.ps1
@@ -6,7 +6,7 @@ function Get-DbaWsfcResourceGroup {
     .DESCRIPTION
         Retrieves detailed information about Windows Server Failover Cluster resource groups, including their current state, persistent state, and which node currently owns them. This function helps DBAs monitor and troubleshoot SQL Server Failover Cluster Instances and Availability Groups by providing visibility into the underlying cluster resource groups that control SQL Server services and resources.
 
-        Use this command when you need to verify resource group health during maintenance windows, troubleshoot failover issues, or confirm which node is currently hosting specific SQL Server resources. The function translates numeric state codes into readable status values (Online, Offline, Failed, Unknown) so you can quickly identify problematic resource groups.
+        Use this command when you need to verify resource group health during maintenance windows, troubleshoot failover issues, or confirm which node is currently hosting specific SQL Server resources. The function translates numeric state codes into readable status values (Online, Offline, Failed, PartialOnline, Pending, Unknown) so you can quickly identify problematic resource groups.
 
         All Windows Server Failover Clustering (Wsfc) commands require local admin on each member node.
 
@@ -48,7 +48,7 @@ function Get-DbaWsfcResourceGroup {
         - ClusterName: The name of the Windows Server Failover Cluster
         - ClusterFqdn: The fully qualified domain name of the cluster
         - Name: The name of the resource group
-        - State: Current resource group state (Online, Offline, Failed, or Unknown)
+        - State: Current resource group state (Online, Offline, Failed, PartialOnline, Pending, or Unknown)
         - PersistentState: The desired persistent state of the resource group
         - OwnerNode: The cluster node that currently owns this resource group
 

--- a/public/Get-DbaWsfcRole.ps1
+++ b/public/Get-DbaWsfcRole.ps1
@@ -40,7 +40,7 @@ function Get-DbaWsfcRole {
         - ClusterFqdn: Fully qualified domain name of the cluster
         - Name: Name of the resource group (key property), typically the cluster role name (e.g., SQL Server instance name)
         - OwnerNode: Name of the node currently hosting this resource group
-        - State: Current state of the resource group translated to readable format (Online, Offline, Failed, or Unknown)
+        - State: Current state of the resource group translated to readable format (Online, Offline, Failed, PartialOnline, Pending, or Unknown)
 
         Additional properties available (from WMI MSCluster_ResourceGroup object):
         - Caption: Short textual description of the resource group

--- a/tests/Get-DbaWsfcResourceGroup.Tests.ps1
+++ b/tests/Get-DbaWsfcResourceGroup.Tests.ps1
@@ -19,6 +19,21 @@ Describe $CommandName -Tag UnitTests {
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }
+
+    InModuleScope dbatools {
+        Context "Translating resource group states" {
+            It "Names every state a resource group can report" {
+                # MSCluster_ResourceGroup.State: a group with one resource offline is PartialOnline (3), a group
+                # in transition is Pending (4). Both used to come back as the bare number.
+                Get-ResourceGroupState -1 | Should -Be "Unknown"
+                Get-ResourceGroupState 0 | Should -Be "Online"
+                Get-ResourceGroupState 1 | Should -Be "Offline"
+                Get-ResourceGroupState 2 | Should -Be "Failed"
+                Get-ResourceGroupState 3 | Should -Be "PartialOnline"
+                Get-ResourceGroupState 4 | Should -Be "Pending"
+            }
+        }
+    }
 }
 
 Describe $CommandName -Tag IntegrationTests {
@@ -41,7 +56,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Translates the state of every resource group" {
-            $untranslatedGroups = ($wsfcResourceGroups | Where-Object { $PSItem.State -notin "Unknown", "Online", "Offline", "Failed" }).Name
+            $untranslatedGroups = ($wsfcResourceGroups | Where-Object { $PSItem.State -notin "Unknown", "Online", "Offline", "Failed", "PartialOnline", "Pending" }).Name
             $untranslatedGroups | Should -BeNullOrEmpty
         }
 

--- a/tests/Get-DbaWsfcRole.Tests.ps1
+++ b/tests/Get-DbaWsfcRole.Tests.ps1
@@ -42,7 +42,7 @@ Describe $CommandName -Tag IntegrationTests {
         It "Translates the state of every role" {
             # The state was read from $resource.State, a variable this command never assigns, so it
             # was empty for every role on every cluster.
-            $untranslatedRoles = ($wsfcRoles | Where-Object { $PSItem.State -notin "Unknown", "Online", "Offline", "Failed" }).Name
+            $untranslatedRoles = ($wsfcRoles | Where-Object { $PSItem.State -notin "Unknown", "Online", "Offline", "Failed", "PartialOnline", "Pending" }).Name
             $untranslatedRoles | Should -BeNullOrEmpty
         }
 


### PR DESCRIPTION
## Problem

`Get-DbaWsfcResourceGroup` and `Get-DbaWsfcRole` report `State = 3` for a resource group that has one resource offline, and `4` for a group in transition. The documentation promises "Online, Offline, Failed, or Unknown", and both test files assert that every state is translated - which is how this surfaced in the lab: after a cluster resource restart both SQL Server groups sat at `PartialOnline` for a while (their CEIP service resources had stayed offline) and both files failed with `Expected $null or empty, but got @('SQL Server (MSSQLSERVER)', 'SQL Server (SQL2022)')`.

## Mechanism

`private/functions/Get-ResourceGroupState.ps1` maps -1/0/1/2 and returns the raw number for everything else. `MSCluster_ResourceGroup.State` has two more documented values: 3 = PartialOnline, 4 = Pending.

## What changed

- `Get-ResourceGroupState` names 3 as `PartialOnline` and 4 as `Pending`; anything else still comes back as the number, as before.
- The `.OUTPUTS` / `.DESCRIPTION` of both commands list the two new names.
- Both test files accept them in "Translates the state of every resource group / role".
- New unit test in `Get-DbaWsfcResourceGroup.Tests.ps1` that pins all six translations, run in module scope. Red on old: `Expected 'PartialOnline', but got 3`.

## Tests

- Unit test green in both editions.
- Lab: both files green against the lab cluster with the groups fully online; and with one CEIP resource taken offline on purpose (group `PartialOnline`), the old code fails the translation assertion and the new code passes it. CEIP brought back online afterwards.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
