### PR TITLE
Copy-DbaDbTableData - Name the Query requirement in the parameter guard message

### DIFF
--- a/public/Copy-DbaDbTableData.ps1
+++ b/public/Copy-DbaDbTableData.ps1
@@ -326,7 +326,12 @@ function Copy-DbaDbTableData {
 
     process {
         if ((Test-Bound -Not -ParameterName InputObject) -and ((Test-Bound -Not -ParameterName SqlInstance, Database -And) -or (Test-Bound -Not -ParameterName Table, View))) {
-            Stop-Function -Message "You must pipe in a table or specify SqlInstance, Database and [View|Table]."
+            if (Test-Bound -ParameterName Query) {
+                # Without the hint at Query the message reads as if SqlInstance or Database were missing (see #10676).
+                Stop-Function -Message "When using Query, you still have to specify SqlInstance, Database and [View|Table]. The query determines the data that is copied, but the command needs the table or view as the source object for its metadata."
+            } else {
+                Stop-Function -Message "You must pipe in a table or specify SqlInstance, Database and [View|Table]."
+            }
             return
         }
 

--- a/tests/Copy-DbaDbTableData.Tests.ps1
+++ b/tests/Copy-DbaDbTableData.Tests.ps1
@@ -116,6 +116,20 @@ Describe $CommandName -Tag IntegrationTests {
             $result = Copy-DbaDbTableData -SqlInstance $TestConfig.InstanceCopy2 -Database tempdb -Table dbo.dbatoolsci_example4 -Query "SELECT TOP (1) Id FROM tempdb.dbo.dbatoolsci_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
             $result.RowsCopied | Should -Be 1
         }
+
+        It "Points at the Query requirement when Query is used without a source table" {
+            # The generic message reads as if SqlInstance or Database were missing (#10676).
+            $splatQueryOnly = @{
+                SqlInstance      = $TestConfig.InstanceCopy2
+                Database         = "tempdb"
+                Query            = "SELECT TOP (1) Id FROM dbo.dbatoolsci_example4"
+                DestinationTable = "dbatoolsci_example3"
+                WarningAction    = "SilentlyContinue"
+            }
+            $result = Copy-DbaDbTableData @splatQueryOnly
+            $result | Should -BeNullOrEmpty
+            $WarnVar | Should -Match "When using Query"
+        }
     }
 
     Context "When testing pipeline functionality" {


### PR DESCRIPTION
Fixes #10676

## Problem

`Copy-DbaDbTableData -Query` without `-Table` or `-View` answers with "You must pipe in a table or specify SqlInstance, Database and [View|Table]." - with `-SqlInstance`, `-Database` and `-Query` all supplied, that reads as if the wrong parameters were missing, on what is often the most expensive scenario to get an unclear error on (chunked transfers of large tables).

## Why the requirement itself stays

The resolved SMO table or view is not just metadata garnish in `-Query` mode: it supplies the source connection context (`$sqlObject.Parent`), the structure `AutoCreateTable` scripts, the default `-DestinationTable` name, the clustered-index and primary-key lookups, and the source columns of the output object. Making `-Table` optional with `-Query` means rebuilding all of that from the query alone - a feature-level change with real design questions (what does `AutoCreateTable` script? what do the Source* output columns show?), not a bug fix. The help for `-Query` already documents the requirement ("Still requires specifying a Table or View parameter for metadata purposes").

## What changed

The parameter guard now answers a `-Query` call with a message that names the actual gap:

> When using Query, you still have to specify SqlInstance, Database and [View|Table]. The query determines the data that is copied, but the command needs the table or view as the source object for its metadata.

Everything else about the guard is unchanged, and calls without `-Query` keep the original message. `Copy-DbaDbViewData` exposes `-Query` too and splats into this function, so it gets the same message for free.

## Tests

New regression test beside the existing `-Query` tests: calling with `-Query` and no `-Table` returns nothing and warns with the new message. Red on `development` (the generic message came back), green with the fix - through the testing-dbatools harness on both editions.

Thanks @JankeUwe for the report.

created by Claude and reviewed by Andreas Jordan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
