### PR TITLE
Get-BulkRowsCopiedCount - Read the rows copied counter as Int64

### DIFF
--- a/private/functions/Get-BulkRowsCopiedCount.ps1
+++ b/private/functions/Get-BulkRowsCopiedCount.ps1
@@ -14,6 +14,7 @@ function Get-BulkRowsCopiedCount {
             - Copy-DbaDbTableData
             - Copy-DbaDbViewData
             - Import-DbaCsv
+            - Import-DbaParquet
 
         .EXAMPLE
             Get-BulkRowsCopied $bulkObject
@@ -27,14 +28,17 @@ function Get-BulkRowsCopiedCount {
         Copyright: (c) 2020 by dbatools, licensed under MIT
         License: MIT https://opensource.org/licenses/MIT
     #>
-    [OutputType([int])]
+    [OutputType([long])]
     param (
         [Microsoft.Data.SqlClient.SqlBulkCopy] $BulkCopy
     )
     $BindingFlags = [Reflection.BindingFlags] "NonPublic,GetField,Instance"
     $rowsCopiedField = [Microsoft.Data.SqlClient.SqlBulkCopy].GetField("_rowsCopied", $BindingFlags)
     try {
-        return [int]$rowsCopiedField.GetValue($BulkCopy)
+        # The field is an Int64 in current Microsoft.Data.SqlClient (an Int32 in the legacy library),
+        # so it must not be narrowed to [int]: above [int32]::MaxValue rows that cast throws, and the
+        # -1 then taken for the row count inflates the reported total by billions of rows (see #10675).
+        return [long]$rowsCopiedField.GetValue($BulkCopy)
     } catch {
         return -1;
     }

--- a/public/Copy-DbaDbTableData.ps1
+++ b/public/Copy-DbaDbTableData.ps1
@@ -722,7 +722,13 @@ function Copy-DbaDbTableData {
                         $bulkCopy.WriteToServer($reader)
                         $finalRowCountReported = Get-BulkRowsCopiedCount $bulkCopy
 
-                        $script:totalRowsCopied += (Get-AdjustedTotalRowsCopied -ReportedRowsCopied $finalRowCountReported -PreviousRowsCopied $script:prevRowsCopied).NewRowCountAdded
+                        # -1 signals that the reflection lookup failed, not a wrapped counter, so it must not
+                        # reach Get-AdjustedTotalRowsCopied: fed in as a row count it inflates the total by
+                        # billions of rows (see #10675). The running total from the notifications is then the
+                        # best number available.
+                        if ($finalRowCountReported -ge 0) {
+                            $script:totalRowsCopied += (Get-AdjustedTotalRowsCopied -ReportedRowsCopied $finalRowCountReported -PreviousRowsCopied $script:prevRowsCopied).NewRowCountAdded
+                        }
 
                         $RowsTotal = $script:totalRowsCopied
                         $TotalTime = [math]::Round($elapsed.Elapsed.TotalSeconds, 1)

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -1493,7 +1493,13 @@ WHERE c.object_id = OBJECT_ID(@tableName)
 
                         $finalRowCountReported = Get-BulkRowsCopiedCount $bulkCopy
 
-                        $script:totalRowsCopied += (Get-AdjustedTotalRowsCopied -ReportedRowsCopied $finalRowCountReported -PreviousRowsCopied $script:prevRowsCopied).NewRowCountAdded
+                        # -1 signals that the reflection lookup failed, not a wrapped counter, so it must not
+                        # reach Get-AdjustedTotalRowsCopied: fed in as a row count it inflates the total by
+                        # billions of rows (see #10675). The running total from the notifications is then the
+                        # best number available.
+                        if ($finalRowCountReported -ge 0) {
+                            $script:totalRowsCopied += (Get-AdjustedTotalRowsCopied -ReportedRowsCopied $finalRowCountReported -PreviousRowsCopied $script:prevRowsCopied).NewRowCountAdded
+                        }
 
                         if ($completed) {
                             Write-Progress -Id 1 -Activity "Inserting $($script:totalRowsCopied) rows" -Status "Complete" -Completed

--- a/public/Import-DbaParquet.ps1
+++ b/public/Import-DbaParquet.ps1
@@ -1031,7 +1031,13 @@ WHERE c.object_id = OBJECT_ID(@tableName)
 
                         $finalRowCountReported = Get-BulkRowsCopiedCount $bulkCopy
 
-                        $script:totalRowsCopied += (Get-AdjustedTotalRowsCopied -ReportedRowsCopied $finalRowCountReported -PreviousRowsCopied $script:prevRowsCopied).NewRowCountAdded
+                        # -1 signals that the reflection lookup failed, not a wrapped counter, so it must not
+                        # reach Get-AdjustedTotalRowsCopied: fed in as a row count it inflates the total by
+                        # billions of rows (see #10675). The running total from the notifications is then the
+                        # best number available.
+                        if ($finalRowCountReported -ge 0) {
+                            $script:totalRowsCopied += (Get-AdjustedTotalRowsCopied -ReportedRowsCopied $finalRowCountReported -PreviousRowsCopied $script:prevRowsCopied).NewRowCountAdded
+                        }
 
                         if ($completed) {
                             Write-Progress -Id 1 -Activity "Inserting $($script:totalRowsCopied) rows" -Status "Complete" -Completed

--- a/tests/Get-BulkRowsCopiedCount.Tests.ps1
+++ b/tests/Get-BulkRowsCopiedCount.Tests.ps1
@@ -1,0 +1,52 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName = "dbatools",
+    $CommandName = "Get-BulkRowsCopiedCount",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    Context "Reading the rows copied counter" {
+        It "Returns the counter value below Int32.MaxValue" {
+            InModuleScope "dbatools" {
+                $bulkCopy = New-Object -TypeName Microsoft.Data.SqlClient.SqlBulkCopy -ArgumentList "Server=dummy"
+                $rowsCopiedField = [Microsoft.Data.SqlClient.SqlBulkCopy].GetField("_rowsCopied", [Reflection.BindingFlags]"NonPublic,GetField,Instance")
+                $rowsCopiedField.SetValue($bulkCopy, [long]100000)
+
+                Get-BulkRowsCopiedCount $bulkCopy | Should -Be 100000
+            }
+        }
+
+        It "Returns the counter value above Int32.MaxValue" {
+            # The field is an Int64 in current Microsoft.Data.SqlClient. A cast to [int] throws above
+            # [int32]::MaxValue, the catch then returned -1, and the callers took that for a wrapped
+            # counter and inflated the reported total by billions of rows (#10675).
+            InModuleScope "dbatools" {
+                $bulkCopy = New-Object -TypeName Microsoft.Data.SqlClient.SqlBulkCopy -ArgumentList "Server=dummy"
+                $rowsCopiedField = [Microsoft.Data.SqlClient.SqlBulkCopy].GetField("_rowsCopied", [Reflection.BindingFlags]"NonPublic,GetField,Instance")
+                $rowsCopiedField.SetValue($bulkCopy, [long]3000000000)
+
+                Get-BulkRowsCopiedCount $bulkCopy | Should -Be 3000000000
+            }
+        }
+
+        It "Keeps the total of the callers correct above Int32.MaxValue" {
+            # The pattern of Copy-DbaDbTableData, Import-DbaCsv and Import-DbaParquet: the running total
+            # from the copy notifications, plus the adjustment for the rows after the last notification.
+            InModuleScope "dbatools" {
+                $bulkCopy = New-Object -TypeName Microsoft.Data.SqlClient.SqlBulkCopy -ArgumentList "Server=dummy"
+                $rowsCopiedField = [Microsoft.Data.SqlClient.SqlBulkCopy].GetField("_rowsCopied", [Reflection.BindingFlags]"NonPublic,GetField,Instance")
+                $rowsCopiedField.SetValue($bulkCopy, [long]3000000000)
+
+                $totalRowsCopied = [long]2999995000
+                $prevRowsCopied = [long]2999995000
+                $finalRowCountReported = Get-BulkRowsCopiedCount $bulkCopy
+                if ($finalRowCountReported -ge 0) {
+                    $totalRowsCopied += (Get-AdjustedTotalRowsCopied -ReportedRowsCopied $finalRowCountReported -PreviousRowsCopied $prevRowsCopied).NewRowCountAdded
+                }
+
+                $totalRowsCopied | Should -Be 3000000000
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10675

## Problem

The report: the verbose rows-copied total of `Copy-DbaDbTableData` can over-report against the destination's real row count on the final batch, while the copied data itself is correct.

## What reproduced and what did not

On the current stack (dbatools.library with Microsoft.Data.SqlClient 6.1.5, SQL Server 2022 -> 2025) a multi-batch copy shows correct live counters and a correct final total, with the batch size aligned to the row count and not - the reported symptom does not reproduce below `[int32]::MaxValue` rows. @niphlod is right that the wrapping 4-byte counter itself is history: `SqlBulkCopy._rowsCopied` is an **Int64** in current Microsoft.Data.SqlClient, so the counter never wraps any more.

But the machinery the issue points at does over-report the final total, exactly once the copy exceeds `[int32]::MaxValue` rows:

1. `Get-BulkRowsCopiedCount` reads `_rowsCopied` by reflection and casts it to `[int]`. Above 2,147,483,647 rows that cast throws.
2. The `catch` returns **-1**, the helper's failure sentinel.
3. The three callers feed that sentinel into `Get-AdjustedTotalRowsCopied`, whose integer-wrap branch takes a negative value for a wrapped counter and adds ~1.3 billion phantom rows.

Demonstrated by setting the field via reflection: a 3,000,000,000-row copy reports **4,294,967,295** rows copied while the destination holds the correct 3,000,000,000. The data is right, the reported total is not - the shape the issue describes. Ironically the over-report comes from the workaround for the old 4-byte counter, on a library whose counter no longer wraps.

## What changed

- `Get-BulkRowsCopiedCount` returns the counter as `[long]` (`[OutputType([long])]`); the value passes through unharmed on both the Int64 field of current SqlClient and the Int32 field of the legacy library.
- The three callers with the final-adjustment pattern - `Copy-DbaDbTableData`, `Import-DbaCsv`, `Import-DbaParquet` - skip the final adjustment when the helper signals failure with -1, keeping the running total from the copy notifications instead of adding a bogus wrap correction.

## What deliberately did not change

- `Get-AdjustedTotalRowsCopied` keeps its wrap logic untouched: it is still correct for genuinely wrapped (negative) values that an old library delivers through the `SqlRowsCopied` event.
- `Write-DbaDbTableData` uses only the event-side adjustment and never calls `Get-BulkRowsCopiedCount`, so it has no sentinel path and stays as it is.

## Tests

New `tests/Get-BulkRowsCopiedCount.Tests.ps1` (unit, `InModuleScope`, no instance needed): the helper returns the counter below and above `[int32]::MaxValue`, and the callers' final-adjustment pattern stays correct above it. Red on `development` (`Expected 3000000000, but got -1.`), green with the fix.

Full runs of the four affected test files through the testing-dbatools harness (SQL 2022 -> SQL 2025), both editions: 79/79 green on pwsh and on 5.1.

Copying two billion real rows is not something CI or the lab can afford, which is why the regression test sets the counter field by reflection instead - the same access path the helper itself uses.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
