### PR TITLE
ci-azure - Skip the Azure runner matrix on Dependabot PRs (do Get-DbaBuild)

### DIFF
--- a/.github/workflows/ci-azure-supersede.yml
+++ b/.github/workflows/ci-azure-supersede.yml
@@ -33,7 +33,8 @@ concurrency:
 jobs:
   supersede:
     # Fork PRs get a read-only token that cannot cancel runs; their lanes keep FIFO.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Dependabot PRs never start a ci-azure run, so there is nothing to supersede.
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/ci-azure.yml
+++ b/.github/workflows/ci-azure.yml
@@ -74,6 +74,11 @@ env:
 
 jobs:
   authorize:
+    # Dependabot only ever bumps action pins, and its runs get no repository secrets.
+    # Every job below depends on authorize, so skipping it here keeps the whole matrix
+    # off the Azure runner pools. azure-migration-tests already skips the same way; the
+    # earlier attempts at this only patched that file, which is why it kept firing.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:


### PR DESCRIPTION
Dependabot PRs such as #10663 still fire the full `ci-azure` matrix on the self-hosted Azure VMSS pools. The two earlier attempts (#10566 and 53ea45491) both patched `azure-migration-tests.yml`, which already skips Dependabot correctly, but never touched `ci-azure.yml`.

This gates the `authorize` job on `github.actor != 'dependabot[bot]'`. Every matrix job depends on `authorize`, so the whole workflow completes as skipped in seconds and never touches a runner. The `ci-azure-supersede` helper gets the same gate since there is nothing for it to cancel.

Dependabot bumps only change action pins; the GitHub-hosted workflows (xplat import, cross-platform tests, security lint) still run on them and are enough coverage.

(do Get-DbaBuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mye3A1CnBn1pnEQnFEE7Ze