### PR TITLE
Invoke-DbaDbDecryptObject - Read the family GUID from sys.database_recovery_status instead of DBCC DBINFO

### DIFF
--- a/private/functions/Get-EncryptedObjectKeystream.ps1
+++ b/private/functions/Get-EncryptedObjectKeystream.ps1
@@ -22,8 +22,8 @@ function Get-EncryptedObjectKeystream {
         - Invoke-DbaDbDecryptObject
 
     .PARAMETER FamilyGuid
-        The family GUID of the database that holds the object, as reported by dbi_familyGUID of DBCC DBINFO.
-        One value per database, stable for the life of the database.
+        The family GUID of the database that holds the object, as reported by family_guid of the catalog view
+        sys.database_recovery_status. One value per database, stable for the life of the database.
 
     .PARAMETER ObjectId
         The object id of the encrypted object.

--- a/public/Invoke-DbaDbDecryptObject.ps1
+++ b/public/Invoke-DbaDbDecryptObject.ps1
@@ -305,8 +305,9 @@ function Invoke-DbaDbDecryptObject {
                         Stop-Function -Message "Reading the encrypted objects on $instance without a dedicated admin connection uses DBCC PAGE, which $azurePlatform does not support." -Target $instance -Continue
                     }
 
-                    # DBCC PAGE and DBCC DBINFO are limited to sysadmin, so checking up front gives a clear
-                    # message instead of a permission error in the middle of reading the pages.
+                    # DBCC PAGE is limited to sysadmin, so checking up front gives a clear message instead of
+                    # a permission error in the middle of reading the pages. sys.database_recovery_status, which
+                    # supplies the family GUID, needs only VIEW SERVER STATE, which a sysadmin already holds.
                     $querySysadmin = @"
 SELECT IS_SRVROLEMEMBER('sysadmin') AS IsSysadmin
 "@
@@ -450,16 +451,21 @@ AND p.is_ms_shipped = 0
                             $familyGuid = $null
                             $imageValueMap = @{ }
 
+                            # The family GUID comes from the catalog view sys.database_recovery_status, a typed
+                            # uniqueidentifier present since SQL Server 2005, rather than by scraping dbi_familyGUID
+                            # out of DBCC DBINFO's text dump. The two were measured byte for byte across SQL Server
+                            # 2019, 2022 and 2025, for user databases and master, and always agree, so the swap keeps
+                            # the keystream input identical while dropping a trace flag toggle and a regex over prose.
                             try {
-                                $familyGuidRow = @($db.Query("DBCC DBINFO WITH TABLERESULTS") | Where-Object Field -eq "dbi_familyGUID")
+                                $familyGuidRow = @($db.Query("SELECT family_guid FROM sys.database_recovery_status WHERE database_id = DB_ID()"))
                             } catch {
-                                Stop-Function -Message "Couldn't read dbi_familyGUID of database $($db.Name) on $instance" -ErrorRecord $_ -Target $instance -Continue
+                                Stop-Function -Message "Couldn't read the family GUID of database $($db.Name) on $instance" -ErrorRecord $_ -Target $instance -Continue
                             }
 
-                            if ($familyGuidRow.Count -eq 0) {
-                                Stop-Function -Message "Couldn't read dbi_familyGUID of database $($db.Name) on $instance" -Target $instance -Continue
+                            if ($familyGuidRow.Count -eq 0 -or $null -eq $familyGuidRow[0].family_guid -or $familyGuidRow[0].family_guid -is [System.DBNull]) {
+                                Stop-Function -Message "Couldn't read the family GUID of database $($db.Name) on $instance" -Target $instance -Continue
                             }
-                            $familyGuid = [guid]$familyGuidRow[0].VALUE
+                            $familyGuid = [guid]$familyGuidRow[0].family_guid
 
                             $wantedObjectId = @($objectCollection.ID)
 

--- a/tests/Invoke-DbaDbDecryptObject.Tests.ps1
+++ b/tests/Invoke-DbaDbDecryptObject.Tests.ps1
@@ -723,8 +723,8 @@ SELECT 'áéíñóú¡¿' as SampleUTF8;"
             $routeText = InModuleScope dbatools -Parameters @{ DatabaseName = $dbname; Instance = $TestConfig.InstanceMulti1 } {
                 $server = Connect-DbaInstance -SqlInstance $Instance
                 $db = $server.Databases[$DatabaseName]
-                $familyGuidRow = @($db.Query("DBCC DBINFO WITH TABLERESULTS") | Where-Object Field -eq "dbi_familyGUID")
-                $familyGuid = [guid]$familyGuidRow[0].VALUE
+                $familyGuidRow = @($db.Query("SELECT family_guid FROM sys.database_recovery_status WHERE database_id = DB_ID()"))
+                $familyGuid = [guid]$familyGuidRow[0].family_guid
                 $encryptedId = @(@($db.Query("SELECT m.object_id AS ObjectId FROM sys.sql_modules AS m WHERE m.definition IS NULL")) | ForEach-Object { [int]$PSItem.ObjectId })
 
                 $result = @{ }
@@ -773,8 +773,8 @@ SELECT 'áéíñóú¡¿' as SampleUTF8;"
             $scanText = InModuleScope dbatools -Parameters @{ DatabaseName = $dbname; Instance = $TestConfig.InstanceMulti1 } {
                 $server = Connect-DbaInstance -SqlInstance $Instance
                 $db = $server.Databases[$DatabaseName]
-                $familyGuidRow = @($db.Query("DBCC DBINFO WITH TABLERESULTS") | Where-Object Field -eq "dbi_familyGUID")
-                $familyGuid = [guid]$familyGuidRow[0].VALUE
+                $familyGuidRow = @($db.Query("SELECT family_guid FROM sys.database_recovery_status WHERE database_id = DB_ID()"))
+                $familyGuid = [guid]$familyGuidRow[0].family_guid
 
                 $encryptedId = @($db.Query("SELECT m.object_id AS ObjectId FROM sys.sql_modules AS m WHERE m.definition IS NULL")) | ForEach-Object { [int]$PSItem.ObjectId }
 


### PR DESCRIPTION
(do Invoke-DbaDbDecryptObject)

Reads the database family GUID from the catalog view `sys.database_recovery_status` instead of scraping `dbi_familyGUID` out of the text that `DBCC DBINFO` prints under trace flag 3604. The family GUID is one of the three inputs to the RC4 key that the `-DataPages` path derives, and this changes only where that one value comes from. The `DBCC PAGE` read that pulls the ciphertext is untouched, so the page reader, the seek, the scan and the chain walk are all unchanged.

The two sources were measured against each other, as the sixteen bytes that actually feed the SHA1, on SQL Server 2019, 2022 and 2025, for a user database and for `master`, and they agree everywhere. So the swap leaves every derived key identical while dropping a trace flag toggle and a regex over prose in favour of a typed `uniqueidentifier` read that a parameterised `DB_ID()` selects.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester -Path <command> -ScriptAnalyzer -Compliance`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [x] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose

The `-DataPages` path rebuilds the RC4 key from public metadata, and one of its three inputs is the database family GUID. It obtained that GUID by setting trace flag 3604, running `DBCC DBINFO`, and pulling `dbi_familyGUID` out of the text that arrives on the connection with a regex.

The catalog view `sys.database_recovery_status` exposes the same value as a typed `uniqueidentifier` in its `family_guid` column, and has done since SQL Server 2005, the same floor the rest of the feature already documents. Reading it there is a typed read in place of a text parse, with no trace flag toggle and no regex over prose.

### Approach

The failure this change has to avoid is a quiet one. Per the scheme documented on the original pull request, a wrong family GUID, or the right GUID in the wrong byte orientation, does not throw; it produces a plausible looking but wrong keystream, so an object reads as garbage of the right length rather than failing. The source therefore could not be swapped on the strength of it looking cleaner, and was measured instead.

Both paths end as a `System.Guid` fed through `ToByteArray`, which are the sixteen bytes that seed the SHA1. Comparing those bytes on SQL Server 2019, 2022 and 2025, for a freshly created user database and for `master`, they are byte identical every time, and an end to end decrypt of an encrypted object then recovers the original text exactly on all three.

`DBCC PAGE`, which reads the ciphertext out of `sys.sysobjvalues`, is unchanged and still requires sysadmin, so the up front sysadmin check stays. `sys.database_recovery_status` needs only `VIEW SERVER STATE`, which a sysadmin already holds, so the swap loosens nothing.

The comment based help never named `DBCC DBINFO`, so it needed no change; the inline comments and the private helper's parameter help were updated to name the catalog view.

### Testing

The `-DataPages` half of the suite is the part this change touches, and all of it passed against SQL Server 2025, including the two tests that read the family GUID to build their own oracle and so exercise the swapped source directly:

- Should return the same text by seek, by page list and by page chain
- Should return the same text whether the rows were seeked or scanned

Every other `-DataPages` case passed with them: in row and off row definitions, a blob tree several levels deep, non ASCII text returned unchanged, a read only database snapshot, more than one database in a single call, colliding schema and object names, and the page dump parsing and multi chunk unit tests. An end to end decrypt of a freshly created encrypted procedure recovered the original text exactly, Unicode intact.

The default DAC method is unchanged by this pull request and was not re-exercised here: the tests that cover it need a dedicated admin connection that the environment these tests ran in could not reach, so they are not reported above.

### Commands to test

```powershell
# reads the definitions without a DAC and without writing anything, as before
Invoke-DbaDbDecryptObject -SqlInstance sql01 -Database db1 -DataPages

# a single object, to eyeball that the recovered text matches the original
Invoke-DbaDbDecryptObject -SqlInstance sql01 -Database db1 -ObjectName MyProc -DataPages
```
